### PR TITLE
Correct app name usage information for splinterd

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -45,9 +45,9 @@ const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
 const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 
 fn main() {
-    let matches = clap_app!(splinter =>
+    let matches = clap_app!(splinterd =>
         (version: crate_version!())
-        (about: "Splinter Node")
+        (about: "Splinter Daemon")
         (@arg config: -c --config +takes_value)
         (@arg node_id: --("node-id") +takes_value
           "unique id for the node ")


### PR DESCRIPTION
This corrects the opening two lines of usage to look like:

  splinterd x.y.z
  Splinter Daemon

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>