### PR TITLE
Add client build to tests

### DIFF
--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -66,3 +66,13 @@ services:
       POSTGRES_DB: gameroom_test
     volumes:
       - "../database/tables:/docker-entrypoint-initdb.d"
+
+  gameroom-app-test:
+    build:
+      context: ../gameroom-app
+      args:
+        VUE_APP_BRAND: "acme"
+    image: gameroom-app-test
+    container_name: gameroom-app-test
+    environment:
+      - VUE_APP_BRAND=acme


### PR DESCRIPTION
Adds a build of the client to the test docker-compose file so that it will be built in CI.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>