### PR TITLE
Scabbard state delta catch up

### DIFF
--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -458,10 +458,16 @@ fn resubscribe(
         db_pool,
     );
 
+    let query_string = if gameroom.last_event.is_empty() {
+        "".into()
+    } else {
+        format!("?last_seen_event={}", gameroom.last_event)
+    };
+
     let mut ws = WebSocketClient::new(
         &format!(
-            "{}/scabbard/{}/{}/ws/subscribe",
-            url, gameroom.circuit_id, gameroom.service_id
+            "{}/scabbard/{}/{}/ws/subscribe?{}",
+            url, gameroom.circuit_id, gameroom.service_id, query_string,
         ),
         move |_, event| {
             if let Err(err) = processor.handle_state_change_event(event) {

--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -380,9 +380,12 @@ fn process_admin_event(
                     "{}/scabbard/{}/{}/ws/subscribe",
                     url, msg_proposal.circuit_id, service_id
                 ),
-                move |_, changes| {
-                    if let Err(err) = processor.handle_state_changes(changes) {
-                        error!("An error occurred while handling state changes {:?}", err);
+                move |_, event| {
+                    if let Err(err) = processor.handle_state_change_event(event) {
+                        error!(
+                            "An error occurred while handling a state change event: {:?}",
+                            err
+                        );
                     }
                     WsResponse::Empty
                 },
@@ -447,7 +450,7 @@ fn resubscribe(
     url: &str,
     gameroom: &ActiveGameroom,
     db_pool: &ConnectionPool,
-) -> WebSocketClient<Vec<StateChangeEvent>> {
+) -> WebSocketClient<StateChangeEvent> {
     let processor = XoStateDeltaProcessor::new(
         &gameroom.circuit_id,
         &gameroom.requester_node_id,
@@ -460,9 +463,12 @@ fn resubscribe(
             "{}/scabbard/{}/{}/ws/subscribe",
             url, gameroom.circuit_id, gameroom.service_id
         ),
-        move |_, changes| {
-            if let Err(err) = processor.handle_state_changes(changes) {
-                error!("An error occurred while handling state changes {:?}", err);
+        move |_, event| {
+            if let Err(err) = processor.handle_state_change_event(event) {
+                error!(
+                    "An error occurred while handling a state change event: {:?}",
+                    err
+                );
             }
             WsResponse::Empty
         },

--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -552,6 +552,7 @@ fn parse_splinter_services(
                 })
                 .collect(),
             status: "Pending".to_string(),
+            last_event: "".to_string(),
             created_time: timestamp,
             updated_time: timestamp,
         })
@@ -1263,6 +1264,7 @@ mod test {
                 "value": "test_value"
             })],
             status: "Pending".to_string(),
+            last_event: "".to_string(),
             created_time: timestamp,
             updated_time: timestamp,
         }

--- a/examples/gameroom/daemon/src/authorization_handler/state_delta.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/state_delta.rs
@@ -23,7 +23,7 @@ use gameroom_database::{
     models::{NewXoGame, XoGame},
     ConnectionPool,
 };
-use splinter::service::scabbard::StateChangeEvent;
+use splinter::service::scabbard::{StateChange, StateChangeEvent};
 
 use crate::authorization_handler::sabre::{get_xo_contract_address, XO_PREFIX};
 
@@ -46,19 +46,20 @@ impl XoStateDeltaProcessor {
         }
     }
 
-    pub fn handle_state_changes(
+    pub fn handle_state_change_event(
         &self,
-        changes: Vec<StateChangeEvent>,
+        change_event: StateChangeEvent,
     ) -> Result<(), StateDeltaError> {
-        changes
-            .iter()
-            .try_for_each(|change| self.handle_state_change(change))
+        for change in change_event.state_changes {
+            self.handle_state_change(&change)?;
+        }
+        Ok(())
     }
 
-    fn handle_state_change(&self, change: &StateChangeEvent) -> Result<(), StateDeltaError> {
+    fn handle_state_change(&self, change: &StateChange) -> Result<(), StateDeltaError> {
         debug!("Received state change: {}", change);
         match change {
-            StateChangeEvent::Set { key, .. } if key == &self.contract_address => {
+            StateChange::Set { key, .. } if key == &self.contract_address => {
                 debug!("Xo contract created successfully");
                 let time = SystemTime::now();
                 let conn = &*self.db_pool.get()?;
@@ -90,7 +91,7 @@ impl XoStateDeltaProcessor {
                 })
                 .map_err(StateDeltaError::from)
             }
-            StateChangeEvent::Set { key, value } if &key[..6] == XO_PREFIX => {
+            StateChange::Set { key, value } if &key[..6] == XO_PREFIX => {
                 let time = SystemTime::now();
                 let game_state: Vec<String> = String::from_utf8(value.to_vec())
                     .map_err(|err| StateDeltaError::XoPayloadParseError(format!("{:?}", err)))
@@ -147,7 +148,7 @@ impl XoStateDeltaProcessor {
                 })
                 .map_err(StateDeltaError::from)
             }
-            StateChangeEvent::Delete { .. } => {
+            StateChange::Delete { .. } => {
                 debug!("Delete state skipping...");
                 Ok(())
             }

--- a/examples/gameroom/database/src/helpers/gameroom.rs
+++ b/examples/gameroom/database/src/helpers/gameroom.rs
@@ -129,6 +129,7 @@ pub fn fetch_active_gamerooms(
             gameroom_service::circuit_id,
             gameroom_service::service_id,
             gameroom_service::status,
+            gameroom_service::last_event,
             gameroom_proposal::requester,
             gameroom_proposal::requester_node_id,
         ))
@@ -197,6 +198,21 @@ pub fn update_gameroom_service_status(
     ))
     .execute(conn)
     .map(|_| ())
+}
+
+pub fn update_gameroom_service_last_event(
+    conn: &PgConnection,
+    circuit_id: &str,
+    updated_time: &SystemTime,
+    event_id: &str,
+) -> QueryResult<()> {
+    diesel::update(gameroom_service::table.filter(gameroom_service::circuit_id.eq(circuit_id)))
+        .set((
+            gameroom_service::updated_time.eq(updated_time),
+            gameroom_service::last_event.eq(event_id),
+        ))
+        .execute(conn)
+        .map(|_| ())
 }
 
 pub fn insert_proposal_vote_record(

--- a/examples/gameroom/database/src/helpers/mod.rs
+++ b/examples/gameroom/database/src/helpers/mod.rs
@@ -24,8 +24,8 @@ pub use gameroom::{
     insert_gameroom, insert_gameroom_members, insert_gameroom_proposal, insert_gameroom_services,
     insert_proposal_vote_record, list_gameroom_members_with_status, list_gamerooms_with_paging,
     list_gamerooms_with_paging_and_status, list_proposals_with_paging,
-    update_gameroom_member_status, update_gameroom_proposal_status, update_gameroom_service_status,
-    update_gameroom_status,
+    update_gameroom_member_status, update_gameroom_proposal_status,
+    update_gameroom_service_last_event, update_gameroom_service_status, update_gameroom_status,
 };
 pub use gameroom_user::{fetch_user_by_email, insert_user};
 pub use notification::{

--- a/examples/gameroom/database/src/models.rs
+++ b/examples/gameroom/database/src/models.rs
@@ -128,6 +128,7 @@ pub struct GameroomService {
     pub allowed_nodes: Vec<String>,
     pub arguments: Vec<serde_json::Value>,
     pub status: String,
+    pub last_event: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,
 }
@@ -141,6 +142,7 @@ pub struct NewGameroomService {
     pub allowed_nodes: Vec<String>,
     pub arguments: Vec<serde_json::Value>,
     pub status: String,
+    pub last_event: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,
 }
@@ -200,6 +202,7 @@ pub struct ActiveGameroom {
     pub circuit_id: String,
     pub service_id: String,
     pub status: String,
+    pub last_event: String,
     pub requester: String,
     pub requester_node_id: String,
 }

--- a/examples/gameroom/database/src/schema.rs
+++ b/examples/gameroom/database/src/schema.rs
@@ -85,6 +85,7 @@ table! {
         allowed_nodes -> Array<Text>,
         arguments -> Array<Json>,
         status -> Text,
+        last_event -> Text,
         created_time -> Timestamp,
         updated_time -> Timestamp,
     }

--- a/examples/gameroom/database/tables/gameroom_tables.sql
+++ b/examples/gameroom/database/tables/gameroom_tables.sql
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS gameroom_service (
   allowed_nodes             TEXT[][]    NOT NULL,
   arguments                 JSON []     NOT NULL,
   status                    TEXT        NOT NULL,
+  last_event                TEXT        NOT NULL,
   created_time              TIMESTAMP   NOT NULL,
   updated_time              TIMESTAMP   NOT NULL,
   FOREIGN KEY (circuit_id) REFERENCES gameroom(circuit_id) ON DELETE CASCADE

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -39,7 +39,7 @@ mio = "0.6"
 mio-extras = "2"
 openssl = "0.10"
 protobuf = "2"
-sawtooth = { version = "0.1", default-features = false, features = ["lmdb-store", "receipt-store"] }
+sawtooth = { version = "0.2", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.4"
 sawtooth-sdk = { version = "0.3", optional = true }
 serde = "1.0"

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -56,7 +56,6 @@ impl fmt::Display for RestApiServerError {
 #[derive(Debug)]
 pub enum ResponseError {
     ActixError(ActixError),
-    CatchUpWsError(EventDealerError),
     CatchUpHistoryError(String),
 }
 
@@ -64,7 +63,6 @@ impl Error for ResponseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             ResponseError::ActixError(err) => Some(err),
-            ResponseError::CatchUpWsError(err) => Some(err),
             ResponseError::CatchUpHistoryError(_) => None,
         }
     }
@@ -78,8 +76,9 @@ impl fmt::Display for ResponseError {
                 "Failed to get response when setting up websocket: {}",
                 err
             ),
-            ResponseError::CatchUpWsError(err) => write!(f, "{}", err),
-            ResponseError::CatchUpHistoryError(msg) => f.write_str(&msg),
+            ResponseError::CatchUpHistoryError(msg) => {
+                write!(f, "failed to catch-up event subscriber: {}", msg)
+            }
         }
     }
 }
@@ -92,7 +91,7 @@ impl From<ActixError> for ResponseError {
 
 impl From<EventDealerError> for ResponseError {
     fn from(err: EventDealerError) -> Self {
-        ResponseError::CatchUpWsError(err)
+        ResponseError::CatchUpHistoryError(err.to_string())
     }
 }
 

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -96,12 +96,6 @@ impl From<EventDealerError> for ResponseError {
     }
 }
 
-impl From<EventHistoryError> for ResponseError {
-    fn from(err: EventHistoryError) -> Self {
-        ResponseError::CatchUpHistoryError(err.to_string())
-    }
-}
-
 #[derive(Debug)]
 pub struct EventDealerError {
     pub context: String,
@@ -131,20 +125,5 @@ impl fmt::Display for EventDealerError {
         } else {
             f.write_str(&self.context)
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct EventHistoryError(pub Box<dyn Error + 'static>);
-
-impl Error for EventHistoryError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&*self.0)
-    }
-}
-
-impl fmt::Display for EventHistoryError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Unable to read or write to event history: {}", self.0)
     }
 }

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -56,14 +56,12 @@ impl fmt::Display for RestApiServerError {
 #[derive(Debug)]
 pub enum ResponseError {
     ActixError(ActixError),
-    CatchUpHistoryError(String),
 }
 
 impl Error for ResponseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             ResponseError::ActixError(err) => Some(err),
-            ResponseError::CatchUpHistoryError(_) => None,
         }
     }
 }
