### PR TITLE
Remove redundant closure from map()

### DIFF
--- a/client/src/splinter_client.rs
+++ b/client/src/splinter_client.rs
@@ -88,6 +88,6 @@ impl SplinterClient {
 fn resolve_hostname(hostname: &str) -> Result<SocketAddr, SplinterError> {
     hostname
         .to_socket_addrs()?
-        .find(|addr| addr.is_ipv4())
+        .find(std::net::SocketAddr::is_ipv4)
         .ok_or(SplinterError::CouldNotResolveHostName)
 }

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -37,11 +37,7 @@ pub struct Pool {
 
 impl fmt::Debug for Pool {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut ids = self
-            .entries
-            .values()
-            .map(|entry| entry.id())
-            .collect::<Vec<usize>>();
+        let mut ids = self.entries.values().map(Entry::id).collect::<Vec<usize>>();
         ids.sort();
         write!(f, "Pool {{ {:?} }}", ids)
     }

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -67,7 +67,10 @@ impl PeerMap {
     ///
     /// This list does not include any of the redirected peer ids.
     fn peer_ids(&self) -> Vec<String> {
-        self.peers.keys().map(|left| left.to_string()).collect()
+        self.peers
+            .keys()
+            .map(std::string::ToString::to_string)
+            .collect()
     }
 
     /// Insert a new peer id for a given mesh id


### PR DESCRIPTION
Clippy complains that a closure is redundant if you
can just call the method directly on an object
of type x.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>