### PR TITLE
Register and Login tests for Gameroom app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,13 @@ jobs:
       before_script:
         - set -e
         - docker-compose -f tests/test-splinter.yaml build
+      script:
+        - docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-splinter
+    - stage: Run Gameroom Tests
+      before_script:
+        - set -e
         - docker-compose -f examples/gameroom/tests/docker-compose.yaml build
         - docker-compose -f examples/gameroom/tests/cypress/docker-compose.yaml build
       script:
-        - docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-splinter
         - docker-compose -f examples/gameroom/tests/docker-compose.yaml up --abort-on-container-exit
         - docker-compose -f examples/gameroom/tests/cypress/docker-compose.yaml up --abort-on-container-exit

--- a/examples/gameroom/gameroom-app/src/views/Login.vue
+++ b/examples/gameroom/gameroom-app/src/views/Login.vue
@@ -28,6 +28,7 @@ limitations under the License.
             class="form-input"
             type="email"
             v-model="email"
+            data-cy="email"
           />
         </label>
         <label class="form-label">
@@ -36,10 +37,11 @@ limitations under the License.
             class="form-input"
             type="password"
             v-model="password"
+            data-cy="password"
           />
         </label>
         <div class="submit-container">
-          <button class="btn-action large" type="submit" :disabled="!canSubmit">
+          <button class="btn-action large" type="submit" data-cy="submit" :disabled="!canSubmit">
             <div v-if="submitting" class="spinner" />
             <div class="btn-text" v-else> Log In </div>
           </button>

--- a/examples/gameroom/gameroom-app/src/views/Register.vue
+++ b/examples/gameroom/gameroom-app/src/views/Register.vue
@@ -26,6 +26,7 @@ limitations under the License.
           <input
             class="form-input"
             type="email"
+            data-cy="email"
             v-model="email"
             v-focus
           />
@@ -36,8 +37,10 @@ limitations under the License.
               <input
                 class="input"
                 type="password"
+                data-cy="privateKey"
                 v-model="privateKey"/>
-              <button class="form-button" type="button" @click.prevent="generatePrivateKey">
+              <button class="form-button" type="button" data-cy="generatePrivateKey"
+                @click.prevent="generatePrivateKey">
                 <i class="icon material-icons-round">autorenew</i>
               </button>
             </div>
@@ -47,6 +50,7 @@ limitations under the License.
           <input
             class="form-input"
             type="password"
+            data-cy="password"
             v-model="password"
           />
         </label>
@@ -55,11 +59,12 @@ limitations under the License.
           <input
             class="form-input"
             type="password"
+            data-cy="confirmPassword"
             v-model="confirmPassword"
           />
         </label>
         <div class="submit-container">
-          <button class="btn-action large" type="submit" :disabled="!canSubmit">
+          <button class="btn-action large" type="submit" data-cy="submit" :disabled="!canSubmit">
             <div v-if="submitting" class="spinner" />
             <div v-else> Register </div>
           </button>

--- a/examples/gameroom/tests/cypress/Dockerfile
+++ b/examples/gameroom/tests/cypress/Dockerfile
@@ -14,6 +14,12 @@
 
 FROM cypress/base:10
 
+RUN apt-get update \
+ && apt-get install -y \
+    postgresql-client \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # Optionally pass proxy information to get internet connectivity within npm ci
 # postinstall hooks when running behind corporate proxies.
 ARG http_proxy

--- a/examples/gameroom/tests/cypress/cypress.json
+++ b/examples/gameroom/tests/cypress/cypress.json
@@ -1,7 +1,6 @@
 {
   "baseUrl": "http://localhost:8080",
   "video": false,
-  "supportFile": false,
   "pluginsFile": false,
   "integrationFolder": "./integration/"
 }

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -14,6 +14,9 @@
 
 version: '3'
 
+volumes:
+  cargo-registry:
+
 services:
 
   gameroom-app-test:
@@ -41,3 +44,69 @@ services:
     volumes:
       - ../cypress:/app/cypress
       - ../cypress/cypress.json:/app/cypress.json
