### PR TITLE
Default auth mailbox

### DIFF
--- a/libsplinter/src/admin/mailbox.rs
+++ b/libsplinter/src/admin/mailbox.rs
@@ -1,0 +1,194 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp;
+use std::error::Error;
+use std::fmt;
+use std::time::SystemTime;
+
+use crate::storage::sets::DurableOrderedSet;
+
+use super::messages::AdminServiceEvent;
+
+/// A simple entry for AdminServiceEvent values, marked with a timestamp
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct EventEntry {
+    timestamp: SystemTime,
+    event: AdminServiceEvent,
+}
+
+impl cmp::Ord for EventEntry {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.timestamp.cmp(&other.timestamp)
+    }
+}
+
+impl cmp::PartialOrd for EventEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::borrow::Borrow<SystemTime> for EventEntry {
+    fn borrow(&self) -> &SystemTime {
+        &self.timestamp
+    }
+}
+
+/// A Mailbox stores all admin services events that have occurred, ordered by a timestamp generated
+/// upon addition to the mailbox.
+///
+/// These events are stored in a durable ordered set, determined by the caller.
+#[derive(Clone)]
+pub struct Mailbox {
+    durable_set: Box<dyn DurableOrderedSet<EventEntry, SystemTime>>,
+}
+
+impl Mailbox {
+    /// Constructs a new event mailbox with the given backing store.
+    pub fn new(durable_set: Box<dyn DurableOrderedSet<EventEntry, SystemTime>>) -> Self {
+        Self { durable_set }
+    }
+
+    /// Add an event to the mailbox.  Returns the recorded event time and a copy of the event.
+    ///
+    /// # Errors
+    ///
+    /// Returns a MailboxError if there is an issue with the underlying storage set.
+    pub fn add(
+        &mut self,
+        event: AdminServiceEvent,
+    ) -> Result<(SystemTime, AdminServiceEvent), MailboxError> {
+        let entry = EventEntry {
+            timestamp: SystemTime::now(),
+            event,
+        };
+        self.durable_set.add(entry.clone()).map_err(|err| {
+            MailboxError::with_source("Unable to add event to storage", Box::new(err))
+        })?;
+
+        Ok((entry.timestamp, entry.event))
+    }
+
+    /// Returns an iterator over all of the values in the mailbox.
+    pub fn iter<'a>(
+        &'a self,
+    ) -> Result<Box<(dyn Iterator<Item = (SystemTime, AdminServiceEvent)> + 'a)>, MailboxError>
+    {
+        Ok(Box::new(
+            self.durable_set
+                .iter()
+                .map_err(|err| {
+                    MailboxError::with_source(
+                        "Unable to iterate over underlying storage",
+                        Box::new(err),
+                    )
+                })?
+                .map(|event| (event.timestamp, event.event)),
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub struct MailboxError {
+    pub context: String,
+    pub source: Option<Box<dyn Error + Send>>,
+}
+
+impl MailboxError {
+    fn with_source(context: &str, source: Box<dyn Error + Send>) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(source),
+        }
+    }
+}
+
+impl Error for MailboxError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for MailboxError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::admin::messages::{self, AdminServiceEvent, CircuitProposal, ProposalType};
+    use crate::storage::sets::mem::DurableBTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn test_iterate() {
+        let mut mailbox = Mailbox::new(DurableBTreeSet::new_boxed());
+
+        mailbox
+            .add(make_event("circuit_one", "default"))
+            .expect("Unable to add event");
+        mailbox
+            .add(make_event("gameroom_one", "gameroom"))
+            .expect("Unable to add event");
+        mailbox
+            .add(make_event("circuit_two", "default"))
+            .expect("Unable to add event");
+
+        assert_eq!(
+            vec![
+                make_event("circuit_one", "default"),
+                make_event("gameroom_one", "gameroom"),
+                make_event("circuit_two", "default"),
+            ],
+            mailbox
+                .iter()
+                .expect("Unable to create an iterator")
+                .map(|(_, evt)| evt)
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    fn make_event(circuit_id: &str, event_type: &str) -> AdminServiceEvent {
+        AdminServiceEvent::ProposalSubmitted(CircuitProposal {
+            proposal_type: ProposalType::Create,
+            circuit_id: circuit_id.into(),
+            circuit_hash: "not real hash for tests".into(),
+            circuit: messages::CreateCircuit {
+                circuit_id: circuit_id.into(),
+                roster: vec![],
+                members: vec![],
+                authorization_type: messages::AuthorizationType::Trust,
+                persistence: messages::PersistenceType::Any,
+                durability: messages::DurabilityType::NoDurability,
+                routes: messages::RouteType::Any,
+                circuit_management_type: event_type.into(),
+                application_metadata: vec![],
+            },
+            votes: vec![],
+            requester: vec![],
+            requester_node_id: "another-node".into(),
+        })
+    }
+}

--- a/libsplinter/src/admin/messages.rs
+++ b/libsplinter/src/admin/messages.rs
@@ -426,6 +426,18 @@ pub enum AdminServiceEvent {
     CircuitReady(CircuitProposal),
 }
 
+impl AdminServiceEvent {
+    pub fn proposal(&self) -> &CircuitProposal {
+        match self {
+            AdminServiceEvent::ProposalSubmitted(proposal) => proposal,
+            AdminServiceEvent::ProposalVote((proposal, _)) => proposal,
+            AdminServiceEvent::ProposalAccepted((proposal, _)) => proposal,
+            AdminServiceEvent::ProposalRejected((proposal, _)) => proposal,
+            AdminServiceEvent::CircuitReady(proposal) => proposal,
+        }
+    }
+}
+
 #[cfg(feature = "events")]
 impl ParseBytes<AdminServiceEvent> for AdminServiceEvent {
     fn from_bytes(bytes: &[u8]) -> Result<AdminServiceEvent, ParseError> {

--- a/libsplinter/src/admin/messages.rs
+++ b/libsplinter/src/admin/messages.rs
@@ -25,7 +25,7 @@ use crate::protos::admin::{self, CircuitCreateRequest};
 
 use super::error::MarshallingError;
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct CreateCircuit {
     pub circuit_id: String,
     pub roster: Vec<SplinterService>,
@@ -160,27 +160,27 @@ impl CreateCircuit {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum AuthorizationType {
     Trust,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum PersistenceType {
     Any,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum DurabilityType {
     NoDurability,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum RouteType {
     Any,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SplinterNode {
     pub node_id: String,
     pub endpoint: String,
@@ -204,7 +204,7 @@ impl SplinterNode {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SplinterService {
     pub service_id: String,
     pub service_type: String,
@@ -251,7 +251,7 @@ impl SplinterService {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct CircuitProposal {
     pub proposal_type: ProposalType,
     pub circuit_id: String,
@@ -326,7 +326,7 @@ impl CircuitProposal {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum ProposalType {
     Create,
     UpdateRoster,
@@ -335,7 +335,7 @@ pub enum ProposalType {
     Destroy,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct CircuitProposalVote {
     pub circuit_id: String,
     pub circuit_hash: String,
@@ -371,7 +371,7 @@ impl CircuitProposalVote {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct VoteRecord {
     pub public_key: Vec<u8>,
     pub vote: Vote,
@@ -410,13 +410,13 @@ impl VoteRecord {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum Vote {
     Accept,
     Reject,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "eventType", content = "message")]
 pub enum AdminServiceEvent {
     ProposalSubmitted(CircuitProposal),

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -14,6 +14,7 @@
 
 mod consensus;
 pub mod error;
+mod mailbox;
 pub mod messages;
 mod open_proposals;
 mod shared;

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -57,7 +57,7 @@ impl fmt::Display for RestApiServerError {
 pub enum ResponseError {
     ActixError(ActixError),
     CatchUpWsError(EventDealerError),
-    CatchUpHistoryError(EventHistoryError),
+    CatchUpHistoryError(String),
 }
 
 impl Error for ResponseError {
@@ -65,7 +65,7 @@ impl Error for ResponseError {
         match self {
             ResponseError::ActixError(err) => Some(err),
             ResponseError::CatchUpWsError(err) => Some(err),
-            ResponseError::CatchUpHistoryError(err) => Some(err),
+            ResponseError::CatchUpHistoryError(_) => None,
         }
     }
 }
@@ -79,7 +79,7 @@ impl fmt::Display for ResponseError {
                 err
             ),
             ResponseError::CatchUpWsError(err) => write!(f, "{}", err),
-            ResponseError::CatchUpHistoryError(err) => write!(f, "{}", err),
+            ResponseError::CatchUpHistoryError(msg) => f.write_str(&msg),
         }
     }
 }
@@ -98,7 +98,7 @@ impl From<EventDealerError> for ResponseError {
 
 impl From<EventHistoryError> for ResponseError {
     fn from(err: EventHistoryError) -> Self {
-        ResponseError::CatchUpHistoryError(err)
+        ResponseError::CatchUpHistoryError(err.to_string())
     }
 }
 

--- a/libsplinter/src/storage/mod.rs
+++ b/libsplinter/src/storage/mod.rs
@@ -22,6 +22,7 @@
 //! the selected storage.
 
 pub mod memory;
+pub mod sets;
 pub mod yaml;
 
 use std::ops::{Deref, DerefMut};

--- a/libsplinter/src/storage/sets/mem.rs
+++ b/libsplinter/src/storage/sets/mem.rs
@@ -1,0 +1,503 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-memory implementations of the DurableSet traits.
+
+use std::borrow::Borrow;
+use std::cmp::Ord;
+use std::collections::{BTreeSet, HashSet};
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+
+use super::{DurableOrderedSet, DurableRange, DurableSet, DurableSetError};
+
+/// An in-memory, DurableSet, backed by a HashSet.
+#[derive(Default)]
+pub struct DurableHashSet<V: Hash + Eq> {
+    inner: Arc<Mutex<HashSet<V>>>,
+}
+
+impl<V: Send + Hash + Eq> DurableHashSet<V> {
+    /// Constructs a new DurableHashSet.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+impl<V: Send + Hash + Eq + Clone> DurableSet for DurableHashSet<V> {
+    type Item = V;
+
+    /// Add an item to the set.
+    fn add(&mut self, item: Self::Item) -> Result<(), DurableSetError> {
+        self.inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new("Poisoned lock error occurred while attempting to insert item")
+            })?
+            .insert(item);
+
+        Ok(())
+    }
+
+    /// Remove an item to the set.
+    fn remove(&mut self, item: &Self::Item) -> Result<Option<Self::Item>, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new("Poisoned lock error occurred while attempting to remove item")
+            })?
+            .take(item))
+    }
+
+    fn iter<'a>(&'a self) -> Result<Box<(dyn Iterator<Item = Self::Item> + 'a)>, DurableSetError> {
+        Ok(Box::new(SnapShotIter {
+            snapshot: self
+                .inner
+                .lock()
+                .map_err(|_| {
+                    DurableSetError::new("Poisoned lock error occurred while attempting to iterate")
+                })?
+                .iter()
+                .cloned()
+                .collect(),
+        }))
+    }
+
+    fn contains(&self, item: &Self::Item) -> Result<bool, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to check if the set contains \
+                     an item",
+                )
+            })?
+            .contains(item))
+    }
+
+    fn len(&self) -> Result<u64, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to return the length of the set",
+                )
+            })?
+            .len() as u64)
+    }
+}
+
+struct SnapShotIter<V: Send + Clone> {
+    snapshot: std::collections::VecDeque<V>,
+}
+
+impl<V: Send + Clone> Iterator for SnapShotIter<V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.snapshot.pop_front()
+    }
+}
+
+/// An in-memory, DurableOrderedSet, backed by a BTreeSet.
+#[derive(Default, Clone)]
+pub struct DurableBTreeSet<V: Ord + Send> {
+    inner: Arc<Mutex<BTreeSet<V>>>,
+}
+
+impl<V: Ord + Send> DurableBTreeSet<V> {
+    pub fn new_boxed<Index>() -> Box<dyn DurableOrderedSet<V, Index>>
+    where
+        Index: Ord + Send + Clone,
+        V: Send + Ord + Borrow<Index> + Clone + 'static,
+    {
+        Box::new(Self {
+            inner: Arc::new(Mutex::new(BTreeSet::new())),
+        })
+    }
+}
+
+impl<V> DurableSet for DurableBTreeSet<V>
+where
+    V: Send + Ord + Clone,
+{
+    type Item = V;
+
+    /// Add an item to the set.
+    fn add(&mut self, item: Self::Item) -> Result<(), DurableSetError> {
+        self.inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new("Poisoned lock error occurred while attempting to insert item")
+            })?
+            .insert(item);
+
+        Ok(())
+    }
+
+    /// Remove an item to the set.
+    fn remove(&mut self, item: &Self::Item) -> Result<Option<Self::Item>, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new("Poisoned lock error occurred while attempting to remove item")
+            })?
+            .take(item))
+    }
+
+    fn iter<'a>(&'a self) -> Result<Box<(dyn Iterator<Item = Self::Item> + 'a)>, DurableSetError> {
+        Ok(Box::new(SnapShotIter {
+            snapshot: self
+                .inner
+                .lock()
+                .map_err(|_| {
+                    DurableSetError::new("Poisoned lock error occurred while attempting to iterate")
+                })?
+                .iter()
+                .cloned()
+                .collect(),
+        }))
+    }
+
+    fn contains(&self, item: &Self::Item) -> Result<bool, DurableSetError> {
+        Ok(self.inner
+            .lock()
+            .map_err(|_| DurableSetError::new("Poisoned lock error occurred while attempting to check if the set contains an item"))?
+            .contains(item))
+    }
+
+    fn len(&self) -> Result<u64, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to return the length of the set",
+                )
+            })?
+            .len() as u64)
+    }
+}
+
+impl<V, Index> DurableOrderedSet<V, Index> for DurableBTreeSet<V>
+where
+    Index: Ord + Send,
+    V: Send + Ord + Borrow<Index> + Clone + 'static,
+{
+    fn get_by_index(&self, index_value: &Index) -> Result<Option<Self::Item>, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to retrieve an item by index",
+                )
+            })?
+            .get(index_value)
+            .cloned())
+    }
+
+    fn contains_by_index(&self, index_value: &Index) -> Result<bool, DurableSetError> {
+        Ok(self.inner
+            .lock()
+            .map_err(|_| DurableSetError::new("Poisoned lock error occurred while attempting to check if the set contains an item"))?
+            .contains(index_value))
+    }
+
+    /// Returns an iterator over a range
+    fn range_iter<'a>(
+        &'a self,
+        range: DurableRange<&Index>,
+    ) -> Result<Box<(dyn Iterator<Item = Self::Item> + 'a)>, DurableSetError> {
+        Ok(Box::new(SnapShotIter {
+            snapshot: self
+                .inner
+                .lock()
+                .map_err(|_| {
+                    DurableSetError::new("Poisoned lock error occurred while attempting to iterate")
+                })?
+                .range((range.start, range.end))
+                .cloned()
+                .collect(),
+        }))
+    }
+
+    fn first(&self) -> Result<Option<Self::Item>, DurableSetError> {
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to get first item",
+                )
+            })?
+            .iter()
+            .next()
+            .cloned())
+    }
+
+    fn last(&self) -> Result<Option<Self::Item>, DurableSetError> {
+        // We can use the last function on the BTreeSet's iterator, as it is O(1)
+        Ok(self
+            .inner
+            .lock()
+            .map_err(|_| {
+                DurableSetError::new(
+                    "Poisoned lock error occurred while attempting to get last item",
+                )
+            })?
+            .iter()
+            .last()
+            .cloned())
+    }
+
+    fn clone_boxed_ordered_set(&self) -> Box<dyn DurableOrderedSet<V, Index>> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    /// Test that DurableHashSet add will insert the items provided and verify that they are in the
+    /// set by iterating over all the members
+    #[test]
+    fn test_hash_add() {
+        let mut hash_set = DurableHashSet::new();
+        assert!(hash_set.is_empty().expect("Unable to get is_empty"));
+        hash_set
+            .add("hello".to_string())
+            .expect("unable to add value");
+        hash_set
+            .add("bonjour".to_string())
+            .expect("unable to add value");
+        hash_set
+            .add("guten tag".to_string())
+            .expect("unable to add value");
+
+        assert!(!hash_set.is_empty().expect("Unable to get is_empty"));
+        assert_eq!(3, hash_set.len().expect("Unable to get len"));
+        let mut contents = hash_set
+            .iter()
+            .expect("Could not create iterator")
+            .collect::<Vec<_>>();
+
+        contents.sort();
+        assert_eq!(vec!["bonjour", "guten tag", "hello"], contents);
+    }
+
+    /// Using DurableHashSet, insert three items and remove:
+    /// a) an non-existent entry
+    /// b) an existing item
+    /// c) the same item
+    /// Verify the removeal by iterating over the remaining items.
+    #[test]
+    fn test_hash_remove() {
+        let mut hash_set = DurableHashSet::new();
+        hash_set
+            .add("hello".to_string())
+            .expect("unable to add value");
+        hash_set
+            .add("bonjour".to_string())
+            .expect("unable to add value");
+        hash_set
+            .add("guten tag".to_string())
+            .expect("unable to add value");
+
+        // Check that a non-existent key returns None
+        assert_eq!(
+            None,
+            hash_set
+                .remove(&"goodbye".to_string())
+                .expect("Unable to remove")
+        );
+        // Remove a known key
+        assert_eq!(
+            Some("hello".into()),
+            hash_set
+                .remove(&"hello".to_string())
+                .expect("Unable to remove")
+        );
+        // Check that the key is now removed
+        assert_eq!(
+            None,
+            hash_set
+                .remove(&"hello".to_string())
+                .expect("Unable to remove")
+        );
+
+        let mut contents = hash_set
+            .iter()
+            .expect("Could not create iterator")
+            .collect::<Vec<_>>();
+
+        contents.sort();
+        assert_eq!(vec!["bonjour", "guten tag"], contents,);
+    }
+
+    /// Using DurableBTreeSet, insert three items, sorted by integer IDS.
+    /// - Verify that an item can be retrieved by integer index
+    /// - Verify that the items are iterated in order
+    #[test]
+    fn test_btree_add_int() {
+        let mut btree_set: Box<dyn DurableOrderedSet<IntRecord, u32>> =
+            DurableBTreeSet::new_boxed();
+        btree_set
+            .add(int_rec(3, "hello", b"hello_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(int_rec(1, "bon_jour", b"bon_jour_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(int_rec(2, "guten_tag", b"guten_tag_bytes"))
+            .expect("unable to add value");
+
+        assert_eq!(
+            Some(int_rec(3, "hello", b"hello_bytes")),
+            btree_set.get_by_index(&3).expect("unable to get value")
+        );
+
+        assert_eq!(
+            vec![
+                int_rec(1, "bon_jour", b"bon_jour_bytes"),
+                int_rec(2, "guten_tag", b"guten_tag_bytes"),
+                int_rec(3, "hello", b"hello_bytes"),
+            ],
+            btree_set
+                .iter()
+                .expect("could not iterate")
+                .collect::<Vec<_>>()
+        )
+    }
+
+    /// Using DurableBTreeSet, insert three items, sorted and indexed by integer IDs.
+    /// - Verify that the items can be selected based on ranges using the index, and are returned
+    ///   in order.
+    #[test]
+    fn test_btree_range_int() {
+        let mut btree_set: Box<dyn DurableOrderedSet<IntRecord, u32>> =
+            DurableBTreeSet::new_boxed();
+        btree_set
+            .add(int_rec(3, "hello", b"hello_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(int_rec(1, "bon_jour", b"bon_jour_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(int_rec(2, "guten_tag", b"guten_tag_bytes"))
+            .expect("unable to add value");
+
+        let total = btree_set.len().expect("Unable to get length");
+        assert_eq!(3, total);
+        assert_eq!(
+            vec![
+                int_rec(2, "guten_tag", b"guten_tag_bytes"),
+                int_rec(3, "hello", b"hello_bytes"),
+            ],
+            btree_set
+                .range_iter((&2..).into())
+                .expect("could not iterate")
+                .collect::<Vec<_>>()
+        )
+    }
+
+    /// Using DurableBTreeSet, insert three items, sorted and indexed by String.
+    /// - Verify that the items can be selected based on ranges using the index, and are returned
+    ///   in order.
+    #[test]
+    fn test_btree_range_str() {
+        let mut btree_set: Box<dyn DurableOrderedSet<StrRecord, String>> =
+            DurableBTreeSet::new_boxed();
+        btree_set
+            .add(str_rec("hello", b"hello_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(str_rec("bon_jour", b"bon_jour_bytes"))
+            .expect("unable to add value");
+        btree_set
+            .add(str_rec("guten_tag", b"guten_tag_bytes"))
+            .expect("unable to add value");
+
+        let total = btree_set.len().expect("Unable to get length");
+        assert_eq!(3, total);
+        assert_eq!(
+            vec![
+                str_rec("guten_tag", b"guten_tag_bytes"),
+                str_rec("hello", b"hello_bytes"),
+            ],
+            btree_set
+                .range_iter((&"g".to_string()..).into())
+                .expect("could not iterate")
+                .collect::<Vec<_>>()
+        )
+    }
+
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    struct IntRecord(u32, String, Vec<u8>);
+
+    fn int_rec(id: u32, name: &str, value: &[u8]) -> IntRecord {
+        IntRecord(id, name.into(), value.to_vec())
+    }
+
+    impl Ord for IntRecord {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.0.cmp(&other.0)
+        }
+    }
+
+    impl std::cmp::PartialOrd for IntRecord {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Borrow<u32> for IntRecord {
+        fn borrow(&self) -> &u32 {
+            &self.0
+        }
+    }
+
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    struct StrRecord(String, Vec<u8>);
+
+    fn str_rec(name: &str, value: &[u8]) -> StrRecord {
+        StrRecord(name.into(), value.to_vec())
+    }
+
+    impl Ord for StrRecord {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.0.cmp(&other.0)
+        }
+    }
+
+    impl std::cmp::PartialOrd for StrRecord {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Borrow<String> for StrRecord {
+        fn borrow(&self) -> &String {
+            &self.0
+        }
+    }
+}

--- a/libsplinter/src/storage/sets/mod.rs
+++ b/libsplinter/src/storage/sets/mod.rs
@@ -1,0 +1,202 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Durable sets, both ordered and unordered. Implementations of these sets must be thread-safe.
+
+pub mod mem;
+
+use std::borrow::Borrow;
+use std::cmp::Ord;
+use std::error::Error;
+use std::fmt;
+use std::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+/// A Durable Set.
+///
+/// This trait provides an API for interacting with Durable sets that may be backed by a
+/// wide variety of persistent storage.
+pub trait DurableSet: Send + Sync {
+    type Item: Send;
+
+    /// Add an item to the set.
+    fn add(&mut self, item: Self::Item) -> Result<(), DurableSetError>;
+
+    /// Remove an item to the set.
+    fn remove(&mut self, item: &Self::Item) -> Result<Option<Self::Item>, DurableSetError>;
+
+    /// Get a value based on the query item.
+    fn contains(&self, item: &Self::Item) -> Result<bool, DurableSetError>;
+
+    /// Returns an iterator over the contents of the set.
+    fn iter<'a>(&'a self) -> Result<Box<(dyn Iterator<Item = Self::Item> + 'a)>, DurableSetError>;
+
+    /// Returns the count of the values in the set.
+    fn len(&self) -> Result<u64, DurableSetError>;
+
+    fn is_empty(&self) -> Result<bool, DurableSetError> {
+        Ok(self.len()? == 0)
+    }
+}
+
+/// A Durable, Ordered Set.
+///
+/// This trait extends the API `DurableSet` to include requirements around ordering of value, as
+/// well as Indexing on a sub-value.
+///
+/// This set contains values of type `V`, which may be indexed by `Index` type.  Items in the set
+/// can be selected based on their `Index` value.
+pub trait DurableOrderedSet<V, Index>: DurableSet<Item = V>
+where
+    Index: Ord + Send,
+    V: Send + Ord + Borrow<Index>,
+{
+    /// Get a value based on the index.
+    fn get_by_index(&self, index_value: &Index) -> Result<Option<Self::Item>, DurableSetError>;
+
+    /// Check for the existence of a value based on the index.
+    fn contains_by_index(&self, index_value: &Index) -> Result<bool, DurableSetError>;
+
+    /// Returns an iterator over a range of index keys.
+    fn range_iter<'a>(
+        &'a self,
+        range: DurableRange<&Index>,
+    ) -> Result<Box<(dyn Iterator<Item = Self::Item> + 'a)>, DurableSetError>;
+
+    /// Returns the first item in the set, based on the natural Item order.
+    fn first(&self) -> Result<Option<Self::Item>, DurableSetError>;
+
+    /// Returns the last item in the set, based on the natural Item order.
+    fn last(&self) -> Result<Option<Self::Item>, DurableSetError>;
+
+    /// Clones this instance into a boxed durable ordered set.
+    fn clone_boxed_ordered_set(&self) -> Box<dyn DurableOrderedSet<V, Index>>;
+}
+
+impl<V, Index> Clone for Box<dyn DurableOrderedSet<V, Index>>
+where
+    Index: Ord + Send,
+    V: Send + Ord + Borrow<Index>,
+{
+    fn clone(&self) -> Self {
+        self.clone_boxed_ordered_set()
+    }
+}
+
+/// A Range describing the start and end bounds for a range iterator on a DurableOrderedSet.
+///
+/// This struct is similar to the various implementations of the RangeBounds trait in the standard
+/// library, but is necessary for implementing the most generic set of bounds while still allowing
+/// DurableOrderedSet to be used as in a boxed-dyn context.
+pub struct DurableRange<T> {
+    pub start: Bound<T>,
+    pub end: Bound<T>,
+}
+
+impl<T> From<Range<T>> for DurableRange<T> {
+    fn from(range: Range<T>) -> Self {
+        Self {
+            start: Bound::Included(range.start),
+            end: Bound::Excluded(range.end),
+        }
+    }
+}
+
+impl<T> From<RangeInclusive<T>> for DurableRange<T> {
+    fn from(range: RangeInclusive<T>) -> Self {
+        let (start, end) = range.into_inner();
+        Self {
+            start: Bound::Included(start),
+            end: Bound::Included(end),
+        }
+    }
+}
+
+impl<T> From<RangeFull> for DurableRange<T> {
+    fn from(_: RangeFull) -> Self {
+        Self {
+            start: Bound::Unbounded,
+            end: Bound::Unbounded,
+        }
+    }
+}
+
+impl<T> From<RangeFrom<T>> for DurableRange<T> {
+    fn from(range: RangeFrom<T>) -> Self {
+        Self {
+            start: Bound::Included(range.start),
+            end: Bound::Unbounded,
+        }
+    }
+}
+
+impl<T> From<RangeTo<T>> for DurableRange<T> {
+    fn from(range: RangeTo<T>) -> Self {
+        Self {
+            start: Bound::Unbounded,
+            end: Bound::Excluded(range.end),
+        }
+    }
+}
+
+impl<T> From<RangeToInclusive<T>> for DurableRange<T> {
+    fn from(range: RangeToInclusive<T>) -> Self {
+        Self {
+            start: Bound::Unbounded,
+            end: Bound::Included(range.end),
+        }
+    }
+}
+
+/// An error that may occur with the underlying implementation of the DurableSet
+#[derive(Debug)]
+pub struct DurableSetError {
+    pub context: String,
+    pub source: Option<Box<dyn Error + Send>>,
+}
+
+impl DurableSetError {
+    pub fn new(context: &str) -> Self {
+        Self {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn with_source(context: &str, source: Box<dyn Error + Send>) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(source),
+        }
+    }
+}
+
+impl Error for DurableSetError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for DurableSetError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}


### PR DESCRIPTION
As of this PR, all AuthServiceEvents are stored in a single Mailbox, and filtered by circuit management time when a connection occurs.

The mailbox replaces the old `LocalEventHistory` struct, but retains the limit of 100 events in memory.

Alternative backing set implementations, such as one backed by a database, implement the `DurableOrderedSet` trait.  This PR provides the in-memory implementation, `DurableBTreeSet` (which, to be fair, is not durable).