@@ -76,9 +74,6 @@ impl fmt::Display for ResponseError {
                 "Failed to get response when setting up websocket: {}",
                 err
             ),
-            ResponseError::CatchUpHistoryError(msg) => {
-                write!(f, "failed to catch-up event subscriber: {}", msg)
-            }
         }
     }
 }
@@ -86,43 +81,5 @@ impl fmt::Display for ResponseError {
 impl From<ActixError> for ResponseError {
     fn from(err: ActixError) -> Self {
         ResponseError::ActixError(err)
-    }
-}
-
-impl From<EventDealerError> for ResponseError {
-    fn from(err: EventDealerError) -> Self {
-        ResponseError::CatchUpHistoryError(err.to_string())
-    }
-}
-
-#[derive(Debug)]
-pub struct EventDealerError {
-    pub context: String,
-    pub source: Option<Box<dyn Error + Send>>,
-}
-
-impl EventDealerError {
-    pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
-        Self { context, source }
-    }
-}
-
-impl Error for EventDealerError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        if let Some(ref err) = self.source {
-            Some(&**err)
-        } else {
-            None
-        }
-    }
-}
-
-impl fmt::Display for EventDealerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref err) = self.source {
-            write!(f, "{}: {}", self.context, err)
-        } else {
-            f.write_str(&self.context)
-        }
     }
 }

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -64,9 +64,9 @@ use std::boxed::Box;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use errors::{EventDealerError, ResponseError, RestApiServerError};
+pub use errors::{ResponseError, RestApiServerError};
 