+
+  gameroomd-acme:
+    image: gameroomd
+    container_name: gameroomd-acme
+    build:
+      context: ../../../..
+      dockerfile: ./examples/gameroom/daemon/Dockerfile
+    volumes:
+      - cargo-registry:/root/.cargo/registry
+    expose:
+      - 8000
+    ports:
+      - "8000:8000"
+    depends_on:
+      - splinterd-node
+    command: |
+      bash -c "
+        # we need to wait for the db to have started.
+        until PGPASSWORD=gameroom_test psql -h db-cypress-test -U gameroom_test -c '\q'; do
+            >&2 echo \"Database is unavailable - sleeping\"
+            sleep 1
+        done
+
+        # check if splinterd-node is available
+        while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-node:8085/status) -ne 200 ]] ; do
+           >&2 echo \"SplinterD is unavailable - sleeping\"
+           sleep 1
+        done
+
+        gameroomd -vv --database-url postgres://gameroom_test:gameroom_test@db-cypress-test:5432/gameroom_test \
+          -b gameroomd-acme:8000 --splinterd-url http://splinterd-node:8085
+      "
+
+  splinterd-node:
+    image: splinterd-node
+    expose:
+      - 8080
+      - 8043
+      - 8945
+      - 8085
+    ports:
+      - 8090:8085
+    volumes:
+      - ../:/project/tests
+    build:
+      context: ../../../..
+      dockerfile: splinterd/Dockerfile
+    entrypoint: |
+      bash -c "
+        splinterd --generate-certs -c ./project/tests/splinterd-node-0-docker.toml -vv
+      "
+
+  db-cypress-test:
+    image: postgres:alpine
+    container_name: db-cypress-test
+    restart: always
+    expose:
+      - 5432
+    ports:
+        - "5430:5432"
+    environment:
+      POSTGRES_USER: gameroom_test
+      POSTGRES_PASSWORD: gameroom_test
+      POSTGRES_DB: gameroom_test
+    volumes:
+      - "../../database/tables:/docker-entrypoint-initdb.d"

--- a/examples/gameroom/tests/cypress/fixtures/credentials.json
+++ b/examples/gameroom/tests/cypress/fixtures/credentials.json
@@ -1,0 +1,6 @@
+{
+  "aliceEmail": "alice@acme.com",
+  "bobEmail": "bob@bubba.com",
+  "privateKey": "1111111111111111111111111111111111111111111111111111111111111111",
+  "password": "test_password"
+}

--- a/examples/gameroom/tests/cypress/fixtures/views.json
+++ b/examples/gameroom/tests/cypress/fixtures/views.json
@@ -1,0 +1,4 @@
+{
+  "register": "/index.html#/register",
+  "login": "/index.html#/login"
+}

--- a/examples/gameroom/tests/cypress/integration/login.spec.js
+++ b/examples/gameroom/tests/cypress/integration/login.spec.js
@@ -1,0 +1,58 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+context('Login', function() {
+  let aliceEmail
+  let bobEmail
+  let privateKey
+  let password
+
+  beforeEach(function() {
+    cy.exec('npm run-script clear:db')
+    cy.fixture('credentials.json').then(credentials => {
+      aliceEmail = credentials.aliceEmail
+      bobEmail = credentials.bobEmail
+      privateKey = credentials.privateKey
+      password = credentials.password
+    })
+    cy.fixture('views.json').then(views => {
+      cy.visit(views.register)
+      cy.register(aliceEmail, privateKey, password, password)
+      cy.dataCy('submit').click()
+      cy.url().should('contain', 'dashboard')
+      cy.visit(views.login)
+    })
+  })
+
+  it('Unregistered User', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.login(bobEmail, password)
+    cy.dataCy('submit').click()
+    cy.url().should('contain', 'login')
+  })
+
+  it('Wrong Password', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.login(aliceEmail, '1234')
+    cy.dataCy('submit').click()
+    cy.url().should('contain', 'login')
+  })
+
+  it('Happy Path login', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.login(aliceEmail, password)
+    cy.dataCy('submit').click()
+    cy.url().should('contain', 'dashboard')
+  })
+})

