### PR TITLE
Add Zac Skalko as a codeowner and maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @davececchi @dplumb94 @eloaverona @jsmitchell @peterschwarz @ltseeley @rbuysse @RyanLassigBanks @shannynalayna @vaporos
+*       @agunde406 @chenette @davececchi @dplumb94 @eloaverona @jsmitchell @peterschwarz @ltseeley @rbuysse @RyanLassigBanks @shannynalayna @vaporos @zapplebee

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,3 +15,4 @@
 | Ryan Beck-Buysse | rbuysse |
 | Shannyn Telander | shannynalayna |
 | Shawn Amundson | vaporos |
+| Zac Skalko | zapplebee |


### PR DESCRIPTION
Add Zac as a codeowner and maintainer of Splinter

Signed-off-by: DavidCecchi <david_cecchi@cargill.com>