### PR TITLE
Add features for 'admin-service' and 'scabbard-service'

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -13,6 +13,20 @@
 # limitations under the License.
 
 [features]
+default = []
+
+stable = [
+    "admin-service",
+    "sawtooth-signing-compat",
+    "scabbard-service",
+]
+
+experimental = [
+    "events",
+    "ursa-compat",
+    "zmq-transport",
+]
+
 admin-service = []
 scabbard-service = []
 zmq-transport = ["zmq"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 [features]
+admin-service = []
 zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -14,6 +14,7 @@
 
 [features]
 admin-service = []
+scabbard-service = []
 zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]

--- a/libsplinter/src/hex.rs
+++ b/libsplinter/src/hex.rs
@@ -15,7 +15,9 @@
 use std::error::Error;
 use std::fmt::{self, Write};
 
+#[cfg(feature = "admin-service")]
 use serde::de;
+#[cfg(feature = "admin-service")]
 use serde::{Deserializer, Serializer};
 
 pub fn to_hex(bytes: &[u8]) -> String {
@@ -48,6 +50,7 @@ pub fn parse_hex(hex: &str) -> Result<Vec<u8>, HexError> {
     Ok(res)
 }
 
+#[cfg(feature = "admin-service")]
 pub fn as_hex<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -55,6 +58,7 @@ where
     serializer.serialize_str(&to_hex(data))
 }
 
+#[cfg(feature = "admin-service")]
 pub fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! mutex_lock_unwrap {
     };
 }
 
+#[cfg(feature = "admin-service")]
 pub mod admin;
 pub mod channel;
 pub mod circuit;

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -39,6 +39,7 @@ pub mod error;
 mod factory;
 mod processor;
 mod registry;
+#[cfg(feature = "scabbard-service")]
 pub mod scabbard;
 mod sender;
 

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -24,7 +24,7 @@ name = "splinterd"
 path = "src/main.rs"
 
 [dependencies]
-splinter = { path = "../libsplinter", features = ["admin-service", "sawtooth-signing-compat"] }
+splinter = { path = "../libsplinter", features = ["admin-service", "sawtooth-signing-compat", "scabbard-service"] }
 clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -24,7 +24,7 @@ name = "splinterd"
 path = "src/main.rs"
 
 [dependencies]
-splinter = { path = "../libsplinter", features = ["sawtooth-signing-compat"] }
+splinter = { path = "../libsplinter", features = ["admin-service", "sawtooth-signing-compat"] }
 clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"

--- a/tests/test-splinter.yaml
+++ b/tests/test-splinter.yaml
@@ -26,10 +26,18 @@ services:
       - ../:/project/splinter
     command: |
         bash -c "
+            echo \"Running workspace tests...\" && \
             cargo test && \
-            echo \"Running optional feature tests...\" && \
-            (cd libsplinter && cargo test --features zmq-transport) &&
-            cargo test signing::sawtooth --manifest-path libsplinter/Cargo.toml \
-                --features \"sawtooth-signing-compat\"
+            echo \"Running features=default tests...\" && \
+            cargo test \
+                --manifest-path libsplinter/Cargo.toml && \
+            echo \"Running features=stable tests...\" && \
+            cargo test \
+                --manifest-path libsplinter/Cargo.toml \
+                --features stable && \
+            echo \"Running features=experimental feature tests...\" && \
+            cargo test \
+                --manifest-path libsplinter/Cargo.toml \
+                --features experimental
         "
     stop_signal: SIGKILL


### PR DESCRIPTION
This also adds 'stable' and 'experimental' in order to run the builds.

admin-service and scabbard-service are off be default as they may move outside libsplinter at some point (as services/ libraries like the health service).