### PR TITLE
Add Context object for WebSocket callbacks

### DIFF
--- a/libsplinter/src/events/reactor.rs
+++ b/libsplinter/src/events/reactor.rs
@@ -125,7 +125,7 @@ impl Igniter {
         ws: &WebSocketClient<T>,
     ) -> Result<(), WebSocketError> {
         self.sender
-            .send(ReactorMessage::StartWs(ws.listen()?))
+            .send(ReactorMessage::StartWs(ws.listen(self.clone())?))
             .map_err(|err| {
                 WebSocketError::ListenError(format!("Failed to start ws {}: {}", ws.url(), err))
             })


### PR DESCRIPTION
`on_open`, `on_message`, and `on_error` callbacks for `WebSocketClient`
now take an additional `Context` object as an argument. `Context`
contains a copy of the original `WebSocketClient` and it's `Igniter`. This is
meant to make it easier to restart a WebSocket connection, start another
WebSocket,  and dispatch http futures from within a WebSocket callback.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>