-pub use events::{EventDealer, EventSender};
+pub use events::{new_websocket_event_sender, EventSender};
 
 /// A `RestResourceProvider` provides a list of resources that are consumed by `RestApi`.
 pub trait RestResourceProvider {

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -64,9 +64,9 @@ use std::boxed::Box;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use errors::{EventDealerError, EventHistoryError, ResponseError, RestApiServerError};
+pub use errors::{EventDealerError, ResponseError, RestApiServerError};
 
-pub use events::{EventDealer, EventHistory, EventSender, LocalEventHistory};
+pub use events::{EventDealer, EventSender};
 
 /// A `RestResourceProvider` provides a list of resources that are consumed by `RestApi`.
 pub trait RestResourceProvider {

--- a/libsplinter/src/service/scabbard/error.rs
+++ b/libsplinter/src/service/scabbard/error.rs
@@ -132,3 +132,22 @@ impl From<StateWriteError> for ScabbardStateError {
         ScabbardStateError(err.to_string())
     }
 }
+
+#[derive(Debug)]
+pub enum StateSubscriberError {
+    UnableToHandleEvent(String),
+    Unsubscribe,
+}
+
+impl Error for StateSubscriberError {}
+
+impl std::fmt::Display for StateSubscriberError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            StateSubscriberError::UnableToHandleEvent(msg) => {
+                write!(f, "unable to handle event: {}", msg)
+            }
+            StateSubscriberError::Unsubscribe => f.write_str("unsubscribe"),
+        }
+    }
+}

