### PR TITLE
Store last scabbard state root

### DIFF
--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -62,6 +62,7 @@ fn run() -> Result<(), GameroomDaemonError> {
     log_spec_builder.default(log_level);
     log_spec_builder.module("hyper", log::LevelFilter::Warn);
     log_spec_builder.module("tokio", log::LevelFilter::Warn);
+    log_spec_builder.module("trust_dns", log::LevelFilter::Warn);
 
     Logger::with(log_spec_builder.build()).start()?;
 


### PR DESCRIPTION
Read and write the current state root from the state db by utilising an
additional index in the database, "current_state_root".  This is read at
startup, and stored on each commit.

Also,
- filter trust_dns messages