### PR TITLE
Add notification REST API design

### DIFF
--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -327,7 +327,163 @@ paths:
         500:
           description: Internal service error
 
+  /biome/notifications:
+    post:
+      description: Publish a list of notifications
+      tags:
+        - Biome
+      requestBody:
+        $ref: '#/components/requestBodies/CreateNotifications'
+      responses:
+        200:
+          description: Notifications have been published
+        400:
+          description: Malformed notifications list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /biome/users/{user_id}/notifications:
+    get:
+      description: Retrieve a list of notifications for a given user from the notifications database
+      tags:
+        - Biome
+      parameters:
+        - name: user_id
+          in: path
+          description: user to retrieve notifications for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Notifications have been retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NotificationProperties'
+        403:
+          description: User is forbidden to retrieve notifications for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: user {user} not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /biome/users/{user_id}/notifications/{notification_id}:
+    get:
+      description: Fetch a notification for a given user
+      tags:
+        - Biome
+      parameters:
+        - name: user_id
+          in: path
+          description: user to fetch a notification for
+          required: true
+          schema:
+            type: string
+        - name: notification_id
+          in: path
+          description: notification to fetch
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Notification has been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationProperties'
+        403:
+          description: User is forbidden to retrieve notifications for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Notification {notification} for {user} not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      description: Update a notification for a given user
+      tags:
+        - Biome
+      parameters:
+        - name: user_id
+          in: path
+          description: user to fetch a notification for
+          required: true
+          schema:
+            type: string
+        - name: notification_id
+          in: path
+          description: notification to fetch
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Notification has been updated
+        403:
+          description: User is forbidden to update notifications for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Notification {notification} for {user} not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
+  requestBodies:
+    CreateNotifications:
+      description: Create new notifications
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/NotificationProperties'
+              - $ref: '#/components/schemas/NotificationRecipients'
+              - $ref: '#/components/schemas/NotificationRequiredProperties'
+
   schemas:
     Error:
       additionalProperties: false
@@ -469,3 +625,45 @@ components:
         prev: /nodes?offset=0&limit=10
         next: /nodes?offset=20&limit=10
         last: /nodes?offset=40&limit=10
+
+    NotificationRequiredProperties:
+      type: object
+      required:
+        - recipients
+
+    NotificationRecipients:
+      type: object
+      properties:
+        recipients:
+          type: array
+          items:
+            type: string
+
+    NotificationProperties:
+      type: object
+      properties:
+        hash:
+          type: string
+          example: 1c9b512cef6d6a9064d0cf0eb4b9a957af98bfcec3eb4be2bfb047cf73051cfcca8fa1c142ee12c419d36c55c391b7df38751dae64a1238dfe1e319e9ff22113
+        payload:
+          type: object
+          properties:
+            title:
+              type: string
+            body:
+              type: string
+        created:
+          type: string
+          example: 1573230770
+        read:
+          type: boolean
+        origin:
+          type: string
+          example: grid-product-catalog
+        link:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+          example:
+            productName: soybeans


### PR DESCRIPTION
Adds the openapi specification for POSTing notifications, GETting all notifications for a user, GETting a specific notification for a user, and PATCHing a notification.

Signed-off-by: Davey Newhall <newhall@bitwise.io>