### PR TITLE
Check for batch status after batch is submitted

### DIFF
--- a/examples/gameroom/daemon/openapi.yml
+++ b/examples/gameroom/daemon/openapi.yml
@@ -633,6 +633,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: wait
+          in: query
+          description: Time gameroomd should wait for the batch to be processed. If set to "false" gameroomd will not wait.
+          required: false
+          schema:
+            type: integer
+            default: 30
       requestBody:
         content:
           application/octet-stream:
@@ -640,21 +647,42 @@ paths:
               type: string
               format: binary
       responses:
-          202:
-            description:  The payload was accepted
+          200:
+            description:  A list with the batch statuses of the submitted batches.
             content:
               application/json:
                 schema:
                   properties:
                     data:
-                      type: string
-                      example: "The payload was submitted successfully"
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/BatchStatus'
+          202:
+            description:  Returned if any of the batches are still pending after timeout or if wait is set to false. Response includes a list with the batch statuses of the submitted batches.
+            content:
+              application/json:
+                schema:
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/BatchStatus'
           400:
             description: Request was malformed
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/Error'
+                  allOf:
+                    - $ref: '#/components/schemas/Error'
+                    - type: object
+                      properties:
+                          data:
+                            description: List of BatchStatus
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/BatchStatus'
+
+
           500:
             description: Internal server error
 
@@ -1040,3 +1068,38 @@ components:
           example:
             name: Jane User
             organization: Acme Corporation
+
+    BatchStatus:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Batch header signature
+              example: 6ff35474a572087e08fd6a54d563bd8172951b363e5c9731f1a40a855e14bba45dac515364a08d8403f4fb5d4a206174b7f63c29e4f4e425dc71b95494b8a798
+            status:
+              type: object
+              description: Batch status
+              properties:
+                statusType:
+                  type: string
+                  enum:
+                    - Unknown
+                    - Invalid
+                    - Valid
+                    - Pending
+                    - Committed
+                message:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        transaction_id:
+                          type: string
+                          example: f4e147ff464013deccb3e68bb8619beffb29ff86b401257c93bcf8ef76d7ca173fa84b4f4a58414ad2d00a2c9f810cbb726e01cd26ebd44720239d9d35853099
+                        error_message:
+                          type: string
+                          example: "Wasm contract returned invalid transaction: xo, 0.3.3"
+                        error_data:
+                          type: array
+                          items:
+                            type: integer

