### PR TITLE
Update from_proto to return a 400 response for malformed json

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -16,6 +16,8 @@
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
 
 #[macro_export]
 macro_rules! rwlock_read_unwrap {


### PR DESCRIPTION
`from_payload` would incorrectly emit a 500 internal server error if the JSON consumed
was malformed. Now it emits a 400 bad request.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>