### PR TITLE
Add google font link

### DIFF
--- a/examples/gameroom/gameroom-app/public/index.html
+++ b/examples/gameroom/gameroom-app/public/index.html
@@ -22,6 +22,7 @@ limitations under the License.
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="img/logo-<%= VUE_APP_BRAND %>.png">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Round">
+    <link href="https://fonts.googleapis.com/css?family=Raleway&display=swap" rel="stylesheet">
     <title>Gameroom</title>
   </head>
   <body>


### PR DESCRIPTION
Adds a google font link for Raleway. This will ensure that it loads properly across platforms.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>