### PR TITLE
Store scabbard transaction receipts

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -33,6 +33,7 @@ byteorder = "1"
 url = "1.7.1"
 openssl = "0.10"
 mio = "0.6"
+sawtooth = { version = "0.1", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.4"
 sawtooth-sdk = { version = "0.3", optional = true }
 serde = "1.0"

--- a/libsplinter/src/service/scabbard/consensus.rs
+++ b/libsplinter/src/service/scabbard/consensus.rs
@@ -383,8 +383,14 @@ mod tests {
             Some(Box::new(service_sender.clone())),
             peer_services.clone(),
             Box::new(HashVerifier),
-            ScabbardState::new(Path::new("/tmp/network_sender.lmdb"), 1024 * 1024, vec![])
-                .expect("failed to create state"),
+            ScabbardState::new(
+                Path::new("/tmp/network-sender-state.lmdb"),
+                1024 * 1024,
+                Path::new("/tmp/network-sender-receipts.lmdb"),
+                1024 * 1024,
+                vec![],
+            )
+            .expect("failed to create state"),
         )));
         let consensus_sender = ScabbardConsensusNetworkSender::new("0".into(), shared);
 

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -32,11 +32,15 @@ use super::{Scabbard, SERVICE_TYPE};
 
 const DEFAULT_STATE_DB_DIR: &str = "/var/lib/splinter";
 const DEFAULT_STATE_DB_SIZE: usize = 1028 * 1028 * 1028;
+const DEFAULT_RECEIPT_DB_DIR: &str = "/var/lib/splinter";
+const DEFAULT_RECEIPT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 
 pub struct ScabbardFactory {
     service_types: Vec<String>,
     state_db_dir: String,
     state_db_size: usize,
+    receipt_db_dir: String,
+    receipt_db_size: usize,
     signature_verifier_factory: Box<dyn SignatureVerifierFactory>,
 }
 