--- a/examples/gameroom/daemon/src/rest_api/routes/mod.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/mod.rs
@@ -55,37 +55,53 @@ const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b',');
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ErrorResponse {
+pub struct ErrorResponse<T: Serialize> {
     code: String,
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<T>,
 }
 
-impl ErrorResponse {
-    pub fn internal_error() -> ErrorResponse {
+impl ErrorResponse<String> {
+    pub fn internal_error() -> ErrorResponse<String> {
         ErrorResponse {
             code: "500".to_string(),
             message: "The server encountered an error".to_string(),
+            data: None,
         }
     }
 
-    pub fn bad_request(message: &str) -> ErrorResponse {
+    pub fn bad_request(message: &str) -> ErrorResponse<String> {
         ErrorResponse {
             code: "400".to_string(),
             message: message.to_string(),
+            data: None,
         }
     }
 
-    pub fn not_found(message: &str) -> ErrorResponse {
+    pub fn not_found(message: &str) -> ErrorResponse<String> {
         ErrorResponse {
             code: "404".to_string(),
             message: message.to_string(),
+            data: None,
         }
     }
 
-    pub fn unauthorized(message: &str) -> ErrorResponse {
+    pub fn unauthorized(message: &str) -> ErrorResponse<String> {
         ErrorResponse {
             code: "401".to_string(),
             message: message.to_string(),
+            data: None,
+        }
+    }
+}
+
+impl<T: Serialize> ErrorResponse<T> {
+    pub fn bad_request_with_data(message: &str, data: T) -> ErrorResponse<T> {
+        ErrorResponse {
+            code: "400".to_string(),
+            message: message.to_string(),
+            data: Some(data),
         }
     }
 }

--- a/examples/gameroom/daemon/src/rest_api/routes/submit.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/submit.rs
@@ -12,11 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
 use actix_web::{client::Client, dev::Body, http::StatusCode, web, Error, HttpResponse};
-use futures::Future;
+use futures::{
+    future,
+    future::{Either, IntoFuture},
+    Future,
+};
 use splinter::node_registry::Node;
+use splinter::service::scabbard::{BatchInfo, BatchStatus};
 
 use super::{ErrorResponse, SuccessResponse};
+
+use crate::rest_api::RestApiResponseError;
+
+const DEFAULT_WAIT: u64 = 30; // default wait time in seconds for batch to be commited
 
 pub fn submit_signed_payload(
     client: web::Data<Client>,
@@ -64,8 +77,17 @@ pub fn submit_scabbard_payload(
     circuit_id: web::Path<String>,
     node_info: web::Data<Node>,
     signed_payload: web::Bytes,
+    query: web::Query<HashMap<String, String>>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let service_id = format!("gameroom_{}", node_info.identity);
+    let wait = query
+        .get("wait")
+        .map(|val| match val.as_ref() {
+            "false" => 0,
+            _ => val.parse().unwrap_or(DEFAULT_WAIT),
+        })
+        .unwrap_or_else(|| DEFAULT_WAIT);
+
     Box::new(
         client
             .post(format!(
@@ -73,30 +95,246 @@ pub fn submit_scabbard_payload(
                 *splinterd_url, &circuit_id, &service_id
             ))
             .send_body(Body::Bytes(signed_payload))
-            .map_err(Error::from)
+            .map_err(|err| {
+                RestApiResponseError::InternalError(format!("Failed to send request {}", err))
+            })
             .and_then(|mut resp| {
                 let status = resp.status();
-                let body = resp.body().wait()?;
+                let body = resp.body().wait().map_err(|err| {
+                    RestApiResponseError::InternalError(format!(
+                        "Failed to receive response body {}",
+                        err
+                    ))
+                })?;
 
                 match status {
-                    StatusCode::ACCEPTED => Ok(HttpResponse::Accepted().json(
-                        SuccessResponse::new("The payload was submitted successfully"),
-                    )),
+                    StatusCode::ACCEPTED => {
+                        let link = match parse_link(&body) {
+                            Ok(value) => value,
+                            Err(err) => {
+                                debug!("Internal Server Error. Error parsing splinter daemon response {}", err);
+                                return Err(RestApiResponseError::InternalError(format!("{}", err)))
+                            }
+                        };
+                        Ok(link)
+                    }
                     StatusCode::BAD_REQUEST => {
-                        let body_value: serde_json::Value = serde_json::from_slice(&body)?;
+                        let body_value: serde_json::Value = serde_json::from_slice(&body).map_err(|err| {
+                                RestApiResponseError::InternalError(format!(
+                                    "Failed to parse response body {}",
+                                    err
+                                ))
+                            })?;
                         let message = match body_value.get("message") {
-                            Some(value) => value.as_str().unwrap_or("Request was malformed."),
+                            Some(value) => value.as_str().unwrap_or("Request malformed."),
                             None => "Request malformed.",
                         };
-                        Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&message)))
+                        Err(RestApiResponseError::BadRequest(message.to_string()))
                     }
                     _ => {
+                        let body_value: serde_json::Value = serde_json::from_slice(&body).map_err(|err| {
+                                RestApiResponseError::InternalError(format!(
+                                    "Failed to parse response body {}",
+                                    err
+                                ))
+                            })?;
+                        let message = match body_value.get("message") {
+                            Some(value) => value.as_str().unwrap_or("Unknown cause"),
+                            None => "Unknown cause",
+                        };
                         debug!(
-                            "Internal Server Error. Gameroom service responded with an error {}",
-                            resp.status()
+                            "Internal Server Error. Gameroom service responded with an error {} with message {}",
+                            resp.status(),
+                            message
                         );
-                        Ok(HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error()))
+                        Err(RestApiResponseError::InternalError(message.to_string()))
+                    }
+                }
+            }).then(move |resp| match resp {
+                Ok(link) => {
+                    let start = Instant::now();
+                    Either::A(check_batch_status(client, &splinterd_url, &link, start, wait).then(|resp| {
+                        match resp {
+                           Ok(batches_info) => {
+                               let invalid_batches = batches_info.iter().filter(|batch| {
+                                  if let BatchStatus::Invalid(_) =  batch.status {
+                                      return true
+                                  }
+                                  false
+                              }).collect::<Vec<&BatchInfo>>();
+                              if !invalid_batches.is_empty() {
+                                  let error_message = process_failed_baches(&invalid_batches);
+                                  return Ok(HttpResponse::BadRequest()
+                                       .json(ErrorResponse::bad_request_with_data(&error_message, batches_info)));
+                              }
+
+                              if batches_info.iter().any(|batch| batch.status == BatchStatus::Pending) {
+                                  return Ok(HttpResponse::Accepted()
+                                       .json(SuccessResponse::new(batches_info)));
+                              }
+
+                              Ok(HttpResponse::Ok()
+                                       .json(SuccessResponse::new(batches_info)))
+
+                           }
+                           Err(err) => match err {
+                               RestApiResponseError::BadRequest(message) => {
+                                  Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&message)))
+                               }
+                               _ => {
+                                   Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()))
+                               }
+                           }
+                        }
+                    }))
+                }
+                Err(err) => match err {
+                    RestApiResponseError::BadRequest(message) => {
+                        Either::B(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&message)).into_future())
+                    }
+                    _ => {
+                        Either::B(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()).into_future())
+
+                    }
+                }
+            })
+    )
+}
+
+fn parse_link(response_bytes: &[u8]) -> Result<String, RestApiResponseError> {
+    let mut response_value: HashMap<String, String> = serde_json::from_slice(&response_bytes)
+        .map_err(|err| {
+            RestApiResponseError::InternalError(format!(
+                "Failed to parse batches_ids from splinterd response {}",
+                err
+            ))
+        })?;
+
+    if let Some(link) = response_value.remove("link") {
+        Ok(link)
+    } else {
+        Err(RestApiResponseError::InternalError(
+            "The splinter daemon did not return a link for batch status".to_string(),
+        ))
+    }
+}
+
+fn process_failed_baches(invalid_batches: &[&BatchInfo]) -> String {
+    if invalid_batches.is_empty() {
+        "".to_string()
+    } else if invalid_batches.len() == 1 {
+        if let BatchStatus::Invalid(invalid_transactions) = &invalid_batches[0].status {
+            if invalid_transactions.len() <= 1 {
+                "A transaction failed. Please try again. If it continues to fail contact your administrator for help.".to_string()
+            } else {
+                "Several transactions failed. Please try again. If it continues to fail contact your administrator for help.".to_string()
+            }
+        } else {
+            "".to_string()
+        }
+    } else {
+        "Several transactions failed. Please try again. If it continues to fail please contact your administrator.".to_string()
+    }
+}
+
+fn check_batch_status(
+    client: web::Data<Client>,
+    splinterd_url: &str,
+    link: &str,
+    start_time: Instant,
+    wait: u64,
+) -> Box<dyn Future<Item = Vec<BatchInfo>, Error = RestApiResponseError>> {
+    let splinterd_url = splinterd_url.to_owned();
+    let link = link.to_owned();
+    debug!("Checking batch status {}", link);
+    Box::new(
+        client
+            .get(format!("{}{}", splinterd_url, link))
+            .send()
+            .map_err(|err| {
+                RestApiResponseError::InternalError(format!("Failed to send request {}", err))
+            })
+            .and_then(move |mut resp| {
+                let body = match resp.body().wait() {
+                    Ok(b) => b,
+                    Err(err) => {
+                        return Either::B(future::err(RestApiResponseError::InternalError(
+                            format!("Failed to receive response body {}", err),
+                        )))
+                    }
+                };
+                match resp.status() {
+                    StatusCode::OK => {
+                        let batches_info: Vec<BatchInfo> = match serde_json::from_slice(&body) {
+                            Ok(b) => b,
+                            Err(err) => {
+                                return Either::B(future::err(RestApiResponseError::InternalError(
+                                    format!("Failed to parse response body {}", err),
+                                )))
+                            }
+                        };
+
+                        // If batch status is still pending and the wait time has not yet passed,
+                        // send request again to re-check the batch status
+                        if batches_info
+                            .iter()
+                            .any(|batch_info| match batch_info.status {
+                                BatchStatus::Pending => true,
+                                BatchStatus::Valid(_) => true,
+                                _ => false,
+                            })
+                            && Instant::now().duration_since(start_time) < Duration::from_secs(wait)
+                        {
+                            // wait one second before sending request again
+                            sleep(Duration::from_secs(1));
+                            Either::A(check_batch_status(
+                                client,
+                                &splinterd_url,
+                                &link,
+                                start_time,
+                                wait,
+                            ))
+                        } else {
+                            Either::B(future::ok(batches_info))
+                        }
+                    }
+                    StatusCode::BAD_REQUEST => {
+                        let body_value: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(b) => b,
+                            Err(err) => {
+                                return Either::B(future::err(RestApiResponseError::InternalError(
+                                    format!("Failed to parse response body {}", err),
+                                )))
+                            }
+                        };
+
+                        let message = match body_value.get("message") {
+                            Some(value) => value.as_str().unwrap_or("Request malformed."),
+                            None => "Request malformed.",
+                        };
+
+                        Either::B(future::err(RestApiResponseError::BadRequest(
+                            message.to_string(),
+                        )))
+                    }
+                    _ => {
+                        let body_value: serde_json::Value = match serde_json::from_slice(&body) {
+                            Ok(b) => b,
+                            Err(err) => {
+                                return Either::B(future::err(RestApiResponseError::InternalError(
+                                    format!("Failed to parse response body {}", err),
+                                )))
+                            }
+                        };
+
+                        let message = match body_value.get("message") {
+                            Some(value) => value.as_str().unwrap_or("Unknown cause"),
+                            None => "Unknown cause",
+                        };
+
+                        Either::B(future::err(RestApiResponseError::InternalError(
+                            message.to_string(),
+                        )))
                     }
                 }
             }),

--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -27,6 +27,7 @@ import {
   Ballot,
   Game,
   Player,
+  BatchInfo,
 } from './models';
 
 import { hashGameName } from '@/utils/xo-games';
@@ -161,7 +162,7 @@ export async function submitPayload(payload: Uint8Array): Promise<void> {
   });
 }
 
