### PR TITLE
Inital Peering Manager

### DIFF
--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -146,6 +146,14 @@ pub trait Service: Send {
         message_context: &ServiceMessageContext,
     ) -> Result<(), ServiceError>;
 
+    // Handle responses from peering manager
+    fn handle_peering_manager_response(
+        &self,
+        _: PeeringManagerResponse,
+    ) -> Result<(), ServiceError> {
+        Ok(())
+    }
+
     /// Cast the service as `&dyn Any`.
     ///
     /// This allows for downcasting the `Service` to a specific implementation.

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -49,6 +49,7 @@ pub use processor::JoinHandles;
 pub use processor::ServiceProcessor;
 pub use processor::ShutdownHandle;
 pub use registry::StandardServiceNetworkRegistry;
+use sender::PeeringManagerResponse;
 
 pub use error::{
     FactoryCreateError, ServiceConnectionError, ServiceDestroyError, ServiceDisconnectionError,

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -140,6 +140,11 @@ impl ServiceProcessor {
         }
     }
 
+    pub fn register_peering_manager(&self, pm: &mut PeeringManager) {
+        let services = rwlock_read_unwrap!(self.shared_state).services.clone();
+        pm.add_services(&services);
+    }
+
     /// Once the service processor is started it will handle incoming messages from the splinter
     /// node and route it to a running service.
     ///

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -528,6 +528,11 @@ fn run_service_loop(
                     .handle_message(direct_message.get_payload(), &msg_context)
                     .map_err(to_process_err!("unable to handle circuit direct message"))?;
             }
+            ServiceMessage::PeeringManagerResponse(response) => {
+                service
+                    .handle_peering_manager_response(response)
+                    .map_err(to_process_err!("unable to handle peering manager message"))?;
+            }
         }
     }
     Ok(())

--- a/libsplinter/src/service/sender.rs
+++ b/libsplinter/src/service/sender.rs
@@ -26,13 +26,36 @@ use crate::service::{ServiceMessageContext, ServiceNetworkSender};
 #[derive(Debug, Clone)]
 pub enum ServiceMessage {
     AdminDirectMessage(AdminDirectMessage),
+    PeeringManagerResponse(PeeringManagerResponse),
     CircuitDirectMessage(CircuitDirectMessage),
+}
+
+#[derive(Debug)]
+pub enum PeeringManagerRequest {
+    Shutdown,
+    Connect {
+        requester_service_id: String,
+        endpoint: String,
+        peer_id: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum PeeringManagerResponse {
+    Connected { peer_id: String },
+    Error { message: String },
 }
 
 #[derive(Debug, Clone)]
 pub enum ProcessorMessage {
     ServiceMessage(ServiceMessage),
     Shutdown,
+}
+
+impl From<PeeringManagerResponse> for ProcessorMessage {
+    fn from(message: PeeringManagerResponse) -> Self {
+        ProcessorMessage::ServiceMessage(ServiceMessage::PeeringManagerResponse(message))
+    }
 }
 
 /// An implementation of a ServiceNetworkSender that should be used for AdminDirectMessage.


### PR DESCRIPTION
Initial draft of the peering manager. I’m submitting this as draft pr because I’m not sure if this is the right pattern, and It’s more for trying to spark a meaningful discussion.

This iteration is based on a discussion I had with @vaporos and @agunde406 a few weeks ago, where the peering manager runs in its own thread and is dispatched messages from services (currently just the admin service). The flow of the peering manager is as follows.

1) SplinterD creates a peering connector
2) SplinterD creates a peering manger by giving it a peer connector
3) SplinterD starts the peering manager 
3) SplinterD creates an admin service
4) SplinterD creates service processor giving a sender for the peering manager (`PmSender`).
5) SplinterD adds the admin service to the service processor
6) SplinterD registers the peering manager with the service processor. This is meant to give the peering manager a copy of the service senders the processor has `Sender<ProcessorMessage>`.
7) SplinterD starts the service processor
8) Admin service uses `PmSender` to create peer connections.
9) The status of this request is dispatched back to the admin service via `handle_peering_message` callback

I think this is the right way to go if the peering manager is it’s own thread and services send it requests via channels. Which is a thing we really like to do...

As I mentioned above, I’m not super confident this is the right pattern. It feels awkward, in the sense that services have this callback for peering manager messages that only certain services need. I wonder if there’s a better way to facilitate service to node communication. To be clear, I’m not talking about a service talking to another service on a different node, I’m talking about passing messages from a service to another part its node (i.e. the peering manager). The consensus seems to be to use network messages and dispatchers like we do for service to service communication, but that seems a bit too heavy weight for the something like the peering manager because, from the service’s perspective, it’s not talking to a different node, it’s talking to another part of its node. This is why I opted for using channels directly to the peering manager instead of setting up a dispatcher. 

An alternative way of implementing the peering manager I was thinking of would be to have it be an object that the admin service owns, as opposed to the admin service having it's own thread.
 