### PR TITLE
Replace Private XO transact git dependency

### DIFF
--- a/examples/private_xo/Cargo.toml
+++ b/examples/private_xo/Cargo.toml
@@ -39,7 +39,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 simple_logger = "1.0"
 splinter = { path = "../../libsplinter" }
-transact = { git = "https://github.com/bitwiseio/transact", features = [ "sawtooth-compat" ] }
+transact = { version = "0.1", features = [ "sawtooth-compat" ] }
 urlencoded = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
 


### PR DESCRIPTION
Replace the Private XO example's transact dependency with the released
version published to crates.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>