### PR TITLE
Add NodeRegistry Trait to libsplinter

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -14,6 +14,8 @@
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate serde_derive;
 
 #[macro_export]
 macro_rules! rwlock_read_unwrap {
@@ -51,6 +53,7 @@ pub mod collections;
 pub mod mesh;
 pub mod n_phase;
 pub mod network;
+pub mod node_registry;
 pub mod protos;
 pub mod storage;
 pub mod transport;

--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum NodeRegistryError {
+    /// This error is returned when a node is not found.
+    NotFoundError(String),
+    /// This error is returned when the user attempts to create a node with an identity that
+    /// already exists.
+    DuplicateNodeError(String),
+    /// This error is returned when the user attempts to filter the nodes list using an invalid
+    /// filter.
+    InvalidFilterError(String),
+    /// This error is returned when an internal error occurred.
+    InternalError(Box<dyn Error>),
+}
+
+impl Error for NodeRegistryError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            NodeRegistryError::NotFoundError(_) => None,
+            NodeRegistryError::DuplicateNodeError(_) => None,
+            NodeRegistryError::InvalidFilterError(_) => None,
+            NodeRegistryError::InternalError(err) => Some(err.as_ref()),
+        }
+    }
+}
+
+impl fmt::Display for NodeRegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NodeRegistryError::NotFoundError(e) => write!(f, "Node not found: {}", e),
+            NodeRegistryError::DuplicateNodeError(e) => write!(f, "Duplicate identity: {}", e),
+            NodeRegistryError::InvalidFilterError(e) => write!(f, "Invalid filter: {}", e),
+            NodeRegistryError::InternalError(e) => write!(f, "Internal error: {}", e),
+        }
+    }
+}

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -1,0 +1,102 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;
+use error::NodeRegistryError;
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Node {
+    /// The Splinter identity of the node.
+    pub identity: String,
+    /// A map with node metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+pub trait NodeRegistry: Send {
+    /// Registers a new node.
+    ///
+    /// # Arguments
+    ///
+    /// * `identity` - The Splinter ID of the node.
+    /// * `data` - A map with node metadata.
+    ///
+    fn create_node(
+        &self,
+        identity: &str,
+        data: HashMap<String, String>,
+    ) -> Result<(), NodeRegistryError>;
+
+    /// Returns a list of nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `filters` - A map that defines list filters. The key is the property to be filtered by
+    /// and the value is a tuple. The first item of the tuple defines the operator "=", "<", ">",
+    /// "<=" or "<=". The second item in the tuple is the value to compare the node property
+    /// against. If the filters map has more than one key-value pair, this function should return
+    /// only nodes that match all the provided filters.
+    ///
+    fn list_nodes(
+        &self,
+        filters: Option<HashMap<String, (String, String)>>,
+    ) -> Result<Vec<Node>, NodeRegistryError>;
+
+    /// Returns a node with the given identity.
+    ///
+    /// # Arguments
+    ///
+    ///  * `identity` - The Splinter identity of the node.
+    ///
+    fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError>;
+
+    /// Updates a node with the given identity.
+    /// The node's exiting metadata properties that are not in the updates map will not be
+    /// changed. New properties that are not already in the nodes's metadata will be added to
+    /// the metadata.
+    ///
+    /// # Arguments
+    ///
+    ///  * `identity` - The Splinter identity of the node.
+    ///  * `updates` - A map containing the updated properties.
+    ///
+    fn update_node(
+        &self,
+        identity: &str,
+        updates: HashMap<String, String>,
+    ) -> Result<(), NodeRegistryError>;
+
+    /// Deletes a node with the given identity.
+    ///
+    /// # Arguments
+    ///
+    ///  * `identity` - The Splinter identity of the node.
+    ///
+    fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError>;
+
+    /// Clone implementation for Box<NodeRegistry>.
+    /// The implementation of Clone for NodeRegistry calls this method.
+    ///
+    /// # Example
+    ///  fn clone_box(&self) -> Box<NodeRegistry> {
+    ///     Box::new(Clone::clone(self))
+    ///  }
+    fn clone_box(&self) -> Box<NodeRegistry>;
+}
+
+impl Clone for Box<NodeRegistry> {
+    fn clone(&self) -> Box<NodeRegistry> {
+        self.clone_box()
+    }
+}


### PR DESCRIPTION
The Splinter Daemon REST API will rely on implementers of this trait to
fetch and update information about the Splinter Nodes on the network.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>