### PR TITLE
Add create user and credentials capability to biome

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -75,6 +75,7 @@ ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
 biome = ["database"]
+biome-credentials = ["biome", "database"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]
 
@@ -85,6 +86,7 @@ features = [
     "sawtooth-signing-compat",
     "events",
     "biome",
+    "biome-credentials",
     "biome-notifications",
     "database"
   ]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -74,7 +74,7 @@ zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
-biome = []
+biome = ["database"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]
 

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -27,6 +27,7 @@ actix-web = { version = "1.0", default-features = false, features = ["flate2-zli
 actix-web-actors = "1.0"
 atomicwrites = "0.2"
 awc = { version = "0.2", optional = true }
+bcrypt = {version = "0.6", optional = true}
 byteorder = "1"
 crossbeam-channel = "0.3"
 diesel = { version = "1.0", features = ["postgres", "r2d2", "serde_json"], optional = true }
@@ -75,7 +76,7 @@ ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
 biome = ["database"]
-biome-credentials = ["biome", "database"]
+biome-credentials = ["biome", "database", "bcrypt"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]
 

--- a/libsplinter/src/biome/credentials/credentials_store.rs
+++ b/libsplinter/src/biome/credentials/credentials_store.rs
@@ -1,0 +1,75 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::database::helpers::{fetch_credential_by_username, insert_credential};
+use super::{CredentialsStore, CredentialsStoreError, UserCredentials};
+
+use crate::database::ConnectionPool;
+
+/// Manages creating, updating and fetching UserCredentials from the databae
+pub struct SplinterCredentialsStore {
+    connection_pool: ConnectionPool,
+}
+
+impl SplinterCredentialsStore {
+    /// Creates a new SplinterCredentialsStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    pub fn new(connection_pool: ConnectionPool) -> SplinterCredentialsStore {
+        SplinterCredentialsStore { connection_pool }
+    }
+}
+
+impl CredentialsStore<UserCredentials> for SplinterCredentialsStore {
+    fn add_credentials(&self, credentials: UserCredentials) -> Result<(), CredentialsStoreError> {
+        let duplicate_credentials =
+            fetch_credential_by_username(&*self.connection_pool.get()?, &credentials.username)
+                .map_err(|err| CredentialsStoreError::QueryError {
+                    context: "Failed check for existing username".to_string(),
+                    source: Box::new(err),
+                })?;
+        if duplicate_credentials.is_some() {
+            return Err(CredentialsStoreError::DuplicateError(format!(
+                "Username already in use: {}",
+                credentials.username
+            )));
+        }
+        insert_credential(&*self.connection_pool.get()?, credentials.into()).map_err(|err| {
+            CredentialsStoreError::OperationError {
+                context: "Failed to add credentials".to_string(),
+                source: Box::new(err),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn update_credentials(
+        &self,
+        _user_id: &str,
+        _username: &str,
+        _password: &str,
+    ) -> Result<(), CredentialsStoreError> {
+        unimplemented!()
+    }
+
+    fn remove_credentials(&self, _user_id: &str) -> Result<UserCredentials, CredentialsStoreError> {
+        unimplemented!()
+    }
+
+    fn fetch_credential(&self, _user_id: &str) -> Result<UserCredentials, CredentialsStoreError> {
+        unimplemented!()
+    }
+}

--- a/libsplinter/src/biome/credentials/database/helpers/credentials.rs
+++ b/libsplinter/src/biome/credentials/database/helpers/credentials.rs
@@ -1,0 +1,41 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::models::{NewUserCredentialsModel, UserCredentialsModel};
+use super::super::schema::user_credentials;
+
+use diesel::{
+    dsl::insert_into, pg::PgConnection, prelude::*, result::Error::NotFound, QueryResult,
+};
+
+pub fn fetch_credential_by_username(
+    conn: &PgConnection,
+    username: &str,
+) -> QueryResult<Option<UserCredentialsModel>> {
+    user_credentials::table
+        .filter(user_credentials::username.eq(username))
+        .first::<UserCredentialsModel>(conn)
+        .map(Some)
+        .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+}
+
+pub fn insert_credential(
+    conn: &PgConnection,
+    credential: NewUserCredentialsModel,
+) -> QueryResult<()> {
+    insert_into(user_credentials::table)
+        .values(&vec![credential])
+        .execute(conn)
+        .map(|_| ())
+}

--- a/libsplinter/src/biome/credentials/database/helpers/mod.rs
+++ b/libsplinter/src/biome/credentials/database/helpers/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod credentials;
+
+pub use credentials::{fetch_credential_by_username, insert_credential};

--- a/libsplinter/src/biome/credentials/database/migrations/2019-11-13-214153_create_credentials/down.sql
+++ b/libsplinter/src/biome/credentials/database/migrations/2019-11-13-214153_create_credentials/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS user_credentials;

--- a/libsplinter/src/biome/credentials/database/migrations/2019-11-13-214153_create_credentials/up.sql
+++ b/libsplinter/src/biome/credentials/database/migrations/2019-11-13-214153_create_credentials/up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS  user_credentials (
+  id                        BIGSERIAL       PRIMARY KEY,
+  user_id                   TEXT            NOT NULL,
+  username                  TEXT            NOT NULL,
+  password                  TEXT            NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES splinter_user(id) ON DELETE CASCADE
+);

--- a/libsplinter/src/biome/credentials/database/mod.rs
+++ b/libsplinter/src/biome/credentials/database/mod.rs
@@ -14,6 +14,7 @@
 
 //! Defines methods and utilities to interact with credentials tables in the database.
 
+pub(super) mod helpers;
 pub(super) mod models;
 pub(super) mod schema;
 

--- a/libsplinter/src/biome/credentials/database/mod.rs
+++ b/libsplinter/src/biome/credentials/database/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines methods and utilities to interact with credentials tables in the database.
+
+pub(super) mod models;
+pub(super) mod schema;
+
+embed_migrations!("./src/biome/credentials/database/migrations");
+
+use diesel::pg::PgConnection;
+
+use crate::database::error::DatabaseError;
+
+/// Run database migrations to create tables defined in the credentials module
+///
+/// # Arguments
+///
+/// * `conn` - Connection to database
+///
+pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
+    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+
+    info!("Successfully applied migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/biome/credentials/database/models.rs
+++ b/libsplinter/src/biome/credentials/database/models.rs
@@ -12,18 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides support for user management in splinter applications
-//!
-//! ## Features
-//!
-//! * `biome-credentials`: API to register and authenticate a user using an username and password.
-//!   Not recommend for use in production.
-//! * `biome-notifications`: API to create and manage user notifications.
+use super::schema::*;
+use crate::biome::users::database::models::UserModel;
 
-#[cfg(feature = "biome-credentials")]
-pub mod credentials;
+#[derive(Queryable, Identifiable, Associations, PartialEq, Debug)]
+#[table_name = "user_credentials"]
+#[belongs_to(UserModel, foreign_key = "user_id")]
+pub struct UserCredentialsModel {
+    pub id: i64,
+    pub user_id: String,
+    pub username: String,
+    pub password: String,
+}
 
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-
-pub mod users;
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "user_credentials"]
+pub struct NewUserCredentialsModel {
+    pub user_id: String,
+    pub username: String,
+    pub password: String,
+}

--- a/libsplinter/src/biome/credentials/database/schema.rs
+++ b/libsplinter/src/biome/credentials/database/schema.rs
@@ -12,18 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides support for user management in splinter applications
-//!
-//! ## Features
-//!
-//! * `biome-credentials`: API to register and authenticate a user using an username and password.
-//!   Not recommend for use in production.
-//! * `biome-notifications`: API to create and manage user notifications.
-
-#[cfg(feature = "biome-credentials")]
-pub mod credentials;
-
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-
-pub mod users;
+table! {
+    user_credentials {
+        id -> Int8,
+        user_id -> Text,
+        username -> Text,
+        password -> Text,
+    }
+}

--- a/libsplinter/src/biome/credentials/error.rs
+++ b/libsplinter/src/biome/credentials/error.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bcrypt::BcryptError;
+
+use std::error::Error;
+use std::fmt;
+
+/// Represents UserCredentialsBuilder errors
+#[derive(Debug)]
+pub enum UserCredentialsBuilderError {
+    /// Returned when a required field was not set
+    MissingRequiredField(String),
+    /// Returned when a error occurs while attempting to encrypt the password
+    EncryptionError(Box<dyn Error>),
+}
+
+impl Error for UserCredentialsBuilderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            UserCredentialsBuilderError::MissingRequiredField(_) => None,
+            UserCredentialsBuilderError::EncryptionError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for UserCredentialsBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UserCredentialsBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "failed to build user credentials: {}", s)
+            }
+            UserCredentialsBuilderError::EncryptionError(ref s) => {
+                write!(f, "failed encrypt password: {}", s)
+            }
+        }
+    }
+}
+
+impl From<BcryptError> for UserCredentialsBuilderError {
+    fn from(err: BcryptError) -> UserCredentialsBuilderError {
+        UserCredentialsBuilderError::EncryptionError(Box::new(err))
+    }
+}

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -15,6 +15,8 @@
 //! Defines a basic API to register and authenticate a SplinterUser using a username and a password.
 //! Not recommended for use in production.
 
