### PR TITLE
Fix POST gameroom/propose endpoint

### DIFF
--- a/examples/gameroom/daemon/openapi.yml
+++ b/examples/gameroom/daemon/openapi.yml
@@ -224,8 +224,12 @@ paths:
                   alias:
                     description: Name of new gameroom
                     example: my_gameroom
-                  member:
-                    $ref: '#/components/schemas/Member'
+                  members:
+                    description: List of node ids that will be part of the circuit, not including own node.
+                    type: array
+                    items:
+                      type: string
+                      example: acme-node-000
                 required:
                   - alias
                   - member
@@ -905,30 +909,6 @@ components:
           description: status of the gameroom
           type: string
           example: 'ACCEPTED'
-
-    Member:
-      type: object
-      description: Member of the gameroom
-      properties:
-        identity:
-          type: string
-          example: acme-node-000
-        metadata:
-          $ref: '#/components/schemas/MemberMetadata'
-
-
-    MemberMetadata:
-      type: object
-      properties:
-        organization:
-          type: string
-          example: Acme Corporation
-        endpoint:
-          type: string
-          example: tls://127.0.0.1:8080
-        public_key:
-          type: string
-
 
     AuthResponseData:
       type: object

--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -51,7 +51,7 @@ export interface Node {
 
 export interface NewGameroomProposal {
   alias: string;
-  member: [Node];
+  members: string[];
 }
 
 export interface Member {

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -143,10 +143,11 @@ export default class Dashboard extends Vue {
   async createGameroom() {
     if (this.canSubmitNewGameroom) {
         this.submitting = true;
+        const member = this.newGameroom.member ? this.newGameroom.member.identity : '';
         try {
           await gamerooms.proposeGameroom({
             alias: this.newGameroom.alias,
-            member: [this.newGameroom.member as Node],
+            members: [member],
           });
           this.setSuccess('Your invitation has been sent!');
         } catch (e) {


### PR DESCRIPTION
Currently, when a gameroom is proposed, the Gameroom UI passes back metadata including the connection URL, like so:
```
POST /gamerooms/propose

{
    “alias”: “Acme + Bubba”,
    “members”: [
        {
           “identity”: “bubba-node-000”,
            “metadata”: {
                  “organization”: “Bubba Bakery”,
                  “endpoint”: “tls://splinterd-node-bubba:8044”,
             }
        }
    ],    
}
```
The Gameroom REST API should instead lookup the URL based on the identity string alone to prevent the browser from using arbitrary values (correctness should be enforced by the gameroom REST API). And thus, the "members" list should just be a list of identities. This PR applies these changes.