### PR TITLE
Enforce that if any warnings exist clippy will fail

### DIFF
--- a/docker/compose/run-lint.yaml
+++ b/docker/compose/run-lint.yaml
@@ -40,7 +40,7 @@ services:
     image: clippy-splinter:${ISOLATION_ID}
     volumes:
       - ../../:/project/splinter
-    command:  cargo clippy -- -D clippy::all
+    command:  cargo clippy -- -D warnings
 
   lint-gameroom-client:
     build:

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -18,7 +18,7 @@ extern crate log;
 use splinter::{
     actix_web::HttpResponse,
     futures::IntoFuture,
-    rest_api::{Method, Request, Resource, RestResourceProvider},
+    rest_api::{Method, Resource, RestResourceProvider},
     service::{
         error::{ServiceDestroyError, ServiceError, ServiceStartError, ServiceStopError},
         Service, ServiceMessageContext, ServiceNetworkRegistry,

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -49,7 +49,7 @@ impl Service for HealthService {
 
     fn start(
         &mut self,
-        service_registry: &dyn ServiceNetworkRegistry,
+        _service_registry: &dyn ServiceNetworkRegistry,
     ) -> Result<(), ServiceStartError> {
         info!("Starting health service");
         Ok(())
@@ -57,7 +57,7 @@ impl Service for HealthService {
 
     fn stop(
         &mut self,
-        service_registry: &dyn ServiceNetworkRegistry,
+        _service_registry: &dyn ServiceNetworkRegistry,
     ) -> Result<(), ServiceStopError> {
         info!("Stopping health service");
         Ok(())
@@ -70,7 +70,7 @@ impl Service for HealthService {
 
     fn handle_message(
         &self,
-        message_bytes: &[u8],
+        _message_bytes: &[u8],
         _: &ServiceMessageContext,
     ) -> Result<(), ServiceError> {
         info!("Handling a messge");

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -100,6 +100,9 @@ impl SplinterDaemon {
         let mut inproc_tranport = InprocTransport::default();
         let mut transports = vec![transport, Box::new(inproc_tranport.clone())];
 
+        // Allowing unused_variable because health_inproc must be available later if feature
+        // health is enabled
+        #[allow(unused_variables)]
         let health_inproc = if cfg!(feature = "health") {
             let inproc_tranport = InprocTransport::default();
             transports.push(Box::new(inproc_tranport.clone()));

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -97,16 +97,16 @@ pub struct SplinterDaemon {
 
 impl SplinterDaemon {
     pub fn start(&mut self, transport: Box<dyn Transport + Send>) -> Result<(), StartError> {
-        let mut inproc_tranport = InprocTransport::default();
-        let mut transports = vec![transport, Box::new(inproc_tranport.clone())];
+        let mut inproc_transport = InprocTransport::default();
+        let mut transports = vec![transport, Box::new(inproc_transport.clone())];
 
         // Allowing unused_variable because health_inproc must be available later if feature
         // health is enabled
         #[allow(unused_variables)]
         let health_inproc = if cfg!(feature = "health") {
-            let inproc_tranport = InprocTransport::default();
-            transports.push(Box::new(inproc_tranport.clone()));
-            Some(inproc_tranport)
+            let inproc_transport = InprocTransport::default();
+            transports.push(Box::new(inproc_transport.clone()));
+            Some(inproc_transport)
         } else {
             None
         };
@@ -296,7 +296,7 @@ impl SplinterDaemon {
             .map_err(|_| StartError::ThreadError("Unable to spawn main loop".into()))?;
 
         let orchestrator_connection =
-            inproc_tranport
+            inproc_transport
                 .connect(ADMIN_SERVICE_ADDRESS)
                 .map_err(|err| {
                     StartError::TransportError(format!(
@@ -376,7 +376,7 @@ impl SplinterDaemon {
         let (rest_api_shutdown_handle, rest_api_join_handle) = rest_api_builder.build()?.run()?;
 
         let (admin_shutdown_handle, service_processor_join_handle) =
-            Self::start_admin_service(inproc_tranport, admin_service, Arc::clone(&running))?;
+            Self::start_admin_service(inproc_transport, admin_service, Arc::clone(&running))?;
 
         let r = running.clone();
         ctrlc::set_handler(move || {


### PR DESCRIPTION
Also fixes warnings that are in master and a typo.

clippy will now fail if there are any warnings, including
rustc warnings. Before it would only fail if there was a
clippy warning.