### PR TITLE
Simplify Service where services can be connected

### DIFF
--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -450,8 +450,8 @@ mod tests {
             splinter_node("other-node", "tcp://otherplace:8000"),
         ]));
         proposed_circuit.set_roster(protobuf::RepeatedField::from_vec(vec![
-            splinter_service("service-a", "sabre"),
-            splinter_service("service-b", "sabre"),
+            splinter_service("service-a", "sabre", "test-node"),
+            splinter_service("service-b", "sabre", "other-node"),
         ]));
 
         let mut request = admin::CircuitCreateRequest::new();
@@ -523,10 +523,15 @@ mod tests {
         node
     }
 
-    fn splinter_service(service_id: &str, service_type: &str) -> admin::SplinterService {
+    fn splinter_service(
+        service_id: &str,
+        service_type: &str,
+        allowed_node: &str,
+    ) -> admin::SplinterService {
         let mut service = admin::SplinterService::new();
         service.set_service_id(service_id.into());
         service.set_service_type(service_type.into());
+        service.set_allowed_nodes(vec![allowed_node.into()].into());
         service
     }
 

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -154,6 +154,15 @@ impl Service for AdminService {
             })?
             .restart_services()
             .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+
+        self.admin_service_shared
+            .lock()
+            .map_err(|_| {
+                ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
+            })?
+            .add_services_to_directory()
+            .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+
         Ok(())
     }
 

--- a/libsplinter/src/admin/shared.rs
+++ b/libsplinter/src/admin/shared.rs
@@ -22,8 +22,10 @@ use protobuf::{Message, RepeatedField};
 
 use crate::circuit::SplinterState;
 use crate::circuit::{
-    service::SplinterNode as StateNode, AuthorizationType, Circuit as StateCircuit, DurabilityType,
-    PersistenceType, RouteType, ServiceDefinition as StateServiceDefinition,
+    service::SplinterNode as StateNode,
+    service::{Service, ServiceId},
+    AuthorizationType, Circuit as StateCircuit, DurabilityType, PersistenceType, RouteType,
+    ServiceDefinition as StateServiceDefinition,
 };
 use crate::consensus::{Proposal, ProposalId};
 use crate::hex::to_hex;
@@ -1148,7 +1150,7 @@ impl AdminServiceShared {
                     .map(|node| node.id().to_string())
                     .collect::<Vec<String>>(),
             )
-            .with_roster(roster)
+            .with_roster(roster.clone())
             .with_auth(auth)
             .with_persistence(persistence)
             .with_durability(durability)
@@ -1162,6 +1164,7 @@ impl AdminServiceShared {
         let mut splinter_state = self.splinter_state.write().map_err(|err| {
             AdminSharedError::CommitError(format!("Unable to unlock splinter state: {}", err))
         })?;
+
         for member in members {
             splinter_state
                 .add_node(member.id().to_string(), member)
@@ -1180,6 +1183,63 @@ impl AdminServiceShared {
                     err
                 ))
             })?;
