### PR TITLE
Implement Error/Display for ConfigError

### DIFF
--- a/splinterd/src/config.rs
+++ b/splinterd/src/config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error;
+use std::fmt;
 use std::fs::File;
 use std::io;
 use std::io::Read;
@@ -103,5 +105,23 @@ impl From<io::Error> for ConfigError {
 impl From<de::Error> for ConfigError {
     fn from(e: de::Error) -> Self {
         ConfigError::TomlParseError(e)
+    }
+}
+
+impl Error for ConfigError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ConfigError::ReadError(source) => Some(source),
+            ConfigError::TomlParseError(source) => Some(source),
+        }
+    }
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfigError::ReadError(source) => source.fmt(f),
+            ConfigError::TomlParseError(source) => write!(f, "Invalid File Format: {}", source),
+        }
     }
 }

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
             .map_err(ConfigError::from)
             .and_then(Config::from_file)
             .unwrap_or_else(|err| {
-                warn!("No config file loaded {:?}", err);
+                warn!("Unable to load {}: {}", config_file_path, err);
                 Config::default()
             })
     };


### PR DESCRIPTION
This commit improves the error messages provided by the ConfigError, when one occurs during startup of the splinterd process.