--- a/examples/gameroom/tests/cypress/integration/register.spec.js
+++ b/examples/gameroom/tests/cypress/integration/register.spec.js
@@ -1,0 +1,91 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+context('Unauthorized', function() {
+  it('Failed access', function() {
+    cy.log('Visiting the dashboard, unauthed')
+    cy.visit('/index.html#/dashboard/home')
+    cy.url().should('include', 'login')
+  })
+})
+
+context('Register', function() {
+  let aliceEmail
+  let privateKey
+  let password
+
+  beforeEach(function() {
+    cy.exec('npm run-script clear:db')
+    cy.fixture('views.json').then(views => {
+      cy.visit(views.register)
+    })
+
+    cy.fixture('credentials.json').then(user => {
+      aliceEmail = user.aliceEmail
+      privateKey = user.privateKey
+      password = user.password
+    })
+
+  })
+
+  it('Validate generatePrivateKey button', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.dataCy('generatePrivateKey').click()
+    cy.dataCy('privateKey').invoke('val').then(value => {
+      expect(value).to.have.lengthOf(64)
+      expect(value).to.match(/^[a-zA-Z0-9]+$/)
+    })
+
+    cy.dataCy('submit').should('be.disabled')
+  })
+
+  it('Happy path register with generated key', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.register(aliceEmail, '1234', password, password)
+
+    cy.dataCy('submit').click()
+    cy.url().should('contain', 'register')
+
+    cy.dataCy('generatePrivateKey').click()
+    cy.dataCy('submit').click()
+    cy.url().should('contain', 'dashboard')
+  })
+
+  it('Different Password', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.register(aliceEmail, privateKey,
+                password, 'different_password')
+    cy.dataCy('submit').click()
+
+    cy.url().should('contain', 'register')
+  })
+
+  it('Bad Public Key', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.register(aliceEmail, '1234', password, password)
+    cy.dataCy('submit').click()
+
+    cy.url().should('contain', 'register')
+
+  })
+
+  it('Happy path register', function() {
+    cy.dataCy('submit').should('be.disabled')
+    cy.register(aliceEmail, privateKey, password, password)
+    cy.dataCy('submit').click()
+
+    cy.url().should('contain', 'dashboard')
+  })
+})

--- a/examples/gameroom/tests/cypress/package.json
+++ b/examples/gameroom/tests/cypress/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.3",
   "description": "Gameroom App Integration tests",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "clear:db": "./scripts/clear_db.sh"
   },
   "keywords": [],
   "author": "Cargill Incorporated",

--- a/examples/gameroom/tests/cypress/scripts/clear_db.sh
+++ b/examples/gameroom/tests/cypress/scripts/clear_db.sh
@@ -1,0 +1,17 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PGPASSWORD=gameroom_test psql -h db-cypress-test -U gameroom_test -c \
+    'TRUNCATE gameroom_user, gameroom, gameroom_proposal, proposal_vote_record,
+      gameroom_member, gameroom_service, gameroom_notification, xo_games';

--- a/examples/gameroom/tests/cypress/support/commands.js
+++ b/examples/gameroom/tests/cypress/support/commands.js
@@ -1,0 +1,28 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+Cypress.Commands.add("dataCy", (value) => cy.get(`[data-cy=${value}]`))
+
+Cypress.Commands.add("register", (email, privateKey, password, confirmPassword) => {
+  cy.dataCy('email').clear().type(email)
+  cy.dataCy('privateKey').clear().type(privateKey)
+  cy.dataCy('password').clear().type(password)
+  cy.dataCy('confirmPassword').clear().type(confirmPassword)
+})
+
+Cypress.Commands.add("login", (email, password) => {
+  cy.dataCy('email').clear().type(email)
+  cy.dataCy('password').clear().type(password)
+})

--- a/examples/gameroom/tests/cypress/support/index.d.ts
+++ b/examples/gameroom/tests/cypress/support/index.d.ts
@@ -1,0 +1,21 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare namespace Cypress {
+  interface Chainable<Subject> {
+    dataCy(value: any): Chainable<any>,
+    register(email: string, privateKey: string, password: string, confirmPassword: string): Chainable<string>,
+    login(email: string, password: string): Chainable<string>
+  }
+}

--- a/examples/gameroom/tests/cypress/support/index.js
+++ b/examples/gameroom/tests/cypress/support/index.js
@@ -1,0 +1,15 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+require('./commands')

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-node_id = "012"
+node_id = "Node-123"
 
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"


### PR DESCRIPTION
Adds some initial Cypress tests for the Gameroom app register and login views. Since these tests involve interactions between the database and the gameroom app, there is a docker-compose file which will initialize these services which is also been added in this pr. This pr also includes a  So, these tests are most easily ran with docker.

 Use `docker-compose -f examples/gameroom/tests/cypress/docker-compose.yaml up --abort-on-container-exit` to run these tests from the top-level splinter directory