### PR TITLE
Allow users to supply private key on registration

### DIFF
--- a/examples/gameroom/gameroom-app/src/scss/partials/_forms.scss
+++ b/examples/gameroom/gameroom-app/src/scss/partials/_forms.scss
@@ -52,6 +52,32 @@ input:focus {
     flex-direction: column;
     padding-bottom: 1rem;
 
+    .form-input-icon-wrapper {
+      display: flex;
+      flex-direction: row;
+      background-color: white;
+      width: 100%;
+      height: 3rem;
+      padding-left: .5em;
+      margin-top: .25rem;
+      font-size: 1.2rem;
+      outline: none;
+      @include rounded-border;
+
+      .input {
+        flex-grow:2;
+        border: none;
+      }
+
+      .form-button {
+        background: none;
+        border: none;
+        .icon {
+          color: $color-text-form;
+        }
+      }
+    }
+
     .form-input {
       width: 100%;
       height: 3rem;

--- a/examples/gameroom/gameroom-app/src/store/modules/user.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/user.ts
@@ -28,6 +28,12 @@ const userState = {
   },
 };
 
+interface Registration {
+  email: string;
+  privateKey: string;
+  password: string;
+}
+
 interface Creds {
   email: string;
   password: string;
@@ -46,18 +52,18 @@ const getters = {
 };
 
 const actions = {
-  async register({ commit }: any, creds: Creds) {
-    const keys = crypto.createKeyPair();
+  async register({ commit }: any, reg: Registration) {
+    const publicKey = crypto.getPublicKey(reg.privateKey);
     await userCreate({
-      email: creds.email,
-      hashedPassword: crypto.hashSHA256(creds.email, creds.password),
-      publicKey: keys.publicKey,
-      encryptedPrivateKey: crypto.encrypt(creds.password, keys.privateKey),
+      email: reg.email,
+      hashedPassword: crypto.hashSHA256(reg.email, reg.password),
+      publicKey,
+      encryptedPrivateKey: crypto.encrypt(reg.password, reg.privateKey),
     });
     commit('setUser', {
-      email: creds.email,
-      publicKey: keys.publicKey,
-      privateKey: keys.privateKey,
+      email: reg.email,
+      publicKey,
+      privateKey: reg.privateKey,
     });
   },
   async authenticate({ commit }: any, creds: Creds) {

--- a/examples/gameroom/gameroom-app/src/views/Register.vue
+++ b/examples/gameroom/gameroom-app/src/views/Register.vue
@@ -21,7 +21,7 @@ limitations under the License.
     </toast>
     <div class="auth-wrapper">
       <form class="auth-form" @submit.prevent="register">
-        <label class= "form-label">
+        <label class="form-label">
           <div>Email</div>
           <input
             class="form-input"
@@ -29,6 +29,18 @@ limitations under the License.
             v-model="email"
             v-focus
           />
+        </label>
+        <label class="form-label">
+          <div>Private Key</div>
+            <div class="form-input-icon-wrapper">
+              <input
+                class="input"
+                type="text"
+                v-model="privateKey"/>
+              <button class="form-button" type="button" @click.prevent="generatePrivateKey">
+                <i class="icon material-icons-round">autorenew</i>
+              </button>
+            </div>
         </label>
         <label class="form-label">
           <div>Password</div>
@@ -66,12 +78,14 @@ limitations under the License.
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 import Toast from '../components/Toast.vue';
+import * as crypto from '@/utils/crypto';
 
 @Component({
   components: { Toast },
 })
 export default class Register extends Vue {
   email = '';
+  privateKey = '';
   password = '';
   confirmPassword = '';
   submitting = false;
@@ -80,6 +94,7 @@ export default class Register extends Vue {
   get canSubmit() {
     if (!this.submitting &&
         this.email !== '' &&
+        this.privateKey !== '' &&
         this.password !== '' &&
         this.confirmPassword !== '') {
       return true;
@@ -91,6 +106,11 @@ export default class Register extends Vue {
     this.error = '';
   }
 
+  generatePrivateKey() {
+    const privKey = crypto.createPrivateKey();
+    this.privateKey = privKey;
+  }
+
   async register() {
     if (this.password !== this.confirmPassword) {
       this.error = 'Passwords do not match.';
@@ -100,6 +120,7 @@ export default class Register extends Vue {
     try {
       await this.$store.dispatch('user/register', {
         email: this.email,
+        privateKey: this.privateKey,
         password: this.password,
       });
       this.$router.push({ name: 'dashboard' });


### PR DESCRIPTION
Adds a private key input to registration. A user can supply their own key or hit the generate button to generate one. This allows us to have a set list of keys to use for demo.

To test, try registration with generated private keys and a private key generated from elsewhere.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>