### PR TITLE
Re-add color to logging

### DIFF
--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -29,7 +29,7 @@ mod rest_api;
 
 use std::thread;
 
-use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use flexi_logger::{style, DeferredNow, LogSpecBuilder, Logger};
 use gameroom_database::ConnectionPool;
 use log::Record;
 use sawtooth_sdk::signing::create_context;
@@ -47,6 +47,7 @@ pub fn log_format(
     now: &mut DeferredNow,
     record: &Record,
 ) -> Result<(), std::io::Error> {
+    let level = record.level();
     write!(
         w,
         "[{}] T[{:?}] {} [{}] {}",
@@ -54,7 +55,7 @@ pub fn log_format(
         thread::current().name().unwrap_or("<unnamed>"),
         record.level(),
         record.module_path().unwrap_or("<unnamed>"),
-        &record.args()
+        style(level, &record.args()),
     )
 }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -28,7 +28,7 @@ mod node_registry;
 mod registry_config;
 mod routes;
 
-use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use flexi_logger::{style, DeferredNow, LogSpecBuilder, Logger};
 use log::Record;
 
 use crate::certs::{make_ca_cert, make_ca_signed_cert, write_file, CertError};
@@ -91,6 +91,7 @@ pub fn log_format(
     now: &mut DeferredNow,
     record: &Record,
 ) -> Result<(), std::io::Error> {
+    let level = record.level();
     write!(
         w,
         "[{}] T[{:?}] {} [{}] {}",
@@ -98,7 +99,7 @@ pub fn log_format(
         thread::current().name().unwrap_or("<unnamed>"),
         record.level(),
         record.module_path().unwrap_or("<unnamed>"),
-        &record.args()
+        style(level, &record.args()),
     )
 }
 


### PR DESCRIPTION
When timestamps and thread names were added, the coloring
for warnings and errors was accidentally removed. This
adds it back in.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>