### PR TITLE
Add dockerfile for splinter-dev image

### DIFF
--- a/ci/splinter-dev
+++ b/ci/splinter-dev
@@ -1,0 +1,112 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:bionic
+
+# Install base dependencies
+RUN apt-get update \
+ && apt-get install -y -q \
+    build-essential \
+    curl \
+    gcc \
+    g++ \
+    libpq-dev \
+    libssl-dev \
+    libsasl2-dev \
+    libzmq3-dev \
+    openssl \
+    pkg-config \
+    python \
+    unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/root/.cargo/bin
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+# Install cargo deb
+RUN cargo install cargo-deb
+
+# Install protoc
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
+    && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
+    && rm protoc-3.7.1-linux-x86_64.zip
+
+# Copy dependencies
+COPY protos /build/protos
+
+# Create empty cargo projects for top-level projects
+WORKDIR /build
+RUN USER=root cargo new --bin cli
+RUN USER=root cargo new --bin client
+RUN USER=root cargo new --lib libsplinter
+RUN USER=root cargo new --bin splinterd
+
+# Create empty Cargo projects for gameroom
+RUN USER=root cargo new --bin examples/gameroom/daemon
+RUN USER=root cargo new --bin examples/gameroom/database
+
+# Create empty Cargo projects for private counter
+RUN USER=root cargo new --bin examples/private_counter/cli
+RUN USER=root cargo new --bin examples/private_counter/service
+
+# Create empty Cargo projects for private xo
+RUN USER=root cargo new --bin examples/private_xo
+
+
+# Copy over Cargo.toml files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
+
+# Do release builds for each Cargo.toml
+RUN find . -name 'Cargo.toml' -exec \
+    sh -c 'x="{}"; cargo build --release --manifest-path "$x" ' \;
+
+# Clean up built files
+RUN rm \
+    target/release/gameroom-database* \
+    target/release/gameroomd* \
+    target/release/libsplinter* \
+    target/release/pcounter* \
+    target/release/private-counter* \
+    target/release/private-xo* \
+    target/release/splinter-cli* \
+    target/release/splinterd* \
+    target/release/deps/gameroom_database* \
+    target/release/deps/gameroomd* \
+    target/release/deps/libsplinter* \
+    target/release/deps/pcounter* \
+    target/release/deps/private_counter* \
+    target/release/deps/private_xo* \
+    target/release/deps/splinter_cli* \
+    target/release/deps/splinterd*
+


### PR DESCRIPTION
The image built from this dockerfile will eventually replace ubuntu
in the FROM line in all splinter build images.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>