### PR TITLE
Remove known errors during .deb package install

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -33,5 +33,5 @@ FROM ubuntu:bionic
 COPY --from=builder /build/target/debian/splinter-cli_*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/splinter-cli_*.deb || true \
+ && dpkg --unpack /tmp/splinter-cli_*.deb \
  && apt-get -f -y install

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -39,7 +39,7 @@ RUN apt-get update \
 COPY --from=BUILDER /build/target/debian/gameroom*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/gameroom*.deb || true \
+ && dpkg --unpack /tmp/gameroom*.deb \
  && apt-get -f -y install
 
 # Fetch the XO smart contract

--- a/examples/private_counter/cli/Dockerfile-installed-bionic
+++ b/examples/private_counter/cli/Dockerfile-installed-bionic
@@ -29,7 +29,7 @@ FROM ubuntu:bionic
 COPY --from=BUILDER /build/target/debian/private-counter-cli*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/private-counter-cli*.deb || true \
+ && dpkg --unpack /tmp/private-counter-cli*.deb \
  && apt-get -f -y install
 
 EXPOSE 8000

--- a/examples/private_counter/service/Dockerfile-installed-bionic
+++ b/examples/private_counter/service/Dockerfile-installed-bionic
@@ -32,7 +32,7 @@ FROM ubuntu:bionic
 COPY --from=BUILDER /build/target/debian/private-counter-service*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/private-counter-service*.deb || true \
+ && dpkg --unpack /tmp/private-counter-service*.deb \
  && apt-get -f -y install
 
 EXPOSE 8000

--- a/examples/private_xo/Dockerfile-installed-bionic
+++ b/examples/private_xo/Dockerfile-installed-bionic
@@ -30,7 +30,7 @@ FROM ubuntu:bionic
 COPY --from=BUILDER /build/target/debian/private-xo-service*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/private-xo-service*.deb || true \
+ && dpkg --unpack /tmp/private-xo-service*.deb \
  && apt-get -f -y install
 
 EXPOSE 8000

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -33,5 +33,5 @@ FROM ubuntu:bionic
 COPY --from=builder /build/target/debian/splinter-daemon*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/splinter-daemon*.deb || true \
+ && dpkg --unpack /tmp/splinter-daemon*.deb \
  && apt-get -f -y install


### PR DESCRIPTION
Switching from "-i" to "--unpack" gets rid of the caught missing
dependency errors while installing built .deb packages.

Displaying these errors, though caught, could be confusing to new
users of the project.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>