### PR TITLE
Add Splinter db

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,3 +50,16 @@ services:
       build:
         context: .
         dockerfile: splinterd/api/openapi.dockerfile
+
+  splinter-db:
+    image: postgres
+    container_name: splinter-db
+    restart: always
+    expose:
+      - 5432
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: splinter_admin
+      POSTGRES_PASSWORD: splinter_test
+      POSTGRES_DB: splinter

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -64,6 +64,8 @@ default = []
 
 experimental = [
     "zmq-transport",
+    "biome",
+    "biome-notifications",
     "database"
 ]
 
@@ -71,6 +73,8 @@ zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
+biome = []
+biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]
 
 [package.metadata.docs.rs]
@@ -79,5 +83,7 @@ features = [
     "ursa-compat",
     "sawtooth-signing-compat",
     "events",
+    "biome",
+    "biome-notifications",
     "database"
   ]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -49,6 +49,8 @@ ursa = { version = "0.1", optional = true }
 hyper = { version = "0.12", optional = true }
 tokio = { version = "0.1.22", optional = true }
 awc = { version = "0.2", optional = true }
+diesel = { version = "1.0", features = ["postgres", "r2d2", "serde_json"], optional = true }
+diesel_migrations = { version = "1.4", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -61,13 +63,15 @@ glob = "0.2"
 default = []
 
 experimental = [
-    "zmq-transport"
+    "zmq-transport",
+    "database"
 ]
 
 zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
+database = ["diesel", "diesel_migrations"]
 
 [package.metadata.docs.rs]
 features = [
@@ -75,4 +79,5 @@ features = [
     "ursa-compat",
     "sawtooth-signing-compat",
     "events",
+    "database"
   ]

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(feature = "biome-notifications")]
+pub mod notifications;

--- a/libsplinter/src/biome/notifications/database/migrations/2019-11-11-231339_create_notifications/down.sql
+++ b/libsplinter/src/biome/notifications/database/migrations/2019-11-11-231339_create_notifications/down.sql
@@ -1,0 +1,16 @@
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE notification_properties;
+DROP TABLE user_notifications;
+DROP TABLE notifications;

--- a/libsplinter/src/biome/notifications/database/migrations/2019-11-11-231339_create_notifications/up.sql
+++ b/libsplinter/src/biome/notifications/database/migrations/2019-11-11-231339_create_notifications/up.sql
@@ -1,0 +1,37 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id                        TEXT        PRIMARY KEY,
+  payload_title             TEXT        NOT NULL,
+  payload_body              TEXT        NOT NULL,
+  created                   TIMESTAMP   NOT NULL,
+  recipients                TEXT[]      NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS notification_properties (
+  id                        BIGSERIAL   PRIMARY KEY,
+  notification_id           TEXT        NOT NULL,
+  property                  TEXT        NOT NULL,
+  property_value            TEXT        NOT NULL,
+  FOREIGN KEY (notification_id) REFERENCES notifications(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS user_notifications (
+  notification_id           TEXT        PRIMARY KEY,
+  user_id                   TEXT        NOT NULL,
+  unread                    BOOL        NOT NULL,
+  FOREIGN KEY (notification_id) REFERENCES notifications(id) ON DELETE CASCADE
+);

--- a/libsplinter/src/biome/notifications/database/mod.rs
+++ b/libsplinter/src/biome/notifications/database/mod.rs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+pub(crate) mod models;
+pub(crate) mod schema;
+
+embed_migrations!("./src/biome/notifications/database/migrations");
+
+use diesel::pg::PgConnection;
+
+pub use crate::database::error::DatabaseError;
+
+pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
+    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+
+    info!("Successfully applied migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/biome/notifications/database/models.rs
+++ b/libsplinter/src/biome/notifications/database/models.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::time::SystemTime;
+
+use super::schema::{notification_properties, notifications, user_notifications};
+
+#[derive(Insertable, Queryable)]
+#[table_name = "notifications"]
+pub struct Notification {
+    pub id: String,
+    pub payload_title: String,
+    pub payload_body: String,
+    pub created: SystemTime,
+    pub recipients: Vec<String>,
+}
+
+#[derive(Insertable, Queryable)]
+#[table_name = "user_notifications"]
+pub struct UserNotification {
+    pub notification_id: String,
+    pub user_id: String,
+    pub unread: bool,
+}
+
+#[derive(Insertable, Queryable)]
+#[table_name = "notification_properties"]
+pub struct NotificationProperty {
+    pub id: i64,
+    pub notification_id: String,
+    pub property: String,
+    pub property_value: String,
+}

--- a/libsplinter/src/biome/notifications/database/schema.rs
+++ b/libsplinter/src/biome/notifications/database/schema.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+table! {
+    notifications (id) {
+        id -> Text,
+        payload_title -> Text,
+        payload_body -> Text,
+        created -> Timestamp,
+        recipients -> Array<Text>,
+    }
+}
+
+table! {
+    user_notifications (notification_id) {
+        notification_id -> Text,
+        user_id -> Text,
+        unread -> Bool,
+    }
+}
+
+table! {
+    notification_properties (id) {
+        id -> Int8,
+        notification_id -> Text,
+        property -> Text,
+        property_value -> Text,
+    }
+}
+
+joinable!(user_notifications -> notifications (notification_id));
+joinable!(notification_properties -> notifications (notification_id));
+
+allow_tables_to_appear_in_same_query!(notifications, user_notifications, notification_properties);

--- a/libsplinter/src/biome/notifications/mod.rs
+++ b/libsplinter/src/biome/notifications/mod.rs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+pub mod database;

--- a/libsplinter/src/database/error.rs
+++ b/libsplinter/src/database/error.rs
@@ -1,0 +1,46 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum DatabaseError {
+    ConnectionError(Box<dyn Error>),
+    QueryError(Box<dyn Error>),
+}
+
+impl Error for DatabaseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            DatabaseError::ConnectionError(e) => Some(&**e),
+            DatabaseError::QueryError(e) => Some(&**e),
+        }
+    }
+}
+
+impl fmt::Display for DatabaseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DatabaseError::ConnectionError(e) => write!(f, "Unable to connect to database: {}", e),
+            DatabaseError::QueryError(e) => write!(f, "Database query failed: {}", e),
+        }
+    }
+}
+
+impl From<diesel::result::Error> for DatabaseError {
+    fn from(err: diesel::result::Error) -> Self {
+        DatabaseError::QueryError(Box::new(err))
+    }
+}

