### PR TITLE
Add log for peer connection initiation

### DIFF
--- a/libsplinter/src/network/peer.rs
+++ b/libsplinter/src/network/peer.rs
@@ -98,6 +98,7 @@ impl PeerConnector {
             return Ok(());
         }
 
+        debug!("Connecting to {} at {}...", node_id, endpoint);
         let connection = transport
             .connect(&endpoint)
             .map_err(|err| PeerConnectorError::connection_failed(node_id, format!("{:?}", err)))?;


### PR DESCRIPTION
Add a debug log message for the initiation of peer connections.  This is
useful for tracking down issues where the connection is taking a long
time to connect, but the remote endpoint in question isn't displayed
until the connect process completes (successfully or otherwise).

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>