@@ -44,12 +48,16 @@ impl ScabbardFactory {
     pub fn new(
         state_db_dir: Option<String>,
         state_db_size: Option<usize>,
+        receipt_db_dir: Option<String>,
+        receipt_db_size: Option<usize>,
         signature_verifier_factory: Box<dyn SignatureVerifierFactory>,
     ) -> Self {
         ScabbardFactory {
             service_types: vec![SERVICE_TYPE.into()],
             state_db_dir: state_db_dir.unwrap_or_else(|| DEFAULT_STATE_DB_DIR.into()),
             state_db_size: state_db_size.unwrap_or(DEFAULT_STATE_DB_SIZE),
+            receipt_db_dir: receipt_db_dir.unwrap_or_else(|| DEFAULT_RECEIPT_DB_DIR.into()),
+            receipt_db_size: receipt_db_size.unwrap_or(DEFAULT_RECEIPT_DB_SIZE),
             signature_verifier_factory,
         }
     }
@@ -86,6 +94,7 @@ impl ServiceFactory for ScabbardFactory {
                 .into_iter(),
         );
         let state_db_dir = Path::new(&self.state_db_dir);
+        let receipt_db_dir = Path::new(&self.receipt_db_dir);
         let admin_keys_str = args.get("admin_keys").ok_or_else(|| {
             FactoryCreateError::InvalidArguments("admin_keys argument not provided".into())
         })?;
@@ -102,6 +111,8 @@ impl ServiceFactory for ScabbardFactory {
             peer_services,
             &state_db_dir,
             self.state_db_size,
+            &receipt_db_dir,
+            self.receipt_db_size,
             self.signature_verifier_factory.create_verifier(),
             admin_keys,
         )
@@ -247,6 +258,8 @@ mod tests {
         );
 
         let factory = ScabbardFactory::new(
+            Some("/tmp".into()),
+            Some(1024 * 1024),
             Some("/tmp".into()),
             Some(1024 * 1024),
             Box::new(HashVerifier),

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -31,7 +31,7 @@ use crate::signing::SignatureVerifierFactory;
 use super::{Scabbard, SERVICE_TYPE};
 
 const DEFAULT_STATE_DB_DIR: &str = "/var/lib/splinter";
-const DEFAULT_STATE_DB_SIZE: usize = 1028 * 1028 * 1028;
+const DEFAULT_STATE_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 const DEFAULT_RECEIPT_DB_DIR: &str = "/var/lib/splinter";
 const DEFAULT_RECEIPT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -30,26 +30,26 @@ use crate::signing::SignatureVerifierFactory;
 
 use super::{Scabbard, SERVICE_TYPE};
 
-const DEFAULT_DB_DIR: &str = "/var/lib/splinter";
-const DEFAULT_DB_SIZE: usize = 1028 * 1028 * 1028;
+const DEFAULT_STATE_DB_DIR: &str = "/var/lib/splinter";
+const DEFAULT_STATE_DB_SIZE: usize = 1028 * 1028 * 1028;
 
 pub struct ScabbardFactory {
     service_types: Vec<String>,
-    db_dir: String,
-    db_size: usize,
+    state_db_dir: String,
+    state_db_size: usize,
     signature_verifier_factory: Box<dyn SignatureVerifierFactory>,
 }
 
 impl ScabbardFactory {
     pub fn new(
-        db_dir: Option<String>,
-        db_size: Option<usize>,
+        state_db_dir: Option<String>,
+        state_db_size: Option<usize>,
         signature_verifier_factory: Box<dyn SignatureVerifierFactory>,
     ) -> Self {
         ScabbardFactory {
             service_types: vec![SERVICE_TYPE.into()],
-            db_dir: db_dir.unwrap_or_else(|| DEFAULT_DB_DIR.into()),
-            db_size: db_size.unwrap_or(DEFAULT_DB_SIZE),
+            state_db_dir: state_db_dir.unwrap_or_else(|| DEFAULT_STATE_DB_DIR.into()),
+            state_db_size: state_db_size.unwrap_or(DEFAULT_STATE_DB_SIZE),
             signature_verifier_factory,
         }
     }
@@ -85,7 +85,7 @@ impl ServiceFactory for ScabbardFactory {
                 })?
                 .into_iter(),
         );
-        let db_dir = Path::new(&self.db_dir);
+        let state_db_dir = Path::new(&self.state_db_dir);
         let admin_keys_str = args.get("admin_keys").ok_or_else(|| {
             FactoryCreateError::InvalidArguments("admin_keys argument not provided".into())
         })?;
@@ -100,8 +100,8 @@ impl ServiceFactory for ScabbardFactory {
             service_id,
             circuit_id,
             peer_services,
-            &db_dir,
-            self.db_size,
+            &state_db_dir,
+            self.state_db_size,
             self.signature_verifier_factory.create_verifier(),
             admin_keys,
         )

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -62,6 +62,7 @@ pub struct Scabbard {
 }
 
 impl Scabbard {
+    #[allow(clippy::too_many_arguments)]
     /// Generate a new Scabbard service.
     pub fn new(
         service_id: String,
@@ -72,6 +73,10 @@ impl Scabbard {
         state_db_dir: &Path,
         // The size of sabre's LMDB database
         state_db_size: usize,
+        // The directory in which to create the transaction receipt store's LMDB database
+        receipt_db_dir: &Path,
+        // The size of the transaction receipt store's LMDB database
+        receipt_db_size: usize,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts
         admin_keys: Vec<String>,
@@ -83,8 +88,15 @@ impl Scabbard {
         .map(|digest| to_hex(&*digest))
         .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
         let state_db_path = state_db_dir.join(format!("{}-state.lmdb", hash));
-        let state = ScabbardState::new(state_db_path.as_path(), state_db_size, admin_keys)
-            .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
+        let receipt_db_path = receipt_db_dir.join(format!("{}-receipts.lmdb", hash));
+        let state = ScabbardState::new(
+            state_db_path.as_path(),
+            state_db_size,
+            receipt_db_path.as_path(),
+            receipt_db_size,
+            admin_keys,
+        )
+        .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
         let shared = ScabbardShared::new(
             VecDeque::new(),
             None,
@@ -313,6 +325,8 @@ pub mod tests {
             HashSet::new(),
             Path::new("/tmp"),
             1024 * 1024,
+            Path::new("/tmp"),
+            1024 * 1024,
             Box::new(HashVerifier),
             vec![],
         )
@@ -331,6 +345,8 @@ pub mod tests {
             HashSet::new(),
             Path::new("/tmp"),
             1024 * 1024,
+            Path::new("/tmp"),
+            1024 * 1024,
             Box::new(HashVerifier),
             vec![],
         )
@@ -347,6 +363,8 @@ pub mod tests {
             "connect_and_disconnect".into(),
             "test_circuit",
             HashSet::new(),
+            Path::new("/tmp"),
+            1024 * 1024,
             Path::new("/tmp"),
             1024 * 1024,
             Box::new(HashVerifier),

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -69,9 +69,9 @@ impl Scabbard {
         // List of other scabbard services on the same circuit that this service shares state with
         peer_services: HashSet<String>,
         // The directory in which to create sabre's LMDB database
-        db_dir: &Path,
+        state_db_dir: &Path,
         // The size of sabre's LMDB database
-        db_size: usize,
+        state_db_size: usize,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts
         admin_keys: Vec<String>,
@@ -82,8 +82,8 @@ impl Scabbard {
         )
         .map(|digest| to_hex(&*digest))
         .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
-        let db_path = db_dir.join(format!("{}.lmdb", hash));
-        let state = ScabbardState::new(db_path.as_path(), db_size, admin_keys)
+        let state_db_path = state_db_dir.join(format!("{}-state.lmdb", hash));
+        let state = ScabbardState::new(state_db_path.as_path(), state_db_size, admin_keys)
             .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
         let shared = ScabbardShared::new(
             VecDeque::new(),

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -63,15 +63,15 @@ pub struct ScabbardState {
 
 impl ScabbardState {
     pub fn new(
-        db_path: &Path,
-        db_size: usize,
+        state_db_path: &Path,
+        state_db_size: usize,
         admin_keys: Vec<String>,
     ) -> Result<Self, ScabbardStateError> {
         // Initialize the database
         let mut indexes = INDEXES.to_vec();
         indexes.push(CURRENT_STATE_ROOT_INDEX);
         let db = Box::new(LmdbDatabase::new(
-            LmdbContext::new(db_path, indexes.len(), Some(db_size))?,
+            LmdbContext::new(state_db_path, indexes.len(), Some(state_db_size))?,
             &indexes,
         )?);
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -291,6 +291,8 @@ impl SplinterDaemon {
             vec![Box::new(ScabbardFactory::new(
                 None,
                 None,
+                None,
+                None,
                 Box::new(SawtoothSecp256k1SignatureVerifier::new()),
             ))],
             orchestrator_connection,


### PR DESCRIPTION
Adds the `TransactionReceiptStore` from the `sawtooth` crate to
`ScabbardState` for storing transaction receipts that are committed. The
receipt store provides an absolute history of all transactions that were
committed by the scabbard service, which can be used to "catch-up"
state-delta subscribers that may be behind.

Signed-off-by: Logan Seeley <seeley@bitwise.io>