### PR TITLE
Add new components to design system for login register sapling

### DIFF
--- a/canopy/design-system/package.json
+++ b/canopy/design-system/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "node-sass": "^4.12.0",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",

--- a/canopy/design-system/src/App.js
+++ b/canopy/design-system/src/App.js
@@ -24,7 +24,6 @@ import {
 import './App.scss';
 
 import SideNav from './components/navigation/SideNav';
-import Components from './views/Components';
 
 const tabs = [
   {
@@ -32,7 +31,10 @@ const tabs = [
     nested: [
       {
         name: 'Introduction',
-        route: '/overview/introduction'
+        route: '/overview/introduction',
+        component: lazy(() =>
+          import('!babel-loader!mdx-loader!./views/Introduction.mdx')
+        )
       },
       {
         name: 'Conventions',
@@ -45,7 +47,10 @@ const tabs = [
     nested: [
       {
         name: 'Colors',
-        route: '/design/colors'
+        route: '/design/colors',
+        component: lazy(() =>
+          import('!babel-loader!mdx-loader!./views/Colors.mdx')
+        )
       },
       {
         name: 'Buttons',
@@ -53,7 +58,10 @@ const tabs = [
       },
       {
         name: 'Typography',
-        route: '/design/typography'
+        route: '/design/typography',
+        component: lazy(() =>
+          import('!babel-loader!mdx-loader!./views/Typography.mdx')
+        )
       }
     ]
   },
@@ -61,22 +69,27 @@ const tabs = [
     name: 'Components',
     nested: [
       {
-        name: 'Modals',
-        route: '/design/modals'
+        name: 'Progress',
+        route: '/components/progress',
+        component: lazy(() =>
+          import('!babel-loader!mdx-loader!./views/Progress.mdx')
+        )
+      },
+      {
+        name: 'TabBox',
+        route: '/components/tabbox',
+        component: lazy(() =>
+          import('!babel-loader!mdx-loader!./views/TabBox.mdx')
+        )
       }
     ]
   }
 ];
 
-const Introduction = lazy(() =>
-  import('!babel-loader!mdx-loader!./views/Introduction.mdx')
-);
-const Colors = lazy(() =>
-  import('!babel-loader!mdx-loader!./views/Colors.mdx')
-);
-const Typography = lazy(() =>
-  import('!babel-loader!mdx-loader!./views/Typography.mdx')
-);
+const flatRoutes = tabs
+  .map(t => t.nested)
+  .flat()
+  .filter(({ component }) => Boolean(component));
 
 function App() {
   return (
@@ -87,25 +100,17 @@ function App() {
           <Switch>
             <Redirect exact from="/" to="/overview/introduction" />
             <Redirect exact from="/overview" to="/overview/introduction" />
-            <Route path="/overview/introduction">
-              <Suspense fallback={<div>Loading...</div>}>
-                <Introduction />
-              </Suspense>
-            </Route>
             <Redirect exact from="/design" to="/design/colors" />
-            <Route path="/design/colors">
-              <Suspense fallback={<div>Loading...</div>}>
-                <Colors />
-              </Suspense>
-            </Route>
-            <Route path="/design/typography">
-              <Suspense fallback={<div>Loading...</div>}>
-                <Typography />
-              </Suspense>
-            </Route>
-            <Route path="/components">
-              <Components />
-            </Route>
+            {flatRoutes.map(({ route, component }) => {
+              const C = component;
+              return (
+                <Route path={route} exact key={route}>
+                  <Suspense fallback={<div>Loading...</div>}>
+                    <C />
+                  </Suspense>
+                </Route>
+              );
+            })}
           </Switch>
         </div>
       </div>

--- a/canopy/design-system/src/components/progress/Progress.js
+++ b/canopy/design-system/src/components/progress/Progress.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Progress({ max, value }) {
+  return <progress className="progress" max={max} value={value} />;
+}
+
+Progress.propTypes = {
+  max: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired
+};

--- a/canopy/design-system/src/components/progress/Progress.scss
+++ b/canopy/design-system/src/components/progress/Progress.scss
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+$progress-size: 6rem;
+
+$progress-colors: (
+  'background': $color-canopy,
+  'gutter': $background-light,
+  'leaf': $color-canopy-light
+);
+
+@function asRGBString($color) {
+  @return 'rgb(' + red($color) + ',' + green($color) + ',' + blue($color) + ')';
+}
+
+@function makeLoadingSvg($colorKey) {
+  $svg-ns: 'xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"';
+  $svgMime: 'data:image/svg+xml;utf8,';
+  $svgDimensions: 'height="100" width="100" viewBox="-10 -10 120 120"';
+  $svgOpen: '<svg ' + $svg-ns + ' ' + $svgDimensions +
+    ' shape-rendering="geometricPrecision">';
+  $svgClose: '</svg>';
+  $d: 'M 85,8 C 18,20 -6,29 20,73 L 10,88 L 15,93 L 30,78 C 93,98 98,62, 85,8 z M 70,30 C 56,38 43,47 40,60 L 35,55 C 44,41 56,34 70,30 z';
+  $path: '<path style="fill:' +
+    asRGBString(map-get($progress-colors, $colorKey)) + ';" d="' + $d + '"/>';
+  @return url($svgMime+$svgOpen+$path+$svgClose);
+}
+
+@mixin progressGutter {
+  border-radius: 50%;
+  background-color: map-get($progress-colors, 'background');
+  background-size: cover;
+  background-image: makeLoadingSvg('gutter');
+}
+
+@mixin progressLeaf {
+  background-color: transparent;
+  background-size: cover;
+  background-image: makeLoadingSvg('leaf');
+}
+
+progress.progress {
+  appearance: none;
+  border: none;
+  width: $progress-size;
+  height: $progress-size;
+  @include progressGutter;
+
+  &[value] {
+    border-radius: 50%;
+    color: map-get($progress-colors, 'leaf');
+    background-color: map-get($progress-colors, 'background');
+  }
+
+  &[value]::-webkit-progress-bar {
+    @include progressGutter;
+  }
+
+  &[value]::-webkit-progress-value {
+    @include progressLeaf;
+  }
+
+  &[value]::-moz-progress-bar {
+    @include progressLeaf;
+  }
+}

--- a/canopy/design-system/src/components/tabBox/TabBox.js
+++ b/canopy/design-system/src/components/tabBox/TabBox.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default function TabBox({ contents, keyExtractor }) {
+  const titles = contents.map(({ title }) => title);
+  const contentElements = contents.map(({ content }) => content);
+  const keys = contents.map(keyExtractor);
+
+  const [selectedTab, setSelectedTab] = useState(0);
+  const Content =
+    contentElements[selectedTab] &&
+    typeof contentElements[selectedTab] === 'string'
+      ? () => <>{contentElements[selectedTab]}</>
+      : contentElements[selectedTab];
+
+  return (
+    <div className="tab-box">
+      <div className="tab-box-options">
+        {titles.map((title, index) => {
+          const Title = title;
+          const selected = index === selectedTab;
+          return (
+            <button
+              role="tab"
+              type="button"
+              aria-selected={selected}
+              tabIndex={selected ? 0 : -1}
+              key={keys[index]}
+              className={classnames('tab-box-option', selected && 'active')}
+              onClick={() => setSelectedTab(index)}
+            >
+              {typeof Title === 'string' ? Title : <Title />}
+            </button>
+          );
+        })}
+      </div>
+      <div className="tab-box-content">
+        <Content />
+      </div>
+    </div>
+  );
+}
+
+TabBox.defaultProps = {
+  keyExtractor: (_, contentIndex) => contentIndex
+};
+
+TabBox.propTypes = {
+  contents: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      content: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+    })
+  ).isRequired,
+  keyExtractor: PropTypes.func
+};

--- a/canopy/design-system/src/components/tabBox/TabBox.scss
+++ b/canopy/design-system/src/components/tabBox/TabBox.scss
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.tab-box {
+  .tab-box-options {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    align-content: stretch;
+
+    .tab-box-option {
+      flex-basis: $padding-s * 6;
+      flex-grow: 1;
+      min-width: $padding-s * 6;
+      padding: $padding-s;
+      text-decoration: underline;
+      color: $text-light;
+      background-color: $background-light;
+      cursor: pointer;
+      font-family: $fontFamily-primary !important;
+      border: 1px solid $text-light;
+      outline: none;
+
+      &:focus {
+        outline: none;
+      }
+
+      &:not(:first-of-type) {
+        margin-left: -1px;
+      }
+
+      &.active {
+        background-color: $color-canopy-light;
+        border-bottom-color: $color-canopy-light;
+      }
+    }
+  }
+
+  .tab-box-content {
+    padding: $padding-s;
+    border: 1px solid $text-light;
+    border-top: 0;
+    overflow-y: auto;
+    height: 30vh;
+  }
+
+  clear: both;
+}

--- a/canopy/design-system/src/styles/components.scss
+++ b/canopy/design-system/src/styles/components.scss
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import './../components/progress/Progress.scss';
+@import './../components/tabBox/TabBox.scss';

--- a/canopy/design-system/src/styles/core.scss
+++ b/canopy/design-system/src/styles/core.scss
@@ -17,6 +17,7 @@
 @import './layout.scss';
 @import './navigation.scss';
 @import './colors.scss';
+@import './components.scss';
 
 html {
   font-size: 18px;

--- a/canopy/design-system/src/views/Progress.mdx
+++ b/canopy/design-system/src/views/Progress.mdx
@@ -1,0 +1,26 @@
+<!-- Copyright 2019 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+import ProgressWithControl from './ProgressExample'
+
+# Progress
+
+Move the range slider to see what the progress component looks like at different values.
+<ProgressWithControl/>
+
+Use via a semantic HTML progress element
+
+```HTML
+    <progress class="progress" max="100" value="50"></progress>
+```

--- a/canopy/design-system/src/views/ProgressExample.js
+++ b/canopy/design-system/src/views/ProgressExample.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import Progress from '../components/progress/Progress';
+
+export default function ProgressWithControl() {
+  const [value, setValue] = useState(50);
+  return (
+    <>
+      <Progress value={value} max={100} />
+      <br />
+      <input
+        type="range"
+        min="0"
+        max="100"
+        onChange={e => setValue(parseInt(e.target.value, 10))}
+      />
+    </>
+  );
+}

--- a/canopy/design-system/src/views/TabBox.mdx
+++ b/canopy/design-system/src/views/TabBox.mdx
@@ -1,0 +1,38 @@
+<!-- Copyright 2019 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+import TabBox from '../components/tabBox/TabBox';
+
+# TabBox
+
+A TabBox or recipe box component.
+
+<TabBox contents={[{title: () => <>I am the very model</>, content: "of a modern-major-general"},{title: "I've Information", content: () => <h1>I've information vegetable, animal, and mineral
+I know the kings of England, and I quote the fights historical
+From marathon to Waterloo in order categorical</h1>}]}/>
+
+
+See the HTML example (aria labels have been omitted for legibility):
+
+```HTML
+    <div class="tab-box">
+      <div class="tab-box-options">
+        <button class="tab-box-option">Option 1</button>
+        <button class="tab-box-option">Option 2</button>
+      </div>
+      <div class="tab-box-content">
+        Some option's content
+      </div>
+    </div>
+```


### PR DESCRIPTION
The login/register sapling needed two new components a TabBox and a Loading or Progress item.

This PR adds both as well as pages to see them in action.

To validate this, clone this branch
`cd canopy/design-system`
`yarn`
`yarn start`
Navigate to 0.0.0.0:3000/components/progress and Navigate to 0.0.0.0:3000/components/tabbox