### PR TITLE
Use game name hash in games route

### DIFF
--- a/examples/gameroom/gameroom-app/src/components/DropdownNotification.vue
+++ b/examples/gameroom/gameroom-app/src/components/DropdownNotification.vue
@@ -38,6 +38,7 @@ limitations under the License.
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import * as moment from 'moment';
 import { GameroomNotification, Gameroom } from '@/store/models';
+import { hashGameName } from '@/utils/xo-games';
 
 
 @Component
@@ -56,7 +57,7 @@ export default class DropdownNotification extends Vue {
     switch (notification) {
       case('gameroom_proposal'): return {name: 'invitations'};
       case('circuit_active'): return {name: 'gamerooms', params: {id: `${this.notification.target}`}};
-      case('new_game_created'): return {name: 'games', params: {id: `${this.notification.target}`, gameName: `${this.getGameName(this.notification.notification_type)}`}};
+      case('new_game_created'): return {name: 'games', params: {id: `${this.notification.target}`, gameNameHash: `${hashGameName(this.getGameName(this.notification.notification_type))}`}};
       default: return '';
     }
   }

--- a/examples/gameroom/gameroom-app/src/router.ts
+++ b/examples/gameroom/gameroom-app/src/router.ts
@@ -79,7 +79,7 @@ const router = new Router({
           },
         },
         {
-          path: 'gamerooms/:id/games/:gameName',
+          path: 'gamerooms/:id/games/:gameNameHash',
           name: 'games',
           component: () => import('@/views/GameDetail.vue'),
           meta: {

--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -29,6 +29,8 @@ import {
   Player,
 } from './models';
 
+import { hashGameName } from '@/utils/xo-games';
+
 export const gameroomAPI = axios.create({
   baseURL: '/api',
 });
@@ -125,6 +127,7 @@ export async function listGames(circuitID: string): Promise<Game[]> {
       Promise.all([player2]).then((p2) => game.player_2 = player2);
     }
     game.commited = true;
+    game.game_name_hash = hashGameName(game.game_name);
     return game as Game;
   });
   return Promise.all(games);

--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -114,6 +114,7 @@ export interface Gameroom {
 export interface Game {
   id: number;
   game_name: string;
+  game_name_hash: string;
   circuit_id: string;
   player_1: Player;
   player_2: Player;

--- a/examples/gameroom/gameroom-app/src/utils/xo-games.ts
+++ b/examples/gameroom/gameroom-app/src/utils/xo-games.ts
@@ -14,6 +14,8 @@
 
 import { Game } from '@/store/models';
 
+const crypto = require('crypto');
+
 export function gameIsOver(gameStatus: string) {
     return gameStatus === 'P1-WIN' || gameStatus === 'P2-WIN' || gameStatus === 'TIE';
   }
@@ -24,4 +26,8 @@ export function userIsInGame(game: Game, publicKey: string) {
 
 export function userCanJoinGame(game: Game, publicKey: string) {
     return !game.player_1 || (!game.player_2 && game.player_1.publicKey !== publicKey);
+}
+
+export function hashGameName(gameName: string) {
+  return crypto.createHash('md5').update(gameName).digest('hex');
 }

--- a/examples/gameroom/gameroom-app/src/views/GameDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameDetail.vue
@@ -47,7 +47,7 @@ export default class GameDetail extends Vue {
 
   get game() {
     return this.$store.getters['games/getGames'].find(
-      (game: Game) => game.game_name === this.$route.params.gameName);
+      (game: Game) => game.game_name_hash === this.$route.params.gameNameHash);
   }
 
   get gameroomLink() {


### PR DESCRIPTION
There is a bug that causes the vue router to break if `%` is present in 
the game name when accessing the route 
`/gamerooms/<circuit_id>/games/<url_encoded_game_name>`. To go around 
this bug instead of using the url encoded game name in the route, a md5 
hash of the game name will be used. 

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>