### PR TITLE
Use wss protocol if app is running on https server

### DIFF
--- a/examples/gameroom/gameroom-app/src/main.ts
+++ b/examples/gameroom/gameroom-app/src/main.ts
@@ -28,7 +28,9 @@ new Vue({
   render: (h) => h(App),
 }).$mount('#app');
 
-Vue.use(VueNativeSock, `ws://${window.location.host}/ws/subscribe`, {
+const protocol = ('https:' === document.location.protocol ? 'wss' : 'ws');
+
+Vue.use(VueNativeSock, `${protocol}://${window.location.host}/ws/subscribe`, {
   store,
   format: 'json',
   reconnection: true,


### PR DESCRIPTION
This solves an issue with the websocket not connecting if the app is running on a secure HTTP server

Signed-off-by: Darian Plumb <dplumb@bitwise.io>