### PR TITLE
Add Mock Sender

### DIFF
--- a/libsplinter/src/channel/mock.rs
+++ b/libsplinter/src/channel/mock.rs
@@ -1,0 +1,57 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use crate::channel::{SendError, Sender};
+
+/// The mock sender allows for tests of components or functions that take a Sender to test the sent
+/// values synchronously. Removes the need for blocking (beyond the Arc/Mutex combo internally) on
+/// a receiver.
+#[derive(Clone)]
+pub struct MockSender<T: Clone> {
+    sent: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: Clone> Default for MockSender<T> {
+    fn default() -> Self {
+        MockSender {
+            sent: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl<T: Clone> MockSender<T> {
+    pub fn new(sent: Arc<Mutex<Vec<T>>>) -> Self {
+        MockSender { sent }
+    }
+
+    pub fn sent(&self) -> Vec<T> {
+        self.sent.lock().unwrap().clone()
+    }
+}
+
+impl<T: Any + Clone + Send> Sender<T> for MockSender<T> {
+    fn send(&self, message: T) -> Result<(), SendError> {
+        self.sent.lock().unwrap().push(message);
+        Ok(())
+    }
+
+    fn box_clone(&self) -> Box<Sender<T>> {
+        Box::new(MockSender {
+            sent: self.sent.clone(),
+        })
+    }
+}

--- a/libsplinter/src/channel/mod.rs
+++ b/libsplinter/src/channel/mod.rs
@@ -16,6 +16,8 @@
 // that is used must have the following Receiver trait implemented, then the receiver end of the
 // channel can be passed to the NetworkMessageSender.
 mod crossbeam;
+#[cfg(test)]
+pub mod mock;
 mod mpsc;
 
 pub trait Receiver<T>: Send {


### PR DESCRIPTION
Replace the creation of the mock network sender for a general MockSender in a mock module that is only available during the test configuration.