### PR TITLE
Add Service SDK Traits

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -52,6 +52,7 @@ pub mod mesh;
 pub mod n_phase;
 pub mod network;
 pub mod protos;
+pub mod service;
 pub mod signing;
 pub mod storage;
 pub mod transport;

--- a/libsplinter/src/service/error.rs
+++ b/libsplinter/src/service/error.rs
@@ -1,0 +1,142 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Errors that can occur in a service
+use std::borrow::Borrow;
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct ServiceSendError(pub Box<dyn Error>);
+
+impl Error for ServiceSendError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceSendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to send message: {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct ServiceConnectionError(pub Box<dyn Error>);
+
+impl Error for ServiceConnectionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to connect service: {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct ServiceDisconnectionError(pub Box<dyn Error>);
+
+impl Error for ServiceDisconnectionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceDisconnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to disconnect service: {}", self.0)
+    }
+}
+#[derive(Debug)]
+pub struct ServiceStartError(pub Box<dyn Error>);
+
+impl Error for ServiceStartError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to start service: {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct ServiceStopError(pub Box<dyn Error>);
+
+impl Error for ServiceStopError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceStopError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to stop service : {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub struct ServiceDestroyError(pub Box<dyn Error>);
+
+impl Error for ServiceDestroyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.0.borrow())
+    }
+}
+
+impl std::fmt::Display for ServiceDestroyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unable to destroy service: {}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub enum ServiceError {
+    /// Returned if an error is detected when parsing a message
+    InvalidMessageFormat(Box<dyn Error>),
+    /// Returned if an error is detected during the handling of a message
+    UnableToHandleMessage(Box<dyn Error>),
+    /// Returned if an error occurs during the sending of an outbound message
+    UnableToSendMessage(Box<ServiceSendError>),
+}
+
+impl Error for ServiceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ServiceError::InvalidMessageFormat(ref err) => Some(err.borrow()),
+            ServiceError::UnableToHandleMessage(ref err) => Some(err.borrow()),
+            ServiceError::UnableToSendMessage(err) => Some(err),
+        }
+    }
+}
+
+impl std::fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ServiceError::InvalidMessageFormat(ref err) => {
+                write!(f, "message is in an invalid format: {}", err)
+            }
+            ServiceError::UnableToHandleMessage(ref err) => {
+                write!(f, "cannot handle message {}", err)
+            }
+            ServiceError::UnableToSendMessage(ref err) => {
+                write!(f, "unable to send message: {}", err)
+            }
+        }
+    }
+}

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -1,0 +1,79 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;
+
+use crate::service::error::{
+    ServiceConnectionError, ServiceDestroyError, ServiceDisconnectionError, ServiceError,
+    ServiceSendError, ServiceStartError, ServiceStopError,
+};
+
+pub struct ServiceMessageContext {
+    pub sender: String,
+    pub circuit: String,
+    pub correlation_id: String,
+}
+
+pub trait ServiceNetworkRegistry {
+    fn connect(&self, service_id: &str) -> Result<(), ServiceConnectionError>;
+    fn disconnect(&self, service_id: &str) -> Result<(), ServiceDisconnectionError>;
+}
+
+pub trait ServiceNetworkSender {
+    /// Send the message bytes to the given recipient (another service)
+    fn send(&self, recipient: &str, message: &[u8]) -> Result<(), ServiceSendError>;
+
+    /// Send the message bytes to the given recipient (another service)
+    /// and await the reply.  This function blocks until the reply is
+    /// returned.
+    fn send_and_await(&self, recipient: &str, message: &[u8]) -> Result<Vec<u8>, ServiceSendError>;
+
+    /// Send the message bytes back to the origin specified in the given
+    /// message context.
+    fn reply(
+        &self,
+        message_origin: &ServiceMessageContext,
+        message: &[u8],
+    ) -> Result<(), ServiceSendError>;
+}
+
+pub trait Service: Send {
+    /// This service's id
+    fn service_id(&self) -> &str;
+
+    /// This service's message family
+    fn family_name(&self) -> &str;
+
+    /// This service's supported message versions
+    fn family_versions(&self) -> &[String];
+
+    /// Starts the service
+    fn start(&self, service_registry: &dyn ServiceNetworkRegistry)
+        -> Result<(), ServiceStartError>;
+
+    /// Stops Starts the service
+    fn stop(&self, service_registry: &dyn ServiceNetworkRegistry) -> Result<(), ServiceStopError>;
+
+    /// Clean-up any resources before the service is removed.
+    /// Consumes the service (which, given the use of dyn traits,
+    /// this must take a boxed Service instance).
+    fn destroy(self: Box<Self>) -> Result<(), ServiceDestroyError>;
+
+    fn handle_message(
+        &self,
+        message_bytes: &[u8],
+        message_context: &ServiceMessageContext,
+        network_sender: &dyn ServiceNetworkSender,
+    ) -> Result<(), ServiceError>;
+}


### PR DESCRIPTION
Add traits for ServiceNetworkRegistry, ServiceNetworkSender,
and Service. This traits will be used to implement Splinter
Services.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>