### PR TITLE
Remove generate-certs from default features

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,29 @@
 
 version: "2.2"
 
+volumes:
+  splinter-shared:
+
 services:
+  generate-shared:
+      image: splinter-cli
+      build:
+        context: .
+        dockerfile: cli/Dockerfile-installed-${DISTRO}
+        args:
+          - REPO_VERSION=${REPO_VERSION}
+      volumes:
+        - splinter-shared:/splinter_shared
+      command: |
+        bash -c "
+          if [ ! -f /splinter_shared/private/server.key ]
+          then
+            splinter cert generate \
+              -d  /splinter_shared/ \
+              --force
+          fi
+        "
+
   splinterd-node-0:
     image: splinterd-node
     expose:
@@ -26,6 +48,7 @@ services:
     volumes:
       - ./splinterd/sample_configs:/configs
       - ./splinterd/sample_node_registries:/node_registries
+      - splinter-shared:/splinter_shared
     build:
       context: .
       dockerfile: splinterd/Dockerfile-installed-${DISTRO}
@@ -33,10 +56,18 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
+        # We need to wait for the generated certificates and keys to be
+        # available
+        while [ ! -f /splinter_shared/private/server.key ]; do \
+          echo 'waiting for certs and keys'; \
+          sleep 1; \
+        done && \
+        # Copy the generated keys and certificates to its expected location
+        cp -a /splinter_shared/. /etc/splinter/certs && \
         splinterd \
-            --generate-certs \
             -c ./configs/splinterd-node-0-docker.toml \
             --registry-file ./node_registries/nodes.yaml \
+            --insecure \
             -vv
       "
 

