### PR TITLE
Save sabre service state to disk

### DIFF
--- a/libsplinter/src/service/scabbard/consensus.rs
+++ b/libsplinter/src/service/scabbard/consensus.rs
@@ -365,6 +365,7 @@ mod tests {
     use super::*;
 
     use std::collections::{HashSet, VecDeque};
+    use std::path::Path;
 
     use crate::service::scabbard::state::ScabbardState;
     use crate::service::tests::*;
@@ -382,7 +383,8 @@ mod tests {
             VecDeque::new(),
             Some(Box::new(service_sender.clone())),
             peer_services.clone(),
-            ScabbardState::new().expect("failed to create state"),
+            ScabbardState::new(Path::new("/tmp/network_sender.lmdb"), 1024 * 1024)
+                .expect("failed to create state"),
         )));
         let consensus_sender = ScabbardConsensusNetworkSender::new("0".into(), shared);
 

--- a/libsplinter/src/service/scabbard/error.rs
+++ b/libsplinter/src/service/scabbard/error.rs
@@ -14,6 +14,7 @@
 
 use std::error::Error;
 
+use transact::database::error::DatabaseError;
 use transact::execution::adapter::ExecutionAdapterError;
 use transact::execution::executor::ExecutorError;
 use transact::protocol::batch::BatchBuildError;
@@ -92,6 +93,12 @@ impl std::fmt::Display for ScabbardStateError {
 
 impl From<BatchBuildError> for ScabbardStateError {
     fn from(err: BatchBuildError) -> Self {
+        ScabbardStateError(err.to_string())
+    }
+}
+
+impl From<DatabaseError> for ScabbardStateError {
+    fn from(err: DatabaseError) -> Self {
         ScabbardStateError(err.to_string())
     }
 }


### PR DESCRIPTION
Updates the sabre service to save the transact state to disk using LMDB.
This is necessary for persistence across restarts.

Signed-off-by: Logan Seeley <seeley@bitwise.io>