### PR TITLE
Fix splinterd shutdown issues

### DIFF
--- a/libsplinter/src/rest_api/events.rs
+++ b/libsplinter/src/rest_api/events.rs
@@ -74,6 +74,7 @@ impl<T: Serialize + Debug + Clone + 'static, H: EventHistory<T> + Send + Sync + 
     }
 
     pub fn stop(&self) {
+        debug!("Stoping WebSockets...");
         self.senders.iter().for_each(|sender| {
             if let Err(err) = sender.unbounded_send(MessageWrapper::Shutdown) {
                 error!("Failed to shutdown webocket: {:?}", err);

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -470,10 +470,8 @@ impl<T> JoinHandles<T> {
 }
 
 impl ShutdownHandle {
-    pub fn shutdown(self) -> Result<(), ServiceProcessorError> {
-        (*self.do_shutdown)()?;
-
-        Ok(())
+    pub fn shutdown(&self) -> Result<(), ServiceProcessorError> {
+        (*self.do_shutdown)()
     }
 }
 


### PR DESCRIPTION
Fix some of the splinter daemon shutdown issues, by stopping the admin service processes upon shutdown signal. 