### PR TITLE
Add batches endpoint to sabre service

### DIFF
--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -14,6 +14,7 @@
 
 mod consensus;
 mod error;
+mod rest_api;
 mod shared;
 mod state;
 
@@ -59,16 +60,6 @@ impl Scabbard {
             shared: Arc::new(Mutex::new(shared)),
             consensus: None,
         })
-    }
-
-    /// Add a batch to the service's queue.
-    pub fn add_batch_to_queue(&self, batch: BatchPair) -> Result<(), ServiceError> {
-        if let Ok(mut shared) = self.shared.lock() {
-            shared.add_batch_to_queue(batch);
-            Ok(())
-        } else {
-            Err(ServiceError::PoisonedLock("shared lock poisoned".into()))
-        }
     }
 }
 

--- a/libsplinter/src/service/scabbard/rest_api.rs
+++ b/libsplinter/src/service/scabbard/rest_api.rs
@@ -1,0 +1,63 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use transact::protocol::batch::BatchPair;
+use transact::protos::FromBytes;
+
+use crate::actix_web::{web, Error as ActixError, HttpResponse};
+use crate::futures::{stream::Stream, Future, IntoFuture};
+use crate::rest_api::{Method, Resource, RestResourceProvider};
+
+use super::{shared::ScabbardShared, Scabbard};
+
+impl RestResourceProvider for Scabbard {
+    fn resources(&self) -> Vec<Resource> {
+        let shared = self.shared.clone();
+        vec![Resource::new(Method::Post, "/batches", move |_, p| {
+            add_batch_to_queue(p, shared.clone())
+        })]
+    }
+}
+
+fn add_batch_to_queue(
+    payload: web::Payload,
+    shared: Arc<Mutex<ScabbardShared>>,
+) -> Box<Future<Item = HttpResponse, Error = ActixError>> {
+    Box::new(
+        payload
+            .from_err()
+            .fold(web::BytesMut::new(), move |mut body, chunk| {
+                body.extend_from_slice(&chunk);
+                Ok::<_, ActixError>(body)
+            })
+            .and_then(move |body| {
+                let batches: Vec<BatchPair> = match Vec::from_bytes(&body) {
+                    Ok(batches) => batches,
+                    Err(_) => return Box::new(HttpResponse::BadRequest().finish().into_future()),
+                };
+
+                if let Ok(mut shared) = shared.lock() {
+                    for batch in batches {
+                        shared.add_batch_to_queue(batch);
+                    }
+                    Box::new(HttpResponse::Ok().finish().into_future())
+                } else {
+                    Box::new(HttpResponse::InternalServerError().finish().into_future())
+                }
+            })
+            .into_future(),
+    )
+}


### PR DESCRIPTION
Implements the `RestResourceProvider` trait for the sabre service and
adds the `/batches` endpoint for submitting sabre batches.

Signed-off-by: Logan Seeley <seeley@bitwise.io>