### PR TITLE
Return updated notification

### DIFF
--- a/examples/gameroom/daemon/src/rest_api/routes/notification.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/notification.rs
@@ -178,8 +178,7 @@ fn update_gameroom_notification(
     pool: web::Data<ConnectionPool>,
     id: i64,
 ) -> Result<ApiNotification, RestApiResponseError> {
-    if let Some(notification) = helpers::fetch_notification(&*pool.get()?, id)? {
-        helpers::update_gameroom_notification(&*pool.get()?, id)?;
+    if let Some(notification) = helpers::update_gameroom_notification(&*pool.get()?, id)? {
         return Ok(ApiNotification::from(notification));
     }
     Err(RestApiResponseError::NotFound(format!(

--- a/examples/gameroom/database/src/helpers/notification.rs
+++ b/examples/gameroom/database/src/helpers/notification.rs
@@ -44,11 +44,15 @@ pub fn list_unread_notifications_with_paging(
         .load::<GameroomNotification>(conn)
 }
 
-pub fn update_gameroom_notification(conn: &PgConnection, notification_id: i64) -> QueryResult<()> {
+pub fn update_gameroom_notification(
+    conn: &PgConnection,
+    notification_id: i64,
+) -> QueryResult<Option<GameroomNotification>> {
     diesel::update(gameroom_notification::table.find(notification_id))
         .set(gameroom_notification::read.eq(true))
-        .execute(conn)
-        .map(|_| ())
+        .get_result(conn)
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
 }
 
 pub fn insert_gameroom_notification(


### PR DESCRIPTION
Changes the helper to update the notification database entry to
return the updated row, which will return the updated notification
from the PATCH /notification/{notification_id} route.
