### PR TITLE
Add certificate generation subcommand to splinter cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ license = "Apache-2.0"
 clap = "2"
 libc = "0.2"
 log = "0.3.8"
+openssl = "0.10"
 protobuf = "2"
 reqwest = { version = "0.9", optional = true }
 sawtooth-sdk = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,8 +25,9 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = "2"
+flexi_logger = "0.14"
 libc = "0.2"
-log = "0.3.8"
+log = "0.4"
 openssl = "0.10"
 protobuf = "2"
 reqwest = { version = "0.9", optional = true }
@@ -35,5 +36,4 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version ="1.0", optional = true }
 serde_yaml = "0.8"
-simple_logger = "0.4.0"
 splinter = { path = "../libsplinter" }

--- a/cli/src/action/admin.rs
+++ b/cli/src/action/admin.rs
@@ -26,6 +26,7 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::MetadataExt;
 
 use clap::ArgMatches;
+use flexi_logger::ReconfigurationHandle;
 use sawtooth_sdk::signing;
 use serde::{Deserialize, Serialize};
 use splinter::keys::{storage::StorageKeyRegistry, KeyInfo, KeyRegistry};
@@ -40,7 +41,11 @@ const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 pub struct KeyGenAction;
 
 impl Action for KeyGenAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &ReconfigurationHandle,
+    ) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
         let key_name = args.value_of("key_name").unwrap_or("splinter");
@@ -69,7 +74,11 @@ impl Action for KeyGenAction {
 pub struct KeyRegistryGenerationAction;
 
 impl Action for KeyRegistryGenerationAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &ReconfigurationHandle,
+    ) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
         let registry_spec_path = args

--- a/cli/src/action/certs.rs
+++ b/cli/src/action/certs.rs
@@ -25,6 +25,7 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::MetadataExt;
 
 use clap::ArgMatches;
+use flexi_logger::ReconfigurationHandle;
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::error::ErrorStack;
@@ -51,7 +52,11 @@ const CA_CERT: &str = "generated_ca.pem";
 const CA_KEY: &str = "generated_ca.key";
 
 impl Action for CertGenAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &ReconfigurationHandle,
+    ) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
         let common_name = args