+pub(in crate::biome) mod credentials_store;
+
 pub mod database;
 mod error;
 use bcrypt::{hash, DEFAULT_COST};

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -19,6 +19,8 @@ pub(in crate::biome) mod credentials_store;
 
 pub mod database;
 mod error;
+pub(in crate::biome) mod rest_resources;
+
 use bcrypt::{hash, DEFAULT_COST};
 
 use database::models::{NewUserCredentialsModel, UserCredentialsModel};

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -16,3 +16,101 @@
 //! Not recommended for use in production.
 
 pub mod database;
+mod error;
+use bcrypt::{hash, DEFAULT_COST};
+
+use database::models::{NewUserCredentialsModel, UserCredentialsModel};
+
+pub(in crate::biome) use error::UserCredentialsBuilderError;
+
+/// Represents crendentials used to authenticate a user
+pub struct UserCredentials {
+    user_id: String,
+    username: String,
+    password: String,
+}
+
+/// Builder for UsersCredential. It hashes the password upon build.
+#[derive(Default)]
+pub struct UserCredentialsBuilder {
+    user_id: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+impl UserCredentialsBuilder {
+    /// Sets the user_id for the credentials belong to
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id`: unique identifier for the user the credentials belong to
+    ///
+    pub fn with_user_id(mut self, user_id: &str) -> UserCredentialsBuilder {
+        self.user_id = Some(user_id.to_owned());
+        self
+    }
+
+    /// Sets the username for the credentials
+    ///
+    /// # Arguments
+    ///
+    /// * `username`: username that will be used to authenticate the user
+    ///
+    pub fn with_username(mut self, username: &str) -> UserCredentialsBuilder {
+        self.username = Some(username.to_owned());
+        self
+    }
+
+    // Sets the password for the credentials
+    ///
+    /// # Arguments
+    ///
+    /// * `password`: password that will be used to authenticate the user
+    ///
+    pub fn with_password(mut self, password: &str) -> UserCredentialsBuilder {
+        self.password = Some(password.to_owned());
+        self
+    }
+
+    /// Consumes the builder, hashes the password and returns UserCredentials with the hashed
+    /// password
+    pub fn build(self) -> Result<UserCredentials, UserCredentialsBuilderError> {
+        let user_id = self.user_id.ok_or_else(|| {
+            UserCredentialsBuilderError::MissingRequiredField("Missing user_id".to_string())
+        })?;
+        let username = self.username.ok_or_else(|| {
+            UserCredentialsBuilderError::MissingRequiredField("Missing user_id".to_string())
+        })?;
+        let hashed_password = hash(
+            self.password.ok_or_else(|| {
+                UserCredentialsBuilderError::MissingRequiredField("Missing password".to_string())
+            })?,
+            DEFAULT_COST,
+        )?;
+        Ok(UserCredentials {
+            user_id,
+            username,
+            password: hashed_password,
+        })
+    }
+}
+
+impl From<UserCredentialsModel> for UserCredentials {
+    fn from(user_credentials: UserCredentialsModel) -> Self {
+        Self {
+            user_id: user_credentials.user_id,
+            username: user_credentials.username,
+            password: user_credentials.password,
+        }
+    }
+}
+
+impl Into<NewUserCredentialsModel> for UserCredentials {
+    fn into(self) -> NewUserCredentialsModel {
+        NewUserCredentialsModel {
+            user_id: self.user_id,
+            username: self.username,
+            password: self.password,
+        }
+    }
+}

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -21,7 +21,7 @@ use bcrypt::{hash, DEFAULT_COST};
 
 use database::models::{NewUserCredentialsModel, UserCredentialsModel};
 
-pub(in crate::biome) use error::UserCredentialsBuilderError;
+pub use error::{CredentialsStoreError, UserCredentialsBuilderError};
 
 /// Represents crendentials used to authenticate a user
 pub struct UserCredentials {
@@ -93,6 +93,52 @@ impl UserCredentialsBuilder {
             password: hashed_password,
         })
     }
+}
+
+/// Defines methods for CRUD operations and fetching a user’s
+/// credentials without defining a storage strategy
+pub trait CredentialsStore<T> {
+    /// Adds a credential to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `credentials` - Credentials to be added
+    ///
+    ///
+    fn add_credentials(&self, credentials: T) -> Result<(), CredentialsStoreError>;
+
+    /// Replaces a credential of a certain type for a user in the underlying storage with new
+    /// credentials. This assumes that the user has only one credential of a certain type in
+    /// storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `user_id` - The unique identifier of the user credential belongs to
+    ///  * `updated_username` - The updated username for the user
+    ///  * `updated_password` - The updated password for the user
+    ///
+    fn update_credentials(
+        &self,
+        user_id: &str,
+        updated_username: &str,
+        updated_password: &str,
+    ) -> Result<(), CredentialsStoreError>;
+
+    /// Removes a credential from a user from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `user_id` - The unique identifier of the user credential belongs to
+    ///
+    fn remove_credentials(&self, user_id: &str) -> Result<T, CredentialsStoreError>;
+
+    /// Fetches a credential for a user
+    ///
+    /// # Arguments
+    ///
+    ///  * `user_id` - The unique identifier of the user for which the credentials will be returned
+    ///
+    fn fetch_credential(&self, user_id: &str) -> Result<T, CredentialsStoreError>;
 }
 
 impl From<UserCredentialsModel> for UserCredentials {

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -12,18 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides support for user management in splinter applications
-//!
-//! ## Features
-//!
-//! * `biome-credentials`: API to register and authenticate a user using an username and password.
-//!   Not recommend for use in production.
-//! * `biome-notifications`: API to create and manage user notifications.
+//! Defines a basic API to register and authenticate a SplinterUser using a username and a password.
+//! Not recommended for use in production.
 
-#[cfg(feature = "biome-credentials")]
-pub mod credentials;
-
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-
-pub mod users;
+pub mod database;

--- a/libsplinter/src/biome/credentials/rest_resources.rs
+++ b/libsplinter/src/biome/credentials/rest_resources.rs
@@ -1,0 +1,106 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::actix_web::HttpResponse;
+use crate::futures::{Future, IntoFuture};
+use crate::rest_api::{into_bytes, ErrorResponse, Method, Resource};
+
+use super::super::users::{user_store::SplinterUserStore, SplinterUser, UserStore};
+use super::{
+    credentials_store::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
+    UserCredentialsBuilder,
+};
+
+#[derive(Deserialize)]
+struct UsernamePassword {
+    username: String,
+    password: String,
+}
+
+/// Defines a REST endpoint to add a user and credentials to the database
+pub fn make_register_route(
+    credentials_store: Arc<SplinterCredentialsStore>,
+    user_store: Arc<SplinterUserStore>,
+) -> Resource {
+    Resource::build("/biome/register").add_method(Method::Post, move |_, payload| {
+        let credentials_store = credentials_store.clone();
+        let user_store = user_store.clone();
+        Box::new(into_bytes(payload).and_then(move |bytes| {
+            let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload: {}",
+                            err
+                        )))
+                        .into_future();
+                }
+            };
+            let user_id = Uuid::new_v4().to_string();
+            let splinter_user = SplinterUser::new(&user_id);
+            match user_store.add_user(splinter_user) {
+                Ok(()) => {
+                    let credentials_builder: UserCredentialsBuilder = Default::default();
+                    let credentials = match credentials_builder
+                        .with_user_id(&user_id)
+                        .with_username(&username_password.username)
+                        .with_password(&username_password.password)
+                        .build()
+                    {
+                        Ok(credential) => credential,
+                        Err(err) => {
+                            debug!("Failed to create credentials {}", err);
+                            return HttpResponse::InternalServerError()
+                                .json(ErrorResponse::internal_error())
+                                .into_future();
+                        }
+                    };
+
+                    match credentials_store.add_credentials(credentials) {
+                        Ok(()) => HttpResponse::Ok()
+                            .json(json!({ "message": "User created successfully" }))
+                            .into_future(),
+                        Err(err) => {
+                            debug!("Failed to add new credentials to database {}", err);
+                            match err {
+                                CredentialsStoreError::DuplicateError(err) => {
+                                    HttpResponse::BadRequest()
+                                        .json(ErrorResponse::bad_request(&format!(
+                                            "Failed to create user: {}",
+                                            err
+                                        )))
+                                        .into_future()
+                                }
+                                _ => HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future(),
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    debug!("Failed to add new user to database {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            }
+        }))
+    })
+}

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;
+
 pub mod users;

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -26,4 +26,5 @@ pub mod credentials;
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;
 
+pub mod rest_api;
 pub mod users;

--- a/libsplinter/src/biome/rest_api/error.rs
+++ b/libsplinter/src/biome/rest_api/error.rs
@@ -1,0 +1,35 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error for BiomeRestResourceManagerBuilder
+#[derive(Debug)]
+pub enum BiomeRestResourceManagerBuilderError {
+    /// Returned if a required field is missing
+    MissingRequiredField(String),
+}
+
+impl Error for BiomeRestResourceManagerBuilderError {}
+
+impl fmt::Display for BiomeRestResourceManagerBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BiomeRestResourceManagerBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "failed to build BiomeRestResourceManager: {}", s)
+            }
+        }
+    }
+}

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -1,0 +1,145 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides an API for managing Biome REST API endpoints
+//!
+//! Below is an example of building an instance of BiomeRestResourceManager and passing its resources
+//! to a running instance of `RestApi`.
+//!
+//! ```no_run
+//! use splinter::rest_api::{Resource, Method, RestApiBuilder, RestResourceProvider};
+//! use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
+//! use splinter::database::{self, ConnectionPool};
+//!
+//! let connection_pool: ConnectionPool = database::create_connection_pool(
+//!            "postgres://db_admin:db_password@0.0.0.0:5432/db",
+//!        )
+//!        .unwrap();
+//!
+//! let biome_rest_provider_builder: BiomeRestResourceManagerBuilder = Default::default();
+//! let biome_rest_provider = biome_rest_provider_builder
+//!             .with_user_store(connection_pool.clone())
+//!             .build()
+//!             .unwrap();
+//!
+//! RestApiBuilder::new()
+//!     .add_resources(biome_rest_provider.resources())
+//!     .with_bind("localhost:8080")
+//!     .build()
+//!     .unwrap()
+//!     .run();
+//! ```
+
+mod error;
+
+use std::sync::Arc;
+
+use crate::database::ConnectionPool;
+use crate::rest_api::{Resource, RestResourceProvider};
+
+use super::users::user_store::SplinterUserStore;
+
+pub use error::BiomeRestResourceManagerBuilderError;
+
+#[cfg(feature = "biome-credentials")]
+use super::credentials::{
+    credentials_store::SplinterCredentialsStore, rest_resources::make_register_route,
+};
+
+/// Manages Biome REST API endpoints
+pub struct BiomeRestResourceManager {
+    // This is only used if the biome-credentials feature is enabled
+    #[allow(dead_code)]
+    user_store: Arc<SplinterUserStore>,
+    #[cfg(feature = "biome-credentials")]
+    credentials_store: Option<Arc<SplinterCredentialsStore>>,
+}
+
+impl RestResourceProvider for BiomeRestResourceManager {
+    fn resources(&self) -> Vec<Resource> {
+        // This needs to be mutable if biome-credentials feature is enable
+        #[allow(unused_mut)]
+        let mut resources = Vec::new();
+
+        #[cfg(feature = "biome-credentials")]
+        match &self.credentials_store {
+            Some(credentials_store) => resources.push(make_register_route(
+                credentials_store.clone(),
+                self.user_store.clone(),
+            )),
+            None => {
+                debug!(
+                    "Credentials store not provided. Credentials REST API resources will not be'
+                ' included in the biome endpoints."
+                );
+            }
+        };
+        resources
+    }
+}
+
+/// Builder for BiomeRestResourceManager
+#[derive(Default)]
+pub struct BiomeRestResourceManagerBuilder {
+    user_store: Option<SplinterUserStore>,
+    #[cfg(feature = "biome-credentials")]
+    credentials_store: Option<SplinterCredentialsStore>,
+}
+
+impl BiomeRestResourceManagerBuilder {
+    /// Sets a UserStore for the BiomeRestResourceManager
+    ///
+    /// # Arguments
+    ///
+    /// * `pool`: ConnectionPool to database that will serve as backend for UserStore
+    pub fn with_user_store(mut self, pool: ConnectionPool) -> BiomeRestResourceManagerBuilder {
+        self.user_store = Some(SplinterUserStore::new(pool));
+        self
+    }
+
+    #[cfg(feature = "biome-credentials")]
+    /// Sets a CredentialsStore for the BiomeRestResourceManager
+    ///
+    /// # Arguments
+    ///
+    /// * `pool`: ConnectionPool to database that will serve as backend for CredentialsStore
+    pub fn with_credentials_store(
+        mut self,
+        pool: ConnectionPool,
+    ) -> BiomeRestResourceManagerBuilder {
+        self.credentials_store = Some(SplinterCredentialsStore::new(pool));
+        self
+    }
+
+    /// Consumes the builder and returns a BiomeRestResourceManager
+    pub fn build(self) -> Result<BiomeRestResourceManager, BiomeRestResourceManagerBuilderError> {
+        let user_store = self.user_store.ok_or_else(|| {
+            BiomeRestResourceManagerBuilderError::MissingRequiredField(
+                "Missing user store".to_string(),
+            )
+        })?;
+
+        Ok(BiomeRestResourceManager {
+            user_store: Arc::new(user_store),
+            #[cfg(feature = "biome-credentials")]
+            credentials_store: match self.credentials_store {
+                Some(credentials_store) => Some(Arc::new(credentials_store)),
+                None => {
+                    debug!("Building BiomeRestResourceManager without credentials store");
+                    None
+                }
+            },
+        })
+    }
+}

--- a/libsplinter/src/biome/users/database/helpers/mod.rs
+++ b/libsplinter/src/biome/users/database/helpers/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod users;
+
+pub use users::insert_user;

--- a/libsplinter/src/biome/users/database/helpers/users.rs
+++ b/libsplinter/src/biome/users/database/helpers/users.rs
@@ -1,0 +1,25 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::models::UserModel;
+use super::super::schema::splinter_user;
+
+use diesel::{dsl::insert_into, pg::PgConnection, prelude::*, QueryResult};
+
+pub fn insert_user(conn: &PgConnection, user: UserModel) -> QueryResult<()> {
+    insert_into(splinter_user::table)
+        .values(&vec![user])
+        .execute(conn)
+        .map(|_| ())
+}

--- a/libsplinter/src/biome/users/database/migrations/2019-11-13-213120_create_users/down.sql
+++ b/libsplinter/src/biome/users/database/migrations/2019-11-13-213120_create_users/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE splinter_user;

--- a/libsplinter/src/biome/users/database/migrations/2019-11-13-213120_create_users/up.sql
+++ b/libsplinter/src/biome/users/database/migrations/2019-11-13-213120_create_users/up.sql
@@ -1,0 +1,18 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS splinter_user (
+  id                        TEXT        PRIMARY KEY
+);

--- a/libsplinter/src/biome/users/database/mod.rs
+++ b/libsplinter/src/biome/users/database/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines methods and utilities to interact with user tables in the database.
+
+pub(in crate::biome) mod models;
+pub(super) mod schema;
+
+embed_migrations!("./src/biome/users/database/migrations");
+
+use diesel::pg::PgConnection;
+
+use crate::database::error::DatabaseError;
+
+/// Run database migrations to create tables defined in the user module
+///
+/// # Arguments
+///
+/// * `conn` - Connection to database
+///
+pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
+    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+
+    info!("Successfully applied migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/biome/users/database/mod.rs
+++ b/libsplinter/src/biome/users/database/mod.rs
@@ -14,6 +14,7 @@
 
 //! Defines methods and utilities to interact with user tables in the database.
 
+pub(super) mod helpers;
 pub(in crate::biome) mod models;
 pub(super) mod schema;
 

--- a/libsplinter/src/biome/users/database/models.rs
+++ b/libsplinter/src/biome/users/database/models.rs
@@ -11,6 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-pub mod users;
+
+use super::schema::*;
+
+#[derive(Insertable, Queryable, Identifiable, PartialEq, Debug)]
+#[table_name = "splinter_user"]
+#[primary_key(id)]
+pub struct UserModel {
+    pub id: String,
+}

--- a/libsplinter/src/biome/users/database/schema.rs
+++ b/libsplinter/src/biome/users/database/schema.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-pub mod users;
+
+table! {
+    splinter_user (id) {
+        id -> Text,
+    }
+}

--- a/libsplinter/src/biome/users/error.rs
+++ b/libsplinter/src/biome/users/error.rs
@@ -1,0 +1,84 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::database::error::DatabaseError;
+
+/// Represents UserStore errors
+#[derive(Debug)]
+pub enum UserStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+}
+
+impl Error for UserStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            UserStoreError::OperationError { source, .. } => Some(&**source),
+            UserStoreError::QueryError { source, .. } => Some(&**source),
+            UserStoreError::StorageError { source, .. } => Some(&**source),
+            UserStoreError::ConnectionError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for UserStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UserStoreError::OperationError { context, source } => {
+                write!(f, "failed to perform operation: {}: {}", context, source)
+            }
+            UserStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            UserStoreError::StorageError { context, source } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            UserStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+        }
+    }
+}
+
+impl From<DatabaseError> for UserStoreError {
+    fn from(err: DatabaseError) -> UserStoreError {
+        match err {
+            DatabaseError::ConnectionError(_) => UserStoreError::ConnectionError(Box::new(err)),
+            _ => UserStoreError::StorageError {
+                context: "The database returned an error".to_string(),
+                source: Box::new(err),
+            },
+        }
+    }
+}

