### PR TITLE
Refactor AdminService-REST API boundary

### DIFF
--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -14,4 +14,5 @@
 
 pub mod error;
 pub mod messages;
+pub mod rest_api;
 pub mod service;

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -12,58 +12,69 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time;
 
 use crate::actix_web::HttpResponse;
 use crate::futures::{Future, IntoFuture};
 use crate::protos::admin::CircuitManagementPayload;
-use crate::rest_api::{into_protobuf, Method, Request, Resource, RestResourceProvider};
+use crate::rest_api::{
+    into_protobuf, EventDealer, EventSender, Method, Request, Resource, Response, ResponseError,
+    RestResourceProvider,
+};
 use crate::service::ServiceError;
 
-use super::service::{shared::AdminServiceShared, AdminService};
+use super::messages::AdminServiceEvent;
+use super::service::{
+    AdminCommands, AdminService, AdminServiceError, AdminServiceEventSubscriber,
+    AdminSubscriberError,
+};
 
 impl RestResourceProvider for AdminService {
     fn resources(&self) -> Vec<Resource> {
         vec![
-            make_application_handler_registration_route(self.admin_service_shared.clone()),
-            make_submit_route(self.admin_service_shared.clone()),
+            make_application_handler_registration_route(self.commands()),
+            make_submit_route(self.commands()),
         ]
     }
 }
 
