### PR TITLE
Update dependencies to correctly use flate2

### DIFF
--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -19,8 +19,9 @@ authors = ["Cargill Incorporated"]
 edition = "2018"
 
 [dependencies]
-actix = "0.8"
-actix-web = "1.0"
+actix = { version = "0.8", default-features = false }
+actix-web = { version = "1.0", default-features = false, features = ["flate2-zlib"] }
+flate2 = "1.0.10"
 awc = "0.2"
 bcrypt = "0.5"
 clap = "2"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -23,10 +23,11 @@ authors = ["Cargill Incorporated"]
 edition = "2018"
 
 [dependencies]
-actix = "0.8"
-actix-web = "1.0"
+actix = { version = "0.8", default-features = false }
+actix-web = { version = "1.0", default-features = false, features = ["flate2-zlib"] }
+flate2 = "1.0.10"
 actix-service = "0.4"
-actix-http = "0.2"
+actix-http = {version = "0.2", features = ["flate2-zlib"] }
 actix-web-actors = "1.0"
 futures = "0.1"
 atomicwrites = "0.2"


### PR DESCRIPTION
Modify the actix dependencies to make use of the flate2 with libc enabled, which fixes a build issue.

Note, there's a pending Actix-web PR that will fix this, and allow us to remove the explicit flate2 dependencies.