### PR TITLE
Log CircuitErrors and other minor fixes

### DIFF
--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -100,7 +100,7 @@ fn run() -> Result<(), GameroomDaemonError> {
     )?;
 
     ctrlc::set_handler(move || {
-        info!("Recieved Shutdown");
+        info!("Received Shutdown");
 
         if let Err(err) = rest_api_shutdown_handle.shutdown() {
             error!("Unable to cleanly shutdown REST API server: {}", err);

--- a/examples/private_xo/src/main.rs
+++ b/examples/private_xo/src/main.rs
@@ -355,7 +355,7 @@ fn configure_logging(matches: &clap::ArgMatches) {
 
 fn configure_shutdown_handler(running: Arc<AtomicBool>) -> Result<(), CliError> {
     ctrlc::set_handler(move || {
-        info!("Recieved Shutdown");
+        info!("Received Shutdown");
         running.store(false, Ordering::SeqCst);
     })
     .map_err(|err| CliError(format!("Unable to create control c handler: {}", err)))

--- a/libsplinter/src/admin/shared.rs
+++ b/libsplinter/src/admin/shared.rs
@@ -1232,7 +1232,6 @@ impl AdminServiceShared {
                 if service.allowed_nodes().contains(&self.node_id) {
                     continue;
                 }
-                warn!("Adding service {}", service.service_id());
                 let unique_id = ServiceId::new(id.to_string(), service.service_id().to_string());
 
                 let allowed_node = &service.allowed_nodes()[0];

--- a/libsplinter/src/events/ws.rs
+++ b/libsplinter/src/events/ws.rs
@@ -25,7 +25,7 @@
 //! let mut ws = WebSocketClient::new(
 //!    "http://echo.websocket.org", |ctx, msg: Vec<u8>| {
 //!    if let Ok(s) = String::from_utf8(msg.clone()) {
-//!         println!("Recieved {}", s);
+//!         println!("Received {}", s);
 //!    } else {
 //!       println!("malformed message: {:?}", msg);
 //!    };

--- a/libsplinter/src/network/dispatch.rs
+++ b/libsplinter/src/network/dispatch.rs
@@ -389,9 +389,9 @@ impl<MT: Any + Hash + Eq + Debug + Clone> DispatchLoop<MT> {
                 Ok(dispatch_msg) => dispatch_msg,
                 Err(RecvTimeoutError::Timeout) => continue,
                 Err(RecvTimeoutError::Disconnected) => {
-                    error!("Recieved Disconnected Error from receiver");
+                    error!("Received Disconnected Error from receiver");
                     return Err(DispatchLoopError(String::from(
-                        "Recieved Disconnected Error from receiver",
+                        "Received Disconnected Error from receiver",
                     )));
                 }
             };

--- a/libsplinter/src/network/sender.rs
+++ b/libsplinter/src/network/sender.rs
@@ -70,9 +70,9 @@ impl NetworkMessageSender {
                 Ok(send_request) => send_request,
                 Err(RecvTimeoutError::Timeout) => continue,
                 Err(RecvTimeoutError::Disconnected) => {
-                    error!("Recieved Disconnected Error from receiver");
+                    error!("Received Disconnected Error from receiver");
                     return Err(NetworkMessageSenderError::RecvTimeoutError(String::from(
-                        "Recieved Disconnected Error from receiver",
+                        "Received Disconnected Error from receiver",
                     )));
                 }
             };

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -31,7 +31,7 @@ use crate::protos::authorization::{
     AuthorizationMessage, AuthorizationMessageType, ConnectRequest, ConnectRequest_HandshakeMode,
 };
 use crate::protos::circuit::{
-    AdminDirectMessage, CircuitDirectMessage, CircuitMessage, CircuitMessageType,
+    AdminDirectMessage, CircuitDirectMessage, CircuitError, CircuitMessage, CircuitMessageType,
     ServiceConnectResponse, ServiceDisconnectResponse,
 };
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
@@ -457,6 +457,12 @@ pub fn run_incoming_loop(
                                 )),
                             )
                             .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
+                    }
+                    CircuitMessageType::CIRCUIT_ERROR_MESSAGE => {
+                        let response: CircuitError =
+                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                                .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
+                        warn!("Received circuit error message {:?}", response);
                     }
                     msg_type => warn!("Received unimplemented message: {:?}", msg_type),
                 }

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -28,7 +28,7 @@ use crate::protos::authorization::{
     AuthorizationMessage, AuthorizationMessageType, ConnectRequest, ConnectRequest_HandshakeMode,
 };
 use crate::protos::circuit::{
-    AdminDirectMessage, CircuitDirectMessage, CircuitMessage, CircuitMessageType,
+    AdminDirectMessage, CircuitDirectMessage, CircuitError, CircuitMessage, CircuitMessageType,
     ServiceConnectResponse, ServiceDisconnectResponse,
 };
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
@@ -431,6 +431,11 @@ fn process_inbound_msg_with_correlation_id(
             handle_circuit_direct_msg(circuit_direct_message, &shared_state).map_err(
                 to_process_err!("unable to handle inbound circuit direct message"),
             )?;
+        }
+        (CircuitMessageType::CIRCUIT_ERROR_MESSAGE, msg) => {
+            let response: CircuitError = protobuf::parse_from_bytes(&msg)
+                .map_err(to_process_err!("unable to parse circuit error message"))?;
+            warn!("Received circuit error message {:?}", response);
         }
         (msg_type, _) => warn!(
             "Received message ({:?}) that does not have a correlation id",

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -253,7 +253,7 @@ impl SplinterDaemon {
                         }
                         Err(RecvTimeoutError::Disconnected) => {
                             // if the reciever has disconnected, shutdown
-                            warn!("Recieved Disconnected Error from Network");
+                            warn!("Received Disconnected Error from Network");
                             break;
                         }
                         Err(_) => {


### PR DESCRIPTION
Log the CircuitError messages in the Orchestrator and ServiceProcessor, in order to improve the debugging of issues that may have occurred.

A more complete solution to this should have the Orchestrator and ServiceProcessor react to different error codes and conditions in the appropriate way.

Additionally,
- Correct "Recieved" typo
- Remove warn message