--- a/libsplinter/src/database/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/libsplinter/src/database/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/libsplinter/src/database/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/libsplinter/src/database/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/libsplinter/src/database/mod.rs
+++ b/libsplinter/src/database/mod.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+pub mod error;
+
+embed_migrations!("./src/database/migrations");
+
+use std::ops::Deref;
+
+use diesel::{
+    pg::PgConnection,
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+};
+
+pub use super::database::error::DatabaseError;
+
+pub fn create_connection_pool(database_url: &str) -> Result<ConnectionPool, DatabaseError> {
+    let connection_manager = ConnectionManager::<PgConnection>::new(database_url);
+    Ok(ConnectionPool {
+        pool: Pool::builder()
+            .build(connection_manager)
+            .map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?,
+    })
+}
+
+pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
+    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+
+    info!("Successfully applied migrations");
+
+    Ok(())
+}
+
+pub struct Connection(PooledConnection<ConnectionManager<PgConnection>>);
+
+impl Deref for Connection {
+    type Target = PgConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectionPool {
+    pool: Pool<ConnectionManager<PgConnection>>,
+}
+
+impl ConnectionPool {
+    pub fn get(&self) -> Result<Connection, DatabaseError> {
+        self.pool
+            .get()
+            .map(Connection)
+            .map_err(|err| DatabaseError::ConnectionError(Box::new(err)))
+    }
+}

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -56,6 +56,8 @@ macro_rules! mutex_lock_unwrap {
 }
 
 pub mod admin;
+#[cfg(feature = "biome")]
+pub mod biome;
 pub mod channel;
 pub mod circuit;
 pub mod collections;

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -18,6 +18,12 @@ extern crate log;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
+#[macro_use]
+#[cfg(feature = "database")]
+extern crate diesel;
+#[macro_use]
+#[cfg(feature = "database")]
+extern crate diesel_migrations;
 
 #[macro_export]
 macro_rules! rwlock_read_unwrap {
@@ -54,6 +60,8 @@ pub mod channel;
 pub mod circuit;
 pub mod collections;
 pub mod consensus;
+#[cfg(feature = "database")]
+pub mod database;
 #[cfg(feature = "events")]
 pub mod events;
 mod hex;


### PR DESCRIPTION
Adds a postgres image for testing Splinter module endpoints. This also adds migrations for the notifications table and implements a connection pool.