--- a/cli/src/action/certs.rs
+++ b/cli/src/action/certs.rs
@@ -1,0 +1,734 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::fs::{self, metadata, OpenOptions};
+use std::io;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt;
+#[cfg(not(target_os = "linux"))]
+use std::os::unix::fs::MetadataExt;
+
+use clap::ArgMatches;
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, PKeyRef, Private};
+use openssl::rsa::Rsa;
+use openssl::x509::extension::{BasicConstraints, ExtendedKeyUsage, KeyUsage};
+use openssl::x509::{X509NameBuilder, X509Ref, X509};
+
+use crate::error::CliError;
+
+use super::{chown, Action};
+
+pub struct CertGenAction;
+
+const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs/";
+const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
+
+const CLIENT_CERT: &str = "client.crt";
+const CLIENT_KEY: &str = "client.key";
+const SERVER_CERT: &str = "server.crt";
+const SERVER_KEY: &str = "server.key";
+const CA_CERT: &str = "generated_ca.pem";
+const CA_KEY: &str = "generated_ca.key";
+
+impl Action for CertGenAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let common_name = args
+            .value_of("common_name")
+            .unwrap_or("localhost")
+            .to_string();
+
+        let cert_dir_string = args
+            .value_of("cert_dir")
+            .map(ToOwned::to_owned)
+            .or_else(|| env::var(CERT_DIR_ENV).ok())
+            .or_else(|| Some(DEFAULT_CERT_DIR.to_string()))
+            .unwrap();
+
+        let cert_dir = Path::new(&cert_dir_string);
+
+        // Check if the provided cert directory exists
+        if !cert_dir.is_dir() {
+            return Err(CliError::ActionError(format!(
+                "Cert directory does not exist: {}",
+                cert_dir.display()
+            )));
+        }
+
+        let private_cert_path = cert_dir.join("private/");
+        let cert_path = cert_dir.to_path_buf();
+
+        // Check if the provided private key directory for the certs exists, if not create it
+        if !private_cert_path.is_dir() {
+            fs::create_dir_all(private_cert_path.clone()).map_err(|err| {
+                CliError::ActionError(format!("Unable to create private directory: {}", err))
+            })?
+        }
+
+        // check that both directories are writable
+        match cert_dir.metadata() {
+            Ok(metadata) => {
+                if metadata.permissions().readonly() {
+                    return Err(CliError::ActionError(format!(
+                        "Cert directory is not writeable: {}",
+                        absolute_path(&cert_dir)?,
+                    )));
+                }
+            }
+            Err(err) => {
+                return Err(CliError::ActionError(format!(
+                    "Cannot check if cert directory {} is writable: {}",
+                    absolute_path(&cert_dir)?,
+                    err
+                )));
+            }
+        }
+
+        match private_cert_path.metadata() {
+            Ok(metadata) => {
+                if metadata.permissions().readonly() {
+                    return Err(CliError::ActionError(format!(
+                        "Private cert directory is not writeable: {}",
+                        absolute_path(&private_cert_path)?
+                    )));
+                }
+            }
+            Err(err) => {
+                return Err(CliError::ActionError(format!(
+                    "Cannot check if cert directory {} is writable: {}",
+                    absolute_path(&private_cert_path)?,
+                    err
+                )));
+            }
+        }
+
+        // if skip, check each pair of certificate/key to see if it exists. If not generate the
+        // the missing files. If only one of the two files exists, this is an error.
+        if args.is_present("skip") {
+            return handle_skip(cert_path, private_cert_path, common_name);
+        }
+
+        // if force is not present, all files must not exist.
+        if !args.is_present("force") {
+            let client_cert_path = cert_dir.join(CLIENT_CERT);
+            let server_cert_path = cert_dir.join(SERVER_CERT);
+            let ca_cert_path = cert_dir.join(CA_CERT);
+
+            let client_key_path = private_cert_path.join(CLIENT_KEY);
+            let server_key_path = private_cert_path.join(SERVER_KEY);
+            let ca_key_path = private_cert_path.join(CA_KEY);
+            let mut errored = false;
+            if client_cert_path.exists() {
+                error!(
+                    "Client certificate already exists: {}",
+                    absolute_path(&client_cert_path)?,
+                );
+                errored = true;
+            };
+
+            if client_key_path.exists() {
+                error!(
+                    "Client key already exists: {}",
+                    absolute_path(&client_key_path)?,
+                );
+                errored = true;
+            }
+
+            if server_cert_path.exists() {
+                error!(
+                    "Server certificate already exists: {}",
+                    absolute_path(&server_cert_path)?,
+                );
+                errored = true;
+            }
+
+            if server_key_path.exists() {
+                error!(
+                    "Server key already exists: {}",
+                    absolute_path(&server_key_path)?,
+                );
+                errored = true;
+            }
+
+            if ca_cert_path.exists() {
+                error!(
+                    "CA certificate already exists: {}",
+                    absolute_path(&ca_cert_path)?,
+                );
+                errored = true;
+            }
+
+            if ca_key_path.exists() {
+                error!("CA key already exists: {}", absolute_path(&ca_key_path)?);
+                errored = true;
+            }
+
+            if errored {
+                return Err(CliError::ActionError(
+                    "Refusing to overwrite files, exiting".into(),
+                ));
+            } else {
+                // if all files need to be generated log what will be written and generate all
+                log_writing(&cert_path, &private_cert_path)?;
+                create_all_certs(cert_path, private_cert_path, common_name)?;
+            }
+        } else {
+            // if force is true, overwrite all existing files
+            log_overwriting(&cert_path, &private_cert_path)?;
+            create_all_certs(cert_dir.to_path_buf(), private_cert_path, common_name)?;
+        }
+
+        Ok(())
+    }
+}
+
+// if skip, check each pair of certificate/key to see if it exists. If not generate the
+// the missing files. If only one of the two files exists, this is an error.
+fn handle_skip(
+    cert_dir: PathBuf,
+    private_cert_path: PathBuf,
+    common_name: String,
+) -> Result<(), CliError> {
+    let client_cert_path = cert_dir.join(CLIENT_CERT);
+    let server_cert_path = cert_dir.join(SERVER_CERT);
+    let ca_cert_path = cert_dir.join(CA_CERT);
+
+    let client_key_path = private_cert_path.join(CLIENT_KEY);
+    let server_key_path = private_cert_path.join(SERVER_KEY);
+    let ca_key_path = private_cert_path.join(CA_KEY);
+    let cert_path = cert_dir.to_path_buf();
+    let mut ca;
+
+    // if all exists, log existence and return
+    if client_cert_path.exists()
+        && client_key_path.exists()
+        && server_cert_path.exists()
+        && server_key_path.exists()
+        && ca_cert_path.exists()
+        && ca_key_path.exists()
+    {
+        info!(
+            "Client certificate exists, skipping: {}",
+            absolute_path(&client_cert_path)?,
+        );
+        info!(
+            "Client key exists, skipping: {}",
+            absolute_path(&client_key_path)?,
+        );
+        info!(
+            "Server certificate exists, skipping: {}",
+            absolute_path(&server_cert_path)?,
+        );
+        info!(
+            "Server key exists, skipping: {}",
+            absolute_path(&server_key_path)?,
+        );
+        info!(
+            "CA certificate exists, skipping: {}",
+            absolute_path(&ca_cert_path)?,
+        );
+        info!("CA key exists, skipping: {}", absolute_path(&ca_key_path)?);
+        return Ok(());
+    }
+
+    if (ca_cert_path.exists() || ca_key_path.exists())
+        && !(ca_cert_path.exists() && ca_key_path.exists())
+    {
+        // if one exists without the other return an error
+        if ca_cert_path.exists() {
+            return Err(CliError::ActionError(format!(
+                "Matching key for the certificate is missing: {}/{} ",
+                absolute_path(&cert_path)?,
+                CA_KEY
+            )));
+        } else {
+            return Err(CliError::ActionError(format!(
+                "Matching certificate for the key is missing: {}/{} ",
+                absolute_path(&private_cert_path)?,
+                CA_CERT
+            )));
+        }
+    }
+
+    if (client_cert_path.exists() || client_key_path.exists())
+        && !(client_cert_path.exists() && client_key_path.exists())
+    {
+        // if one exists without the other return an error
+        if client_cert_path.exists() {
+            return Err(CliError::ActionError(format!(
+                "Matching key for the certificate is missing: {}/{} ",
+                absolute_path(&cert_path)?,
+                CLIENT_KEY
+            )));
+        } else {
+            return Err(CliError::ActionError(format!(
+                "Matching certificate for the key is missing: {}/{} ",
+                absolute_path(&private_cert_path)?,
+                CLIENT_CERT
+            )));
+        }
+    }
+
+    if (server_cert_path.exists() || server_key_path.exists())
+        && !(server_cert_path.exists() && server_key_path.exists())
+    {
+        // if one exists without the other return an error
+        if server_cert_path.exists() {
+            return Err(CliError::ActionError(format!(
+                "Matching key for the certificate is missing: {}/{} ",
+                absolute_path(&cert_path)?,
+                SERVER_KEY
+            )));
+        } else {
+            return Err(CliError::ActionError(format!(
+                "Matching certificate for the key is missing: {}/{} ",
+                absolute_path(&private_cert_path)?,
+                SERVER_CERT
+            )));
+        }
+    }
+
+    // if ca files exists, log and read the cert and key from the file
+    if ca_cert_path.exists() && ca_key_path.exists() {
+        info!(
+            "CA certificate exists, skipping: {}",
+            absolute_path(&ca_cert_path)?,
+        );
+        info!("CA key exists, skipping: {}", absolute_path(&ca_key_path)?);
+        let ca_cert = get_ca_cert(&ca_cert_path)?;
+        let ca_key = get_ca_key(&ca_key_path)?;
+        ca = Some((ca_key, ca_cert));
+    } else {
+        // if the ca files do not exist, generate them
+        info!("Writing file: {}/{}", absolute_path(&cert_path)?, CA_CERT);
+        info!(
+            "Writing file: {}/{}",
+            absolute_path(&private_cert_path)?,
+            CA_KEY
+        );
+        let (genearte_ca_key, generate_ca_cert) =
+            write_ca(cert_path.clone(), private_cert_path.clone())?;
+        ca = Some((genearte_ca_key, generate_ca_cert));
+    }
+
+    // if the client files exist log
+    if client_cert_path.exists() && client_key_path.exists() {
+        info!(
+            "Client certificate exists, skipping: {}",
+            absolute_path(&client_cert_path)?,
+        );
+        info!(
+            "Client key exists, skipping: {}",
+            absolute_path(&client_key_path)?,
+        );
+    } else {
+        // if the client files do not exist, generate them using the ca
+        info!(
+            "Writing file: {}/{}",
+            absolute_path(&cert_path)?,
+            CLIENT_CERT
+        );
+        info!(
+            "Writing file: {}/{}",
+            absolute_path(&private_cert_path)?,
+            CLIENT_KEY
+        );
+        if let Some((ca_key, ca_cert)) = ca {
+            write_client(
+                cert_path.clone(),
+                private_cert_path.clone(),
+                &ca_key,
+                &ca_cert,
+                &common_name,
+            )?;
+            ca = Some((ca_key, ca_cert));
+        } else {
+            // this should never happen
+            return Err(CliError::ActionError("CA does not exist".into()));
+        }
+    }
+
+    if server_cert_path.exists() && server_key_path.exists() {
+        info!(
+            "Server certificate exists, skipping: {}",
+            absolute_path(&server_cert_path)?,
+        );
+        info!(
+            "Server key exists, skipping: {}",
+            absolute_path(&server_key_path)?,
+        );
+    } else {
+        // if the server files do not exist, generate them using the ca
+        info!(
+            "Writing file: {}/{}",
+            absolute_path(&cert_path)?,
+            SERVER_CERT
+        );
+        info!(
+            "Writing file: {}/{}",
+            absolute_path(&private_cert_path)?,
+            SERVER_KEY
+        );
+        if let Some((ca_key, ca_cert)) = ca {
+            write_server(
+                cert_path,
+                private_cert_path,
+                &ca_key,
+                &ca_cert,
+                &common_name,
+            )?;
+        } else {
+            // this should never happen
+            return Err(CliError::ActionError("CA does not exist".into()));
+        }
+    }
+    Ok(())
+}
+
+// create all certificates and keys from scratch
+fn create_all_certs(
+    cert_path: PathBuf,
+    private_cert_path: PathBuf,
+    common_name: String,
+) -> Result<(), CliError> {
+    // Generate Certificate Authority keys and certificate.
+    // These files are not saved
+    let (ca_key, ca_cert) = write_ca(cert_path.clone(), private_cert_path.clone())?;
+    // Generate client and server keys and certificates
+
+    write_client(
+        cert_path.clone(),
+        private_cert_path.clone(),
+        &ca_key,
+        &ca_cert,
+        &common_name,
+    )?;
+
+    write_server(
+        cert_path,
+        private_cert_path,
+        &ca_key,
+        &ca_cert,
+        &common_name,
+    )?;
+
+    Ok(())
+}
+
+// Generate Certificate Authority keys and certificate.
+fn write_ca(
+    cert_path: PathBuf,
+    private_cert_path: PathBuf,
+) -> Result<(PKey<Private>, X509), CliError> {
+    let (ca_key, ca_cert) = make_ca_cert()?;
+
+    write_file(cert_path.clone(), CA_CERT, &ca_cert.to_pem()?)?;
+
+    write_file(
+        private_cert_path.clone(),
+        CA_KEY,
+        &ca_key.private_key_to_pem_pkcs8()?,
+    )?;
+
+    Ok((ca_key, ca_cert))
+}
+
+// Generate server keys and certificate.
+fn write_server(
+    cert_path: PathBuf,
+    private_cert_path: PathBuf,
+    ca_key: &PKey<Private>,
+    ca_cert: &X509,
+    common_name: &str,
+) -> Result<(), CliError> {
+    let (server_key, server_cert) = make_ca_signed_cert(ca_cert, ca_key, common_name)?;
+
+    write_file(cert_path.clone(), SERVER_CERT, &server_cert.to_pem()?)?;
+
+    write_file(
+        private_cert_path.clone(),
+        SERVER_KEY,
+        &server_key.private_key_to_pem_pkcs8()?,
+    )?;
+    Ok(())
+}
+
+// Generate client keys and certificate.
+fn write_client(
+    cert_path: PathBuf,
+    private_cert_path: PathBuf,
+    ca_key: &PKey<Private>,
+    ca_cert: &X509,
+    common_name: &str,
+) -> Result<(), CliError> {
+    let (server_key, server_cert) = make_ca_signed_cert(ca_cert, ca_key, common_name)?;
+
+    write_file(cert_path.clone(), CLIENT_CERT, &server_cert.to_pem()?)?;
+
+    write_file(
+        private_cert_path.clone(),
+        CLIENT_KEY,
+        &server_key.private_key_to_pem_pkcs8()?,
+    )?;
+    Ok(())
+}
+
+// Make a certificate and private key for the Certificate  Authority
+fn make_ca_cert() -> Result<(PKey<Private>, X509), CliError> {
+    // generate private key
+    let rsa = Rsa::generate(2048)?;
+    let privkey = PKey::from_rsa(rsa)?;
+
+    // build x509 name
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("CN", "generated_ca")?;
+    let x509_name = x509_name.build();
+
+    // build x509 cert
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(&x509_name)?;
+    cert_builder.set_pubkey(&privkey)?;
+
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    cert_builder.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+    cert_builder.append_extension(KeyUsage::new().key_cert_sign().build()?)?;
+
+    cert_builder.sign(&privkey, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    // return private key and ca_cert
+    Ok((privkey, cert))
+}
+
+// Make a certificate and private key signed by the given CA cert and private key
+// Cert could act like both server or client
+fn make_ca_signed_cert(
+    ca_cert: &X509Ref,
+    ca_privkey: &PKeyRef<Private>,
+    common_name: &str,
+) -> Result<(PKey<Private>, X509), CliError> {
+    // generate private key
+    let rsa = Rsa::generate(2048)?;
+    let privkey = PKey::from_rsa(rsa)?;
+
+    // build x509_name
+    let mut x509_name = X509NameBuilder::new()?;
+    x509_name.append_entry_by_text("CN", &common_name)?;
+    let x509_name = x509_name.build();
+
+    // build x509 cert
+    let mut cert_builder = X509::builder()?;
+    cert_builder.set_version(2)?;
+    let serial_number = {
+        let mut serial = BigNum::new()?;
+        serial.rand(159, MsbOption::MAYBE_ZERO, false)?;
+        serial.to_asn1_integer()?
+    };
+    cert_builder.set_serial_number(&serial_number)?;
+    cert_builder.set_subject_name(&x509_name)?;
+    cert_builder.set_issuer_name(ca_cert.subject_name())?;
+    cert_builder.set_pubkey(&privkey)?;
+    let not_before = Asn1Time::days_from_now(0)?;
+    cert_builder.set_not_before(&not_before)?;
+    let not_after = Asn1Time::days_from_now(365)?;
+    cert_builder.set_not_after(&not_after)?;
+
+    // allow keys to be used for both server and client authorization
+    cert_builder.append_extension(
+        ExtendedKeyUsage::new()
+            .server_auth()
+            .client_auth()
+            .build()?,
+    )?;
+
+    // sign the cert by the ca
+    cert_builder.sign(&ca_privkey, MessageDigest::sha256())?;
+    let cert = cert_builder.build();
+
+    // return private key and cert
+    Ok((privkey, cert))
+}
+
+/// write the a file to a temp file name and then rename to final filename
+/// this will guarantee that the final file will ony ever contain valid data
+fn write_file(path_buf: PathBuf, file_name: &str, bytes: &[u8]) -> Result<(), CliError> {
+    let temp_path_buf = path_buf.join(format!(".{}.new", file_name));
+    let temp_path = {
+        if let Some(path) = temp_path_buf.to_str() {
+            path.to_string()
+        } else {
+            return Err(CliError::ActionError(
+                "Path is not valid unicode".to_string(),
+            ));
+        }
+    };
+
+    let final_path_buf = path_buf.join(file_name);
+    let final_path = {
+        if let Some(path) = final_path_buf.to_str() {
+            path.to_string()
+        } else {
+            return Err(CliError::ActionError(
+                "Path is not valid unicode".to_string(),
+            ));
+        }
+    };
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o640)
+        .open(temp_path.clone())?;
+    file.write_all(bytes)?;
+
+    // change permissions
+    let dir = path_buf.as_path();
+    let dir_info = metadata(dir).map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+    #[cfg(not(target_os = "linux"))]
+    let (dir_uid, dir_gid) = (dir_info.uid(), dir_info.gid());
+    #[cfg(target_os = "linux")]
+    let (dir_uid, dir_gid) = (dir_info.st_uid(), dir_info.st_gid());
+    chown(temp_path_buf.as_path(), dir_uid, dir_gid)?;
+
+    fs::rename(temp_path, final_path)?;
+
+    Ok(())
+}
+
+// helper function to get the absolute_path of a provided path
+// this will be used in logging
+fn absolute_path(path: &Path) -> Result<String, CliError> {
+    let temp_path_buf = fs::canonicalize(path)?;
+    if let Some(path) = temp_path_buf.to_str() {
+        Ok(path.to_string())
+    } else {
+        Err(CliError::ActionError(
+            "Path is not valid unicode".to_string(),
+        ))
+    }
+}
+
+// create a X509 certficate from a file
+fn get_ca_cert(cert_path: &Path) -> Result<X509, CliError> {
+    let cert = fs::read(cert_path)?;
+    let cert = X509::from_pem(&cert)?;
+    Ok(cert)
+}
+
+// create a PKey<Private> from a file
+fn get_ca_key(key_path: &Path) -> Result<PKey<Private>, CliError> {
+    let key = fs::read(key_path)?;
+    let rsa = Rsa::private_key_from_pem(&key)?;
+    let privkey = PKey::from_rsa(rsa)?;
+    Ok(privkey)
+}
+
+// helper function to log what files will be written
+fn log_writing(cert_path: &PathBuf, private_cert_path: &PathBuf) -> Result<(), CliError> {
+    info!("Writing file: {}/{}", absolute_path(cert_path)?, CA_CERT);
+    info!(
+        "Writing file: {}/{}",
+        absolute_path(private_cert_path)?,
+        CA_KEY
+    );
+
+    info!(
+        "Writing file: {}/{}",
+        absolute_path(cert_path)?,
+        CLIENT_CERT
+    );
+    info!(
+        "Writing file: {}/{}",
+        absolute_path(private_cert_path)?,
+        CLIENT_KEY
+    );
+
+    info!(
+        "Writing file: {}/{}",
+        absolute_path(cert_path)?,
+        SERVER_CERT
+    );
+    info!(
+        "Writing file: {}/{}",
+        absolute_path(private_cert_path)?,
+        SERVER_KEY
+    );
+    Ok(())
+}
+
+// helper function to log what files will be overwritten
+fn log_overwriting(cert_path: &PathBuf, private_cert_path: &PathBuf) -> Result<(), CliError> {
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(cert_path)?,
+        CA_CERT
+    );
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(private_cert_path)?,
+        CA_KEY
+    );
+
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(cert_path)?,
+        CLIENT_CERT
+    );
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(private_cert_path)?,
+        CLIENT_KEY
+    );
+
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(cert_path)?,
+        SERVER_CERT
+    );
+    info!(
+        "Overwriting file: {}/{}",
+        absolute_path(private_cert_path)?,
+        SERVER_KEY
+    );
+    Ok(())
+}
+
+impl From<io::Error> for CliError {
+    fn from(io_error: io::Error) -> Self {
+        CliError::ActionError(io_error.to_string())
+    }
+}
+
+impl From<ErrorStack> for CliError {
+    fn from(error_stack: ErrorStack) -> Self {
+        CliError::ActionError(error_stack.to_string())
+    }
+}

