### PR TITLE
Allow cors from http-server for Canopy App

### DIFF
--- a/canopy/app/package.json
+++ b/canopy/app/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "author": "Cargill Incorporated",
   "scripts": {
-    "start:saplings": "http-server ./saplings -p 8675",
+    "start:saplings": "http-server ./saplings -p 8675 --cors",
     "start:react": "react-scripts start",
     "start": "run-p start:saplings start:react",
     "build": "react-scripts build",

--- a/canopy/app/src/App.js
+++ b/canopy/app/src/App.js
@@ -56,8 +56,13 @@ function App() {
         bootstrapConfigSapling();
       });
 
-      // Invoke the current sapling
-      appSapling.current(saplingDomNode.current);
+      // Invoke the current sapling if one has been registered
+      if (
+        appSapling.current &&
+        typeof appSapling.current === typeof Function.prototype
+      ) {
+        appSapling.current(saplingDomNode.current);
+      }
     })();
   }, []);
 


### PR DESCRIPTION
Without CORS allowed, Canopy cannot load the scripts correctly. This was left out of the [previous PR](https://github.com/Cargill/splinter/pull/343).