### PR TITLE
Alphabetize dependencies in Cargo.toml files

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,14 +25,14 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = "2"
+libc = "0.2"
 log = "0.3.8"
 protobuf = "2"
-simple_logger = "0.4.0"
-libc = "0.2"
-splinter = { path = "../libsplinter" }
 reqwest = { version = "0.9", optional = true }
 sawtooth-sdk = "0.3"
 serde = "1.0"
+serde_derive = "1.0"
 serde_json = { version ="1.0", optional = true }
 serde_yaml = "0.8"
-serde_derive = "1.0"
+simple_logger = "0.4.0"
+splinter = { path = "../libsplinter" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.3.8"
-splinter = { path = "../libsplinter" }
-protobuf = "2"
-url = "1.7.1"
 openssl = "0.10"
+protobuf = "2"
+splinter = { path = "../libsplinter" }
+url = "1.7.1"

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -23,28 +23,28 @@ license = "Apache-2.0"
 actix = { version = "0.8", default-features = false }
 actix-web = { version = "1.0", default-features = false, features = ["flate2-zlib"] }
 actix-web-actors = "1.0"
-flate2 = "1.0.10"
 bcrypt = "0.5"
 clap = "2"
 ctrlc = "3.0"
 diesel = { version = "1.0.0", features = ["serde_json"] }
-hyper = "0.12"
-tokio = "0.1"
-gameroom-database = { path = "../database" }
-log = "0.4"
+flate2 = "1.0.10"
 flexi_logger = "0.14"
-splinter = { path = "../../../libsplinter", features = ["events"]}
 futures = "0.1"
+gameroom-database = { path = "../database" }
+hyper = "0.12"
+log = "0.4"
+openssl = "0.10"
+percent-encoding = "2.0"
+protobuf = "2"
 rust-crypto = "0.2"
 sabre-sdk = "0.4"
 sawtooth-sdk = "0.3"
-serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-percent-encoding = "2.0"
+serde_json = "1.0"
+splinter = { path = "../../../libsplinter", features = ["events"]}
+tokio = "0.1"
 uuid = { version = "0.7", features = ["v4"]}
-protobuf = "2"
-openssl = "0.10"
 
 [features]
 test-node-endpoint = []

--- a/examples/private_counter/service/Cargo.toml
+++ b/examples/private_counter/service/Cargo.toml
@@ -24,20 +24,20 @@ name = "private-counter"
 path = "src/main.rs"
 
 [dependencies]
-splinter = { path = "../../../libsplinter" }
 clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"
 log = "0.3.0"
 protobuf = "2"
+serde = "1.0.80"
+serde_derive = "1.0.80"
 sha2 = "0.8"
 simple_logger = "0.4.0"
-serde_derive = "1.0.80"
-serde = "1.0.80"
+splinter = { path = "../../../libsplinter" }
 threadpool = "1.0"
 toml = "0.4.8"
 uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
-protoc-rust = "2"
 glob = "0.2"
+protoc-rust = "2"

--- a/examples/private_xo/Cargo.toml
+++ b/examples/private_xo/Cargo.toml
@@ -24,7 +24,6 @@ name = "private-xo"
 path = "src/main.rs"
 
 [dependencies]
-splinter = { path = "../../libsplinter" }
 base64 = "0.10"
 clap = "2.32"
 crossbeam-channel = "0.3"
@@ -39,10 +38,11 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 simple_logger = "1.0"
+splinter = { path = "../../libsplinter" }
 transact = { git = "https://github.com/bitwiseio/transact", features = [ "sawtooth-compat" ] }
 urlencoded = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
-protoc-rust = "2"
 glob = "0.2"
+protoc-rust = "2"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -21,37 +21,37 @@ license = "Apache-2.0"
 
 [dependencies]
 actix = { version = "0.8", default-features = false }
-actix-web = { version = "1.0", default-features = false, features = ["flate2-zlib"] }
-flate2 = "1.0.10"
-actix-service = "0.4"
 actix-http = {version = "0.2", features = ["flate2-zlib"] }
+actix-service = "0.4"
+actix-web = { version = "1.0", default-features = false, features = ["flate2-zlib"] }
 actix-web-actors = "1.0"
-futures = "0.1"
 atomicwrites = "0.2"
-log = "0.3.0"
+awc = { version = "0.2", optional = true }
 byteorder = "1"
-url = "1.7.1"
-openssl = "0.10"
+crossbeam-channel = "0.3"
+diesel = { version = "1.0", features = ["postgres", "r2d2", "serde_json"], optional = true }
+diesel_migrations = { version = "1.4", optional = true }
+flate2 = "1.0.10"
+futures = "0.1"
+hyper = { version = "0.12", optional = true }
+log = "0.3.0"
 mio = "0.6"
+mio-extras = "2"
+openssl = "0.10"
+protobuf = "2"
 sawtooth = { version = "0.1", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.4"
 sawtooth-sdk = { version = "0.3", optional = true }
 serde = "1.0"
-serde_yaml = "0.8"
 serde_derive = "1.0"
 serde_json = "1.0"
-transact = { version = "0.1", features = ["sawtooth-compat"] }
-mio-extras = "2"
-crossbeam-channel = "0.3"
-uuid = { version = "0.7", features = ["v4"]}
-protobuf = "2"
-zmq = { version = "0.9", optional = true }
-ursa = { version = "0.1", optional = true }
-hyper = { version = "0.12", optional = true }
+serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
-awc = { version = "0.2", optional = true }
-diesel = { version = "1.0", features = ["postgres", "r2d2", "serde_json"], optional = true }
-diesel_migrations = { version = "1.4", optional = true }
+transact = { version = "0.1", features = ["sawtooth-compat"] }
+url = "1.7.1"
+ursa = { version = "0.1", optional = true }
+uuid = { version = "0.7", features = ["v4"]}
+zmq = { version = "0.9", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/services/health/Cargo.toml
+++ b/services/health/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-splinter = { path = "../../libsplinter" }
 log = "0.3.0"
+splinter = { path = "../../libsplinter" }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -24,23 +24,23 @@ name = "splinterd"
 path = "src/main.rs"
 
 [dependencies]
-splinter = { path = "../libsplinter", features = ["sawtooth-signing-compat"] }
-health = { path = "../services/health", optional = true }
+bytes = "0.4"
 clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"
-log = "0.4"
 flexi_logger = "0.14"
-bytes = "0.4"
-serde_derive = "1.0.80"
-serde = "1.0.80"
-serde_yaml = "0.8"
-serde_json = "1.0"
-percent-encoding = "2.0"
-toml = "0.4.8"
-protobuf = "2"
+health = { path = "../services/health", optional = true }
+log = "0.4"
 openssl = "0.10"
+percent-encoding = "2.0"
+protobuf = "2"
+serde = "1.0.80"
+serde_derive = "1.0.80"
+serde_json = "1.0"
+serde_yaml = "0.8"
+splinter = { path = "../libsplinter", features = ["sawtooth-signing-compat"] }
 tempdir = "0.3"
+toml = "0.4.8"
 
 [features]
 default = []


### PR DESCRIPTION
Makes reading of Cargo.toml files easier, and removes any implied
methodology behind the ordering of dependencies.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>