-export async function submitBatch(payload: Uint8Array, circuitID: string): Promise<void> {
+export async function submitBatch(payload: Uint8Array, circuitID: string): Promise<BatchInfo[]> {
   const options = {
     method: 'POST',
     url: `http://${window.location.host}/api/gamerooms/${circuitID}/batches`,
@@ -171,12 +172,15 @@ export async function submitBatch(payload: Uint8Array, circuitID: string): Promi
     },
   };
 
-  await rp(options).then((body) => {
-    return;
+  return await rp(options).then((rawBody) => {
+    const jsonBody = JSON.parse(rawBody);
+    const batchesInfo = jsonBody.data as BatchInfo[];
+    return batchesInfo;
   })
   .catch((err) => {
-    console.error(err.message);
-    throw new Error('Failed to send request. Contact administrator for help.');
+     console.error(err.message);
+     const error = JSON.parse(err.response.body);
+     throw new Error(error.message || 'Failed to send request. Contact administrator for help.');
   });
 }
 

--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -130,3 +130,19 @@ export interface Player {
   publicKey: string;
   organization: string;
 }
+
+export interface BatchInfo {
+  id: string;
+  status: BatchStatus;
+}
+
+export interface BatchStatus {
+  statusType: string;
+  message: BatchMessage[];
+}
+
+export interface BatchMessage {
+  transaction_id: string;
+  error_message: string;
+  error_data: number[];
+}

--- a/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
@@ -226,19 +226,22 @@ import store from '@/store';
       if (this.canSubmitNewGame) {
           this.submitting = true;
           try {
-            await
+             await
               this.$store.dispatch(
                 'games/createGame',
                 {gameName: this.newGameName, circuitID: this.$route.params.id},
               );
+
+             this.$store.commit(
+              'games/setUncommittedGame',
+              {gameName: this.newGameName, circuitID: this.$route.params.id},
+             );
+
           } catch (e) {
             console.error(e);
             this.$emit('error', e.message);
           }
-          this.$store.commit(
-            'games/setUncommittedGame',
-            {gameName: this.newGameName, circuitID: this.$route.params.id},
-          );
+
           this.submitting = false;
           this.closeNewGameModal();
       }

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -47,8 +47,8 @@ use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
-pub use state::StateChangeEvent;
-use state::{BatchInfo, ScabbardState};
+use state::ScabbardState;
+pub use state::{BatchInfo, BatchStatus, StateChangeEvent};
 
 const SERVICE_TYPE: &str = "scabbard";
 

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -405,7 +405,7 @@ impl From<InvalidTransactionResult> for InvalidTransaction {
 pub struct BatchInfo {
     pub id: String,
     pub status: BatchStatus,
-    #[serde(skip_serializing)]
+    #[serde(skip, default = "SystemTime::now")]
     pub timestamp: SystemTime,
 }
 

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -435,7 +435,7 @@ components:
                       example: f4e147ff464013deccb3e68bb8619beffb29ff86b401257c93bcf8ef76d7ca173fa84b4f4a58414ad2d00a2c9f810cbb726e01cd26ebd44720239d9d35853099
                     error_message:
                       type: string
-                      example: "Wasm contract retruned invalid transaction: xo, 0.3.3"
+                      example: "Wasm contract returned invalid transaction: xo, 0.3.3"
                     error_data:
                       type: array
                       items:


### PR DESCRIPTION
When a batch is submitted via the `/gamerooms/{circuit_id}/batches` endpoint in Gameroomd it will submit the batch and then wait for the batch to be processed and return the batch status (default max wait is 30secs).

For now, if a transaction fails the UI will show a toast with a message about the invalid transaction. In the future a more robust implementation for logging and storing the batch status should be implemented.