--- a/libsplinter/src/biome/users/mod.rs
+++ b/libsplinter/src/biome/users/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod database;
 mod error;
+pub(in crate::biome) mod user_store;
 
 pub use error::UserStoreError;
 

--- a/libsplinter/src/biome/users/mod.rs
+++ b/libsplinter/src/biome/users/mod.rs
@@ -18,6 +18,9 @@
 //! application.
 
 pub mod database;
+mod error;
+
+pub use error::UserStoreError;
 
 use database::models::UserModel;
 
@@ -43,6 +46,55 @@ impl SplinterUser {
     pub fn id(&self) -> String {
         self.id.to_string()
     }
+}
+
+/// Defines methods for CRUD operations and fetching and listing users
+/// without defining a storage strategy
+pub trait UserStore<T> {
+    /// Adds a user to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `user` - The user to be added
+    ///
+    ///
+    fn add_user(&self, user: T) -> Result<(), UserStoreError>;
+
+    /// Updates a user information in the underling storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `user` - The user with the updated information
+    ///
+    fn update_user(&self, updated_user: T) -> Result<(), UserStoreError>;
+
+    /// Removes a user from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The unique id of the user to be removed
+    ///
+    fn remove_user(&self, id: &str) -> Result<T, UserStoreError>;
+
+    /// Fetches a user from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The unique id of the user to be returned
+    ///
+    fn fetch_user(&self, id: &str) -> Result<T, UserStoreError>;
+
+    /// List all users from the underlying storage
+    ///
+    fn list_users(&self, id: &str) -> Result<Vec<T>, UserStoreError>;
+
+    /// Checks that a user with the given id exists
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The unique id of the user.
+    ///
+    fn is_user(&self, id: &str) -> Result<bool, UserStoreError>;
 }
 
 impl From<UserModel> for SplinterUser {

--- a/libsplinter/src/biome/users/mod.rs
+++ b/libsplinter/src/biome/users/mod.rs
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-pub mod users;
+
+//! Defines a basic representation of a user and provides an API to manage users.
+//!
+//! Users are central entity in the biome module. They represent a real person who uses a splinter
+//! application.
+
+pub mod database;

--- a/libsplinter/src/biome/users/mod.rs
+++ b/libsplinter/src/biome/users/mod.rs
@@ -18,3 +18,40 @@
 //! application.
 
 pub mod database;
+
+use database::models::UserModel;
+
+/// Represents a user of a splinter application
+pub struct SplinterUser {
+    id: String,
+}
+
+impl SplinterUser {
+    /// Creates a new SplinterUser
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id`: unique identifier for the user being created
+    ///
+    pub fn new(user_id: &str) -> Self {
+        SplinterUser {
+            id: user_id.to_string(),
+        }
+    }
+
+    /// Returns the user's id.
+    pub fn id(&self) -> String {
+        self.id.to_string()
+    }
+}
+
+impl From<UserModel> for SplinterUser {
+    fn from(user: UserModel) -> Self {
+        SplinterUser { id: user.id }
+    }
+}
+impl Into<UserModel> for SplinterUser {
+    fn into(self) -> UserModel {
+        UserModel { id: self.id }
+    }
+}

--- a/libsplinter/src/biome/users/user_store.rs
+++ b/libsplinter/src/biome/users/user_store.rs
@@ -1,0 +1,66 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::database::helpers::insert_user;
+use super::{SplinterUser, UserStore, UserStoreError};
+use crate::database::ConnectionPool;
+
+/// Manages creating, updating and fetching SplinterUser from the databae
+pub struct SplinterUserStore {
+    connection_pool: ConnectionPool,
+}
+
+impl SplinterUserStore {
+    /// Creates a new SplinterUserStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    pub fn new(connection_pool: ConnectionPool) -> SplinterUserStore {
+        SplinterUserStore { connection_pool }
+    }
+}
+
+impl UserStore<SplinterUser> for SplinterUserStore {
+    fn add_user(&self, user: SplinterUser) -> Result<(), UserStoreError> {
+        let user_model = user.into();
+        insert_user(&*self.connection_pool.get()?, user_model).map_err(|err| {
+            UserStoreError::OperationError {
+                context: "Failed to add user".to_string(),
+                source: Box::new(err),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn update_user(&self, _updated_user: SplinterUser) -> Result<(), UserStoreError> {
+        unimplemented!()
+    }
+
+    fn remove_user(&self, _id: &str) -> Result<SplinterUser, UserStoreError> {
+        unimplemented!()
+    }
+
+    fn fetch_user(&self, _id: &str) -> Result<SplinterUser, UserStoreError> {
+        unimplemented!()
+    }
+
+    fn list_users(&self, _id: &str) -> Result<Vec<SplinterUser>, UserStoreError> {
+        unimplemented!()
+    }
+
+    fn is_user(&self, _id: &str) -> Result<bool, UserStoreError> {
+        unimplemented!()
+    }
+}

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -53,6 +53,7 @@
 
 mod errors;
 mod events;
+mod response_models;
 
 use actix_web::{
     error::ErrorBadRequest, middleware, web, App, Error as ActixError, HttpRequest, HttpResponse,
@@ -67,6 +68,8 @@ use std::thread;
 pub use errors::{EventDealerError, EventHistoryError, ResponseError, RestApiServerError};
 
 pub use events::{EventDealer, EventHistory, EventSender, LocalEventHistory};
+
+pub use response_models::ErrorResponse;
 
 /// A `RestResourceProvider` provides a list of resources that are consumed by `RestApi`.
 pub trait RestResourceProvider {

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -347,6 +347,17 @@ pub fn into_protobuf<M: Message>(
         .into_future()
 }
 
+pub fn into_bytes(payload: web::Payload) -> impl Future<Item = Vec<u8>, Error = ActixError> {
+    payload
+        .from_err::<ActixError>()
+        .fold(web::BytesMut::new(), move |mut body, chunk| {
+            body.extend_from_slice(&chunk);
+            Ok::<_, ActixError>(body)
+        })
+        .and_then(|body| Ok(body.to_vec()))
+        .into_future()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/libsplinter/src/rest_api/response_models.rs
+++ b/libsplinter/src/rest_api/response_models.rs
@@ -1,0 +1,50 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Model for a error response to an REST request
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    code: String,
+    message: String,
+}
+
+impl ErrorResponse {
+    pub fn internal_error() -> ErrorResponse {
+        ErrorResponse {
+            code: "500".to_string(),
+            message: "The server encountered an error".to_string(),
+        }
+    }
+
+    pub fn bad_request(message: &str) -> ErrorResponse {
+        ErrorResponse {
+            code: "400".to_string(),
+            message: message.to_string(),
+        }
+    }
+
+    pub fn not_found(message: &str) -> ErrorResponse {
+        ErrorResponse {
+            code: "404".to_string(),
+            message: message.to_string(),
+        }
+    }
+
+    pub fn unauthorized(message: &str) -> ErrorResponse {
+        ErrorResponse {
+            code: "401".to_string(),
+            message: message.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
This PR:

- Adds a user module to biome: 
   - Defines a user
   - Defines a user store trait
   - Adds database migrations, models, schemas and helper methods for users
   - Partially implements user store:  `add_user` method
- Adds a user module to credentials module to biome: 
   - Defines user credentials to include username and password
   - Defines a credentials store trait
   - Adds database migrations, models, schemas and helper methods for credentials
   - Partially implements credentials store:  `add_credentials` method
   - Implements a method that returns a Resource for `/biome/register` endpoint
- Adds a BiomeRestResourceManager to biome, responsible to provide the biome routes for users of the biome module (like splinterd) 


 
