### PR TITLE
Add required fields for build and installation

### DIFF
--- a/canopy/canopyjs/package.json
+++ b/canopy/canopyjs/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
+    "@types/uuid": "^3.4.5",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
     "eslint": "^6.5.1",

--- a/canopy/canopyjs/package.json
+++ b/canopy/canopyjs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "canopyjs",
   "private": true,
+  "version": "0.0.0-alpha",
   "author": "Cargill Incorporated",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
In order to install this dependency in Saplings, a version is required.

Additionally, the transpilation from TS to JS requires additional types to be defined.

These two changes will allow canopyjs to be built and installed.