### PR TITLE
Enforce a node id is unique on a network

### DIFF
--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -302,7 +302,7 @@ impl From<MeshSendError> for SendError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ConnectionError {
     AddError(String),
     RemoveError(String),

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
         (@arg insecure:  --("insecure")
           "if set tls should accept all peer certificates")
         (@arg generate_certs:  --("generate-certs")
-          "if set, the certs will be generated and insecure will be false, only use for development")
+          "if set, the certs will be generated and run in insecure mode, only use for development")
         (@arg common_name: --("common-name") +takes_value
           "the common name that should be used in the generated cert, defaults to localhost")
         (@arg bind: --("bind") +takes_value


### PR DESCRIPTION
Before it was possible, when using Trust Authorization,
for a new node to "steal" the node id of an already connected
node. This change will remove a connection if it tries to
authorize for a node id that is already connected and
authorized.