### PR TITLE
Add initial implementation of loading saplings

### DIFF
--- a/canopy/app/.eslintignore
+++ b/canopy/app/.eslintignore
@@ -1,0 +1,1 @@
+saplings/*

--- a/canopy/app/.eslintrc
+++ b/canopy/app/.eslintrc
@@ -7,7 +7,8 @@
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "rules": {
     "react/jsx-filename-extension": 0,
-    "react/prefer-stateless-function": 0
+    "react/prefer-stateless-function": 0,
+    "import/prefer-default-export": 0
   },
   "settings": {
     "import/resolver": {

--- a/canopy/app/package.json
+++ b/canopy/app/package.json
@@ -3,7 +3,9 @@
   "license": "Apache-2.0",
   "author": "Cargill Incorporated",
   "scripts": {
-    "start": "react-scripts start",
+    "start:saplings": "http-server ./saplings -p 8675",
+    "start:react": "react-scripts start",
+    "start": "run-p start:saplings start:react",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -28,6 +30,11 @@
     ]
   },
   "dependencies": {
+    "@babel/parser": "^7.7.2",
+    "babel-plugin-macros": "^2.6.1",
+    "es6-promisify": "^6.0.2",
+    "js-yaml": "^3.13.1",
+    "little-loader": "^0.2.0",
     "node-sass": "^4.12.0",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
@@ -44,8 +51,10 @@
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "http-server": "^0.11.1",
     "husky": "^3.0.9",
     "lint-staged": "^9.4.2",
+    "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2"
   }
 }

--- a/canopy/app/saplings/configSaplings.yml
+++ b/canopy/app/saplings/configSaplings.yml
@@ -1,0 +1,4 @@
+- namespace: login
+  runtimeFiles:
+    - 0.0.0.0:8675/loginRegisterSapling.js
+  workerFiles: []

--- a/canopy/app/saplings/loginRegisterSapling.js
+++ b/canopy/app/saplings/loginRegisterSapling.js
@@ -1,0 +1,3 @@
+window.$CANOPY.registerConfigSapling('login', () => {
+  console.log('Registering Login Sapling');
+});

--- a/canopy/app/saplings/userSaplings.yml
+++ b/canopy/app/saplings/userSaplings.yml
@@ -1,0 +1,6 @@
+- displayName: Vanilla
+  namespace: vanilla
+  runtimeFiles:
+    - 0.0.0.0:8675/vanilla.js
+  workerFiles: []
+  icon: https://via.placeholder.com/48

--- a/canopy/app/saplings/vanilla.js
+++ b/canopy/app/saplings/vanilla.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+window.$CANOPY.registerApp(function(domNode) {
+  console.log('Rendering Vanilla JS App');
+  domNode.innerHTML = `<h1>Hello World from a vanilla JS Canopy App<h1>`;
+});

--- a/canopy/app/src/getSaplings.macro.js
+++ b/canopy/app/src/getSaplings.macro.js
@@ -1,0 +1,39 @@
+const { createMacro } = require('babel-plugin-macros');
+const fs = require('fs');
+const path = require('path');
+const { parseExpression } = require('@babel/parser');
+const yaml = require('js-yaml');
+
+function loadYaml(yamlPath) {
+  return yaml.safeLoad(
+    fs.readFileSync(path.resolve(path.join(__dirname, yamlPath)), 'utf8')
+  );
+}
+
+function replaceReferenceWithPromiseResolveExpression(resplacement) {
+  return function doReplace(reference) {
+    // In order to make the return signature align with the logical future state,
+    // loading from an API call,
+    // the macro returns a function that returns a promise.
+    reference.replaceWith(
+      parseExpression(`() => Promise.resolve(${JSON.stringify(resplacement)})`)
+    );
+  };
+}
+
+function saplingMacro({ references }) {
+  const { getUserSaplings = [], getConfigSaplings = [] } = references;
+
+  const userSaplings = loadYaml('../saplings/userSaplings.yml');
+  const configSaplings = loadYaml('../saplings/configSaplings.yml');
+
+  getUserSaplings.forEach(
+    replaceReferenceWithPromiseResolveExpression(userSaplings)
+  );
+
+  getConfigSaplings.forEach(
+    replaceReferenceWithPromiseResolveExpression(configSaplings)
+  );
+}
+
+module.exports = createMacro(saplingMacro);

--- a/canopy/app/src/loadSaplings.js
+++ b/canopy/app/src/loadSaplings.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import promiseLoader from 'promiseLoader';
+import { getUserSaplings, getConfigSaplings } from './getSaplings.macro';
+
+async function loadCurrentSapling(userSaplingsResponse) {
+  // Saplings will be guaranteed to to have a collision-free namespace that
+  // coresponds with the place entry in the URL's path
+
+  // for instance /example and all of its child paths
+  // (/example/first, /example/first/a, example/second)
+  // would all let load the Sapling with `example` in its namespace attribute
+
+  // saplings themselves can take over routing at that point to manage their
+  // own routing (ie preventing full page refreshes, push on history)
+
+  const topLevelPathRgx = /\/([^/]+)/i;
+  const pathMatches = topLevelPathRgx.exec(window.location.pathname);
+  const saplingNamespaceToLoad =
+    pathMatches && pathMatches[1] ? pathMatches[1] : null;
+  const currentSaplingManifest = userSaplingsResponse.find(
+    ({ namespace }) => saplingNamespaceToLoad === namespace
+  );
+
+  if (currentSaplingManifest) {
+    await Promise.all(
+      currentSaplingManifest.runtimeFiles.map(saplingFile =>
+        promiseLoader(`http://${saplingFile}`)
+      )
+    );
+    return true;
+  }
+
+  return false;
+}
+
+async function loadConfigSaplings(configSaplingResponse) {
+  // Config Saplings need to be loaded with every page load.
+  // An example of a Config Saplings would be a module to handle
+  // user login/registration.
+  const configSaplingRuntimeFiles = configSaplingResponse
+    .map(s => s.runtimeFiles)
+    .flatMap(r => r);
+
+  if (configSaplingRuntimeFiles.length === 0) {
+    return false;
+  }
+
+  await Promise.all(
+    configSaplingRuntimeFiles.map(saplingFile =>
+      promiseLoader(`http://${saplingFile}`)
+    )
+  );
+  return true;
+}
+
+export async function loadAllSaplings() {
+  const [userSaplingsResponse, configSaplingResponse] = await Promise.all([
+    getUserSaplings(),
+    getConfigSaplings()
+  ]);
+
+  const configSaplingsAreLoaded = await loadConfigSaplings(
+    configSaplingResponse
+  );
+
+  const saplingIsLoaded = await loadCurrentSapling(userSaplingsResponse);
+
+  return {
+    saplingIsLoaded,
+    configSaplingsAreLoaded,
+    configSaplingResponse,
+    userSaplingsResponse
+  };
+}

--- a/canopy/app/src/promiseLoader.js
+++ b/canopy/app/src/promiseLoader.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import littleLoader from 'little-loader';
+import { promisify } from 'es6-promisify';
+
+export default promisify(littleLoader);


### PR DESCRIPTION
~~I want to acknowledge that the Saplings included here are transpiled code. The purpose of this code existing here is to demonstrate that Saplings can be build with and DOM framework and the source is not included.~~

While we considered using a module approach, in place of this more traditional loading, it did not seem to add value at this time.

You can validate these changes by running `yarn start`. You should see a page at `0.0.0.0:3000` and have ~~four~~ one links across the top. Clicking one of these should force a page reload with the correct Saplings being loaded.