### PR TITLE
Remove hardcoded protocols for octet-stream submission

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -17,6 +17,7 @@
     "generate-proto-files": "node scripts/compile_protobuf.js > src/compiled_protos.json"
   },
   "dependencies": {
+    "@types/node": "^12.12.6",
     "@types/protobufjs": "^6.0.0",
     "@types/request-promise": "^4.1.44",
     "@types/sjcl": "^1.0.28",
@@ -25,7 +26,6 @@
     "moment": "^2.24.0",
     "protobufjs": "^6.8.8",
     "request": "^2.88.0",
-    "request-promise": "^4.2.4",
     "sawtooth-sdk": "^1.0.5",
     "sjcl": "^1.0.8",
     "vue": "^2.6.10",

--- a/examples/gameroom/gameroom-app/src/components/xo/XOBoard.vue
+++ b/examples/gameroom/gameroom-app/src/components/xo/XOBoard.vue
@@ -135,6 +135,14 @@ export default class XOBoard extends Vue {
   }
 
   canSelect(cell: string): boolean {
+    let submitting = false;
+    this.boardArray.forEach((boardCell) => {
+      if (boardCell === '?') {
+        submitting = true;
+      }
+    });
+    if (submitting) { return false; }
+
     if (this.disabled) {
       return false;
     }

--- a/examples/gameroom/gameroom-app/src/store/modules/games.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/games.ts
@@ -56,17 +56,17 @@ const actions = {
        throw err;
      }
   },
-  async take({ commit, rootGetters }: any, {gameName, cellIndex, circuitID}: any) {
+  async take({ commit, rootGetters, dispatch }: any, {gameName, cellIndex, circuitID}: any) {
     const user = rootGetters['user/getUser'];
     const payload = new Buffer(`${gameName},take,${cellIndex + 1}`, 'utf-8');
     const gameAdress = calculateGameAddress(gameName);
     const transaction = createTransaction(payload, [gameAdress], [gameAdress], user);
     const batchBytes = createBatch([transaction], user);
     try {
-      const response = await submitBatch(batchBytes, circuitID);
       commit('setPendingTake', {gameName, cellIndex});
-      return response;
+      await submitBatch(batchBytes, circuitID);
     } catch (err) {
+      await dispatch('games/listGames', circuitID, {root: true});
       throw err;
     }
   },

--- a/examples/gameroom/gameroom-app/tsconfig.json
+++ b/examples/gameroom/gameroom-app/tsconfig.json
@@ -13,6 +13,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
+      "node",
       "webpack-env"
     ],
     "paths": {


### PR DESCRIPTION
Replaces request-promise with built in XMLHTTPRequest functionality.
This fixes a bug where the app could not submit batches or payloads over
TLS. This is because protocol had to be included in the URL for
request-promise, which was hard coded as http. Removing the dependency
allows us to just use a relative URL which will get handled by the proxy

Signed-off-by: Darian Plumb <dplumb@bitwise.io>