--- a/libsplinter/src/service/scabbard/error.rs
+++ b/libsplinter/src/service/scabbard/error.rs
@@ -24,6 +24,7 @@ use transact::state::merkle::StateDatabaseError;
 
 #[derive(Debug)]
 pub enum ScabbardError {
+    BatchVerificationFailed(Box<dyn Error + Send>),
     ConsensusFailed(ScabbardConsensusManagerError),
     InitializationFailed(Box<dyn Error + Send>),
     LockPoisoned,
@@ -34,6 +35,7 @@ pub enum ScabbardError {
 impl Error for ScabbardError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            ScabbardError::BatchVerificationFailed(err) => Some(&**err),
             ScabbardError::ConsensusFailed(err) => Some(err),
             ScabbardError::InitializationFailed(err) => Some(&**err),
             ScabbardError::LockPoisoned => None,
@@ -46,6 +48,9 @@ impl Error for ScabbardError {
 impl std::fmt::Display for ScabbardError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            ScabbardError::BatchVerificationFailed(err) => {
+                write!(f, "failed to verify batch: {}", err)
+            }
             ScabbardError::ConsensusFailed(err) => write!(f, "scabbard consensus failed: {}", err),
             ScabbardError::InitializationFailed(err) => {
                 write!(f, "failed to initialize scabbard: {}", err)

--- a/libsplinter/src/service/scabbard/error.rs
+++ b/libsplinter/src/service/scabbard/error.rs
@@ -30,6 +30,7 @@ pub enum ScabbardError {
     LockPoisoned,
     MessageTypeUnset,
     NotConnected,
+    StateInteractionFailed(ScabbardStateError),
 }
 
 impl Error for ScabbardError {
@@ -41,6 +42,7 @@ impl Error for ScabbardError {
             ScabbardError::LockPoisoned => None,
             ScabbardError::MessageTypeUnset => None,
             ScabbardError::NotConnected => None,
+            ScabbardError::StateInteractionFailed(err) => Some(err),
         }
     }
 }
@@ -60,6 +62,9 @@ impl std::fmt::Display for ScabbardError {
             ScabbardError::NotConnected => {
                 write!(f, "attempted to send message, but service isn't connected")
             }
+            ScabbardError::StateInteractionFailed(err) => {
+                write!(f, "interaction with scabbard state failed: {}", err)
+            }
         }
     }
 }
@@ -67,6 +72,12 @@ impl std::fmt::Display for ScabbardError {
 impl From<ScabbardConsensusManagerError> for ScabbardError {
     fn from(err: ScabbardConsensusManagerError) -> Self {
         ScabbardError::ConsensusFailed(err)
+    }
+}
+
+impl From<ScabbardStateError> for ScabbardError {
+    fn from(err: ScabbardStateError) -> Self {
+        ScabbardError::StateInteractionFailed(err)
     }
 }
 

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -230,12 +230,12 @@ impl Service for Scabbard {
             .take_network_sender()
             .ok_or_else(|| ServiceStopError::Internal(Box::new(ScabbardError::NotConnected)))?;
 
-        // Shutdown event dealer and disconnect websockets
+        // Shutdown event senders and disconnect websockets
         self.shared
             .lock()
             .map_err(|_| ServiceStopError::PoisonedLock("shared lock poisoned".into()))?
             .state_mut()
-            .shutdown_event_dealer();
+            .shutdown_event_senders();
 
         service_registry.disconnect(self.service_id())?;
 

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -48,7 +48,7 @@ use error::ScabbardError;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
 use state::ScabbardState;
-pub use state::{BatchInfo, BatchStatus, StateChangeEvent};
+pub use state::{BatchInfo, BatchStatus, StateChange, StateChangeEvent};
 
 const SERVICE_TYPE: &str = "scabbard";
 

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -46,7 +46,7 @@ use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
-pub use state::{BatchInfo, BatchStatus, StateChange, StateChangeEvent};
+pub use state::{BatchInfo, BatchStatus, Events, StateChange, StateChangeEvent};
 use state::{ScabbardState, StateSubscriber};
 
 const SERVICE_TYPE: &str = "scabbard";
@@ -152,6 +152,14 @@ impl Scabbard {
             .iter()
             .map(|signature| state.batch_history().get_batch_info(signature))
             .collect::<Vec<_>>())
+    }
+
+    pub fn get_events_since(&self, event_id: Option<String>) -> Result<Events, ScabbardError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| ScabbardError::LockPoisoned)?
+            .get_events_since(event_id)?)
     }
 
     pub fn add_state_subscriber(

--- a/libsplinter/src/service/scabbard/shared.rs
+++ b/libsplinter/src/service/scabbard/shared.rs
@@ -24,8 +24,6 @@ use crate::service::{ServiceError, ServiceNetworkSender};
 use crate::signing::hash::HashVerifier;
 use crate::signing::SignatureVerifier;
 
-use super::state::{BatchHistory, ScabbardState};
-
 /// Data structure used to store information that's shared between components in this service
 pub struct ScabbardShared {
     /// Queue of batches that have been submitted locally via the REST API, but have not yet been
@@ -39,7 +37,6 @@ pub struct ScabbardShared {
     /// Tracks which batches are currently being evaluated, indexed by corresponding proposal IDs.
     proposed_batches: HashMap<ProposalId, BatchPair>,
     signature_verifier: Box<dyn SignatureVerifier>,
-    state: ScabbardState,
 }
 
 impl ScabbardShared {
@@ -48,7 +45,6 @@ impl ScabbardShared {
         network_sender: Option<Box<dyn ServiceNetworkSender>>,
         peer_services: HashSet<String>,
         signature_verifier: Box<dyn SignatureVerifier>,
-        state: ScabbardState,
     ) -> Self {
         ScabbardShared {
             batch_queue,
@@ -56,7 +52,6 @@ impl ScabbardShared {
             peer_services,
             proposed_batches: HashMap::new(),
             signature_verifier,
-            state,
         }
     }
 
@@ -98,14 +93,6 @@ impl ScabbardShared {
 
     pub fn remove_proposed_batch(&mut self, proposal_id: &ProposalId) -> Option<BatchPair> {
         self.proposed_batches.remove(&proposal_id)
-    }
-
-    pub fn state_mut(&mut self) -> &mut ScabbardState {
-        &mut self.state
-    }
-
-    pub fn batch_history(&mut self) -> &mut BatchHistory {
-        self.state.batch_history()
     }
 
     pub fn verify_batches(&self, batches: &[BatchPair]) -> Result<bool, ServiceError> {

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -471,7 +471,7 @@ impl BatchHistory {
         Self::default()
     }
 
-    pub fn add_batch(&mut self, signature: &str) -> Result<(), ScabbardStateError> {
+    pub fn add_batch(&mut self, signature: &str) {
         self.history.insert(
             signature.to_string(),
             BatchInfo {
@@ -488,8 +488,6 @@ impl BatchHistory {
                 .min_by_key(|(_, v)| v.timestamp)
                 .and_then(|(k, _)| self.history.remove(&k));
         }
-
-        Ok(())
     }
 
     fn update_batch_status(&mut self, signature: &str, status: BatchStatus) {
@@ -513,15 +511,15 @@ impl BatchHistory {
         }
     }
 
-    pub fn get_batch_info(&self, signature: &str) -> Result<BatchInfo, ScabbardStateError> {
+    pub fn get_batch_info(&self, signature: &str) -> BatchInfo {
         if let Some(info) = self.history.get(signature) {
-            Ok(info.clone())
+            info.clone()
         } else {
-            Ok(BatchInfo {
+            BatchInfo {
                 id: signature.to_string(),
                 status: BatchStatus::Unknown,
                 timestamp: SystemTime::now(),
-            })
+            }
         }
     }
 }


### PR DESCRIPTION
Updates the scabbard service to catch-up a subscriber if it has missed
any state change events. When the subscriber sends the WebSocket
subscription request, it can specify the ID of the last state change
event it received; if this is specified, any state changes that occurred
after the specified one will be sent to the subscriber. If no ID is
specified with the subscription request, all state change events will be
sent (scabbard assumes that this is a new subscriber that will need to
be caught-up).

Also updates gameroomd to specify the last event it saw when it resubscribes.