### PR TITLE
CanopyJS user implementation

### DIFF
--- a/canopy/app/package.json
+++ b/canopy/app/package.json
@@ -32,9 +32,7 @@
   "dependencies": {
     "@babel/parser": "^7.7.2",
     "babel-plugin-macros": "^2.6.1",
-    "es6-promisify": "^6.0.2",
     "js-yaml": "^3.13.1",
-    "little-loader": "^0.2.0",
     "node-sass": "^4.12.0",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",

--- a/canopy/app/src/UserStore.js
+++ b/canopy/app/src/UserStore.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const UserContext = React.createContext();
+
+export function UserProvider({ children }) {
+  const userState = React.useState(null);
+  return (
+    <UserContext.Provider value={userState}>{children}</UserContext.Provider>
+  );
+}
+
+export function useUserState() {
+  const userState = React.useContext(UserContext);
+  if (userState === undefined) {
+    throw new Error('useUserState must be used within a UserProvider');
+  }
+  return userState;
+}
+
+UserProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};

--- a/canopy/app/src/promiseLoader.js
+++ b/canopy/app/src/promiseLoader.js
@@ -14,7 +14,19 @@
  * limitations under the License.
  */
 
-import littleLoader from 'little-loader';
-import { promisify } from 'es6-promisify';
+function promiseLoader(scriptUrl) {
+  const canopyUrl = new URL(window.location);
+  const saplingUrl = new URL(scriptUrl);
+  return new Promise((resolve, reject) => {
+    const body = document.querySelector('body');
+    const script = document.createElement('script');
+    script.async = true;
+    script.crossOrigin = canopyUrl.origin !== saplingUrl.origin;
+    script.src = scriptUrl;
+    script.onload = resolve;
+    script.onerror = reject;
+    body.insertAdjacentElement('beforeend', script);
+  });
+}
 
-export default promisify(littleLoader);
+export default promiseLoader;

--- a/canopy/canopyjs/src/index.spec.ts
+++ b/canopy/canopyjs/src/index.spec.ts
@@ -17,19 +17,25 @@
 const bootstrap = (): void => {
   /* no op */
 };
-
-interface MockCanopy {
-  registerConfigSapling: jest.Mock;
-  registerApp: jest.Mock;
-}
+const completeUser = { userId: 'COMPLETE', displayName: 'canopy' };
+const minimalUser = { userId: 'MINIMAL' };
 
 // In order to prevent the need to overwrite the window interface,
 // a intentional `any` is cast here.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).$CANOPY = {
   registerConfigSapling: jest.fn(),
-  registerApp: jest.fn()
+  registerApp: jest.fn(),
+  getUser: jest.fn(() => completeUser),
+  setUser: jest.fn()
 };
+
+interface MockCanopy {
+  registerConfigSapling: jest.Mock;
+  registerApp: jest.Mock;
+  getUser: jest.Mock;
+  setUser: jest.Mock;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const $CANOPY = (window as any).$CANOPY as MockCanopy;
@@ -56,6 +62,32 @@ describe('CanopyJS', () => {
       registerConfigSapling('login', bootstrap);
       expect($CANOPY.registerConfigSapling.mock.calls[0][0]).toEqual('login');
       expect($CANOPY.registerConfigSapling.mock.calls[0][1]).toEqual(bootstrap);
+    });
+  });
+
+  describe('getUser()', () => {
+    it('should call getUser from window object', async () => {
+      expect.assertions(1);
+      // dynamic import is used here to ensure that the window.$CANOPY object has been set up
+      const { getUser } = await import('./index');
+      expect(getUser()).toEqual(completeUser);
+    });
+  });
+
+  describe('setUser(user)', () => {
+    it('should call setUser from window object with a complete user object', async () => {
+      expect.assertions(1);
+      // dynamic import is used here to ensure that the window.$CANOPY object has been set up
+      const { setUser } = await import('./index');
+      setUser(completeUser);
+      expect($CANOPY.setUser.mock.calls[0][0]).toEqual(completeUser);
+    });
+    it('it should call setUser from window object with a minimal user object', async () => {
+      expect.assertions(1);
+      // dynamic import is used here to ensure that the window.$CANOPY object has been set up
+      const { setUser } = await import('./index');
+      setUser(minimalUser);
+      expect($CANOPY.setUser.mock.calls[0][0]).toEqual(minimalUser);
     });
   });
 });

--- a/canopy/canopyjs/src/index.ts
+++ b/canopy/canopyjs/src/index.ts
@@ -13,6 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+interface User {
+  userId: string;
+  displayName?: string;
+}
+
+interface SetUser {
+  (user: User): void;
+}
+
+interface GetUser {
+  (): User;
+}
+
 interface RegisterApp {
   (bootstrapFunction: (domNode: Node) => void): void;
 }
@@ -26,6 +40,8 @@ interface RegisterConfigSapling {
 interface Canopy {
   registerApp: RegisterApp;
   registerConfigSapling: RegisterConfigSapling;
+  getUser: GetUser;
+  setUser: SetUser;
 }
 
 function assertAndGetWindowCanopy(): Canopy {
@@ -43,4 +59,9 @@ function assertAndGetWindowCanopy(): Canopy {
 
 const canopy = assertAndGetWindowCanopy();
 
-export const { registerApp, registerConfigSapling }: Canopy = canopy;
+export const {
+  registerApp,
+  registerConfigSapling,
+  getUser,
+  setUser
+}: Canopy = canopy;


### PR DESCRIPTION
A Sapling can now use the CanopyJS functions to set and get a user from Canopy.

That user data is stored in a React Context and is exposed via the `window.$CANOPY` object.

The reason that the refactor of `promiseLoader` is here is that React was barking about setting one of its refs to a function from a cross origin script that was not explicitly stated on script load.

The deletion of the `canopyState` object is intended to bring as much of that state into the React application as possible. Some variable names have been updated to better reflect their intent because of this.