### PR TITLE
Add experimental circuit routes to the Splinter Daemon REST API

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -68,3 +68,11 @@ zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
+
+[package.metadata.docs.rs]
+features = [
+    "zmq-transport",
+    "ursa-compat",
+    "sawtooth-signing-compat",
+    "events",
+  ]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[features]
-zmq-transport = ["zmq"]
-ursa-compat = ["ursa"]
-sawtooth-signing-compat = ["sawtooth-sdk"]
-events = ["hyper", "tokio", "awc"]
-
 [package]
 name = "splinter"
 version = "0.3.6"
@@ -62,3 +56,15 @@ tempdir = "0.3"
 [build-dependencies]
 protoc-rust = "2"
 glob = "0.2"
+
+[features]
+default = []
+
+experimental = [
+    "zmq-transport"
+]
+
+zmq-transport = ["zmq"]
+ursa-compat = ["ursa"]
+sawtooth-signing-compat = ["sawtooth-sdk"]
+events = ["hyper", "tokio", "awc"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -47,10 +47,12 @@ default = []
 experimental = [
     "config-builder",
     "config-toml",
+    "circuit-read",
 ]
 
 config-builder = []
 config-toml = ["config-builder"]
+circuit-read = []
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -105,6 +105,83 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /circuits:
+    get:
+      tags:
+          - Circuits
+      description: Experimental - List of circuits in Splinter state
+      parameters:
+        - name: offset
+          in: query
+          description: paging offset
+          required: false
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          description: maximum number of items to return (max 100)
+          required: false
+          schema:
+            type: integer
+            default: 100
+        - name: filter
+          in: query
+          description: node id that must be present in the circuits returned
+          required: false
+          schema:
+            type: string
+          example: "node-001"
+      responses:
+        200:
+          description: list of circuits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Circuit'
+                  paging:
+                    $ref: '#/components/schemas/Paging'
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /circuits/{circuit_id}:
+    get:
+      tags:
+        - Circuits
+      description: Experimental - Fetch a circuit in Splinter State by its circuit id
+      parameters:
+        - name: circuit_id
+          in: path
+          description: cirucit id of circuit to fetch
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Circuit
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/Circuit"
+        404:
+          description: The circuit with {circuit_id} was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  
   /keys:
     get:
       tags:
@@ -440,6 +517,55 @@ components:
                       type: array
                       items:
                         type: integer
+    Circuit:
+      type: object
+      properties:
+        circuit_id:
+          type: string
+          example: alpha
+        authorization_type:
+          type: string
+          example: Trust
+        persistence:
+          type: string
+          example: Any
+        routes:
+          type: string
+          example: Any
+        circuit_management_type:
+          type: string
+          example: Gameroom
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/CircuitMember'
+        roster:
+          type: array
+          items:
+            $ref: '#/components/schemas/CircuitService'
+
+    CircuitMember:
+      type: object
+      properties:
+        node_id:
+          type: string
+          example: node-000
+        endpoint:
+          type: string
+          example: tls://127.0.0.1:8080
+
+    CircuitService:
+      type: object
+      properties:
+        service_id:
+          type: string
+          example: service-a
+        service_type:
+          type: string
+          example: scabbard
+        allowed_nodes:
+          type: array
+          item: string
 
     Paging:
       type: object

--- a/splinterd/src/routes/circuit.rs
+++ b/splinterd/src/routes/circuit.rs
@@ -1,0 +1,525 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{get_response_paging_info, Paging, DEFAULT_LIMIT, DEFAULT_OFFSET};
+use splinter::actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
+use splinter::circuit::{
+    AuthorizationType, DurabilityType, PersistenceType, Roster, RouteType, SplinterState,
+};
+use splinter::futures::{future::IntoFuture, Future};
+use splinter::rest_api::{Method, Resource, RestResourceProvider};
+
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug)]
+pub enum CircuitRouteError {
+    NotFound(String),
+    PoisonedLock,
+}
+
+impl StdError for CircuitRouteError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            CircuitRouteError::NotFound(_) => None,
+            CircuitRouteError::PoisonedLock => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CircuitRouteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CircuitRouteError::NotFound(msg) => write!(f, "Circuit not found: {}", msg),
+            CircuitRouteError::PoisonedLock => write!(f, "Splinter State lock was poisoned"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct CircuitResponse {
+    id: String,
+    auth: AuthorizationType,
+    members: Vec<String>,
+    roster: Roster,
+    persistence: PersistenceType,
+    durability: DurabilityType,
+    routes: RouteType,
+    circuit_management_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ListCircuitsResponse {
+    data: Vec<CircuitResponse>,
+    paging: Paging,
+}
+
+#[derive(Clone)]
+pub struct CircuitResourceProvider {
+    node_id: String,
+    state: Arc<RwLock<SplinterState>>,
+}
+
+impl CircuitResourceProvider {
+    pub fn new(node_id: String, state: Arc<RwLock<SplinterState>>) -> Self {
+        Self { node_id, state }
+    }
+}
+
+impl RestResourceProvider for CircuitResourceProvider {
+    fn resources(&self) -> Vec<Resource> {
+        vec![
+            make_fetch_circuit_resource(self.state.clone()),
+            make_list_circuits_resource(self.state.clone()),
+        ]
+    }
+}
+
+fn make_fetch_circuit_resource(state: Arc<RwLock<SplinterState>>) -> Resource {
+    Resource::new(Method::Get, "/circuits/{circuit_id}", move |r, _| {
+        fetch_circuit(r, web::Data::new(state.clone()))
+    })
+}
+
+fn make_list_circuits_resource(state: Arc<RwLock<SplinterState>>) -> Resource {
+    Resource::new(Method::Get, "/circuits", move |r, _| {
+        list_circuits(r, web::Data::new(state.clone()))
+    })
+}
+
+pub fn fetch_circuit(
+    request: HttpRequest,
+    state: web::Data<Arc<RwLock<SplinterState>>>,
+) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+    let circuit_id = request
+        .match_info()
+        .get("circuit_id")
+        .unwrap_or("")
+        .to_string();
+    Box::new(
+        web::block(move || {
+            let circuit = {
+                let state = state.read().map_err(|_| CircuitRouteError::PoisonedLock)?;
+                state.circuit(&circuit_id).cloned()
+            };
+            if let Some(circuit) = circuit {
+                let circuit_response = CircuitResponse {
+                    id: circuit_id,
+                    auth: circuit.auth().clone(),
+                    members: circuit.members().to_vec(),
+                    roster: circuit.roster().clone(),
+                    persistence: circuit.persistence().clone(),
+                    durability: circuit.durability().clone(),
+                    routes: circuit.routes().clone(),
+                    circuit_management_type: circuit.circuit_management_type().to_string(),
+                };
+                Ok(circuit_response)
+            } else {
+                Err(CircuitRouteError::NotFound(format!(
+                    "Unable to find circuit: {}",
+                    circuit_id
+                )))
+            }
+        })
+        .then(|res| match res {
+            Ok(circuit) => Ok(HttpResponse::Ok().json(circuit)),
+            Err(err) => match err {
+                BlockingError::Error(err) => match err {
+                    CircuitRouteError::PoisonedLock => {
+                        error!("{}", err);
+                        Ok(HttpResponse::InternalServerError().into())
+                    }
+                    CircuitRouteError::NotFound(err) => Ok(HttpResponse::NotFound().json(err)),
+                },
+                _ => Ok(HttpResponse::InternalServerError().into()),
+            },
+        }),
+    )
+}
+
+pub fn list_circuits(
+    req: HttpRequest,
+    state: web::Data<Arc<RwLock<SplinterState>>>,
+) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+    let query: web::Query<HashMap<String, String>> =
+        if let Ok(q) = web::Query::from_query(req.query_string()) {
+            q
+        } else {
+            return Box::new(
+                HttpResponse::BadRequest()
+                    .json(json!({
+                        "message": "Invalid query"
+                    }))
+                    .into_future(),
+            );
+        };
+
+    let offset = match query.get("offset") {
+        Some(value) => match value.parse::<usize>() {
+            Ok(val) => val,
+            Err(err) => {
+                return Box::new(
+                    HttpResponse::BadRequest()
+                        .json(format!(
+                            "Invalid offset value passed: {}. Error: {}",
+                            value, err
+                        ))
+                        .into_future(),
+                )
+            }
+        },
+        None => DEFAULT_OFFSET,
+    };
+
+    let limit = match query.get("limit") {
+        Some(value) => match value.parse::<usize>() {
+            Ok(val) => val,
+            Err(err) => {
+                return Box::new(
+                    HttpResponse::BadRequest()
+                        .json(format!(
+                            "Invalid limit value passed: {}. Error: {}",
+                            value, err
+                        ))
+                        .into_future(),
+                )
+            }
+        },
+        None => DEFAULT_LIMIT,
+    };
+
+    let mut link = format!("{}?", req.uri().path());
+
+    let filters = match query.get("filter") {
+        Some(value) => {
+            link.push_str(&format!("filter={}&", value));
+            Some(value.to_string())
+        }
+        None => None,
+    };
+
+    Box::new(query_list_circuits(
+        state,
+        link,
+        filters,
+        Some(offset),
+        Some(limit),
+    ))
+}
+
+fn query_list_circuits(
+    state: web::Data<Arc<RwLock<SplinterState>>>,
+    link: String,
+    filters: Option<String>,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    web::block(move || {
+        let circuits = state
+            .read()
+            .map_err(|_| CircuitRouteError::PoisonedLock)?
+            .circuits()
+            .clone();
+        let offset_value = offset.unwrap_or(0);
+        let limit_value = limit.unwrap_or_else(|| circuits.len());
+        if !circuits.is_empty() {
+            if let Some(filter) = filters {
+                let circuits_data: Vec<CircuitResponse> = circuits
+                    .into_iter()
+                    .filter(|(_, circuit)| circuit.members().contains(&filter))
+                    .skip(offset_value)
+                    .take(limit_value)
+                    .map(|(circuit_id, circuit)| CircuitResponse {
+                        id: circuit_id,
+                        auth: circuit.auth().clone(),
+                        members: circuit.members().to_vec(),
+                        roster: circuit.roster().clone(),
+                        persistence: circuit.persistence().clone(),
+                        durability: circuit.durability().clone(),
+                        routes: circuit.routes().clone(),
+                        circuit_management_type: circuit.circuit_management_type().to_string(),
+                    })
+                    .collect();
+                let total_count = circuits_data.len();
+                Ok((circuits_data, link, limit, offset, total_count))
+            } else {
+                let circuits_data: Vec<CircuitResponse> = circuits
+                    .into_iter()
+                    .skip(offset_value)
+                    .take(limit_value)
+                    .map(|(circuit_id, circuit)| CircuitResponse {
+                        id: circuit_id,
+                        auth: circuit.auth().clone(),
+                        members: circuit.members().to_vec(),
+                        roster: circuit.roster().clone(),
+                        persistence: circuit.persistence().clone(),
+                        durability: circuit.durability().clone(),
+                        routes: circuit.routes().clone(),
+                        circuit_management_type: circuit.circuit_management_type().to_string(),
+                    })
+                    .collect();
+                let total_count = circuits_data.len();
+                Ok((circuits_data, link, limit, offset, total_count))
+            }
+        } else {
+            Ok((vec![], link, limit, offset, circuits.len()))
+        }
+    })
+    .then(|res| match res {
+        Ok((circuits, link, limit, offset, total_count)) => {
+            Ok(HttpResponse::Ok().json(ListCircuitsResponse {
+                data: circuits,
+                paging: get_response_paging_info(limit, offset, &link, total_count),
+            }))
+        }
+        Err(err) => match err {
+            BlockingError::Error(err) => match err {
+                CircuitRouteError::PoisonedLock => {
+                    error!("{}", err);
+                    Ok(HttpResponse::InternalServerError().into())
+                }
+                CircuitRouteError::NotFound(err) => Ok(HttpResponse::NotFound().json(err)),
+            },
+            _ => Ok(HttpResponse::InternalServerError().into()),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic;
+
+    use splinter::actix_web::{
+        http::{header, StatusCode},
+        test, web, App,
+    };
+    use splinter::circuit::{directory::CircuitDirectory, Circuit, ServiceDefinition};
+    use splinter::storage::get_storage;
+
+    #[test]
+    /// Tests a GET /circuit/{identity} request returns the expected circuit.
+    fn test_fetch_circuit_ok() {
+        let splinter_state = filled_splinter_state();
+
+        let mut app = test::init_service(App::new().data(splinter_state.clone()).service(
+            web::resource("/circuits/{circuit_id}").route(web::get().to_async(fetch_circuit)),
+        ));
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/circuits/{}", get_circuit_1().id))
+            .to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let circuit: CircuitResponse = serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+        assert_eq!(circuit, get_circuit_1())
+    }
+
+    #[test]
+    /// Tests a GET /circuits/{identity} request returns NotFound when an invalid identity is
+    /// passed
+    fn test_fetch_circuit_not_found() {
+        let splinter_state = filled_splinter_state();
+        let mut app = test::init_service(App::new().data(splinter_state.clone()).service(
+            web::resource("/circuits/{circuit_id}").route(web::get().to_async(fetch_circuit)),
+        ));
+
+        let req = test::TestRequest::get()
+            .uri("/circuit/Circuit-not-valid")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    /// Tests a GET /circuits request with no filters returns the expected circuits.
+    fn test_list_circuits_ok() {
+        let splinter_state = filled_splinter_state();
+
+        let mut app = test::init_service(
+            App::new()
+                .data(splinter_state.clone())
+                .service(web::resource("/circuits").route(web::get().to_async(list_circuits))),
+        );
+
+        let req = test::TestRequest::get().uri("/circuits").to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let circuits: ListCircuitsResponse =
+            serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+        assert_eq!(circuits.data, vec![get_circuit_1(), get_circuit_2()]);
+        assert_eq!(
+            circuits.paging,
+            create_test_paging_response(0, 100, 0, 0, 0, 2, "/circuits?")
+        )
+    }
+
+    #[test]
+    /// Tests a GET /circuits request with filter returns the expected circuit.
+    fn test_list_circuit_with_filters_ok() {
+        let splinter_state = filled_splinter_state();
+
+        let mut app = test::init_service(
+            App::new()
+                .data(splinter_state.clone())
+                .service(web::resource("/circuits").route(web::get().to_async(list_circuits))),
+        );
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/circuits?filter={}", "node_1"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let circuits: ListCircuitsResponse =
+            serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+        assert_eq!(circuits.data, vec![get_circuit_1()]);
+        let link = format!("/circuits?filter={}&", "node_1");
+        assert_eq!(
+            circuits.paging,
+            create_test_paging_response(0, 100, 0, 0, 0, 1, &link)
+        )
+    }
+
+    fn create_test_paging_response(
+        offset: usize,
+        limit: usize,
+        next_offset: usize,
+        previous_offset: usize,
+        last_offset: usize,
+        total: usize,
+        link: &str,
+    ) -> Paging {
+        let base_link = format!("{}limit={}&", link, limit);
+        let current_link = format!("{}offset={}", base_link, offset);
+        let first_link = format!("{}offset=0", base_link);
+        let next_link = format!("{}offset={}", base_link, next_offset);
+        let previous_link = format!("{}offset={}", base_link, previous_offset);
+        let last_link = format!("{}offset={}", base_link, last_offset);
+
+        Paging {
+            current: current_link,
+            offset,
+            limit,
+            total,
+            first: first_link,
+            prev: previous_link,
+            next: next_link,
+            last: last_link,
+        }
+    }
+
+    fn get_circuit_1() -> CircuitResponse {
+        let service_definition =
+            ServiceDefinition::builder("service_1".to_string(), "type_a".to_string())
+                .with_allowed_nodes(vec!["node_1".to_string()])
+                .build();
+        CircuitResponse {
+            id: "circuit_1".to_string(),
+            auth: AuthorizationType::Trust,
+            members: vec!["node_1".to_string(), "node_2".to_string()],
+            roster: Roster::Standard(vec![service_definition]),
+            persistence: PersistenceType::Any,
+            durability: DurabilityType::NoDurability,
+            routes: RouteType::Any,
+            circuit_management_type: "circuit_1_type".to_string(),
+        }
+    }
+
+    fn get_circuit_2() -> CircuitResponse {
+        let service_definition =
+            ServiceDefinition::builder("service_2".to_string(), "other_type".to_string())
+                .with_allowed_nodes(vec!["node_3".to_string()])
+                .build();
+        CircuitResponse {
+            id: "circuit_2".to_string(),
+            auth: AuthorizationType::Trust,
+            members: vec!["node_3".to_string(), "node_4".to_string()],
+            roster: Roster::Standard(vec![service_definition]),
+            persistence: PersistenceType::Any,
+            durability: DurabilityType::NoDurability,
+            routes: RouteType::Any,
+            circuit_management_type: "circuit_2_type".to_string(),
+        }
+    }
+
+    fn setup_splinter_state() -> Arc<RwLock<SplinterState>> {
+        let mut storage = get_storage("memory", CircuitDirectory::new).unwrap();
+        let circuit_directory = storage.write().clone();
+        let state = Arc::new(RwLock::new(SplinterState::new(
+            "memory".to_string(),
+            circuit_directory,
+        )));
+        state
+    }
+
+    fn filled_splinter_state() -> Arc<RwLock<SplinterState>> {
+        let service_definition_1 =
+            ServiceDefinition::builder("service_1".to_string(), "type_a".to_string())
+                .with_allowed_nodes(vec!["node_1".to_string()])
+                .build();
+
+        let service_definition_2 =
+            ServiceDefinition::builder("service_2".to_string(), "other_type".to_string())
+                .with_allowed_nodes(vec!["node_3".to_string()])
+                .build();
+
+        let circuit_1 = Circuit::builder()
+            .with_id("circuit_1".into())
+            .with_auth(AuthorizationType::Trust)
+            .with_members(vec!["node_1".to_string(), "node_2".to_string()])
+            .with_roster(vec![service_definition_1])
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurability)
+            .with_routes(RouteType::Any)
+            .with_circuit_management_type("circuit_1_type".into())
+            .build()
+            .expect("Should have built a correct circuit");
+
+        let circuit_2 = Circuit::builder()
+            .with_id("circuit_2".into())
+            .with_auth(AuthorizationType::Trust)
+            .with_members(vec!["node_3".to_string(), "node_4".to_string()])
+            .with_roster(vec![service_definition_2])
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurability)
+            .with_routes(RouteType::Any)
+            .with_circuit_management_type("circuit_2_type".into())
+            .build()
+            .expect("Should have built a correct circuit");
+
+        let splinter_state = setup_splinter_state();
+        splinter_state
+            .write()
+            .expect("SplinterState lock was poisoned")
+            .add_circuit("circuit_1".into(), circuit_1)
+            .expect("Unable to add circuit_1");
+        splinter_state
+            .write()
+            .expect("SplinterState lock was poisoned")
+            .add_circuit("circuit_2".into(), circuit_2)
+            .expect("Unable to add circuit_2");
+
+        splinter_state
+    }
+}

--- a/splinterd/src/routes/mod.rs
+++ b/splinterd/src/routes/mod.rs
@@ -13,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "circuit-read")]
+mod circuit;
 mod keys;
 mod node;
 mod status;
 
+#[cfg(feature = "circuit-read")]
+pub use circuit::CircuitResourceProvider;
 pub use keys::KeyRegistryManager;
 pub use node::*;
 use percent_encoding::{AsciiSet, CONTROLS};

--- a/tests/test-splinter.yaml
+++ b/tests/test-splinter.yaml
@@ -27,8 +27,10 @@ services:
     command: |
         bash -c "
             cargo test && \
+            echo \"Running experimental feature tests...\" && \
+            (cd libsplinter && cargo test --features experimental) &&
+            (cd splinterd && cargo test --features experimental) &&
             echo \"Running optional feature tests...\" && \
-            (cd libsplinter && cargo test --features zmq-transport) &&
             cargo test signing::sawtooth --manifest-path libsplinter/Cargo.toml \
                 --features \"sawtooth-signing-compat\"
         "


### PR DESCRIPTION
This also move zmq transport to experimental and adds test to test splinter daemon and lib splinter with the experimental feature. 

