### PR TITLE
Add Canopy lint/unit tests to travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,5 +46,14 @@
 /examples/gameroom/gameroom-app/dist
 /examples/gameroom/gameroom-app/package-lock.json
 
+# Canopy
+**/node_modules
+**/.pnp
+**/.pnp.js
+**/yarn.lock
+/canopy/**/coverage
+/canopy/**/build
+/canopy**/dist
+
 /target
 /Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,15 @@ jobs:
       script:
         - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit clippy-splinter
 
+    - stage: Lint/Unit Test Canopy
+      script:
+        - docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-canopy-app
+        - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit lint-canopy-app
+        - docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-canopyjs
+        - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit lint-canopyjs
+        - docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-design-system
+        - docker-compose -f docker/compose/run-lint.yaml up --abort-on-container-exit lint-design-system
+
     - stage: Run Splinter/Gameroom Unit Tests
       before_script:
         - set -e

--- a/canopy/app/.eslintrc
+++ b/canopy/app/.eslintrc
@@ -4,6 +4,9 @@
     "jest": true,
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "rules": {
     "react/jsx-filename-extension": 0,

--- a/canopy/app/Dockerfile
+++ b/canopy/app/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:lts-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN yarn install
+
+COPY . .

--- a/canopy/app/package.json
+++ b/canopy/app/package.json
@@ -43,7 +43,7 @@
     "react-scripts": "3.2.0"
   },
   "devDependencies": {
-    "eslint": "6.1.0",
+    "eslint": "^6.6.0",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",

--- a/canopy/canopyjs/.eslintrc
+++ b/canopy/canopyjs/.eslintrc
@@ -13,6 +13,9 @@
     "jest": true,
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "rules": {
     "import/no-default-export": 2,
     "import/prefer-default-export": 0

--- a/canopy/canopyjs/Dockerfile
+++ b/canopy/canopyjs/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:lts-alpine
+
+WORKDIR /canopyjs
+
+COPY package*.json ./
+
+RUN yarn install
+
+COPY . .

--- a/canopy/canopyjs/package.json
+++ b/canopy/canopyjs/package.json
@@ -17,7 +17,7 @@
     "@types/uuid": "^3.4.5",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
-    "eslint": "^6.5.1",
+    "eslint": "^6.6.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",

--- a/canopy/design-system/.eslintrc
+++ b/canopy/design-system/.eslintrc
@@ -4,9 +4,13 @@
     "jest": true,
     "browser": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "rules": {
     "react/jsx-filename-extension": 0,
-    "react/prefer-stateless-function": 0
+    "react/prefer-stateless-function": 0,
+    "import/prefer-default-export": 0
   }
 }

--- a/canopy/design-system/Dockerfile
+++ b/canopy/design-system/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:lts-alpine
+
+WORKDIR /design-system
+
+COPY package*.json ./
+
+RUN yarn install
+
+COPY . .

--- a/canopy/design-system/package.json
+++ b/canopy/design-system/package.json
@@ -40,7 +40,7 @@
     "autoprefixer": "^9.7.0",
     "babel-loader": "^8.0.6",
     "cli-foreachfile": "^1.0.5",
-    "eslint": "6.1.0",
+    "eslint": "^6.6.0",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",

--- a/canopy/design-system/src/components/colors/ColorBlock.js
+++ b/canopy/design-system/src/components/colors/ColorBlock.js
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export function ColorBlock({ colors }) {
   return (
-    <div  className="color-block display-flex flexDirection-column alignItems-center"
-          style={{width: '100%', borderRadius: '4px', height: '10rem'}}>
-      <div className="colors display-flex flexDirection-column"
-            style={{width: '100%', height: '100%'}}>
+    <div
+      className="color-block display-flex flexDirection-column alignItems-center"
+      style={{ width: '100%', borderRadius: '4px', height: '10rem' }}
+    >
+      <div
+        className="colors display-flex flexDirection-column"
+        style={{ width: '100%', height: '100%' }}
+      >
         {colors.map(color => {
           return (
             <div
               className={`color background-${color} display-flex justifyContent-center alignItems-center`}
-              style={{width: '100%'}}
+              style={{ width: '100%' }}
               key={color.name}
             >
               {color}
@@ -36,3 +41,11 @@ export function ColorBlock({ colors }) {
     </div>
   );
 }
+
+ColorBlock.propTypes = {
+  colors: PropTypes.arrayOf(PropTypes.object)
+};
+
+ColorBlock.defaultProps = {
+  colors: []
+};

--- a/canopy/design-system/src/components/content/ColumnBlock.js
+++ b/canopy/design-system/src/components/content/ColumnBlock.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export function ColumnBlock({ children }) {
   return (
@@ -22,3 +23,11 @@ export function ColumnBlock({ children }) {
     </div>
   );
 }
+
+ColumnBlock.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element)
+};
+
+ColumnBlock.defaultProps = {
+  children: []
+};

--- a/canopy/design-system/src/components/content/ColumnItem.js
+++ b/canopy/design-system/src/components/content/ColumnItem.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export function ColumnItem({ children }) {
   return (
@@ -22,3 +23,11 @@ export function ColumnItem({ children }) {
     </div>
   );
 }
+
+ColumnItem.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element)
+};
+
+ColumnItem.defaultProps = {
+  children: []
+};

--- a/canopy/design-system/src/components/navigation/NavItemExpandable.js
+++ b/canopy/design-system/src/components/navigation/NavItemExpandable.js
@@ -41,6 +41,13 @@ export function NavItemExpandable({ nested, children }) {
                     borderBottom-1
                     borderStyle-solid
                     borderColor-smoke"
+        role="button"
+        tabIndex="0"
+        onKeyPress={e => {
+          if (e.key === 'Enter') {
+            setIsOpen(!isOpen);
+          }
+        }}
         onClick={() => setIsOpen(!isOpen)}
       >
         {children}
@@ -74,9 +81,14 @@ export function NavItemExpandable({ nested, children }) {
 }
 
 NavItemExpandable.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.object
+  ]),
   nested: PropTypes.arrayOf(PropTypes.object)
 };
 
 NavItemExpandable.defaultProps = {
+  children: [],
   nested: []
 };

--- a/canopy/design-system/src/components/navigation/SideNav.js
+++ b/canopy/design-system/src/components/navigation/SideNav.js
@@ -55,18 +55,14 @@ export default class SideNav extends React.Component {
                     <span>{tab.name}</span>
                   </NavItemExpandable>
                 );
-              } else {
-                return (
-                  <li
-                    className="tab paddingTop-s paddingBottom-s"
-                    key={tab.name}
-                  >
-                    <NavLink to={tab.route} aria-label={tab.name}>
-                      {tab.name}
-                    </NavLink>
-                  </li>
-                );
               }
+              return (
+                <li className="tab paddingTop-s paddingBottom-s" key={tab.name}>
+                  <NavLink to={tab.route} aria-label={tab.name}>
+                    {tab.name}
+                  </NavLink>
+                </li>
+              );
             })}
           </ul>
         </nav>

