### PR TITLE
Remove splinter client from cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,6 @@ clap = "2"
 log = "0.3.8"
 protobuf = "2"
 simple_logger = "0.4.0"
-splinter-client = { path = "../client" }
 libc = "0.2"
 libsplinter = { path = "../libsplinter" }
 sawtooth-sdk = "0.3"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -59,17 +59,6 @@ COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
 WORKDIR /build/libsplinter
 RUN cargo build --release
 
-# Create empty cargo project for client
-WORKDIR /build
-RUN USER=root cargo new --lib client
-
-# Copy over client Cargo.toml
-COPY client/Cargo.toml /build/client/Cargo.toml
-
-# Do a release build to cache client dependencies
-WORKDIR /build/client
-RUN cargo build --release
-
 # Create empty cargo project for cli
 WORKDIR /build
 RUN USER=root cargo new --bin cli
@@ -84,14 +73,11 @@ RUN cargo build --release
 # Remove the auto-generated .rs files and the built files
 WORKDIR /build
 RUN rm cli/target/release/deps/*splinter*
-RUN rm client/target/release/*splinter* \
-    client/target/release/deps/*splinter*
 RUN rm libsplinter/target/release/*splinter* \
     libsplinter/target/release/deps/*splinter*
 
 # Copy over source files
 COPY cli/src /build/cli/src
-COPY client/src /build/client/src
 COPY libsplinter/src /build/libsplinter/src
 COPY protos/ /build/protos/
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -11,19 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use splinter_client::error::SplinterError;
-
 #[derive(Debug)]
 pub enum CliError {
-    ClientError(SplinterError),
     RequiresArgs,
     InvalidSubcommand,
     ActionError(String),
     EnvironmentError(String),
-}
-
-impl From<SplinterError> for CliError {
-    fn from(e: SplinterError) -> Self {
-        CliError::ClientError(e)
-    }
 }


### PR DESCRIPTION
This is not currently used and increasing the
time required to build the cli.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>