### PR TITLE
Fix POST gameroom/propose endpoint

### DIFF
--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -51,7 +51,7 @@ export interface Node {
 
 export interface NewGameroomProposal {
   alias: string;
-  member: [Node];
+  members: string[];
 }
 
 export interface Member {

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -143,10 +143,11 @@ export default class Dashboard extends Vue {
   async createGameroom() {
     if (this.canSubmitNewGameroom) {
         this.submitting = true;
+        const member = this.newGameroom.member ? this.newGameroom.member.identity : '';
         try {
           await gamerooms.proposeGameroom({
             alias: this.newGameroom.alias,
-            member: [this.newGameroom.member as Node],
+            members: [member],
           });
           this.setSuccess('Your invitation has been sent!');
         } catch (e) {


### PR DESCRIPTION
Currently, when a gameroom is proposed, the Gameroom UI passes back metadata including the connection URL, like so:
```
POST /gamerooms/propose

{
    “alias”: “Acme + Bubba”,
    “members”: [
        {
           “identity”: “bubba-node-000”,
            “metadata”: {
                  “organization”: “Bubba Bakery”,
                  “endpoint”: “tls://splinterd-node-bubba:8044”,
             }
        }
    ],    
}
```
The Gameroom REST API should instead lookup the URL based on the identity string alone to prevent the browser from using arbitrary values (correctness should be enforced by the gameroom REST API). And thus, the "members" list should just be a list of identities. This PR applies these changes.