### PR TITLE
Decouple EventDealer and EventHistory

### DIFF
--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -64,7 +64,7 @@ use std::boxed::Box;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use errors::{EventHistoryError, ResponseError, RestApiServerError};
+pub use errors::{EventDealerError, EventHistoryError, ResponseError, RestApiServerError};
 
 pub use events::{EventDealer, EventHistory, LocalEventHistory};
 


### PR DESCRIPTION
Decouple the event history from the event dealer.  This will allow the
storage of events to be managed seperately from the event history, where
items can be stored in a persistence-friendly format.  Likewise, the
stored values do not have to match the serialization format for the
events themselves, but can use whatever format new underlying storage
requires.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>