### PR TITLE
Add shared config to canopy

### DIFF
--- a/canopy/app/saplings/canopyConfig.yml
+++ b/canopy/app/saplings/canopyConfig.yml
@@ -1,0 +1,2 @@
+canopyConfig:
+  splinterEndpoint: ""

--- a/canopy/app/src/getSaplings.macro.js
+++ b/canopy/app/src/getSaplings.macro.js
@@ -22,10 +22,15 @@ function replaceReferenceWithPromiseResolveExpression(resplacement) {
 }
 
 function saplingMacro({ references }) {
-  const { getUserSaplings = [], getConfigSaplings = [] } = references;
+  const {
+    getUserSaplings = [],
+    getConfigSaplings = [],
+    getSharedConfig = []
+  } = references;
 
   const userSaplings = loadYaml('../saplings/userSaplings.yml');
   const configSaplings = loadYaml('../saplings/configSaplings.yml');
+  const sharedConfig = loadYaml('../saplings/canopyConfig.yml');
 
   getUserSaplings.forEach(
     replaceReferenceWithPromiseResolveExpression(userSaplings)
@@ -33,6 +38,10 @@ function saplingMacro({ references }) {
 
   getConfigSaplings.forEach(
     replaceReferenceWithPromiseResolveExpression(configSaplings)
+  );
+
+  getSharedConfig.forEach(
+    replaceReferenceWithPromiseResolveExpression(sharedConfig)
   );
 }
 


### PR DESCRIPTION
Adds shared config to canopy. This can be used for configuration such as the splinter endpoint that should be used by various saplings. This config is intended to be set and accessed in a similar way to the userSaplings and loginRegister configurations but it should contain more general specifications.

