### PR TITLE
Remove disconnected peers, and limit accept thread exit

### DIFF
--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -258,7 +258,14 @@ impl Network {
             }
         };
 
-        self.mesh.send(Envelope::new(mesh_id, msg.to_vec()))?;
+        match self.mesh.send(Envelope::new(mesh_id, msg.to_vec())) {
+            Ok(()) => (),
+            Err(MeshSendError::Disconnected(_)) => {
+                rwlock_write_unwrap!(self.peers).remove(peer_id);
+            }
+            Err(err) => return Err(SendError::from(err)),
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Remove disconnected peer

When attempting a send via Network, and it results in a Disconnected error, remove the peer from the `PeerMap`. This will allow the system to accept allow the returned peer to reconnect. 

## Only exit the transport Listener thread on IoError

Only exit if there was an IoError via listening for incoming connections.  This error should also be logged, for future debugging purposes (in order to fine-tune the response to these errors).

Likewise, the loop should not be exited if the connection cannot be added to network (though, this probably indicates that other parts of the system - mesh, specifically - are shutting down).
