### PR TITLE
Add initial gameroom README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ to build a wide variety of architectural patterns.
 Splinter allows the same network to do two-party private communication,
 multi-party private communication, and network-wide multi-party shared state,
 all managed via consensus. A Splinter network enables multi-party or two-party
-private conversations using circuits and services. 
+private conversations using circuits and services.
 
-- A **circuit** is a virtual network within the Splinter network which safely 
+- A **circuit** is a virtual network within the Splinter network which safely
   and securely enforces privacy boundaries.
 
 - A **service** is an endpoint within a circuit that sends and receives private
@@ -36,4 +36,8 @@ Splinter includes example applications that you can run as demos.
 
 - Private XO demo: Two services talk over a circuit to play a private game of
   tic tac toe. See the [Private XO README](examples/private_xo/README.md).
+
+- Gameroom demo: Web application that allows you to set up a dynamic
+  two-party circuit (called a "gameroom") and play tic tac toe on a distributed
+  ledger. See the [Gameroom README](examples/gameroom/README.md).
 

--- a/examples/gameroom/README.md
+++ b/examples/gameroom/README.md
@@ -1,0 +1,38 @@
+# How to Run the Gameroom Demo
+
+Gameroom is a demo Splinter application that allows you to set up a dynamic
+two-party circuit (called a "gameroom") and play tic tac toe with shared state,
+as managed by two-phase-commit consensus. This example application sets up
+Splinter nodes for two imaginary organizations: Acme Corporation and Bubba
+Bakery.
+
+**Note:** This demo uses the Sabre smart contract engine provided in
+[Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre) and the XO smart
+contract provided in the [Hyperledger Sawtooth Rust
+SDK](https://github.com/hyperledger/sawtooth-sdk-rust/tree/master/examples/xo_rust).
+
+**Prerequisites**:
+This demo requires [Docker Engine](https://docs.docker.com/engine)
+and [Docker Compose](https://docs.docker.com/compose).
+
+1. Clone the [splinter repository](https://github.com/Cargill/splinter).
+
+1. To start Gameroom, run the following command from the Splinter root
+   directory:
+
+     ```
+     docker-compose -f examples/gameroom/docker-compose.yaml up
+     ```
+
+1. In a browser, navigate to the web application UI for each organization:
+
+    - Acme UI: <http://localhost:8080>
+
+    - Bubba Bakery UI: <http://localhost:8081>
+
+1. When you are finished, shut down the demo with the following command:
+
+     ```
+     docker-compose -f examples/gameroom/docker-compose.yaml down
+     ```
+


### PR DESCRIPTION
Also: In the main splinter README, add gameroom demo blurb and link
(and delete two trailing spaces).

Signed-off-by: Anne Chenette <chenette@bitwise.io>