### PR TITLE
Check whether game name contains '%'

### DIFF
--- a/examples/gameroom/gameroom-app/src/scss/components/_gameroom-details.scss
+++ b/examples/gameroom/gameroom-app/src/scss/components/_gameroom-details.scss
@@ -57,6 +57,9 @@
     color: $color-text-disabled;
   }
 
+  .invalidInput {
+    color: #ff6659;
+  }
     /* games list styling */
   .data-container {
     @include overlay(1);

--- a/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
@@ -24,6 +24,7 @@ limitations under the License.
             Game name
             <input class="form-input" type="text" v-model="newGameName" />
           </label>
+          <span class='invalidInput'>{{ invalidGameNameMessage }}</span>
           <div class="flex-container button-container">
             <button class="btn-action outline small"
                     type="reset"
@@ -120,6 +121,7 @@ import Modal from '@/components/Modal.vue';
       newGameName = '';
       displayModal = false;
       submitting = false;
+      invalidGameNameMessage = '';
 
       mounted() {
         gamerooms.listGamerooms().then(() => {
@@ -162,9 +164,24 @@ import Modal from '@/components/Modal.vue';
        }
      }
 
+     get gameNameIsValid() {
+       if (this.newGameName !== '') {
+         if (this.newGameName.indexOf('%') !== -1) {
+           this.invalidGameNameMessage = 'Invalid character \`%\`.';
+           return false;
+         } else {
+           this.invalidGameNameMessage = '';
+           return true;
+         }
+       } else {
+         this.invalidGameNameMessage = '';
+         return false;
+       }
+     }
+
      get canSubmitNewGame() {
-       if (!this.submitting &&
-           this.newGameName !== '') {
+       if (!this.submitting && this.gameNameIsValid) {
+
          return true;
        }
        return false;


### PR DESCRIPTION
The presence of '%' in the game name causes the vue router to break when 
going to  `/gameroom/<circuit-id>/games/<url-encoded-game-name>`. This 
prevents the user to create a game that contains % as a character.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>