+
+        for service in roster {
+            if service.allowed_nodes().contains(&self.node_id) {
+                continue;
+            }
+
+            let unique_id = ServiceId::new(
+                circuit.circuit_id.to_string(),
+                service.service_id().to_string(),
+            );
+
+            let allowed_node = &service.allowed_nodes()[0];
+            if let Some(member) = splinter_state.node(&allowed_node) {
+                let service = Service::new(service.service_id().to_string(), None, member.clone());
+                splinter_state.add_service(unique_id, service)
+            } else {
+                return Err(AdminSharedError::CommitError(format!(
+                    "Unable to find allowed node {} when adding service {} to directory",
+                    allowed_node,
+                    service.service_id()
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn add_services_to_directory(&self) -> Result<(), AdminSharedError> {
+        let mut splinter_state = self.splinter_state.write().map_err(|err| {
+            AdminSharedError::CommitError(format!("Unable to unlock splinter state: {}", err))
+        })?;
+
+        for (id, circuit) in splinter_state.circuits().clone() {
+            for service in circuit.roster() {
+                if service.allowed_nodes().contains(&self.node_id) {
+                    continue;
+                }
+                warn!("Adding service {}", service.service_id());
+                let unique_id = ServiceId::new(id.to_string(), service.service_id().to_string());
+
+                let allowed_node = &service.allowed_nodes()[0];
+                if let Some(member) = splinter_state.node(&allowed_node) {
+                    // rebuild Node with id
+                    let node =
+                        StateNode::new(allowed_node.to_string(), member.endpoints().to_vec());
+                    let service = Service::new(service.service_id().to_string(), None, node);
+                    splinter_state.add_service(unique_id, service)
+                } else {
+                    return Err(AdminSharedError::CommitError(format!(
+                        "Unable to find allowed node {} when adding service {} to directory",
+                        allowed_node,
+                        service.service_id()
+                    )));
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -132,7 +132,8 @@ impl Handler<CircuitMessageType, CircuitDirectMessage> for CircuitDirectMessageH
                             (network_msg_bytes, &peer_id[..])
                         }
                     } else {
-                        // if the recipient is not connected, send circuit error
+                        // This should not happen as every service should be added on circuit
+                        // creation. If the recipient is not connected, send circuit error
                         let mut error_message = CircuitError::new();
                         error_message.set_correlation_id(msg.get_correlation_id().to_string());
                         error_message.set_service_id(msg_sender.into());

--- a/libsplinter/src/circuit/handlers/mod.rs
+++ b/libsplinter/src/circuit/handlers/mod.rs
@@ -27,9 +27,7 @@ pub use self::admin_message::AdminDirectMessageHandler;
 pub use self::circuit_error::CircuitErrorHandler;
 pub use self::circuit_message::CircuitMessageHandler;
 pub use self::direct_message::CircuitDirectMessageHandler;
-pub use self::service_handlers::ServiceConnectForwardHandler;
 pub use self::service_handlers::ServiceConnectRequestHandler;
-pub use self::service_handlers::ServiceDisconnectForwardHandler;
 pub use self::service_handlers::ServiceDisconnectRequestHandler;
 
 fn create_message(

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -79,8 +79,7 @@ impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectReques
                     }
                 };
 
-                if !service.allowed_nodes.contains(&self.node_id)
-                {
+                if !service.allowed_nodes.contains(&self.node_id) {
                     response.set_status(ServiceConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE);
                     response.set_error_message(format!("{} is not allowed on this node", unique_id))
                 } else {
@@ -145,7 +144,6 @@ impl ServiceConnectRequestHandler {
 
 // Implements a handler that handles ServiceDisconnectRequest
 pub struct ServiceDisconnectRequestHandler {
-    node_id: String,
     state: Arc<RwLock<SplinterState>>,
 }
 
@@ -217,8 +215,8 @@ impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnect
 }
 
 impl ServiceDisconnectRequestHandler {
-    pub fn new(node_id: String, state: Arc<RwLock<SplinterState>>) -> Self {
-        ServiceDisconnectRequestHandler { node_id, state }
+    pub fn new(state: Arc<RwLock<SplinterState>>) -> Self {
+        ServiceDisconnectRequestHandler { state }
     }
 }
 
@@ -497,7 +495,7 @@ mod tests {
             "memory".to_string(),
             circuit_directory,
         )));
-        let handler = ServiceDisconnectRequestHandler::new("123".to_string(), state);
+        let handler = ServiceDisconnectRequestHandler::new(state);
 
         dispatcher.set_handler(
             CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
@@ -554,7 +552,7 @@ mod tests {
             "memory".to_string(),
             circuit_directory,
         )));
-        let handler = ServiceDisconnectRequestHandler::new("123".to_string(), state);
+        let handler = ServiceDisconnectRequestHandler::new(state);
 
         dispatcher.set_handler(
             CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
@@ -617,7 +615,7 @@ mod tests {
         let id = ServiceId::new("alpha".into(), "abc".into());
         state.write().unwrap().add_service(id.clone(), service);
 
-        let handler = ServiceDisconnectRequestHandler::new("123".to_string(), state.clone());
+        let handler = ServiceDisconnectRequestHandler::new(state.clone());
 
         dispatcher.set_handler(
             CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
@@ -679,7 +677,7 @@ mod tests {
             circuit_directory,
         )));
 
-        let handler = ServiceDisconnectRequestHandler::new("123".to_string(), state);
+        let handler = ServiceDisconnectRequestHandler::new(state);
 
         dispatcher.set_handler(
             CircuitMessageType::SERVICE_DISCONNECT_REQUEST,

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -18,9 +18,9 @@ use crate::circuit::{ServiceDefinition, SplinterState};
 use crate::network::dispatch::{DispatchError, Handler, MessageContext};
 use crate::network::sender::SendRequest;
 use crate::protos::circuit::{
-    CircuitMessageType, ServiceConnectForward, ServiceConnectRequest, ServiceConnectResponse,
-    ServiceConnectResponse_Status, ServiceDisconnectForward, ServiceDisconnectRequest,
-    ServiceDisconnectResponse, ServiceDisconnectResponse_Status,
+    CircuitMessageType, ServiceConnectRequest, ServiceConnectResponse,
+    ServiceConnectResponse_Status, ServiceDisconnectRequest, ServiceDisconnectResponse,
+    ServiceDisconnectResponse_Status,
 };
 use crate::rwlock_write_unwrap;
 
@@ -84,22 +84,6 @@ impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectReques
                     response.set_status(ServiceConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE);
                     response.set_error_message(format!("{} is not allowed on this node", unique_id))
                 } else {
-                    let mut forward_message = ServiceConnectForward::new();
-                    forward_message.set_circuit(circuit_name.into());
-                    forward_message.set_service_id(service_id.into());
-                    forward_message.set_node_id(self.node_id.to_string());
-                    forward_message.set_node_endpoint(self.endpoint.to_string());
-                    let forward_bytes = forward_message.write_to_bytes()?;
-                    let network_msg_bytes =
-                        create_message(forward_bytes, CircuitMessageType::SERVICE_CONNECT_FORWARD)?;
-
-                    for member in circuit.members() {
-                        if member != &self.node_id {
-                            let send_request =
-                                SendRequest::new(member.to_string(), network_msg_bytes.clone());
-                            sender.send(send_request)?;
-                        }
-                    }
                     let node = SplinterNode::new(
                         self.node_id.to_string(),
                         vec![self.endpoint.to_string()],
@@ -192,24 +176,6 @@ impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnect
             if circuit.roster().contains(&service_id.to_string())
                 && state.service_directory.contains_key(&unique_id)
             {
-                let mut forward_message = ServiceDisconnectForward::new();
-                forward_message.set_circuit(circuit_name.into());
-                forward_message.set_service_id(service_id.into());
-                forward_message.set_node_id(self.node_id.to_string());
-                let forward_bytes = forward_message.write_to_bytes()?;
-                let network_msg_bytes = create_message(
-                    forward_bytes,
-                    CircuitMessageType::SERVICE_DISCONNECT_FORWARD,
-                )?;
-
-                for member in circuit.members() {
-                    if member != &self.node_id {
-                        let send_request =
-                            SendRequest::new(member.to_string(), network_msg_bytes.clone());
-                        sender.send(send_request)?;
-                    }
-                }
-
                 state.remove_service(&unique_id);
                 response.set_status(ServiceDisconnectResponse_Status::OK);
             // If the circuit exists and has the service in the roster but the service not
@@ -253,137 +219,6 @@ impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnect
 impl ServiceDisconnectRequestHandler {
     pub fn new(node_id: String, state: Arc<RwLock<SplinterState>>) -> Self {
         ServiceDisconnectRequestHandler { node_id, state }
-    }
-}
-
-// Implements a handler that handles ServiceConnectForward Messages
-pub struct ServiceConnectForwardHandler {
-    state: Arc<RwLock<SplinterState>>,
-}
-
-impl Handler<CircuitMessageType, ServiceConnectForward> for ServiceConnectForwardHandler {
-    fn handle(
-        &self,
-        msg: ServiceConnectForward,
-        _: &MessageContext<CircuitMessageType>,
-        _: &dyn Sender<SendRequest>,
-    ) -> Result<(), DispatchError> {
-        debug!("Handle Service Connect Forward {:?}", msg);
-        let circuit_name = msg.get_circuit();
-        let service_id = msg.get_service_id();
-        let node_id = msg.get_node_id().to_string();
-        let node_endpoint = msg.get_node_endpoint();
-
-        let unique_id = ServiceId::new(circuit_name.to_string(), service_id.to_string());
-
-        // hold on to the write lock for the entirety of the function
-        let mut state = rwlock_write_unwrap!(self.state);
-        let circuit_result = state.circuit(circuit_name);
-        if let Some(circuit) = circuit_result {
-            // If the circuit has the service in its roster and the service is not yet connected
-            // add the service to splinter state. Otherwise return
-            if circuit.roster().contains(&service_id.to_string())
-                && !state.service_directory.contains_key(&unique_id)
-            {
-                // This should never return None since we just checked if it exists.
-                // If admin service create a service defination for the admin service
-                let service = {
-                    if !service_id.starts_with("admin::") {
-                        circuit
-                            .roster()
-                            .iter()
-                            .find(|service| service.service_id == service_id)
-                            .expect("Cannot find service in circuit")
-                            .clone()
-                    } else {
-                        ServiceDefinition::builder(service_id.into(), "admin".into())
-                            .with_allowed_nodes(vec![node_id.to_string()])
-                            .build()
-                    }
-                };
-
-                if !service.allowed_nodes.contains(&node_id) && service.allowed_nodes != ["*"] {
-                    warn!(
-                        "Service {} is not allowed to connect to {}",
-                        service_id, node_id
-                    );
-                } else {
-                    let node = SplinterNode::new(node_id, vec![node_endpoint.to_string()]);
-                    let service = Service::new(service_id.to_string(), None, node);
-                    state.add_service(unique_id, service);
-                }
-            } else if circuit.roster().contains(&service_id.to_string())
-                && state.service_directory.contains_key(&unique_id)
-            {
-                warn!("Service is already registered: {}", service_id);
-            } else {
-                warn!(
-                    "Service is not allowed in the circuit: {}:{}",
-                    circuit_name, service_id
-                );
-            }
-        } else {
-            warn!("Circuit does not exist: {}", circuit_name);
-        }
-
-        Ok(())
-    }
-}
-
-impl ServiceConnectForwardHandler {
-    pub fn new(state: Arc<RwLock<SplinterState>>) -> Self {
-        ServiceConnectForwardHandler { state }
-    }
-}
-
-// Implements a handler that handles ServiceDisconnectForward Messages
-pub struct ServiceDisconnectForwardHandler {
-    state: Arc<RwLock<SplinterState>>,
-}
-
-impl Handler<CircuitMessageType, ServiceDisconnectForward> for ServiceDisconnectForwardHandler {
-    fn handle(
-        &self,
-        msg: ServiceDisconnectForward,
-        _: &MessageContext<CircuitMessageType>,
-        _: &dyn Sender<SendRequest>,
-    ) -> Result<(), DispatchError> {
-        debug!("Handle Service Connect Forward {:?}", msg);
-        let circuit_name = msg.get_circuit();
-        let service_id = msg.get_service_id();
-        let unique_id = ServiceId::new(circuit_name.to_string(), service_id.to_string());
-
-        // hold on to the write lock for the entirety of the function
-        let mut state = rwlock_write_unwrap!(self.state);
-        let circuit_result = state.circuit(circuit_name);
-        if let Some(circuit) = circuit_result {
-            // If the circuit has the service in its roster and the service is connected
-            // remove the service from splinter state. Otherwise return
-            if circuit.roster().contains(&service_id.to_string())
-                && state.service_directory.contains_key(&unique_id)
-            {
-                state.remove_service(&unique_id);
-            } else if circuit.roster().contains(&service_id.to_string())
-                && !state.service_directory.contains_key(&unique_id)
-            {
-                warn!("Service not registered: {}", service_id);
-            } else {
-                warn!(
-                    "Service is not allowed in the circuit: {}:{}",
-                    circuit_name, service_id
-                );
-            }
-        } else {
-            warn!("Circuit does not exist: {}", circuit_name);
-        }
-
-        Ok(())
-    }
-}
-
-impl ServiceDisconnectForwardHandler {
-    pub fn new(state: Arc<RwLock<SplinterState>>) -> Self {
-        ServiceDisconnectForwardHandler { state }
     }
 }
 
@@ -522,8 +357,7 @@ mod tests {
 
     #[test]
     // Test that if the service is in a circuit and not connected, a ServiceConnectResponse is
-    // returned with an OK, also test that ServiceConnectForward are sent to other nodes on the
-    // circuit
+    // returned with an OK
     fn test_service_connect_request_handler() {
         let sender = Box::new(MockSender::default());
         let mut dispatcher = Dispatcher::new(sender.box_clone());
@@ -560,23 +394,8 @@ mod tests {
             )
             .unwrap();
         let send_requests = sender.sent();
-        assert_eq!(send_requests.len(), 2);
+        assert_eq!(send_requests.len(), 1);
         let send_request = send_requests.get(0).unwrap().clone();
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let forward_connect: ServiceConnectForward =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_FORWARD
-        );
-        assert_eq!(forward_connect.get_circuit(), "alpha");
-        assert_eq!(forward_connect.get_service_id(), "abc");
-        assert_eq!(forward_connect.get_node_id(), "123");
-
-        let send_request = send_requests.get(1).unwrap().clone();
 
         assert_eq!(send_request.recipient(), "PEER");
 
@@ -604,8 +423,7 @@ mod tests {
 
     #[test]
     // Test that if the service is in a circuit and not connected, a ServiceConnectResponse is
-    // returned with an OK, also test that ServiceConnectForward are sent to other nodes on the
-    // circuit. If services have a * in there allowed nodes they can connect to any node on the
+    // returned with an OK If services have a * in there allowed nodes they can connect to any node on the
     // circiut.
     fn test_service_connect_request_handler_service_any_node() {
         let sender = Box::new(MockSender::default());
@@ -661,23 +479,8 @@ mod tests {
             )
             .unwrap();
         let send_requests = sender.sent();
-        assert_eq!(send_requests.len(), 2);
+        assert_eq!(send_requests.len(), 1);
         let send_request = send_requests.get(0).unwrap().clone();
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let forward_connect: ServiceConnectForward =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_FORWARD
-        );
-        assert_eq!(forward_connect.get_circuit(), "alpha");
-        assert_eq!(forward_connect.get_service_id(), "abc");
-        assert_eq!(forward_connect.get_node_id(), "123");
-
-        let send_request = send_requests.get(1).unwrap().clone();
 
         assert_eq!(send_request.recipient(), "PEER");
 
@@ -764,149 +567,6 @@ mod tests {
             connect_response.get_status(),
             ServiceConnectResponse_Status::ERROR_SERVICE_ALREADY_REGISTERED
         );
-    }
-
-    #[test]
-    // Test that if the service is in a circuit and it is not yet connect, add the service to
-    // splinter state
-    fn test_service_connect_forward_handler() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
-
-        let circuit = build_circuit();
-
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
-
-        let state = Arc::new(RwLock::new(SplinterState::new(
-            "memory".to_string(),
-            circuit_directory,
-        )));
-        let handler = ServiceConnectForwardHandler::new(state.clone());
-
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_FORWARD,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectForward::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        connect_request.set_node_id("123".into());
-        connect_request.set_node_endpoint("127.0.0.1:0".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
-
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_CONNECT_FORWARD,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        assert!(state.read().unwrap().service_directory().get(&id).is_some());
-    }
-
-    #[test]
-    // Test that if the service is in a circuit, it is not yet connected, and allowed to
-    // connect to all nodes, add the service to splinter state
-    fn test_service_connect_forward_handler_all_node() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
-
-        let service_abc = ServiceDefinition::builder("abc".into(), "test".into())
-            .with_allowed_nodes(vec!["*".to_string()])
-            .build();
-
-        let service_def = ServiceDefinition::builder("def".into(), "test".into())
-            .with_allowed_nodes(vec!["*".to_string()])
-            .build();
-
-        let circuit = Circuit::builder()
-            .with_id("alpha".into())
-            .with_auth(AuthorizationType::Trust)
-            .with_members(vec!["123".into(), "345".into()])
-            .with_roster(vec![service_abc, service_def])
-            .with_persistence(PersistenceType::Any)
-            .with_durability(DurabilityType::NoDurabilty)
-            .with_routes(RouteType::Any)
-            .with_circuit_management_type("service_connect_test_app".into())
-            .build()
-            .expect("Should have built a correct circuit");
-
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
-
-        let state = Arc::new(RwLock::new(SplinterState::new(
-            "memory".to_string(),
-            circuit_directory,
-        )));
-        let handler = ServiceConnectForwardHandler::new(state.clone());
-
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_FORWARD,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectForward::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        // abc can connect to any node
-        connect_request.set_node_id("345".into());
-        connect_request.set_node_endpoint("127.0.0.1:0".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
-
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_CONNECT_FORWARD,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        assert!(state.read().unwrap().service_directory().get(&id).is_some());
-    }
-
-    #[test]
-    // Test that if the service is in a circuit and it is not yet connect but the service is
-    // trying to connect to a node not in there allowed nodes list, ignore.
-    fn test_service_connect_forward_handler_wrong_node() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
-
-        let circuit = build_circuit();
-
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
-
-        let state = Arc::new(RwLock::new(SplinterState::new(
-            "memory".to_string(),
-            circuit_directory,
-        )));
-        let handler = ServiceConnectForwardHandler::new(state.clone());
-
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_FORWARD,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectForward::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        // abc is only allowed to connect to 123
-        connect_request.set_node_id("345".into());
-        connect_request.set_node_endpoint("127.0.0.1:0".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
-
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_CONNECT_FORWARD,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        assert!(state.read().unwrap().service_directory().get(&id).is_none());
     }
 
     #[test]
@@ -1022,8 +682,7 @@ mod tests {
 
     #[test]
     // Test that if the service is in a circuit and already connected, a ServiceDisconnectResponse
-    // is returned with an OK, also test that ServiceDisconnectForward are sent to other nodes on
-    // the circuit
+    // is returned with an OK.
     fn test_service_disconnect_request_handler() {
         let sender = Box::new(MockSender::default());
         let mut dispatcher = Dispatcher::new(sender.box_clone());
@@ -1062,23 +721,8 @@ mod tests {
             )
             .unwrap();
         let send_requests = sender.sent();
-        assert_eq!(send_requests.len(), 2);
+        assert_eq!(send_requests.len(), 1);
         let send_request = send_requests.get(0).unwrap().clone();
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let forward_connect: ServiceDisconnectForward =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_DISCONNECT_FORWARD
-        );
-        assert_eq!(forward_connect.get_circuit(), "alpha");
-        assert_eq!(forward_connect.get_service_id(), "abc");
-        assert_eq!(forward_connect.get_node_id(), "123");
-
-        let send_request = send_requests.get(1).unwrap().clone();
 
         assert_eq!(send_request.recipient(), "PEER");
 
@@ -1159,51 +803,6 @@ mod tests {
             disconnect_response.get_status(),
             ServiceDisconnectResponse_Status::ERROR_SERVICE_NOT_REGISTERED
         );
-    }
-
-    #[test]
-    // Test that if the service is in a circuit and it is connected, remove the service from
-    // splinter state
-    fn test_service_disconnect_forward_handler() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
-
-        let circuit = build_circuit();
-
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
-
-        let state = Arc::new(RwLock::new(SplinterState::new(
-            "memory".to_string(),
-            circuit_directory,
-        )));
-
-        let node = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let service = Service::new("abc".to_string(), Some("abc_network".to_string()), node);
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        state.write().unwrap().add_service(id.clone(), service);
-
-        let handler = ServiceDisconnectForwardHandler::new(state.clone());
-
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_DISCONNECT_FORWARD,
-            Box::new(handler),
-        );
-        let mut disconnect_request = ServiceDisconnectForward::new();
-        disconnect_request.set_circuit("alpha".into());
-        disconnect_request.set_service_id("abc".into());
-        disconnect_request.set_node_id("123".into());
-        let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
-
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_DISCONNECT_FORWARD,
-                disconnect_bytes.clone(),
-            )
-            .unwrap();
-
-        assert!(state.read().unwrap().service_directory().get(&id).is_none());
     }
 
     fn build_circuit() -> Circuit {

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -501,7 +501,7 @@ mod tests {
     impl Into<ServiceDefinition> for &str {
         fn into(self) -> ServiceDefinition {
             ServiceDefinition::builder(self.to_string(), "test_type".into())
-                .with_allowed_nodes(vec!["*".into()])
+                .with_allowed_nodes(vec!["test-node".into()])
                 .with_arguments(vec![("test-key".into(), "test-value".into())])
                 .build()
         }

--- a/protos/circuit.proto
+++ b/protos/circuit.proto
@@ -31,10 +31,8 @@ enum CircuitMessageType {
     CIRCUIT_DIRECT_MESSAGE = 3;
     SERVICE_CONNECT_REQUEST = 4;
     SERVICE_CONNECT_RESPONSE = 5;
-    SERVICE_CONNECT_FORWARD = 6;
     SERVICE_DISCONNECT_REQUEST = 7;
     SERVICE_DISCONNECT_RESPONSE = 8;
-    SERVICE_DISCONNECT_FORWARD = 9;
 
     ADMIN_DIRECT_MESSAGE = 100;
 }
@@ -152,21 +150,6 @@ message ServiceConnectResponse {
     string correlation_id = 5;
 }
 
-// To be forwarded to other nodes on the circuit
-message ServiceConnectForward {
-    // the name of the circuit the message is meant for
-    string circuit = 1;
-
-    // the unique id of the service that is connecting to the circuit
-    string service_id = 2;
-
-    // the unique id of the node id that the service connected to
-    string node_id = 3;
-
-    // the network endpoint of the node that the service connected to
-    string node_endpoint = 4;
-}
-
 message ServiceDisconnectRequest {
     // the name of the circuit the message is meant for
     string circuit = 1;
@@ -201,16 +184,4 @@ message ServiceDisconnectResponse {
 
     // id used to correlate this response with the request
     string correlation_id = 5;
-}
-
-// To be forwarded to other nodes on the circuit
-message ServiceDisconnectForward {
-    // the name of the circuit the message is meant for
-    string circuit = 1;
-
-    // the unique id of the service that is connecting to the circuit
-    string service_id = 2;
-
-    // the unique id of the node id that the service connected to
-    string node_id = 3;
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -659,8 +659,7 @@ fn set_up_circuit_dispatcher(
         Box::new(service_connect_request_handler),
     );
 
-    let service_disconnect_request_handler =
-        ServiceDisconnectRequestHandler::new(node_id.to_string(), state.clone());
+    let service_disconnect_request_handler = ServiceDisconnectRequestHandler::new(state.clone());
     dispatcher.set_handler(
         CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
         Box::new(service_disconnect_request_handler),

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -22,8 +22,7 @@ use splinter::admin::{admin_service_id, AdminService};
 use splinter::circuit::directory::CircuitDirectory;
 use splinter::circuit::handlers::{
     AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
-    CircuitMessageHandler, ServiceConnectForwardHandler, ServiceConnectRequestHandler,
-    ServiceDisconnectForwardHandler, ServiceDisconnectRequestHandler,
+    CircuitMessageHandler, ServiceConnectRequestHandler, ServiceDisconnectRequestHandler,
 };
 use splinter::circuit::SplinterState;
 use splinter::keys::{insecure::AllowAllKeyPermissionManager, storage::StorageKeyRegistry};
@@ -660,23 +659,11 @@ fn set_up_circuit_dispatcher(
         Box::new(service_connect_request_handler),
     );
 
-    let service_connect_forward_handler = ServiceConnectForwardHandler::new(state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::SERVICE_CONNECT_FORWARD,
-        Box::new(service_connect_forward_handler),
-    );
-
     let service_disconnect_request_handler =
         ServiceDisconnectRequestHandler::new(node_id.to_string(), state.clone());
     dispatcher.set_handler(
         CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
         Box::new(service_disconnect_request_handler),
-    );
-
-    let service_disconnect_forward_handler = ServiceDisconnectForwardHandler::new(state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::SERVICE_DISCONNECT_FORWARD,
-        Box::new(service_disconnect_forward_handler),
     );
 
     let direct_message_handler =


### PR DESCRIPTION
Before a Service could be connected at any number of allowed nodes. However to alert the rest of the network of their location, the other nodes would need to be explicitly told which node the service was connected on and there was not a catch up procedure implemented if the other node missed the message. This would cause part of the network to not know where services were connected or how to talk to them. This was also seen on circuit start up where a circuit may not be up yet on one of the nodes.

We have decided to enforce that the service will be accessible at the node listed in their allowed nodes (with an error returned if not there) since this information is in the circuit definition. We have also decided to limit the allowed nodes list to one node. Multiple nodes may be supported in the future (to support rolling upgrades for example).