### PR TITLE
Improve splinter component build times

### DIFF
--- a/examples/private_counter/service/Dockerfile
+++ b/examples/private_counter/service/Dockerfile
@@ -37,13 +37,24 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/proto
 
 # Copy dependencies
 COPY protos /build/protos
-COPY libsplinter /build/libsplinter
 
-# Create empty cargo project
+# Create empty cargo project for libsplinter
+WORKDIR /build
+RUN USER=root cargo new --lib libsplinter
+
+# Copy over libsplinter Cargo.toml and build.rs
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+
+# Do a release build to cache dependencies
+WORKDIR /build/libsplinter
+RUN cargo build --release
+
+# Create empty cargo for private_counter
 WORKDIR /build/examples/private_counter
 RUN USER=root cargo new --bin service --name private-counter
 
-# Copy over Cargo.toml file
+# Copy over private_counter Cargo.toml file
 COPY examples/private_counter/service/Cargo.toml /build/examples/private_counter/service/Cargo.toml
 
 # Do a release build to cache dependencies
@@ -51,14 +62,15 @@ WORKDIR /build/examples/private_counter/service
 RUN cargo build --release
 
 # Remove the auto-generated .rs files and the built files
-RUN rm src/*
-RUN rm target/release/private-counter* target/release/deps/private_counter*
+RUN rm src/*.rs
+RUN rm target/release/private-counter* target/release/deps/private_counter* \
+    target/release/deps/*libsplinter*
 
 # Copy over source files
 COPY examples/private_counter/protos /build/examples/private_counter/protos
 COPY examples/private_counter/service/build.rs /build/examples/private_counter/service/build.rs
 COPY examples/private_counter/service/src /build/examples/private_counter/service/src
-COPY libsplinter/src /build/libsplinter/src
+COPY libsplinter/ /build/libsplinter/
 
 # Build the project
 RUN cargo build --release

--- a/examples/private_xo/Dockerfile
+++ b/examples/private_xo/Dockerfile
@@ -40,13 +40,24 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/proto
 
 # Copy dependencies
 COPY protos /build/protos
-COPY libsplinter /build/libsplinter
 
-# Create empty cargo project
+# Create empty cargo project for libsplinter
+WORKDIR /build
+RUN USER=root cargo new --lib libsplinter
+
+# Copy over libsplinter Cargo.toml and build.rs
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+
+# Do a release build to cache dependencies
+WORKDIR /build/libsplinter
+RUN cargo build --release
+
+# Create empty cargo for private_xo
 WORKDIR /build/examples
 RUN USER=root cargo new --bin private_xo
 
-# Copy over Cargo.toml file
+# Copy over private_xo Cargo.toml file
 COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Do a release build to cache dependencies
@@ -55,14 +66,14 @@ RUN cargo build --release
 
 # Remove the auto-generated .rs files and the built files
 RUN rm src/*.rs
-RUN rm target/release/private-xo* target/release/deps/private_xo*
+RUN rm target/release/private-xo* target/release/deps/private_xo* \
+   target/release/deps/*libsplinter*
 
 # Copy over source files
 COPY ./examples/private_xo/protos /build/examples/private_xo/protos
 COPY ./examples/private_xo/build.rs /build/examples/private_xo/build.rs
 COPY ./examples/private_xo/src /build/examples/private_xo/src
 COPY libsplinter/src /build/libsplinter/src
-COPY protos/ /build/protos/
 
 # Build the project
 RUN cargo build --release

--- a/splinterd/Dockerfile
+++ b/splinterd/Dockerfile
@@ -46,9 +46,20 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/proto
 
 # Copy dependencies
 COPY protos /build/protos
-COPY libsplinter /build/libsplinter
 
-# Create empty cargo project
+# Create empty cargo project for libsplinter
+WORKDIR /build
+RUN USER=root cargo new --lib libsplinter
+
+# Copy over Cargo.toml and build.rs
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+
+# Do a release build to cache dependencies
+WORKDIR /build/libsplinter
+RUN cargo build --release
+
+# Create empty cargo project for splinterd
 WORKDIR /build
 RUN USER=root cargo new --bin splinterd
 
@@ -61,9 +72,14 @@ RUN cargo build --release
 
 # Remove the auto-generated .rs files and the built files
 RUN rm src/*.rs
-RUN rm target/release/splinterd* target/release/deps/splinterd*
+RUN rm target/release/splinterd* target/release/deps/splinterd* \
+    target/release/deps/*libsplinter*
 
 # Copy over source files
+WORKDIR /build/libsplinter
+COPY libsplinter /build/libsplinter
+
+WORKDIR /build/splinterd
 COPY splinterd/src ./src
 COPY splinterd/api ./api
 


### PR DESCRIPTION
Previous iterations did not pre-cache splinterd properly. Any
changes to libsplinter source would trigger a full (costly)
rebuild of splinterd dependencies.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>