### PR TITLE
Add organizations to gameroom members on fetch

### DIFF
--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -94,7 +94,14 @@ export async function listGamerooms(): Promise<Gameroom[]> {
 
 export async function fetchGameroom(circuitID: string): Promise<Gameroom> {
   const response = await gameroomAPI.get(`/gamerooms/${circuitID}`);
-  return response.data as Gameroom;
+  const gameroom = response.data;
+  const members = gameroom.members.map(async (member: any) => {
+    const node = await getNode(member.node_id);
+    member.organization = node.metadata.organization;
+    return member as Member;
+  });
+  Promise.all(members).then((m) => gameroom.members = m);
+  return gameroom as Gameroom;
 }
 
 // Nodes

--- a/examples/gameroom/gameroom-app/src/store/modules/notifications.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/notifications.ts
@@ -45,7 +45,7 @@ const actions = {
     await dispatch('proposals/listProposals', null, {root: true});
     await dispatch('gamerooms/listGamerooms', null, {root: true});
     const selectedGameroom = rootGetters['selectedGameroom/getGameroom'];
-    if (selectedGameroom.circuit_id) {
+    if (selectedGameroom) {
       await dispatch('games/listGames', selectedGameroom.circuit_id, {root: true});
     }
     commit('setNotifications', notifications);

--- a/examples/gameroom/gameroom-app/src/store/modules/selectedGameroom.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/selectedGameroom.ts
@@ -33,7 +33,7 @@ const actions = {
   async updateSelectedGameroom({ commit }: any, circuitID: string) {
     try {
       const gameroom = await fetchGameroom(circuitID);
-      commit('setSelectedGameroom', {gameroom});
+      commit('setSelectedGameroom', gameroom);
     } catch (e) {
       console.error(e.message);
     }
@@ -41,7 +41,7 @@ const actions = {
 };
 
 const mutations = {
-  setSelectedGameroom(state: SelectedGameroom, {circuitID, gameroom}: any) {
+  setSelectedGameroom(state: SelectedGameroom, gameroom: Gameroom) {
     state.gameroom = gameroom;
   },
 };

--- a/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
@@ -127,9 +127,7 @@ import GameCard from '@/components/GameCard.vue';
 
       mounted() {
         this.loadingGameroom = true;
-        gamerooms.listGamerooms().then(() => {
-          this.setSelectedGameroom(this.$route.params.id);
-        });
+        this.setSelectedGameroom(this.$route.params.id);
         this.listGames(this.$route.params.id);
       }
 


### PR DESCRIPTION
This was happening on the list route but not the fetch route, causing a bug in the gameroom list. Also cleaned up a few of the relevant vuex actions and lifecycle hooks.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>