### PR TITLE
Make user email the primary key

### DIFF
--- a/examples/gameroom/database/src/helpers/gameroom_user.rs
+++ b/examples/gameroom/database/src/helpers/gameroom_user.rs
@@ -21,7 +21,7 @@ use diesel::{
 
 pub fn fetch_user_by_email(conn: &PgConnection, email: &str) -> QueryResult<Option<GameroomUser>> {
     gameroom_user::table
-        .filter(gameroom_user::email.eq(email))
+        .find(email)
         .first::<GameroomUser>(conn)
         .map(Some)
         .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })

--- a/examples/gameroom/database/src/models.rs
+++ b/examples/gameroom/database/src/models.rs
@@ -21,9 +21,9 @@ use std::time::SystemTime;
 #[derive(Insertable, Queryable)]
 #[table_name = "gameroom_user"]
 pub struct GameroomUser {
+    pub email: String,
     pub public_key: String,
     pub encrypted_private_key: String,
-    pub email: String,
     pub hashed_password: String,
 }
 

--- a/examples/gameroom/database/src/schema.rs
+++ b/examples/gameroom/database/src/schema.rs
@@ -16,10 +16,10 @@
  */
 
 table! {
-    gameroom_user (public_key) {
+    gameroom_user (email) {
+        email -> Text,
         public_key -> Text,
         encrypted_private_key -> Text,
-        email -> Text,
         hashed_password -> Text,
     }
 }

--- a/examples/gameroom/database/tables/gameroom_tables.sql
+++ b/examples/gameroom/database/tables/gameroom_tables.sql
@@ -14,9 +14,9 @@
 
 -- Create tables
 CREATE TABLE IF NOT EXISTS gameroom_user (
-  public_key                TEXT        PRIMARY KEY,
+  email                     TEXT        PRIMARY KEY,
+  public_key                TEXT        NOT NULL,
   encrypted_private_key     TEXT        NOT NULL,
-  email                     TEXT        NOT NULL,
   hashed_password           TEXT        NOT NULL
 );
 


### PR DESCRIPTION
In the Gameroom database the user's primary key should be the user's email and not their public key. This PR changes the table definition, and the rust model, schema and related methods.
