### PR TITLE
Add intial implementation of heartbeats to the Splinter Network

### DIFF
--- a/examples/private_counter/service/src/main.rs
+++ b/examples/private_counter/service/src/main.rs
@@ -65,6 +65,7 @@ use crate::protos::private_counter::{PrivateCounterMessage, PrivateCounterMessag
 
 // Recv timeout in secs
 const TIMEOUT_SEC: u64 = 2;
+const HEARTBEAT: u64 = 60;
 
 #[derive(Debug)]
 pub struct ServiceState {
@@ -232,7 +233,8 @@ fn create_network_and_connect(
     connect_endpoint: &str,
 ) -> Result<Network, ServiceError> {
     let mesh = Mesh::new(512, 128);
-    let network = Network::new(mesh);
+    let network = Network::new(mesh, HEARTBEAT)
+        .map_err(|err| ServiceError(format!("Unable to start network: {}", err)))?;
     let connection = transport.connect(connect_endpoint).map_err(|err| {
         ServiceError(format!(
             "Unable to connect to {}: {:?}",

--- a/examples/private_xo/src/main.rs
+++ b/examples/private_xo/src/main.rs
@@ -45,6 +45,8 @@ use crate::service::consensus::{PrivateXoNetworkSender, PrivateXoProposalManager
 use crate::service::{start_service_loop, ServiceConfig, ServiceError};
 use crate::transaction::{XoState, XoStateError};
 
+const HEARTBEAT: u64 = 60;
+
 fn index(_: &mut Request) -> IronResult<Response> {
     Ok(Response::with((status::Ok, "Private XO Server")))
 }
@@ -234,7 +236,8 @@ fn create_network_and_connect(
     connect_endpoint: &str,
 ) -> Result<Network, CliError> {
     let mesh = Mesh::new(512, 128);
-    let network = Network::new(mesh);
+    let network = Network::new(mesh, HEARTBEAT)
+        .map_err(|err| ServiceError(format!("Unable to start network: {}", err)))?;
     let connection = transport.connect(connect_endpoint).map_err(|err| {
         CliError(format!(
             "Unable to connect to {}: {:?}",

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn test_propose_circuit() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let mut transport = MockConnectingTransport::expect_connections(vec![
             Ok(Box::new(MockConnection::new())),
             Ok(Box::new(MockConnection::new())),

--- a/libsplinter/src/admin/shared.rs
+++ b/libsplinter/src/admin/shared.rs
@@ -1228,7 +1228,7 @@ mod tests {
     #[test]
     fn test_auth_change() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let mut transport = MockConnectingTransport::expect_connections(vec![
             Ok(Box::new(MockConnection::new())),
             Ok(Box::new(MockConnection::new())),
@@ -1304,7 +1304,7 @@ mod tests {
     #[test]
     fn test_unauth_change() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let mut transport = MockConnectingTransport::expect_connections(vec![
             Ok(Box::new(MockConnection::new())),
             Ok(Box::new(MockConnection::new())),
@@ -1979,7 +1979,7 @@ mod tests {
 
     fn setup_peer_connector() -> PeerConnector {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport = MockConnectingTransport::expect_connections(vec![
             Ok(Box::new(MockConnection::new())),
             Ok(Box::new(MockConnection::new())),

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -619,7 +619,7 @@ mod tests {
     }
 
     fn create_network_with_initial_temp_peer() -> (Network, String) {
-        let network = Network::new(Mesh::new(5, 5));
+        let network = Network::new(Mesh::new(5, 5), 0).unwrap();
 
         let mut transport = MockConnectingTransport;
 

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -473,7 +473,7 @@ mod tests {
     }
 
     fn create_network_with_initial_temp_peer() -> (Network, String) {
-        let network = Network::new(Mesh::new(5, 5));
+        let network = Network::new(Mesh::new(5, 5), 0).unwrap();
 
         let mut transport = MockConnectingTransport;
         let connection = transport

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -14,7 +14,7 @@
 use crate::channel::Sender;
 use crate::network::dispatch::{DispatchError, Handler, MessageContext};
 use crate::network::sender::SendRequest;
-use crate::protos::network::{NetworkEcho, NetworkMessage, NetworkMessageType};
+use crate::protos::network::{NetworkEcho, NetworkHeartbeat, NetworkMessage, NetworkMessageType};
 
 use protobuf::Message;
 
@@ -64,6 +64,28 @@ impl Handler<NetworkMessageType, NetworkEcho> for NetworkEchoHandler {
 impl NetworkEchoHandler {
     pub fn new(node_id: String) -> Self {
         NetworkEchoHandler { node_id }
+    }
+}
+
+// Implements a handler that handles NetworkHeartbeat Messages
+#[derive(Default)]
+pub struct NetworkHeartbeatHandler {}
+
+impl Handler<NetworkMessageType, NetworkHeartbeat> for NetworkHeartbeatHandler {
+    fn handle(
+        &self,
+        _msg: NetworkHeartbeat,
+        context: &MessageContext<NetworkMessageType>,
+        _sender: &dyn Sender<SendRequest>,
+    ) -> Result<(), DispatchError> {
+        trace!("Received Heartbeat from {}", context.source_peer_id());
+        Ok(())
+    }
+}
+
+impl NetworkHeartbeatHandler {
+    pub fn new() -> Self {
+        NetworkHeartbeatHandler {}
     }
 }
 

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -33,14 +33,14 @@ use crate::mesh::{
 use crate::transport::Connection;
 
 #[derive(Debug)]
-pub struct NetworkMessage {
+pub struct NetworkMessageWrapper {
     peer_id: String,
     payload: Vec<u8>,
 }
 
-impl NetworkMessage {
+impl NetworkMessageWrapper {
     pub fn new(peer_id: String, payload: Vec<u8>) -> Self {
-        NetworkMessage { peer_id, payload }
+        NetworkMessageWrapper { peer_id, payload }
     }
     pub fn peer_id(&self) -> &str {
         &self.peer_id
@@ -229,7 +229,7 @@ impl Network {
         Ok(())
     }
 
-    pub fn recv(&self) -> Result<NetworkMessage, RecvError> {
+    pub fn recv(&self) -> Result<NetworkMessageWrapper, RecvError> {
         let envelope = self.mesh.recv()?;
         let peer_id = match rwlock_read_unwrap!(self.peers).get_peer_id(envelope.id()) {
             Some(peer_id) => peer_id.to_string(),
@@ -241,10 +241,13 @@ impl Network {
             }
         };
 
-        Ok(NetworkMessage::new(peer_id, envelope.take_payload()))
+        Ok(NetworkMessageWrapper::new(peer_id, envelope.take_payload()))
     }
 
-    pub fn recv_timeout(&self, timeout: Duration) -> Result<NetworkMessage, RecvTimeoutError> {
+    pub fn recv_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<NetworkMessageWrapper, RecvTimeoutError> {
         let envelope = self.mesh.recv_timeout(timeout)?;
         let peer_id = match rwlock_read_unwrap!(self.peers).get_peer_id(envelope.id()) {
             Some(peer_id) => peer_id.to_string(),
@@ -256,7 +259,7 @@ impl Network {
             }
         };
 
-        Ok(NetworkMessage::new(peer_id, envelope.take_payload()))
+        Ok(NetworkMessageWrapper::new(peer_id, envelope.take_payload()))
     }
 }
 

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -19,10 +19,12 @@ pub mod peer;
 pub(crate) mod reply;
 pub mod sender;
 
+use protobuf::Message;
 use uuid::Uuid;
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::thread;
 use std::time::Duration;
 
 use crate::collections::BiHashMap;
@@ -30,6 +32,7 @@ use crate::mesh::{
     AddError, Envelope, Mesh, RecvError as MeshRecvError, RecvTimeoutError as MeshRecvTimeoutError,
     RemoveError, SendError as MeshSendError,
 };
+use crate::protos::network::{NetworkHeartbeat, NetworkMessage, NetworkMessageType};
 use crate::transport::Connection;
 
 #[derive(Debug)]
@@ -157,11 +160,41 @@ pub struct Network {
 }
 
 impl Network {
-    pub fn new(mesh: Mesh) -> Self {
-        Network {
+    pub fn new(mesh: Mesh, heartbeat_interval: u64) -> Result<Self, NetworkStartUpError> {
+        let network = Network {
             peers: Arc::new(RwLock::new(PeerMap::new())),
             mesh,
+        };
+
+        if heartbeat_interval != 0 {
+            let heartbeat_network = network.clone();
+            let heartbeat = NetworkHeartbeat::new().write_to_bytes().map_err(|_| {
+                NetworkStartUpError("cannot create NetworkHeartbeat message".to_string())
+            })?;
+            let mut heartbeat_message = NetworkMessage::new();
+            heartbeat_message.set_message_type(NetworkMessageType::NETWORK_HEARTBEAT);
+            heartbeat_message.set_payload(heartbeat);
+            let heartbeat_bytes = heartbeat_message
+                .write_to_bytes()
+                .map_err(|_| NetworkStartUpError("cannot create NetworkMessage".to_string()))?;
+            let _ = thread::spawn(move || {
+                let interval = Duration::from_secs(heartbeat_interval);
+                thread::sleep(interval);
+                loop {
+                    let peers = rwlock_read_unwrap!(heartbeat_network.peers).peer_ids();
+                    for peer in peers {
+                        heartbeat_network
+                            .send(&peer, &heartbeat_bytes)
+                            .unwrap_or_else(|err| {
+                                error!("Unable to send heartbeat to {}: {:?}", peer, err)
+                            });
+                    }
+                    thread::sleep(interval);
+                }
+            });
         }
+
+        Ok(network)
     }
 
     pub fn peer_ids(&self) -> Vec<String> {
@@ -322,6 +355,17 @@ impl std::fmt::Display for ConnectionError {
     }
 }
 
+#[derive(Debug)]
+pub struct NetworkStartUpError(String);
+
+impl std::error::Error for NetworkStartUpError {}
+
+impl std::fmt::Display for NetworkStartUpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "network failed to startup: {}", self.0)
+    }
+}
+
 impl From<AddError> for ConnectionError {
     fn from(add_error: AddError) -> Self {
         ConnectionError::AddError(format!("Add Error: {:?}", add_error))
@@ -356,7 +400,7 @@ pub mod tests {
     fn test_network() {
         // Setup the first network
         let mesh_one = Mesh::new(5, 5);
-        let network_one = Network::new(mesh_one);
+        let network_one = Network::new(mesh_one, 2).unwrap();
 
         let mut transport = RawTransport::default();
 
@@ -366,7 +410,7 @@ pub mod tests {
         thread::spawn(move || {
             // Setup second network
             let mesh_two = Mesh::new(5, 5);
-            let network_two = Network::new(mesh_two);
+            let network_two = Network::new(mesh_two, 2).unwrap();
 
             // connect to listener and add connection to network
             let connection = assert_ok(transport.connect(&endpoint));
@@ -403,5 +447,16 @@ pub mod tests {
         let message = assert_ok(network_one.recv());
         assert_eq!("123", message.peer_id());
         assert_eq!(b"hello_world", message.payload());
+
+        let heartbeat = NetworkHeartbeat::new().write_to_bytes().unwrap();
+        let mut heartbeat_message = NetworkMessage::new();
+        heartbeat_message.set_message_type(NetworkMessageType::NETWORK_HEARTBEAT);
+        heartbeat_message.set_payload(heartbeat);
+        let heartbeat_bytes = heartbeat_message.write_to_bytes().unwrap();
+
+        // wait for heartbeat
+        let message = assert_ok(network_one.recv());
+        assert_eq!("123", message.peer_id());
+        assert_eq!(heartbeat_bytes, message.payload());
     }
 }

--- a/libsplinter/src/network/peer.rs
+++ b/libsplinter/src/network/peer.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_connect_unidentified_peer() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport =
             MockConnectingTransport::expect_connections(vec![Ok(Box::new(MockConnection))]);
 
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn test_connect_unidentified_peer_idempotent() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport =
             MockConnectingTransport::expect_connections(vec![Ok(Box::new(MockConnection))]);
 
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn test_connect_peer() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport =
             MockConnectingTransport::expect_connections(vec![Ok(Box::new(MockConnection))]);
 
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn test_connect_peer_unable_to_connect() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport = MockConnectingTransport::expect_connections(vec![Err(
             ConnectError::ProtocolError("test error".into()),
         )]);
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn test_connect_unidentified_peer_unable_to_connect() {
         let mesh = Mesh::new(4, 16);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
         let transport = MockConnectingTransport::expect_connections(vec![Err(
             ConnectError::ProtocolError("test error".into()),
         )]);

--- a/libsplinter/src/network/sender.rs
+++ b/libsplinter/src/network/sender.rs
@@ -131,14 +131,14 @@ mod tests {
         let endpoint = listener.endpoint();
 
         let mesh1 = Mesh::new(1, 1);
-        let network1 = Network::new(mesh1.clone());
+        let network1 = Network::new(mesh1.clone(), 0).unwrap();
 
         let running = Arc::new(AtomicBool::new(true));
         let network_message_sender = NetworkMessageSender::new(receiver, network1.clone(), running);
 
         thread::spawn(move || {
             let mesh2 = Mesh::new(1, 1);
-            let network2 = Network::new(mesh2.clone());
+            let network2 = Network::new(mesh2.clone(), 0).unwrap();
             let connection = listener.accept().unwrap();
             network2.add_peer("ABC".to_string(), connection).unwrap();
             let network_message = network2.recv().unwrap();
@@ -170,14 +170,14 @@ mod tests {
         let endpoint = listener.endpoint();
 
         let mesh1 = Mesh::new(5, 5);
-        let network1 = Network::new(mesh1.clone());
+        let network1 = Network::new(mesh1.clone(), 0).unwrap();
 
         let running = Arc::new(AtomicBool::new(true));
         let network_message_sender = NetworkMessageSender::new(receiver, network1.clone(), running);
 
         thread::spawn(move || {
             let mesh2 = Mesh::new(5, 5);
-            let network2 = Network::new(mesh2.clone());
+            let network2 = Network::new(mesh2.clone(), 0).unwrap();
             let connection = listener.accept().unwrap();
             network2.add_peer("ABC".to_string(), connection).unwrap();
             for _ in 0..100 {

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -461,6 +461,7 @@ pub fn run_incoming_loop(
                     msg_type => warn!("Received unimplemented message: {:?}", msg_type),
                 }
             }
+            NetworkMessageType::NETWORK_HEARTBEAT => trace!("Received network heartbeat"),
             _ => warn!("Received unimplemented message"),
         }
     }

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -400,6 +400,7 @@ fn process_incoming_msg(
                 msg_type => warn!("Received unimplemented message: {:?}", msg_type),
             }
         }
+        NetworkMessageType::NETWORK_HEARTBEAT => trace!("Received network heartbeat"),
         _ => warn!("Received unimplemented message"),
     }
 
@@ -626,7 +627,7 @@ pub mod tests {
         let r = running.clone();
 
         let mesh = Mesh::new(512, 128);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
 
         thread::Builder::new()
             .name("standard_direct_message".to_string())
@@ -726,7 +727,7 @@ pub mod tests {
         let r = running.clone();
 
         let mesh = Mesh::new(512, 128);
-        let network = Network::new(mesh.clone());
+        let network = Network::new(mesh.clone(), 0).unwrap();
 
         thread::Builder::new()
             .name("test_admin_direct_message".to_string())

--- a/protos/network.proto
+++ b/protos/network.proto
@@ -27,6 +27,7 @@ enum NetworkMessageType {
 
     // Network Message
     NETWORK_ECHO = 1;
+    NETWORK_HEARTBEAT = 2;
 
     // Message types that indicate that the payload is another message envelope
     CIRCUIT = 100;
@@ -39,3 +40,6 @@ message NetworkEcho {
     string recipient = 2;
     int32 time_to_live = 3;
 }
+
+// This messagE is used to keep connections alive
+message NetworkHeartbeat {}

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -29,6 +29,7 @@ pub struct ConfigBuilder {
     bind: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
+    heartbeat_interval: Option<u64>,
 }
 
 impl ConfigBuilder {
@@ -48,6 +49,7 @@ impl ConfigBuilder {
             bind: None,
             registry_backend: None,
             registry_file: None,
+            heartbeat_interval: None,
         }
     }
 
@@ -121,6 +123,11 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_heartbeat_interval(mut self, heartbeat_interval: u64) -> Self {
+        self.heartbeat_interval = Some(heartbeat_interval);
+        self
+    }
+
     pub fn build(self) -> Config {
         Config {
             storage: self.storage,
@@ -137,6 +144,7 @@ impl ConfigBuilder {
             bind: self.bind,
             registry_backend: self.registry_backend,
             registry_file: self.registry_file,
+            heartbeat_interval: self.heartbeat_interval,
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -50,6 +50,7 @@ pub struct Config {
     bind: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
+    heartbeat_interval: Option<u64>,
 }
 
 impl Config {
@@ -115,5 +116,9 @@ impl Config {
 
     pub fn registry_file(&self) -> Option<String> {
         self.registry_file.clone()
+    }
+
+    pub fn heartbeat_interval(&self) -> Option<u64> {
+        self.heartbeat_interval
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -35,6 +35,7 @@ pub struct TomlConfig {
     bind: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
+    heartbeat_interval: Option<u64>,
 }
 
 impl TomlConfig {
@@ -98,6 +99,10 @@ impl TomlConfig {
         self.registry_file.take()
     }
 
+    pub fn take_heartbeat_interval(&mut self) -> Option<u64> {
+        self.heartbeat_interval.take()
+    }
+
     pub fn apply_to_builder(mut self, mut builder: ConfigBuilder) -> ConfigBuilder {
         if let Some(x) = self.take_storage() {
             builder = builder.with_storage(x);
@@ -140,6 +145,9 @@ impl TomlConfig {
         }
         if let Some(x) = self.take_registry_file() {
             builder = builder.with_registry_file(x);
+        }
+        if let Some(x) = self.take_heartbeat_interval() {
+            builder = builder.with_heartbeat_interval(x);
         }
 
         builder

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -491,6 +491,7 @@ pub struct SplinterDaemonBuilder {
     registry_backend: Option<String>,
     registry_file: Option<String>,
     storage_type: Option<String>,
+    heartbeat_interval: Option<u64>,
 }
 
 impl SplinterDaemonBuilder {
@@ -545,6 +546,11 @@ impl SplinterDaemonBuilder {
 
     pub fn with_storage_type(mut self, value: String) -> Self {
         self.storage_type = Some(value);
+        self
+    }
+
+    pub fn with_heartbeat_interval(mut self, value: u64) -> Self {
+        self.heartbeat_interval = Some(value);
         self
     }
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -33,7 +33,7 @@ use splinter::network::auth::handlers::{
 };
 use splinter::network::auth::AuthorizationManager;
 use splinter::network::dispatch::{DispatchLoop, DispatchMessage, Dispatcher};
-use splinter::network::handlers::NetworkEchoHandler;
+use splinter::network::handlers::{NetworkEchoHandler, NetworkHeartbeatHandler};
 use splinter::network::peer::PeerConnector;
 use splinter::network::sender::{NetworkMessageSender, SendRequest};
 use splinter::network::{ConnectionError, Network, PeerUpdateError, RecvTimeoutError, SendError};
@@ -625,6 +625,13 @@ fn set_up_network_dispatcher(
             auth_manager.clone(),
             Box::new(network_echo_handler),
         )),
+    );
+
+    let network_heartbeat_handler = NetworkHeartbeatHandler::new();
+    // do not add auth guard
+    dispatcher.set_handler(
+        NetworkMessageType::NETWORK_HEARTBEAT,
+        Box::new(network_heartbeat_handler),
     );
 
     let circuit_message_handler = CircuitMessageHandler::new(Box::new(circuit_sender));


### PR DESCRIPTION
This commits adds a loop to Network that will send
heartbeats to every peer based on a provided heartbeat
interval. This will ensure that connections are not
incorrectly closed. 

Currently, every peer will receive
the heartbeat even if the network has received a message
from that peer recently. This will be changed in a future PR.

The default is 30 seconds. Setting the heartbeat_interval to 0 turns off heartbeats. 