--- a/cli/src/action/certs.rs
+++ b/cli/src/action/certs.rs
@@ -55,9 +55,13 @@ impl Action for CertGenAction {
     fn run<'a>(
         &mut self,
         arg_matches: Option<&ArgMatches<'a>>,
-        _logger_handle: &ReconfigurationHandle,
+        logger_handle: &mut ReconfigurationHandle,
     ) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        if args.is_present("quiet") {
+            logger_handle.parse_new_spec("error");
+        }
 
         let common_name = args
             .value_of("common_name")

--- a/cli/src/action/health.rs
+++ b/cli/src/action/health.rs
@@ -26,7 +26,7 @@ impl Action for StatusAction {
     fn run<'a>(
         &mut self,
         arg_matches: Option<&ArgMatches<'a>>,
-        _logger_handle: &ReconfigurationHandle,
+        _logger_handle: &mut ReconfigurationHandle,
     ) -> Result<(), CliError> {
         let url = if let Some(args) = arg_matches {
             args.value_of("url").unwrap_or("http://localhost:8085")

--- a/cli/src/action/health.rs
+++ b/cli/src/action/health.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use clap::ArgMatches;
+use flexi_logger::ReconfigurationHandle;
 use reqwest;
 use serde_json::Value;
 
@@ -22,7 +23,11 @@ use crate::error::CliError;
 pub struct StatusAction;
 
 impl Action for StatusAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &ReconfigurationHandle,
+    ) -> Result<(), CliError> {
         let url = if let Some(args) = arg_matches {
             args.value_of("url").unwrap_or("http://localhost:8085")
         } else {

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -35,7 +35,7 @@ pub trait Action {
     fn run<'a>(
         &mut self,
         arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &ReconfigurationHandle,
+        logger_handle: &mut ReconfigurationHandle,
     ) -> Result<(), CliError>;
 }
 
@@ -65,7 +65,7 @@ impl<'s> Action for SubcommandActions<'s> {
     fn run<'a>(
         &mut self,
         arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &ReconfigurationHandle,
+        logger_handle: &mut ReconfigurationHandle,
     ) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2019 Cargill Incorporated
+// Copyright 2018 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 pub mod admin;
+pub mod certs;
 #[cfg(feature = "health")]
 pub mod health;
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -11,10 +11,28 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::error::Error;
+use std::fmt;
+
 #[derive(Debug)]
 pub enum CliError {
     RequiresArgs,
     InvalidSubcommand,
     ActionError(String),
     EnvironmentError(String),
+}
+
+impl Error for CliError {}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CliError::RequiresArgs => write!(f, "action requires arguments"),
+            CliError::InvalidSubcommand => write!(f, "received invalid subcommand"),
+            CliError::ActionError(msg) => write!(f, "action encountered an error: {}", msg),
+            CliError::EnvironmentError(msg) => {
+                write!(f, "action encountered an environment error: {}", msg)
+            }
+        }
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -154,7 +154,7 @@ fn run() -> Result<(), CliError> {
 
 fn main() {
     if let Err(e) = run() {
-        error!("ERROR: {:?}", e);
+        error!("ERROR: {}", e);
         std::process::exit(1);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,37 +48,38 @@ fn run() -> Result<(), CliError> {
         (@subcommand admin =>
             (about: "Administrative commands")
             (@subcommand keygen =>
-                (about: "generates secp256k1 keys to use when signing circuit proposals")
-                (@arg key_name: +takes_value "name of the key to create; defaults to \"splinter\"")
+                (about: "Generates secp256k1 keys to use when signing circuit proposals")
+                (@arg key_name: +takes_value "Name of the key to create; defaults to \"splinter\"")
                 (@arg key_dir: -d --("key-dir") +takes_value
-                 "name of the directory in which to create the keys; defaults to current working directory")
-                (@arg force: --force "overwrite files if they exist")
-                (@arg quiet: -q --quiet "do not display output")
+                 "Name of the directory in which to create the keys; defaults to current working directory")
+                (@arg force: --force "Overwrite files if they exist")
+                (@arg quiet: -q --quiet "Do not display output")
             )
             (@subcommand keyregistry =>
-                (about: "generates a key registry yaml file and keys, based on a registry \
+                (about: "Generates a key registry yaml file and keys, based on a registry \
                  specification")
                 (@arg target_dir: -d --("target-dir") +takes_value
-                 "name of the directory in which to create the registry file and keys; \
+                 "Name of the directory in which to create the registry file and keys; \
                  defaults to /var/lib/splinter or the value of SPLINTER_STATE_DIR environment \
                  variable")
                 (@arg registry_file: -o --("registry-file") +takes_value
-                 "name of the target registry file (in the target directory); \
+                 "Name of the target registry file (in the target directory); \
                  defaults to \"keys.yaml\"")
                 (@arg registry_spec_path: -i --("input-registry-spec") +takes_value
-                 "name of the input key registry specification; \
+                 "Name of the input key registry specification; \
                  defaults to \"./key_registry_spec.yaml\"")
-                (@arg force: --force "overwrite files if they exist")
-                (@arg quiet: -q --quiet "do not display output")
+                (@arg force: --force "Overwrite files if they exist")
+                (@arg quiet: -q --quiet "Do not display output")
             )
         )
         (@subcommand cert =>
+            (about: "Generate certificates that can be used for development")
             (@subcommand generate =>
-                (about: "generate certificates that can be used for development")
+                (about: "Generate certificates and keys for the ca, server and client")
                 (@arg common_name: --("common-name") +takes_value
-                  "the common name that should be used in the generated cert, default localhost")
+                  "The common name that should be used in the generated cert, default localhost")
                 (@arg cert_dir: -d --("cert-dir") +takes_value
-                  "name of the directory in which to create the certificates")
+                  "Name of the directory in which to create the certificates")
                 (@arg force: --force  conflicts_with[skip] "Overwrite files if they exist")
                 (@arg skip: --skip conflicts_with[force] "Check if files exists, generate if missing")
             )
@@ -91,11 +92,11 @@ fn run() -> Result<(), CliError> {
 
         let app = app.subcommand(
             SubCommand::with_name("health")
-                .about("displays information about network health")
+                .about("Displays information about network health")
                 .subcommand(
                     SubCommand::with_name("status")
                         .about(
-                            "displays a node's version, endpoint, node id, and a list\n\
+                            "Displays a node's version, endpoint, node id, and a list\n\
                              of endpoints of its connected peers",
                         )
                         .arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -121,7 +121,7 @@ fn run() -> Result<(), CliError> {
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);
 
-    Logger::with(log_spec_builder.build())
+    let logger_handle = Logger::with(log_spec_builder.build())
         .format(log_format)
         .start()
         .expect("Failed to create logger");
@@ -146,7 +146,7 @@ fn run() -> Result<(), CliError> {
             SubcommandActions::new().with_command("status", health::StatusAction),
         );
     }
-    subcommands.run(Some(&matches))
+    subcommands.run(Some(&matches), &logger_handle)
 }
 
 fn main() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,6 +84,7 @@ fn run() -> Result<(), CliError> {
                   "Name of the directory in which to create the certificates")
                 (@arg force: --force  conflicts_with[skip] "Overwrite files if they exist")
                 (@arg skip: --skip conflicts_with[force] "Check if files exists, generate if missing")
+                (@arg quiet: -q --quiet "Do not display output")
             )
         )
     );
@@ -113,17 +114,17 @@ fn run() -> Result<(), CliError> {
 
     let matches = app.get_matches();
 
+    // set default to info
     let log_level = match matches.occurrences_of("verbose") {
-        0 => log::LevelFilter::Warn,
-        1 => log::LevelFilter::Info,
-        2 => log::LevelFilter::Debug,
+        0 => log::LevelFilter::Info,
+        1 => log::LevelFilter::Debug,
         _ => log::LevelFilter::Trace,
     };
 
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);
 
-    let logger_handle = Logger::with(log_spec_builder.build())
+    let mut logger_handle = Logger::with(log_spec_builder.build())
         .format(log_format)
         .start()
         .expect("Failed to create logger");
@@ -148,7 +149,7 @@ fn run() -> Result<(), CliError> {
             SubcommandActions::new().with_command("status", health::StatusAction),
         );
     }
-    subcommands.run(Some(&matches), &logger_handle)
+    subcommands.run(Some(&matches), &mut logger_handle)
 }
 
 fn main() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,7 +38,9 @@ pub fn log_format(
 }
 
 fn run() -> Result<(), CliError> {
-    let app = clap_app!(myapp =>
+    // ignore unused_mut while there are experimental features
+    #[allow(unused_mut)]
+    let mut app = clap_app!(myapp =>
         (name: APP_NAME)
         (version: VERSION)
         (author: "Cargill")
@@ -90,7 +92,7 @@ fn run() -> Result<(), CliError> {
     {
         use clap::{Arg, SubCommand};
 
-        let app = app.subcommand(
+        app = app.subcommand(
             SubCommand::with_name("health")
                 .about("Displays information about network health")
                 .subcommand(
@@ -141,7 +143,7 @@ fn run() -> Result<(), CliError> {
     #[cfg(feature = "health")]
     {
         use action::health;
-        subcommands = SubcommandActions::new().with_command(
+        subcommands = subcommands.with_command(
             "health",
             SubcommandActions::new().with_command("status", health::StatusAction),
         );

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -43,7 +43,7 @@ tempdir = "0.3"
 toml = "0.4.8"
 
 [features]
-default = []
+default = ["generate-certs"]
 
 experimental = [
     "config-builder",
@@ -55,6 +55,7 @@ experimental = [
 config-builder = []
 config-toml = ["config-builder"]
 circuit-read = []
+generate-certs = []
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -17,6 +17,7 @@ use crate::config::Config;
 pub struct ConfigBuilder {
     storage: Option<String>,
     transport: Option<String>,
+    cert_dir: Option<String>,
     ca_certs: Option<String>,
     client_cert: Option<String>,
     client_key: Option<String>,
@@ -37,6 +38,7 @@ impl ConfigBuilder {
         Self {
             storage: None,
             transport: None,
+            cert_dir: None,
             ca_certs: None,
             client_cert: None,
             client_key: None,
@@ -60,6 +62,11 @@ impl ConfigBuilder {
 
     pub fn with_transport(mut self, transport: String) -> Self {
         self.transport = Some(transport);
+        self
+    }
+
+    pub fn with_cert_dir(mut self, cert_dir: String) -> Self {
+        self.cert_dir = Some(cert_dir);
         self
     }
 
@@ -132,6 +139,7 @@ impl ConfigBuilder {
         Config {
             storage: self.storage,
             transport: self.transport,
+            cert_dir: self.cert_dir,
             ca_certs: self.ca_certs,
             client_cert: self.client_cert,
             client_key: self.client_key,

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -38,6 +38,7 @@ use toml;
 pub struct Config {
     storage: Option<String>,
     transport: Option<String>,
+    cert_dir: Option<String>,
     ca_certs: Option<String>,
     client_cert: Option<String>,
     client_key: Option<String>,
@@ -68,6 +69,10 @@ impl Config {
 
     pub fn transport(&self) -> Option<String> {
         self.transport.clone()
+    }
+
+    pub fn cert_dir(&self) -> Option<String> {
+        self.cert_dir.clone()
     }
 
     pub fn ca_certs(&self) -> Option<String> {

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -23,6 +23,7 @@ use toml;
 pub struct TomlConfig {
     storage: Option<String>,
     transport: Option<String>,
+    cert_dir: Option<String>,
     ca_certs: Option<String>,
     client_cert: Option<String>,
     client_key: Option<String>,
@@ -49,6 +50,10 @@ impl TomlConfig {
 
     pub fn take_transport(&mut self) -> Option<String> {
         self.transport.take()
+    }
+
+    pub fn take_cert_dir(&mut self) -> Option<String> {
+        self.cert_dir.take()
     }
 
     pub fn take_ca_certs(&mut self) -> Option<String> {
@@ -109,6 +114,9 @@ impl TomlConfig {
         }
         if let Some(x) = self.take_transport() {
             builder = builder.with_transport(x);
+        }
+        if let Some(x) = self.take_cert_dir() {
+            builder = builder.with_cert_dir(x);
         }
         if let Some(x) = self.take_ca_certs() {
             builder = builder.with_ca_certs(x);

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -139,13 +139,13 @@ fn main() {
         (@arg cert_dir: --("cert-dir") +takes_value
           "path to the directory where the certs and keys are")
         (@arg client_cert: --("client-cert") +takes_value
-          "file path the cert for the node when connecting to a node")
+          "file path to the cert for the node when connecting to a node")
         (@arg server_cert: --("server-cert") +takes_value
-          "file path the cert for the node when connecting to a node")
+          "file path to the cert for the node when connecting to a node")
         (@arg server_key:  --("server-key") +takes_value
-          "file path key for the node when connecting to a node as sever")
+          "file path to the key for the node when connecting to a node as server")
         (@arg client_key:  --("client-key") +takes_value
-          "file path key for the node when connecting to a node as client")
+          "file path to the key for the node when connecting to a node as client")
         (@arg insecure:  --("insecure")
           "if set tls should accept all peer certificates")
         (@arg bind: --("bind") +takes_value

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -123,45 +123,45 @@ fn main() {
         (about: "Splinter Daemon")
         (@arg config: -c --config +takes_value)
         (@arg node_id: --("node-id") +takes_value
-          "unique id for the node ")
+          "Unique id for the node ")
         (@arg storage: --("storage") +takes_value
-          "storage type used for node, default yaml")
+          "Storage type used for node, default yaml")
         (@arg transport: --("transport") +takes_value
-          "transport type for sockets, either raw or tls")
+          "Transport type for sockets, either raw or tls")
         (@arg network_endpoint: -n --("network-endpoint") +takes_value
-          "endpoint to connect to the network, tcp://ip:port")
+          "Endpoint to connect to the network, tcp://ip:port")
         (@arg service_endpoint: --("service-endpoint") +takes_value
-          "endpoint that service will connect to, tcp://ip:port")
+          "Endpoint that service will connect to, tcp://ip:port")
         (@arg peers: --peer +takes_value +multiple
-          "endpoint that service will connect to, ip:port")
+          "Endpoint that service will connect to, ip:port")
         (@arg ca_file: --("ca-file") +takes_value
-          "file path to the trusted ca cert")
+          "File path to the trusted ca cert")
         (@arg cert_dir: --("cert-dir") +takes_value
-          "path to the directory where the certs and keys are")
+          "Path to the directory where the certs and keys are")
         (@arg client_cert: --("client-cert") +takes_value
-          "file path to the cert for the node when connecting to a node")
+          "File path to the cert for the node when connecting to a node")
         (@arg server_cert: --("server-cert") +takes_value
-          "file path to the cert for the node when connecting to a node")
+          "File path to the cert for the node when connecting to a node")
         (@arg server_key:  --("server-key") +takes_value
-          "file path to the key for the node when connecting to a node as server")
+          "File path to the key for the node when connecting to a node as server")
         (@arg client_key:  --("client-key") +takes_value
-          "file path to the key for the node when connecting to a node as client")
+          "File path to the key for the node when connecting to a node as client")
         (@arg insecure:  --("insecure")
-          "if set tls should accept all peer certificates")
+          "If set tls should accept all peer certificates")
         (@arg bind: --("bind") +takes_value
-            "connection endpoint for REST API")
+          "Connection endpoint for REST API")
         (@arg registry_backend: --("registry-backend") +takes_value
-            "backend type for the node registry. Possible values: FILE.")
+          "Backend type for the node registry. Possible values: FILE.")
         (@arg registry_file: --("registry-file") +takes_value
-            "file path to the node registry file if registry-backend is FILE.")
+          "File path to the node registry file if registry-backend is FILE.")
         (@arg verbose: -v --verbose +multiple
-         "increase output verbosity"));
+          "Increase output verbosity"));
 
     let app = app.arg(
         Arg::with_name("heartbeat_interval")
             .long("heartbeat")
             .long_help(
-                "how often heartbeat should be sent in seconds, defaults to 30 seconds,\
+                "How often heartbeat should be sent in seconds, defaults to 30 seconds,\
                  0 means off",
             ),
     );
@@ -172,7 +172,7 @@ fn main() {
             Arg::with_name("generate_certs")
                 .long("generate-certs")
                 .long_help(
-                    "deprecated: if set, the certs will be generated and insecure will be false, \
+                    "Deprecated: if set, the certs will be generated and insecure will be false, \
                      only use for development",
                 ),
         )
@@ -180,7 +180,7 @@ fn main() {
             Arg::with_name("common_name")
                 .long("common-name")
                 .long_help(
-                    "deprecated: the common name that should be used in the generated cert, \
+                    "Deprecated: the common name that should be used in the generated cert, \
                      defaults to localhost",
                 )
                 .takes_value(true),

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -154,10 +154,17 @@ fn main() {
             "backend type for the node registry. Possible values: FILE.")
         (@arg registry_file: --("registry-file") +takes_value
             "file path to the node registry file if registry-backend is FILE.")
-        (@arg heartbeat_interval: --("heartbeat") +takes_value
-            "how often heartbeat should be sent in seconds, defaults to 30 seconds, 0 means off")
         (@arg verbose: -v --verbose +multiple
          "increase output verbosity"));
+
+    let app = app.arg(
+        Arg::with_name("heartbeat_interval")
+            .long("heartbeat")
+            .long_help(
+                "how often heartbeat should be sent in seconds, defaults to 30 seconds,\
+                 0 means off",
+            ),
+    );
 
     #[cfg(feature = "generate-certs")]
     let app = app


### PR DESCRIPTION
This subcommand will generate certificates that
can be used for development. They should never be used
in production.

There are options to change where the certs and keys will
be generated. If this is not provided, an environment
variable, SPLINTER_CERT_DIR, will be checked. Other
wise the command will try to write the certs/keys to
/etc/splinter/certs/.

If the files already exist the command will
fail unless --force is provided. You can also use
--skip to see if the files exist or not. --quiet will not
print any information.

This also updates splinterd to check expected locations for the certs, instead of requiring that all are passed in the config or on the command line.

The current --generate-certs option to splitnerd is put behind a feature and deprecated. The feature will remain in default until after the next release.  It will then be removed from default but left as a feature until the following release. At this time the capability will be removed from splinterd all together, forcing the use of the splinter cli command. 