-fn make_submit_route(shared: Arc<Mutex<AdminServiceShared>>) -> Resource {
+fn make_submit_route<A: AdminCommands + Clone + 'static>(admin_commands: A) -> Resource {
     Resource::build("/admin/submit").add_method(Method::Post, move |_, payload| {
-        let shared = shared.clone();
+        let admin_commands = admin_commands.clone();
         Box::new(
             into_protobuf::<CircuitManagementPayload>(payload).and_then(move |payload| {
-                let mut shared = match shared.lock() {
-                    Ok(shared) => shared,
-                    Err(err) => {
-                        debug!("Lock poisoned: {}", err);
-                        return HttpResponse::InternalServerError().finish().into_future();
-                    }
-                };
-
-                match shared.submit(payload) {
+                match admin_commands.submit_circuit_change(payload) {
                     Ok(()) => HttpResponse::Accepted().finish().into_future(),
-                    Err(ServiceError::UnableToHandleMessage(err)) => HttpResponse::BadRequest()
+                    Err(AdminServiceError::ServiceError(ServiceError::UnableToHandleMessage(
+                        err,
+                    ))) => HttpResponse::BadRequest()
                         .json(json!({
                             "message": format!("Unable to handle message: {}", err)
                         }))
                         .into_future(),
-                    Err(ServiceError::InvalidMessageFormat(err)) => HttpResponse::BadRequest()
+                    Err(AdminServiceError::ServiceError(ServiceError::InvalidMessageFormat(
+                        err,
+                    ))) => HttpResponse::BadRequest()
                         .json(json!({
                             "message": format!("Failed to parse payload: {}", err)
                         }))
                         .into_future(),
-                    Err(_) => HttpResponse::InternalServerError().finish().into_future(),
+                    Err(err) => {
+                        error!("{}", err);
+                        HttpResponse::InternalServerError().finish().into_future()
+                    }
                 }
             }),
         )
     })
 }
 
-fn make_application_handler_registration_route(shared: Arc<Mutex<AdminServiceShared>>) -> Resource {
+fn make_application_handler_registration_route<A: AdminCommands + Clone + 'static>(
+    admin_commands: A,
+) -> Resource {
+    let admin_event_dealers = AdminEventDealers::default();
     Resource::build("/ws/admin/register/{type}").add_method(Method::Get, move |request, payload| {
         let circuit_management_type = if let Some(t) = request.match_info().get("type") {
             t.to_string()
@@ -71,27 +82,111 @@ fn make_application_handler_registration_route(shared: Arc<Mutex<AdminServiceSha
             return Box::new(HttpResponse::BadRequest().finish().into_future());
         };
 
-        let unlocked_shared = shared.lock();
+        let initial_events = match admin_commands
+            .get_events_since(&time::SystemTime::UNIX_EPOCH, &circuit_management_type)
+        {
+            Ok(events) => events.map(JsonAdminEvent::from),
+            Err(err) => {
+                error!(
+                    "Unable to load initial set of admin events for {}: {}",
+                    &circuit_management_type, err
+                );
+                return Box::new(HttpResponse::InternalServerError().finish().into_future());
+            }
+        };
 
-        match unlocked_shared {
-            Ok(mut shared) => {
-                let request = Request::from((request, payload));
-                debug!("circuit management type {}", circuit_management_type);
-                match shared.add_subscriber(circuit_management_type, request) {
-                    Ok(res) => {
-                        debug!("Websocket response: {:?}", res);
-                        Box::new(res.into_future())
-                    }
-                    Err(err) => {
-                        debug!("Failed to create websocket: {:?}", err);
-                        Box::new(HttpResponse::InternalServerError().finish().into_future())
-                    }
+        let request = Request::from((request, payload));
+        debug!("Circuit management type \"{}\"", circuit_management_type);
+        match admin_event_dealers.add_event_dealer(
+            request,
+            &circuit_management_type,
+            Box::new(initial_events),
+        ) {
+            Ok((sender, res)) => {
+                debug!("Websocket response: {:?}", res);
+                if let Err(err) = admin_commands.add_event_subscriber(
+                    &circuit_management_type,
+                    Box::new(WsAdminServiceEventSubscriber { sender }),
+                ) {
+                    error!("Unable to add admin event subscriber: {}", err);
+                    return Box::new(HttpResponse::InternalServerError().finish().into_future());
                 }
+                Box::new(res.into_future())
             }
             Err(err) => {
-                debug!("Failed to add socket sender: {:?}", err);
+                debug!("Failed to create websocket: {:?}", err);
                 Box::new(HttpResponse::InternalServerError().finish().into_future())
             }
         }
     })
+}
+
+#[derive(Clone, Default)]
+struct AdminEventDealers {
+    event_dealers_by_type: Arc<Mutex<HashMap<String, EventDealer<JsonAdminEvent>>>>,
+}
+
+impl AdminEventDealers {
+    fn add_event_dealer(
+        &self,
+        request: Request,
+        event_type: &str,
+        initial_events: Box<dyn Iterator<Item = JsonAdminEvent> + Send>,
+    ) -> Result<(EventSender<JsonAdminEvent>, Response), ResponseError> {
+        let mut event_dealers = self.event_dealers_by_type.lock().unwrap();
+        let dealer = event_dealers
+            .entry(event_type.to_string())
+            .or_insert_with(EventDealer::new);
+        dealer.subscribe(request, initial_events)
+    }
+}
+
+struct WsAdminServiceEventSubscriber {
+    sender: EventSender<JsonAdminEvent>,
+}
+
+impl AdminServiceEventSubscriber for WsAdminServiceEventSubscriber {
+    fn handle_event(
+        &self,
+        event: &AdminServiceEvent,
+        timestamp: &time::SystemTime,
+    ) -> Result<(), AdminSubscriberError> {
+        let json_event = JsonAdminEvent {
+            timestamp: *timestamp,
+            event: event.clone(),
+        };
+        self.sender.send(json_event).map_err(|_| {
+            debug!("Dropping admin service event and unsubscribing due to websocket being closed");
+            AdminSubscriberError::Unsubscribe
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct JsonAdminEvent {
+    #[serde(serialize_with = "st_as_millis")]
+    timestamp: time::SystemTime,
+
+    #[serde(flatten)]
+    event: AdminServiceEvent,
+}
+
+impl From<(time::SystemTime, AdminServiceEvent)> for JsonAdminEvent {
+    fn from(raw_evt: (time::SystemTime, AdminServiceEvent)) -> Self {
+        Self {
+            timestamp: raw_evt.0,
+            event: raw_evt.1,
+        }
+    }
+}
+
+pub fn st_as_millis<S>(data: &time::SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let since_the_epoch = data
+        .duration_since(time::UNIX_EPOCH)
+        .expect("Time went backwards");
+
+    serializer.serialize_u128(since_the_epoch.as_millis())
 }

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -1,0 +1,97 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use crate::actix_web::HttpResponse;
+use crate::futures::{Future, IntoFuture};
+use crate::protos::admin::CircuitManagementPayload;
+use crate::rest_api::{into_protobuf, Method, Request, Resource, RestResourceProvider};
+use crate::service::ServiceError;
+
+use super::service::{shared::AdminServiceShared, AdminService};
+
+impl RestResourceProvider for AdminService {
+    fn resources(&self) -> Vec<Resource> {
+        vec![
+            make_application_handler_registration_route(self.admin_service_shared.clone()),
+            make_submit_route(self.admin_service_shared.clone()),
+        ]
+    }
+}
+
+fn make_submit_route(shared: Arc<Mutex<AdminServiceShared>>) -> Resource {
+    Resource::build("/admin/submit").add_method(Method::Post, move |_, payload| {
+        let shared = shared.clone();
+        Box::new(
+            into_protobuf::<CircuitManagementPayload>(payload).and_then(move |payload| {
+                let mut shared = match shared.lock() {
+                    Ok(shared) => shared,
+                    Err(err) => {
+                        debug!("Lock poisoned: {}", err);
+                        return HttpResponse::InternalServerError().finish().into_future();
+                    }
+                };
+
+                match shared.submit(payload) {
+                    Ok(()) => HttpResponse::Accepted().finish().into_future(),
+                    Err(ServiceError::UnableToHandleMessage(err)) => HttpResponse::BadRequest()
+                        .json(json!({
+                            "message": format!("Unable to handle message: {}", err)
+                        }))
+                        .into_future(),
+                    Err(ServiceError::InvalidMessageFormat(err)) => HttpResponse::BadRequest()
+                        .json(json!({
+                            "message": format!("Failed to parse payload: {}", err)
+                        }))
+                        .into_future(),
+                    Err(_) => HttpResponse::InternalServerError().finish().into_future(),
+                }
+            }),
+        )
+    })
+}
+
+fn make_application_handler_registration_route(shared: Arc<Mutex<AdminServiceShared>>) -> Resource {
+    Resource::build("/ws/admin/register/{type}").add_method(Method::Get, move |request, payload| {
+        let circuit_management_type = if let Some(t) = request.match_info().get("type") {
+            t.to_string()
+        } else {
+            return Box::new(HttpResponse::BadRequest().finish().into_future());
+        };
+
+        let unlocked_shared = shared.lock();
+
+        match unlocked_shared {
+            Ok(mut shared) => {
+                let request = Request::from((request, payload));
+                debug!("circuit management type {}", circuit_management_type);
+                match shared.add_subscriber(circuit_management_type, request) {
+                    Ok(res) => {
+                        debug!("Websocket response: {:?}", res);
+                        Box::new(res.into_future())
+                    }
+                    Err(err) => {
+                        debug!("Failed to create websocket: {:?}", err);
+                        Box::new(HttpResponse::InternalServerError().finish().into_future())
+                    }
+                }
+            }
+            Err(err) => {
+                debug!("Failed to add socket sender: {:?}", err);
+                Box::new(HttpResponse::InternalServerError().finish().into_future())
+            }
+        }
+    })
+}

--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -121,6 +121,9 @@ pub enum AdminSharedError {
     UnknownAction(String),
     ValidationFailed(String),
 
+    /// An error occurred while trying to add an admin service event subscriber to the service.
+    UnableToAddSubscriber(String),
+
     /// An error occured while attempting to verify a payload's signature
     SignerError(signing::error::Error),
 
@@ -144,6 +147,7 @@ impl Error for AdminSharedError {
             AdminSharedError::SignerError(_) => None,
             AdminSharedError::CommitError(_) => None,
             AdminSharedError::UpdateProposalsError(err) => Some(err),
+            AdminSharedError::UnableToAddSubscriber(_) => None,
         }
     }
 }
@@ -181,6 +185,9 @@ impl fmt::Display for AdminSharedError {
             AdminSharedError::CommitError(msg) => write!(f, "unable to commit circuit: {}", msg),
             AdminSharedError::UpdateProposalsError(err) => {
                 write!(f, "received error while update open proposal: {}", err)
+            }
+            AdminSharedError::UnableToAddSubscriber(msg) => {
+                write!(f, "unable to add admin service event subscriber: {}", msg)
             }
         }
     }

--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -84,6 +84,25 @@ impl From<ServiceError> for AdminServiceError {
     }
 }
 
+#[derive(Debug)]
+pub enum AdminSubscriberError {
+    UnableToHandleEvent(String),
+    Unsubscribe,
+}
+
+impl Error for AdminSubscriberError {}
+
+impl fmt::Display for AdminSubscriberError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AdminSubscriberError::UnableToHandleEvent(msg) => {
+                write!(f, "Unable to handle event: {}", msg)
+            }
+            AdminSubscriberError::Unsubscribe => f.write_str("Unsubscribe"),
+        }
+    }
+}
+
 impl From<ServiceError> for ProposalManagerError {
     fn from(err: ServiceError) -> Self {
         ProposalManagerError::Internal(Box::new(err))

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -66,7 +66,7 @@ use std::thread;
 
 pub use errors::{EventDealerError, EventHistoryError, ResponseError, RestApiServerError};
 
-pub use events::{EventDealer, EventHistory, LocalEventHistory};
+pub use events::{EventDealer, EventHistory, EventSender, LocalEventHistory};
 
 /// A `RestResourceProvider` provides a list of resources that are consumed by `RestApi`.
 pub trait RestResourceProvider {

--- a/libsplinter/src/storage/sets/mod.rs
+++ b/libsplinter/src/storage/sets/mod.rs
@@ -158,6 +158,12 @@ impl<T> From<RangeToInclusive<T>> for DurableRange<T> {
     }
 }
 
+impl<T> From<(Bound<T>, Bound<T>)> for DurableRange<T> {
+    fn from((start, end): (Bound<T>, Bound<T>)) -> Self {
+        Self { start, end }
+    }
+}
+
 /// An error that may occur with the underlying implementation of the DurableSet
 #[derive(Debug)]
 pub struct DurableSetError {


### PR DESCRIPTION
This PR refactors the admin service REST API boundary to separate the two concepts.  It makes the following additions and changes:

- Adds a trait for `AdminCommands` that expose a set of operations to external callers.  This is used by the REST resources, but could be used directly by applications that have been compiled directly into a single splinter binary.
- Simplifies the EvenDealer surface by removing its direct ownership of the Senders, and returning those wrapped in an EventSender struct.

Several other additions are included, such as:
- A windowed iterator for admin service events that is `Send`
- Initial events passed to the `EventDealer` on `subscribe` are converted to a stream, which should move the read of that iterator to the async thread handling the websocket, not the initial caller.