--- a/docker/compose/run-lint.yaml
+++ b/docker/compose/run-lint.yaml
@@ -50,3 +50,21 @@ services:
     volumes:
       - ../../:/project/splinter/examples/gameroom/gameroom-app
     command: npm run lint
+
+  lint-canopy-app:
+    build:
+      context: ../../canopy/app
+    image: canopy-app:${ISOLATION_ID}
+    command: yarn lint
+
+  lint-canopyjs:
+    build:
+      context: ../../canopy/canopyjs
+    image: canopyjs:${ISOLATION_ID}
+    command: yarn lint
+
+  lint-design-system:
+    build:
+      context: ../../canopy/design-system
+    image: design-system:${ISOLATION_ID}
+    command: yarn lint

--- a/tests/test-splinter.yaml
+++ b/tests/test-splinter.yaml
@@ -33,3 +33,27 @@ services:
                 --features \"sawtooth-signing-compat\"
         "
     stop_signal: SIGKILL
+
+  unit-test-canopy-app:
+    build:
+      context: ../canopy/app
+    environment:
+      - CI=true
+    image: canopy-app:${ISOLATION_ID}
+    command: yarn test
+
+  unit-test-canopyjs:
+    build:
+      context: ../canopy/canopyjs
+    environment:
+      - CI=true
+    image: canopyjs:${ISOLATION_ID}
+    command: yarn test
+
+  unit-test-design-system:
+    build:
+      context: ../canopy/design-system
+    environment:
+      - CI=true
+    image: design-system:${ISOLATION_ID}
+    command: yarn test


### PR DESCRIPTION
Standardizes the eslint version in package.json files across canopy.

Updates all eslintrcs to use the EMCA 2020 parser. This allows ESlint to parse things such as dynamic imports.

Adds Dockerfiles for each Canopy component for linting, as well as services in run-lint.yaml and travis stages.