### PR TITLE
Change Circuit string fields to enums

### DIFF
--- a/libsplinter/src/admin/shared.rs
+++ b/libsplinter/src/admin/shared.rs
@@ -22,8 +22,8 @@ use protobuf::{Message, RepeatedField};
 
 use crate::circuit::SplinterState;
 use crate::circuit::{
-    service::SplinterNode as StateNode, Circuit as StateCircuit,
-    ServiceDefinition as StateServiceDefinition,
+    service::SplinterNode as StateNode, AuthorizationType, Circuit as StateCircuit, DurabilityType,
+    PersistenceType, RouteType, ServiceDefinition as StateServiceDefinition,
 };
 use crate::consensus::{Proposal, ProposalId};
 use crate::hex::to_hex;
@@ -1045,7 +1045,7 @@ impl AdminServiceShared {
         });
 
         let auth = match circuit.get_authorization_type() {
-            Circuit_AuthorizationType::TRUST_AUTHORIZATION => "trust".to_string(),
+            Circuit_AuthorizationType::TRUST_AUTHORIZATION => AuthorizationType::Trust,
             // This should never happen
             Circuit_AuthorizationType::UNSET_AUTHORIZATION_TYPE => {
                 return Err(AdminSharedError::CommitError(
@@ -1055,7 +1055,7 @@ impl AdminServiceShared {
         };
 
         let persistence = match circuit.get_persistence() {
-            Circuit_PersistenceType::ANY_PERSISTENCE => "any".to_string(),
+            Circuit_PersistenceType::ANY_PERSISTENCE => PersistenceType::Any,
             // This should never happen
             Circuit_PersistenceType::UNSET_PERSISTENCE_TYPE => {
                 return Err(AdminSharedError::CommitError(
@@ -1065,7 +1065,7 @@ impl AdminServiceShared {
         };
 
         let durability = match circuit.get_durability() {
-            Circuit_DurabilityType::NO_DURABILITY => "none".to_string(),
+            Circuit_DurabilityType::NO_DURABILITY => DurabilityType::NoDurabilty,
             // This should never happen
             Circuit_DurabilityType::UNSET_DURABILITY_TYPE => {
                 return Err(AdminSharedError::CommitError(
@@ -1075,7 +1075,7 @@ impl AdminServiceShared {
         };
 
         let routes = match circuit.get_routes() {
-            Circuit_RouteType::ANY_ROUTE => "any".to_string(),
+            Circuit_RouteType::ANY_ROUTE => RouteType::Any,
             // This should never happen
             Circuit_RouteType::UNSET_ROUTE_TYPE => {
                 return Err(AdminSharedError::CommitError(

--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -173,7 +173,7 @@ mod tests {
 
     use crate::channel::{SendError, Sender};
     use crate::circuit::directory::CircuitDirectory;
-    use crate::circuit::Circuit;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
     use crate::network::dispatch::Dispatcher;
     use crate::protos::circuit::CircuitMessage;
     use crate::protos::network::NetworkMessage;
@@ -189,12 +189,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["1234".into(), "5678".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("admin_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -255,12 +255,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["1234".into(), "5678".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("admin_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -321,12 +321,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["1234".into(), "5678".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("admin_test_app".into())
             .build()
             .expect("Should have built a correct circuit");

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -106,7 +106,7 @@ mod tests {
     use crate::channel::Sender;
     use crate::circuit::directory::CircuitDirectory;
     use crate::circuit::service::{Service, SplinterNode};
-    use crate::circuit::Circuit;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
     use crate::network::dispatch::Dispatcher;
     use crate::protos::circuit::{CircuitError_Error, CircuitMessage};
     use crate::protos::network::NetworkMessage;
@@ -122,12 +122,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_errors_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -212,12 +212,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_error_test_app".into())
             .build()
             .expect("Should have built a correct circuit");

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -205,7 +205,7 @@ mod tests {
     use crate::channel::{SendError, Sender};
     use crate::circuit::directory::CircuitDirectory;
     use crate::circuit::service::{Service, SplinterNode};
-    use crate::circuit::Circuit;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
     use crate::network::dispatch::Dispatcher;
     use crate::protos::circuit::CircuitMessage;
     use crate::protos::network::NetworkMessage;
@@ -221,12 +221,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -310,12 +310,12 @@ mod tests {
         // Add circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -399,12 +399,12 @@ mod tests {
         // add the circuit and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -486,12 +486,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -574,12 +574,12 @@ mod tests {
         // add circuits and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into(), "345".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -657,12 +657,12 @@ mod tests {
         // add circuits and service to splinter state
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into(), "345".into()])
             .with_roster(vec!["def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("circuit_direct_test_app".into())
             .build()
             .expect("Should have built a correct circuit");

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -401,7 +401,7 @@ mod tests {
     use crate::channel::mock::MockSender;
     use crate::channel::Sender;
     use crate::circuit::directory::CircuitDirectory;
-    use crate::circuit::Circuit;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
     use crate::network::dispatch::Dispatcher;
     use crate::protos::circuit::CircuitMessage;
     use crate::protos::network::NetworkMessage;
@@ -621,12 +621,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into(), "345".into()])
             .with_roster(vec![service_abc, service_def])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("service_connect_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -824,12 +824,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into(), "345".into()])
             .with_roster(vec![service_abc, service_def])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("service_connect_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -1217,12 +1217,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into(), "345".into()])
             .with_roster(vec![service_abc, service_def])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("service_connect_test_app".into())
             .build()
             .expect("Should have built a correct circuit");

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -30,12 +30,12 @@ use crate::storage::get_storage;
 pub struct Circuit {
     #[serde(skip)]
     id: String,
-    auth: String,
+    auth: AuthorizationType,
     members: Vec<String>,
     roster: Roster,
-    persistence: String,
-    durability: String,
-    routes: String,
+    persistence: PersistenceType,
+    durability: DurabilityType,
+    routes: RouteType,
 
     #[serde(default = "Circuit::default_management_type")]
     circuit_management_type: String,
@@ -53,12 +53,12 @@ impl Circuit {
     pub fn new_admin() -> Self {
         Circuit {
             id: "admin".into(),
-            auth: "".into(),
+            auth: AuthorizationType::Trust,
             members: vec![],
             roster: Roster::Admin,
-            persistence: "".into(),
-            durability: "".into(),
-            routes: "".into(),
+            persistence: PersistenceType::Any,
+            durability: DurabilityType::NoDurabilty,
+            routes: RouteType::Any,
             circuit_management_type: "".into(),
         }
     }
@@ -67,7 +67,7 @@ impl Circuit {
         &self.id
     }
 
-    pub fn auth(&self) -> &str {
+    pub fn auth(&self) -> &AuthorizationType {
         &self.auth
     }
 
@@ -79,15 +79,15 @@ impl Circuit {
         &self.roster
     }
 
-    pub fn persistence(&self) -> &str {
+    pub fn persistence(&self) -> &PersistenceType {
         &self.persistence
     }
 
-    pub fn durability(&self) -> &str {
+    pub fn durability(&self) -> &DurabilityType {
         &self.durability
     }
 
-    pub fn routes(&self) -> &str {
+    pub fn routes(&self) -> &RouteType {
         &self.routes
     }
 
@@ -99,12 +99,12 @@ impl Circuit {
 #[derive(Default)]
 pub struct CircuitBuilder {
     id: Option<String>,
-    auth: Option<String>,
+    auth: Option<AuthorizationType>,
     members: Vec<String>,
     roster: Vec<ServiceDefinition>,
-    persistence: Option<String>,
-    durability: Option<String>,
-    routes: Option<String>,
+    persistence: Option<PersistenceType>,
+    durability: Option<DurabilityType>,
+    routes: Option<RouteType>,
 
     circuit_management_type: Option<String>,
 }
@@ -128,26 +128,25 @@ impl CircuitBuilder {
         self
     }
 
-    pub fn with_auth(mut self, auth: String) -> Self {
+    pub fn with_auth(mut self, auth: AuthorizationType) -> Self {
         self.auth = Some(auth);
-
         self
     }
 
-    pub fn with_persistence(mut self, persistence: String) -> Self {
+    pub fn with_persistence(mut self, persistence: PersistenceType) -> Self {
         self.persistence = Some(persistence);
 
         self
     }
 
-    pub fn with_durability(mut self, durability: String) -> Self {
+    pub fn with_durability(mut self, durability: DurabilityType) -> Self {
         self.durability = Some(durability);
 
         self
     }
 
-    pub fn with_routes(mut self, id: String) -> Self {
-        self.routes = Some(id);
+    pub fn with_routes(mut self, route: RouteType) -> Self {
+        self.routes = Some(route);
 
         self
     }
@@ -333,6 +332,26 @@ impl Roster {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum AuthorizationType {
+    Trust,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum PersistenceType {
+    Any,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum DurabilityType {
+    NoDurabilty,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum RouteType {
+    Any,
+}
+
 pub enum RosterIter<'r> {
     Standard(std::slice::Iter<'r, ServiceDefinition>),
     Admin,
@@ -505,12 +524,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("test_app".into())
             .build()
             .expect("Should have built a correct circuit");

--- a/libsplinter/src/storage/yaml.rs
+++ b/libsplinter/src/storage/yaml.rs
@@ -164,7 +164,7 @@ mod tests {
     use super::*;
     use crate::circuit::directory::CircuitDirectory;
     use crate::circuit::service::SplinterNode;
-    use crate::circuit::Circuit;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
 
     /* Creates a state file that looks like the following:
         ---
@@ -204,12 +204,12 @@ mod tests {
 
         let circuit = Circuit::builder()
             .with_id("alpha".into())
-            .with_auth("trust".into())
+            .with_auth(AuthorizationType::Trust)
             .with_members(vec!["123".into()])
             .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence("any".into())
-            .with_durability("none".into())
-            .with_routes("require_direct".into())
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurabilty)
+            .with_routes(RouteType::Any)
             .with_circuit_management_type("state_test_app".into())
             .build()
             .expect("Should have built a correct circuit");
@@ -491,12 +491,12 @@ mod tests {
             let mut storage = YamlStorage::new(path.clone(), CircuitDirectory::new).unwrap();
             let circuit = Circuit::builder()
                 .with_id("alpha".into())
-                .with_auth("trust".into())
+                .with_auth(AuthorizationType::Trust)
                 .with_members(vec!["456".into(), "789".into()])
                 .with_roster(vec!["qwe".into(), "rty".into(), "uio".into()])
-                .with_persistence("any".into())
-                .with_durability("none".into())
-                .with_routes("require_direct".into())
+                .with_persistence(PersistenceType::Any)
+                .with_durability(DurabilityType::NoDurabilty)
+                .with_routes(RouteType::Any)
                 .with_circuit_management_type("state_write_test_app".into())
                 .build()
                 .expect("Should have built a correct circuit");


### PR DESCRIPTION
Change routes, durability, persistence, and authorization circuit fields
from strings to enums.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>