### PR TITLE
Replace 2018 log use with macro_use crate stmt

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 mod actions;
 mod error;
 
@@ -20,9 +23,8 @@ use crate::error::CliError;
 
 use std::str::FromStr;
 
-use ::log::LogLevel;
-use ::log::{error, log};
 use clap::clap_app;
+use log::LogLevel;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/examples/private_counter/cli/src/main.rs
+++ b/examples/private_counter/cli/src/main.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 mod actions;
 mod error;
 
 use crate::actions::{do_add, do_show};
 use crate::error::CliError;
 
-use ::log::LogLevel;
-use ::log::{error, log};
 use clap::clap_app;
+use log::LogLevel;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/examples/private_counter/service/src/main.rs
+++ b/examples/private_counter/service/src/main.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 mod error;
 
 use std::fmt::Write as FmtWrite;
@@ -23,10 +26,9 @@ use std::sync::{Arc, Mutex};
 use std::thread::{Builder, JoinHandle};
 use std::time::Duration;
 
-use ::log::LogLevel;
-use ::log::{debug, error, info, log, warn};
 use clap::{App, Arg};
 use crossbeam_channel;
+use log::LogLevel;
 use protobuf::{self, Message};
 use sha2::{Digest, Sha256};
 use threadpool::ThreadPool;

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -22,8 +22,6 @@ use crate::rwlock_read_unwrap;
 
 use std::sync::{Arc, RwLock};
 
-use ::log::{debug, log, warn};
-
 // Implements a handler that handles CircuitError messages
 pub struct CircuitErrorHandler {
     node_id: String,

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -17,8 +17,6 @@ use crate::network::sender::SendRequest;
 use crate::protos::circuit::{CircuitMessage, CircuitMessageType};
 use crate::protos::network::NetworkMessageType;
 
-use ::log::{debug, log};
-
 // Implements a handler that pass messages to another dispatcher loop
 pub struct CircuitMessageHandler {
     sender: Box<Sender<DispatchMessage<CircuitMessageType>>>,

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -24,7 +24,6 @@ use crate::rwlock_read_unwrap;
 
 use std::sync::{Arc, RwLock};
 
-use ::log::{debug, log, warn};
 use protobuf::Message;
 
 // Implements a handler that handles CircuitDirectMessage

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -26,7 +26,6 @@ use crate::rwlock_write_unwrap;
 
 use std::sync::{Arc, RwLock};
 
-use ::log::{debug, log, warn};
 use protobuf::Message;
 
 // Implements a handler that handles ServiceConnectRequest

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 #[macro_export]
 macro_rules! rwlock_read_unwrap {
     ($lock:expr) => {

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::log::{error, log, warn};
 use crossbeam_channel::TrySendError;
 use mio::{Event, Evented, Events, Poll, PollOpt, Ready, Token};
 use mio_extras::channel as mio_channel;

--- a/libsplinter/src/mesh/reactor.rs
+++ b/libsplinter/src/mesh/reactor.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::log::{error, log};
 use crossbeam_channel;
 use mio::{Event, Events, Token};
 use mio_extras::channel as mio_channel;

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::log::{debug, info, log, warn};
 use protobuf::Message;
 
 use crate::channel::Sender;

--- a/libsplinter/src/network/dispatch.rs
+++ b/libsplinter/src/network/dispatch.rs
@@ -23,8 +23,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use ::log::{error, log, warn};
-
 use crate::channel::{Receiver, RecvTimeoutError, SendError, Sender};
 use crate::network::sender::SendRequest;
 

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -16,7 +16,6 @@ use crate::network::dispatch::{DispatchError, Handler, MessageContext};
 use crate::network::sender::SendRequest;
 use crate::protos::network::{NetworkEcho, NetworkMessage, NetworkMessageType};
 
-use ::log::{debug, log};
 use protobuf::Message;
 
 // Implements a handler that handles NetworkEcho Messages

--- a/libsplinter/src/network/sender.rs
+++ b/libsplinter/src/network/sender.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use ::log::{error, log, warn};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -43,7 +43,6 @@ use libsplinter::rwlock_read_unwrap;
 use libsplinter::storage::get_storage;
 use libsplinter::transport::{AcceptError, ConnectError, Incoming, ListenError, Transport};
 
-use ::log::{debug, error, info, log, warn};
 use crossbeam_channel;
 use protobuf::Message;
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 mod certs;
 mod config;
 mod daemon;
@@ -20,12 +23,11 @@ use crate::certs::{make_ca_cert, make_ca_signed_cert, write_file, CertError};
 use crate::config::{Config, ConfigError};
 use crate::daemon::SplinterDaemon;
 
-use ::log::LogLevel;
-use ::log::{debug, error, info, log, warn};
 use clap::{clap_app, crate_version};
 use libsplinter::transport::raw::RawTransport;
 use libsplinter::transport::tls::{TlsInitError, TlsTransport};
 use libsplinter::transport::Transport;
+use log::LogLevel;
 use openssl::error::ErrorStack;
 use tempdir::TempDir;
 


### PR DESCRIPTION
Replace the 2018 style of use statements for the individual log macros with the classic `macro_use` use-crate statement.  This is a minor stylistic change, in that all use statements are similar (i.e. none of 
them have a leading `::`).

In addition, the syntax causes issues in some editor in both formatting rust code, as well as properly reading the file to determine symbol names.