### PR TITLE
Fix scabbard catch-up

### DIFF
--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -485,7 +485,7 @@ fn resubscribe(
 
     let mut ws = WebSocketClient::new(
         &format!(
-            "{}/scabbard/{}/{}/ws/subscribe?{}",
+            "{}/scabbard/{}/{}/ws/subscribe{}",
             url, gameroom.circuit_id, gameroom.service_id, query_string,
         ),
         move |_, event| {

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -166,6 +166,14 @@ fn make_subscribe_endpoint() -> ServiceEndpoint {
                 .get("last_seen_event")
                 .map(String::from);
 
+            let last_seen_event_id = query.remove("last_seen_event");
+
+            if let Some(ref id) = last_seen_event_id {
+                debug!("Getting all state-delta events since {}", id);
+            } else {
+                debug!("Getting all state-delta events");
+            }
+
             let unseen_events = match scabbard.get_events_since(last_seen_event_id) {
                 Ok(events) => events,
                 Err(err) => {

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -161,10 +161,11 @@ fn make_subscribe_endpoint() -> ServiceEndpoint {
                 }
             };
 
-            let last_seen_event_id = request
-                .match_info()
-                .get("last_seen_event")
-                .map(String::from);
+            let mut query =
+                match web::Query::<HashMap<String, String>>::from_query(request.query_string()) {
+                    Ok(query) => query,
+                    Err(_) => return Box::new(HttpResponse::BadRequest().finish().into_future()),
+                };
 
             let last_seen_event_id = query.remove("last_seen_event");
 


### PR DESCRIPTION
Fixes bugs where scabbard would not properly get the last seen event ID from the websocket subscription request's query string; this caused scabbard to incorrectly send all events.