### PR TITLE
Add gameroom app artifacts to docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,5 +28,9 @@
 /examples/gameroom/daemon/target
 /examples/gameroom/daemon/Cargo.lock
 
+/examples/gameroom/gameroom-app/node_modules
+/examples/gameroom/gameroom-app/dist
+/examples/gameroom/gameroom-app/package-lock.json
+
 /target
 /Cargo.lock


### PR DESCRIPTION
Add the various build artifacts for the gameroom app UI to the
base dockerignore file.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>