### PR TITLE
Clean-up authorization state after peer disconnect

### DIFF
--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -276,6 +276,11 @@ impl Network {
         Ok(())
     }
 
+    /// Adds a peer with a given id.
+    ///
+    /// Note that while this peer id is specified explicitly, the connection will still require to
+    /// complete the authorization handshake, at which point its node id that the remote connection
+    /// has identified itself with may replace the given id.
     pub fn add_peer(
         &self,
         peer_id: String,


### PR DESCRIPTION
This commit adds a DisconnectListener to the Network struct, which will be called when ever a peer is detected as disconnected.

The auth manager listens for disconnects, in order to clean up any auth state that may still exist, in order for connections to be re-connected.