### PR TITLE
Send authorized response to internal "peers"

### DIFF
--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -350,7 +350,11 @@ mod tests {
     use crate::keys::{insecure::AllowAllKeyPermissionManager, storage::StorageKeyRegistry};
     use crate::mesh::Mesh;
     use crate::network::{auth::AuthorizationCallback, Network};
-    use crate::protos::admin;
+    use crate::protos::{
+        admin,
+        authorization::{AuthorizationMessage, AuthorizationMessageType, AuthorizedMessage},
+        network::{NetworkMessage, NetworkMessageType},
+    };
     use crate::service::{error, ServiceNetworkRegistry, ServiceNetworkSender};
     use crate::signing::hash::HashVerifier;
     use crate::storage::get_storage;
@@ -365,8 +369,8 @@ mod tests {
         let mesh = Mesh::new(4, 16);
         let network = Network::new(mesh.clone());
         let mut transport = MockConnectingTransport::expect_connections(vec![
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
         ]);
 
         let mut storage = get_storage("memory", CircuitDirectory::new).unwrap();
@@ -578,7 +582,19 @@ mod tests {
         }
     }
 
-    struct MockConnection;
+    struct MockConnection {
+        auth_response: Option<Vec<u8>>,
+        evented: MockEvented,
+    }
+
+    impl MockConnection {
+        fn new() -> Self {
+            Self {
+                auth_response: Some(authorized_response()),
+                evented: MockEvented::new(),
+            }
+        }
+    }
 
     impl Connection for MockConnection {
         fn send(&mut self, _message: &[u8]) -> Result<(), SendError> {
@@ -586,7 +602,7 @@ mod tests {
         }
 
         fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
-            panic!("MockConnection.recv unexpectedly called")
+            Ok(self.auth_response.take().unwrap_or_else(|| vec![]))
         }
 
         fn remote_endpoint(&self) -> String {
@@ -602,36 +618,73 @@ mod tests {
         }
 
         fn evented(&self) -> &dyn mio::Evented {
-            &MockEvented
+            &self.evented
         }
     }
 
-    struct MockEvented;
+    struct MockEvented {
+        registration: mio::Registration,
+        set_readiness: mio::SetReadiness,
+    }
+
+    impl MockEvented {
+        fn new() -> Self {
+            let (registration, set_readiness) = mio::Registration::new2();
+
+            Self {
+                registration,
+                set_readiness,
+            }
+        }
+    }
 
     impl mio::Evented for MockEvented {
         fn register(
             &self,
-            _poll: &mio::Poll,
-            _token: mio::Token,
-            _interest: mio::Ready,
-            _opts: mio::PollOpt,
+            poll: &mio::Poll,
+            token: mio::Token,
+            interest: mio::Ready,
+            opts: mio::PollOpt,
         ) -> std::io::Result<()> {
+            self.registration.register(poll, token, interest, opts)?;
+            self.set_readiness.set_readiness(mio::Ready::readable())?;
+
             Ok(())
         }
 
         fn reregister(
             &self,
-            _poll: &mio::Poll,
-            _token: mio::Token,
-            _interest: mio::Ready,
-            _opts: mio::PollOpt,
+            poll: &mio::Poll,
+            token: mio::Token,
+            interest: mio::Ready,
+            opts: mio::PollOpt,
         ) -> std::io::Result<()> {
-            Ok(())
+            self.registration.reregister(poll, token, interest, opts)
         }
 
-        fn deregister(&self, _poll: &mio::Poll) -> std::io::Result<()> {
-            Ok(())
+        fn deregister(&self, poll: &mio::Poll) -> std::io::Result<()> {
+            poll.deregister(&self.registration)
         }
+    }
+
+    fn authorized_response() -> Vec<u8> {
+        let msg_type = AuthorizationMessageType::AUTHORIZE;
+        let auth_msg = AuthorizedMessage::new();
+        let mut auth_msg_env = AuthorizationMessage::new();
+        auth_msg_env.set_message_type(msg_type);
+        auth_msg_env.set_payload(auth_msg.write_to_bytes().expect("unable to write to bytes"));
+
+        let mut network_msg = NetworkMessage::new();
+        network_msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+        network_msg.set_payload(
+            auth_msg_env
+                .write_to_bytes()
+                .expect("unable to write to bytes"),
+        );
+
+        network_msg
+            .write_to_bytes()
+            .expect("unable to write to bytes")
     }
 
     struct MockAuthInquisitor;

--- a/libsplinter/src/admin/shared.rs
+++ b/libsplinter/src/admin/shared.rs
@@ -890,7 +890,7 @@ impl AdminServiceShared {
 mod tests {
     use super::*;
 
-    use protobuf::RepeatedField;
+    use protobuf::{Message, RepeatedField};
 
     use crate::circuit::directory::CircuitDirectory;
     use crate::keys::{
@@ -903,6 +903,10 @@ mod tests {
     };
     use crate::protos::admin;
     use crate::protos::admin::{SplinterNode, SplinterService};
+    use crate::protos::authorization::{
+        AuthorizationMessage, AuthorizationMessageType, AuthorizedMessage,
+    };
+    use crate::protos::network::{NetworkMessage, NetworkMessageType};
     use crate::signing::hash::HashVerifier;
     use crate::storage::get_storage;
     use crate::transport::{
@@ -916,9 +920,9 @@ mod tests {
         let mesh = Mesh::new(4, 16);
         let network = Network::new(mesh.clone());
         let mut transport = MockConnectingTransport::expect_connections(vec![
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
         ]);
         let orchestrator_connection = transport
             .connect("inproc://admin-service")
@@ -990,9 +994,9 @@ mod tests {
         let mesh = Mesh::new(4, 16);
         let network = Network::new(mesh.clone());
         let mut transport = MockConnectingTransport::expect_connections(vec![
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
         ]);
         let orchestrator_connection = transport
             .connect("inproc://admin-service")
@@ -1554,8 +1558,8 @@ mod tests {
         let mesh = Mesh::new(4, 16);
         let network = Network::new(mesh.clone());
         let transport = MockConnectingTransport::expect_connections(vec![
-            Ok(Box::new(MockConnection)),
-            Ok(Box::new(MockConnection)),
+            Ok(Box::new(MockConnection::new())),
+            Ok(Box::new(MockConnection::new())),
         ]);
         let peer_connector = PeerConnector::new(network.clone(), Box::new(transport));
         peer_connector
@@ -1563,7 +1567,7 @@ mod tests {
 
     fn setup_orchestrator() -> ServiceOrchestrator {
         let mut transport =
-            MockConnectingTransport::expect_connections(vec![Ok(Box::new(MockConnection))]);
+            MockConnectingTransport::expect_connections(vec![Ok(Box::new(MockConnection::new()))]);
         let orchestrator_connection = transport
             .connect("inproc://admin-service")
             .expect("failed to create connection");
@@ -1631,7 +1635,19 @@ mod tests {
         }
     }
 
-    struct MockConnection;
+    struct MockConnection {
+        auth_response: Option<Vec<u8>>,
+        evented: MockEvented,
+    }
+
+    impl MockConnection {
+        fn new() -> Self {
+            Self {
+                auth_response: Some(authorized_response()),
+                evented: MockEvented::new(),
+            }
+        }
+    }
 
     impl Connection for MockConnection {
         fn send(&mut self, _message: &[u8]) -> Result<(), SendError> {
@@ -1639,7 +1655,7 @@ mod tests {
         }
 
         fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
-            panic!("MockConnection.recv unexpectedly called")
+            Ok(self.auth_response.take().unwrap_or_else(|| vec![]))
         }
 
         fn remote_endpoint(&self) -> String {
@@ -1655,35 +1671,72 @@ mod tests {
         }
 
         fn evented(&self) -> &dyn mio::Evented {
-            &MockEvented
+            &self.evented
         }
     }
 
-    struct MockEvented;
+    struct MockEvented {
+        registration: mio::Registration,
+        set_readiness: mio::SetReadiness,
+    }
+
+    impl MockEvented {
+        fn new() -> Self {
+            let (registration, set_readiness) = mio::Registration::new2();
+
+            Self {
+                registration,
+                set_readiness,
+            }
+        }
+    }
 
     impl mio::Evented for MockEvented {
         fn register(
             &self,
-            _poll: &mio::Poll,
-            _token: mio::Token,
-            _interest: mio::Ready,
-            _opts: mio::PollOpt,
+            poll: &mio::Poll,
+            token: mio::Token,
+            interest: mio::Ready,
+            opts: mio::PollOpt,
         ) -> std::io::Result<()> {
+            self.registration.register(poll, token, interest, opts)?;
+            self.set_readiness.set_readiness(mio::Ready::readable())?;
+
             Ok(())
         }
 
         fn reregister(
             &self,
-            _poll: &mio::Poll,
-            _token: mio::Token,
-            _interest: mio::Ready,
-            _opts: mio::PollOpt,
+            poll: &mio::Poll,
+            token: mio::Token,
+            interest: mio::Ready,
+            opts: mio::PollOpt,
         ) -> std::io::Result<()> {
-            Ok(())
+            self.registration.reregister(poll, token, interest, opts)
         }
 
-        fn deregister(&self, _poll: &mio::Poll) -> std::io::Result<()> {
-            Ok(())
+        fn deregister(&self, poll: &mio::Poll) -> std::io::Result<()> {
+            poll.deregister(&self.registration)
         }
+    }
+
+    fn authorized_response() -> Vec<u8> {
+        let msg_type = AuthorizationMessageType::AUTHORIZE;
+        let auth_msg = AuthorizedMessage::new();
+        let mut auth_msg_env = AuthorizationMessage::new();
+        auth_msg_env.set_message_type(msg_type);
+        auth_msg_env.set_payload(auth_msg.write_to_bytes().expect("unable to write to bytes"));
+
+        let mut network_msg = NetworkMessage::new();
+        network_msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+        network_msg.set_payload(
+            auth_msg_env
+                .write_to_bytes()
+                .expect("unable to write to bytes"),
+        );
+
+        network_msg
+            .write_to_bytes()
+            .expect("unable to write to bytes")
     }
 }

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -163,7 +163,7 @@ impl Mesh {
     /// Create a new handle for sending to the existing connection with the given id.
     ///
     /// This may be faster if many sends on the same Connection are going to be performed because
-    // the internal lock around the pool of senders does not need to be reacquired.
+    /// the internal lock around the pool of senders does not need to be reacquired.
     pub fn outgoing(&self, id: usize) -> Option<Outgoing> {
         rwlock_read_unwrap!(self.outgoings).get(&id).cloned()
     }

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -221,7 +221,17 @@ impl Handler<AuthorizationMessageType, ConnectRequest> for ConnectRequestHandler
                     )?,
                 ))?;
             }
-            Ok(AuthorizationState::Internal) => (),
+            Ok(AuthorizationState::Internal) => {
+                debug!(
+                    "Sending Authorized message to internal peer {}",
+                    context.source_peer_id()
+                );
+                let auth_msg = AuthorizedMessage::new();
+                sender.send(SendRequest::new(
+                    context.source_peer_id().to_string(),
+                    wrap_in_network_auth_envelopes(AuthorizationMessageType::AUTHORIZE, auth_msg)?,
+                ))?;
+            }
             Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
         }
 

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -103,6 +103,14 @@ impl ServiceOrchestrator {
         mesh.send(Envelope::new(mesh_id, connect_request))
             .map_err(|err| NewOrchestratorError(Box::new(err)))?;
 
+        // Wait for the auth response.  Currently, this is on an inproc transport, so this will be
+        // an "ok" response
+        let _authed_response = mesh
+            .recv()
+            .map_err(|err| NewOrchestratorError(Box::new(err)))?;
+
+        debug!("Orchestrator authorized");
+
         // Start thread that handles incoming messages from a splinter node.
         let incoming_mesh = mesh.clone();
         let incoming_running = running.clone();


### PR DESCRIPTION
Send an authorized response to the internal peers (i.e. connections over the `inproc` transport).  The connect messages senders should wait for the response before sending any subsequent messages, otherwise they may enter a race condition with the guard that only accepts messages from authorized peers.
