### PR TITLE
Add generic Gameroom app to docker installed

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -94,6 +94,16 @@ services:
     image: ${REGISTRY}${NAMESPACE}gameroom-app-bubba:${ISOLATION_ID}
     container_name: gameroom-app-bubba
 
+  gameroom-app:
+    build:
+      context: .
+      dockerfile: examples/gameroom/gameroom-app/Dockerfile-installed
+      args:
+        - VUE_APP_BRAND=generic
+        - REPO_VERSION=${REPO_VERSION}
+    image: ${REGISTRY}${NAMESPACE}gameroom-app:${ISOLATION_ID}
+    container_name: gameroom-app
+
   gameroom-database:
     build:
       context: .

--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -6,9 +6,11 @@
   "license": "Apache-2.0",
   "scripts": {
     "serve": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='generic' vue-cli-service serve",
+    "serve-generic": "npm run serve",
     "serve-acme": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service serve",
     "serve-bubba": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='bubba' vue-cli-service serve",
     "build": "npm run generate-proto-files ./protos && cross-env process.env.VUE_APP_BRAND='generic' vue-cli-service build",
+    "build-generic": "npm run build",
     "build-acme": "npm run generate-proto-files ./protos && cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service build",
     "build-bubba": "npm run generate-proto-files ./protos && cross-env process.env.VUE_APP_BRAND='bubba' vue-cli-service build",
     "lint": "cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service lint",


### PR DESCRIPTION
Adds the generic gameroom app to be built in the docker installed compose file alongside the acme and bubba versions. 