--- a/examples/gameroom/README.md
+++ b/examples/gameroom/README.md
@@ -31,12 +31,12 @@ and [Docker Compose](https://docs.docker.com/compose).
      docker-compose -f examples/gameroom/docker-compose.yaml up
      ```
 1. To extract private keys to use in the web application, run bash using the
-   `generate-key-registry` image and read the private key.  For example, to get
+   `generate-shared` image and read the private key.  For example, to get
    Alice's private key:
 
     ```
-    $ docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash
-    root@<container-id>:/# cat /key_registry/alice.priv; echo ""
+    $ docker-compose -f examples/gameroom/docker-compose.yaml run generate-shared bash
+    root@<container-id>:/# cat /gameroom_shared/key_registry/alice.priv; echo ""
     <the private key value>
     root@<container-id>:/#
     ```
@@ -54,4 +54,3 @@ and [Docker Compose](https://docs.docker.com/compose).
      ```
      docker-compose -f examples/gameroom/docker-compose.yaml down
      ```
-

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -16,13 +16,13 @@ version: '3'
 
 volumes:
   cargo-registry:
-  key-registry:
+  gameroom-shared:
   acme-var:
   bubba-var:
 
 services:
 
-    generate-key-registry:
+    generate-shared:
         image: splinter-cli
         build:
           context: ../..
@@ -30,15 +30,30 @@ services:
           args:
             - REPO_VERSION=${REPO_VERSION}
         volumes:
-          - key-registry:/key_registry
+          - gameroom-shared:/gameroom_shared
           - ./key_registry:/input
         command: |
           bash -c "
-            if [ ! -f /key_registry/keys.yaml ]
+            if [ ! -f /gameroom_shared/key_registry/keys.yaml ]
             then
+              mkdir -p /gameroom_shared/key_registry &&
               splinter admin keyregistry \
                 -i /input/key_registry_spec.yaml \
-                -d /key_registry \
+                -d /gameroom_shared/key_registry \
+                --force
+            fi
+            if [ ! -f /gameroom_shared/acme/private/server.key ]
+            then
+              mkdir -p /gameroom_shared/acme &&
+              splinter cert generate \
+                -d  /gameroom_shared/acme \
+                --force
+            fi
+            if [ ! -f /gameroom_shared/bubba/private/server.key ]
+            then
+              mkdir -p /gameroom_shared/bubba &&
+              splinter cert generate \
+                -d  /gameroom_shared/bubba \
                 --force
             fi
           "
@@ -128,23 +143,32 @@ services:
       ports:
         - 8088:8085
       volumes:
-        - key-registry:/key_registry_shared
+        - gameroom-shared:/gameroom_shared
         - acme-var:/var/lib/splinter
         - ./splinterd-config:/configs
         - ./node_registry:/node_registry
       entrypoint: |
         bash -c "
           # We need to wait for the generated key registry to be available
-          while [ ! -f /key_registry_shared/keys.yaml ]; do \
+          while [ ! -f /gameroom_shared/key_registry/keys.yaml ]; do \
             echo 'waiting for key registry'; \
             sleep 1; \
           done && \
+          # We need to wait for the generated certificates and keys to be
+          # available
+          while [ ! -f /gameroom_shared/acme/private/server.key ]; do \
+            echo 'waiting for certs and keys'; \
+            sleep 1; \
+          done && \
           # Copy the generated key registry to its expected location
-          cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          splinterd --generate-certs -c ./configs/splinterd-node-acme.toml -vv \
+          cp -a /gameroom_shared/key_registry/keys.yaml /var/lib/splinter && \
+          # Copy the generated keys and certificates to its expected location
+          cp -a /gameroom_shared/acme/. /etc/splinter/certs && \
+          splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --bind 0.0.0.0:8085
+              --bind 0.0.0.0:8085 \
+              --insecure
         "
 
     db-bubba:
@@ -233,21 +257,30 @@ services:
       ports:
         - 8089:8085
       volumes:
-        - key-registry:/key_registry_shared
+        - gameroom-shared:/gameroom_shared
         - ./splinterd-config:/configs
         - ./node_registry:/node_registry
         - bubba-var:/var/lib/splinter
       entrypoint: |
         bash -c "
           # We need to wait for the generated key registry to be available
-          while [ ! -f /key_registry_shared/keys.yaml ]; do \
+          while [ ! -f /gameroom_shared/key_registry/keys.yaml ]; do \
             echo 'waiting for key registry'; \
             sleep 1; \
           done && \
+          # We need to wait for the generated certificates and keys to be
+          # available
+          while [ ! -f /gameroom_shared/bubba/private/server.key ]; do \
+            echo 'waiting for certs and keys'; \
+            sleep 1; \
+          done && \
           # Copy the generated key registry to its expected location
-          cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          splinterd --generate-certs -c ./configs/splinterd-node-bubba.toml -vv \
+          cp -a /gameroom_shared/key_registry/keys.yaml /var/lib/splinter && \
+          # Copy the generated keys and certificates to its expected location
+          cp -a /gameroom_shared/bubba/. /etc/splinter/certs && \
+          splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --bind 0.0.0.0:8085
+              --bind 0.0.0.0:8085 \
+              --insecure
         "

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -16,6 +16,7 @@ version: '3'
 
 volumes:
   cargo-registry:
+  splinter-shared:
 
 services:
 
@@ -80,6 +81,26 @@ services:
           -b gameroomd-acme:8000 --splinterd-url http://splinterd-node:8085
       "
 
+  generate-shared:
+      image: splinter-cli
+      build:
+        context: ../../../..
+        dockerfile: cli/Dockerfile-installed-${DISTRO}
+        args:
+          - REPO_VERSION=${REPO_VERSION}
+      volumes:
+        - splinter-shared:/splinter_shared
+      command: |
+        bash -c "
+          if [ ! -f /splinter_shared/private/server.key ]
+          then
+            splinter cert generate \
+              -d  /splinter_shared/ \
+              --force
+          fi
+          tail -f /dev/null
+        "
+
   splinterd-node:
     image: splinterd-node
     expose:
@@ -91,6 +112,7 @@ services:
       - 8090:8085
     volumes:
       - ../:/project/tests
+      - splinter-shared:/splinter_shared
     build:
       context: ../../../..
       dockerfile: splinterd/Dockerfile-installed-${DISTRO}
@@ -98,7 +120,15 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        splinterd --generate-certs -c ./project/tests/splinterd-node-0-docker.toml -vv
+        # We need to wait for the generated certificates and keys to be
+        # available
+        while [ ! -f /splinter_shared/private/server.key ]; do \
+          echo 'waiting for certs and keys'; \
+          sleep 1; \
+        done && \
+        # Copy the generated keys and certificates to its expected location
+        cp -a /splinter_shared/. /etc/splinter/certs && \
+        splinterd --insecure -c ./project/tests/splinterd-node-0-docker.toml -vv
       "
 
   db-cypress-test:

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -14,6 +14,9 @@
 
 version: '3'
 
+volumes:
+  splinter-shared:
+
 services:
 
   gameroomd-integration-test:
@@ -33,6 +36,26 @@ services:
            ../tests/bin/run_tests
         "
 
+  generate-shared:
+      image: splinter-cli
+      build:
+        context: ../../..
+        dockerfile: cli/Dockerfile-installed-${DISTRO}
+        args:
+          - REPO_VERSION=${REPO_VERSION}
+      volumes:
+        - splinter-shared:/splinter_shared
+      command: |
+        bash -c "
+          if [ ! -f /splinter_shared/private/server.key ]
+          then
+            splinter cert generate \
+              -d  /splinter_shared/ \
+              --force
+          fi
+          tail -f /dev/null
+        "
+
   splinterd-node:
     image: splinterd-node
     expose:
@@ -44,6 +67,7 @@ services:
       - 8090:8085
     volumes:
       - .:/project/tests
+      - splinter-shared:/splinter_shared
     build:
       context: ../../..
       dockerfile: splinterd/Dockerfile-installed-${DISTRO}
@@ -51,7 +75,15 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        splinterd --generate-certs -c ./project/tests/splinterd-node-0-docker.toml -vv
+        # We need to wait for the generated certificates and keys to be
+        # available
+        while [ ! -f /splinter_shared/private/server.key ]; do \
+          echo 'waiting for certs and keys'; \
+          sleep 1; \
+        done && \
+        # Copy the generated keys and certificates to its expected location
+        cp -a /splinter_shared/. /etc/splinter/certs && \
+        splinterd --insecure -c ./project/tests/splinterd-node-0-docker.toml -vv
       "
 
   db-test:

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -43,7 +43,7 @@ tempdir = "0.3"
 toml = "0.4.8"
 
 [features]
-default = ["generate-certs"]
+default = []
 
 experimental = [
     "config-builder",

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -37,7 +37,6 @@ use crate::config::{Config, ConfigError};
 #[cfg(feature = "config-toml")]
 use crate::config::{ConfigBuilder, TomlConfig};
 use crate::daemon::SplinterDaemonBuilder;
-#[cfg(feature = "generate-certs")]
 use clap::Arg;
 use clap::{clap_app, crate_version};
 use openssl::error::ErrorStack;


### PR DESCRIPTION
This PR remove generate-certs as a default features and updates the docker-compose files to use the splinter-cli to generate the required certs and keys for the splinter daemon. 

Also changes the name of generate-key-registry volume to game_shared and updates the gameroom README to use the new path. 