### PR TITLE
Biome login route

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -40,6 +40,7 @@ mio = "0.6"
 mio-extras = "2"
 openssl = "0.10"
 protobuf = "2"
+rand = { version = "0.7", optional = true }
 sawtooth = { version = "0.2", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.4"
 sawtooth-sdk = { version = "0.3", optional = true }
@@ -75,7 +76,7 @@ zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
-biome = ["database"]
+biome = ["database", "rand"]
 biome-credentials = ["biome", "database", "bcrypt"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -35,6 +35,7 @@ diesel_migrations = { version = "1.4", optional = true }
 flate2 = "1.0.10"
 futures = "0.1"
 hyper = { version = "0.12", optional = true }
+jsonwebtoken = { version = "6.0", optional = true }
 log = "0.3.0"
 mio = "0.6"
 mio-extras = "2"
@@ -76,7 +77,7 @@ zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 events = ["hyper", "tokio", "awc"]
-biome = ["database", "rand"]
+biome = ["database", "jsonwebtoken", "rand"]
 biome-credentials = ["biome", "database", "bcrypt"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]

--- a/libsplinter/src/biome/credentials/credentials_store.rs
+++ b/libsplinter/src/biome/credentials/credentials_store.rs
@@ -69,7 +69,28 @@ impl CredentialsStore<UserCredentials> for SplinterCredentialsStore {
         unimplemented!()
     }
 
-    fn fetch_credential(&self, _user_id: &str) -> Result<UserCredentials, CredentialsStoreError> {
+    fn fetch_credential_by_user_id(
+        &self,
+        _user_id: &str,
+    ) -> Result<UserCredentials, CredentialsStoreError> {
         unimplemented!()
+    }
+
+    fn fetch_credential_by_username(
+        &self,
+        username: &str,
+    ) -> Result<UserCredentials, CredentialsStoreError> {
+        let credentials = fetch_credential_by_username(&*self.connection_pool.get()?, &username)
+            .map_err(|err| CredentialsStoreError::QueryError {
+                context: "Failed to fetch credentials by username".to_string(),
+                source: Box::new(err),
+            })?
+            .ok_or_else(|| {
+                CredentialsStoreError::NotFoundError(format!(
+                    "Failed to find credentials: {}",
+                    username
+                ))
+            })?;
+        Ok(UserCredentials::from(credentials))
     }
 }

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -21,17 +21,23 @@ pub mod database;
 mod error;
 pub(in crate::biome) mod rest_resources;
 
-use bcrypt::{hash, DEFAULT_COST};
+use bcrypt::{hash, verify, DEFAULT_COST};
 
 use database::models::{NewUserCredentialsModel, UserCredentialsModel};
 
-pub use error::{CredentialsStoreError, UserCredentialsBuilderError};
+pub use error::{CredentialsStoreError, UserCredentialsBuilderError, UserCredentialsError};
 
 /// Represents crendentials used to authenticate a user
 pub struct UserCredentials {
     user_id: String,
     username: String,
     password: String,
+}
+
+impl UserCredentials {
+    pub fn verify_password(&self, password: &str) -> Result<bool, UserCredentialsError> {
+        Ok(verify(password, &self.password)?)
+    }
 }
 
 /// Builder for UsersCredential. It hashes the password upon build.

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -146,9 +146,17 @@ pub trait CredentialsStore<T> {
     ///
     /// # Arguments
     ///
-    ///  * `user_id` - The unique identifier of the user for which the credentials will be returned
+    ///  * `user_id` - The unique identifier of the user credential belongs to
     ///
-    fn fetch_credential(&self, user_id: &str) -> Result<T, CredentialsStoreError>;
+    fn fetch_credential_by_user_id(&self, user_id: &str) -> Result<T, CredentialsStoreError>;
+
+    /// Fetches a credential for a user
+    ///
+    /// # Arguments
+    ///
+    ///  * `username` - The username the user uses for login
+    ///
+    fn fetch_credential_by_username(&self, username: &str) -> Result<T, CredentialsStoreError>;
 }
 
 impl From<UserCredentialsModel> for UserCredentials {

--- a/libsplinter/src/biome/credentials/rest_resources.rs
+++ b/libsplinter/src/biome/credentials/rest_resources.rs
@@ -28,10 +28,17 @@ use super::{
 #[derive(Deserialize)]
 struct UsernamePassword {
     username: String,
-    password: String,
+    hashed_password: String,
 }
 
 /// Defines a REST endpoint to add a user and credentials to the database
+/// The payload should be in the JSON format
+/// ```
+///   {
+///       "username": <username of new user>
+///       "hashed_password": <hash of the password the user will use to log in>
+///   }
+/// ```
 pub fn make_register_route(
     credentials_store: Arc<SplinterCredentialsStore>,
     user_store: Arc<SplinterUserStore>,
@@ -60,7 +67,7 @@ pub fn make_register_route(
                     let credentials = match credentials_builder
                         .with_user_id(&user_id)
                         .with_username(&username_password.username)
-                        .with_password(&username_password.password)
+                        .with_password(&username_password.hashed_password)
                         .build()
                     {
                         Ok(credential) => credential,

--- a/libsplinter/src/biome/credentials/rest_resources.rs
+++ b/libsplinter/src/biome/credentials/rest_resources.rs
@@ -19,6 +19,8 @@ use crate::actix_web::HttpResponse;
 use crate::futures::{Future, IntoFuture};
 use crate::rest_api::{into_bytes, ErrorResponse, Method, Resource};
 
+use super::super::rest_api::BiomeRestConfig;
+use super::super::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
 use super::super::users::{user_store::SplinterUserStore, SplinterUser, UserStore};
 use super::{
     credentials_store::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
@@ -103,6 +105,97 @@ pub fn make_register_route(
                 }
                 Err(err) => {
                     debug!("Failed to add new user to database {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            }
+        }))
+    })
+}
+
+/// Defines a REST endpoint for login
+pub fn make_login_route(
+    credentials_store: Arc<SplinterCredentialsStore>,
+    rest_config: Arc<BiomeRestConfig>,
+    token_issuer: Arc<AccessTokenIssuer>,
+) -> Resource {
+    Resource::build("/biome/login").add_method(Method::Post, move |_, payload| {
+        let credentials_store = credentials_store.clone();
+        let rest_config = rest_config.clone();
+        let token_issuer = token_issuer.clone();
+        Box::new(into_bytes(payload).and_then(move |bytes| {
+            let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload: {}",
+                            err
+                        )))
+                        .into_future();
+                }
+            };
+
+            let credentials =
+                match credentials_store.fetch_credential_by_username(&username_password.username) {
+                    Ok(credentials) => credentials,
+                    Err(err) => {
+                        debug!("Failed to fetch credentials {}", err);
+                        match err {
+                            CredentialsStoreError::NotFoundError(_) => {
+                                return HttpResponse::BadRequest()
+                                    .json(ErrorResponse::bad_request(&format!(
+                                        "Username not found: {}",
+                                        username_password.username
+                                    )))
+                                    .into_future();
+                            }
+                            _ => {
+                                return HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future()
+                            }
+                        }
+                    }
+                };
+
+            match credentials.verify_password(&username_password.hashed_password) {
+                Ok(is_valid) => {
+                    if is_valid {
+                        let claim_builder: ClaimsBuilder = Default::default();
+                        let claim = match claim_builder.with_user_id(&credentials.user_id)
+                            .with_issuer(&rest_config.issuer())
+                            .with_duration(rest_config.access_token_duration())
+                            .build() {
+                                Ok(claim) => claim,
+                                Err(err) => {
+                                    debug!("Failed to build claim {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future()}
+                                };
+
+                        let token = match token_issuer.issue_token_with_claims(claim) {
+                                Ok(token) => token,
+                                Err(err) => {
+                                    debug!("Failed to issue token {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future()}
+                                };
+                        HttpResponse::Ok()
+                            .json(json!({ "message": "Successful login", "user_id": credentials.user_id ,"token": token  }))
+                            .into_future()
+                    } else {
+                        HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request("Invalid password"))
+                            .into_future()
+                    }
+                }
+                Err(err) => {
+                    debug!("Failed to verify password {}", err);
                     HttpResponse::InternalServerError()
                         .json(ErrorResponse::internal_error())
                         .into_future()

--- a/libsplinter/src/biome/credentials/rest_resources.rs
+++ b/libsplinter/src/biome/credentials/rest_resources.rs
@@ -44,10 +44,12 @@ struct UsernamePassword {
 pub fn make_register_route(
     credentials_store: Arc<SplinterCredentialsStore>,
     user_store: Arc<SplinterUserStore>,
+    rest_config: Arc<BiomeRestConfig>,
 ) -> Resource {
     Resource::build("/biome/register").add_method(Method::Post, move |_, payload| {
         let credentials_store = credentials_store.clone();
         let user_store = user_store.clone();
+        let rest_config = rest_config.clone();
         Box::new(into_bytes(payload).and_then(move |bytes| {
             let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
                 Ok(val) => val,
@@ -70,6 +72,7 @@ pub fn make_register_route(
                         .with_user_id(&user_id)
                         .with_username(&username_password.username)
                         .with_password(&username_password.hashed_password)
+                        .with_password_encryption_cost(rest_config.password_encryption_cost())
                         .build()
                     {
                         Ok(credential) => credential,

--- a/libsplinter/src/biome/rest_api/config.rs
+++ b/libsplinter/src/biome/rest_api/config.rs
@@ -1,0 +1,90 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use super::error::BiomeRestConfigBuilderError;
+
+const DEFAULT_ISSUER: &str = "self-issued";
+const DEFAULT_DURATION: u64 = 5400; // in seconds = 90 minutes
+
+/// Configuration for Biome REST resources
+#[derive(Deserialize, Debug)]
+pub struct BiomeRestConfig {
+    /// The issuer for JWT tokens issued by this service
+    issuer: String,
+    /// Duration of JWT tokens issued by this service
+    access_token_duration: Duration,
+}
+
+impl BiomeRestConfig {
+    pub fn issuer(&self) -> String {
+        self.issuer.to_owned()
+    }
+
+    pub fn access_token_duration(&self) -> Duration {
+        self.access_token_duration.to_owned()
+    }
+}
+
+/// Builder for BiomeRestConfig
+pub struct BiomeRestConfigBuilder {
+    issuer: Option<String>,
+    access_token_duration: Option<Duration>,
+}
+
+impl Default for BiomeRestConfigBuilder {
+    fn default() -> BiomeRestConfigBuilder {
+        BiomeRestConfigBuilder {
+            issuer: Some(DEFAULT_ISSUER.to_string()),
+            access_token_duration: Some(Duration::from_secs(DEFAULT_DURATION)),
+        }
+    }
+}
+
+impl BiomeRestConfigBuilder {
+    pub fn new() -> Self {
+        BiomeRestConfigBuilder {
+            issuer: None,
+            access_token_duration: None,
+        }
+    }
+
+    pub fn with_issuer(mut self, issuer: &str) -> Self {
+        self.issuer = Some(issuer.to_string());
+        self
+    }
+
+    pub fn with_access_token_duration_in_secs(mut self, duration: u64) -> Self {
+        self.access_token_duration = Some(Duration::from_secs(duration));
+        self
+    }
+
+    pub fn build(self) -> Result<BiomeRestConfig, BiomeRestConfigBuilderError> {
+        if self.issuer.is_none() {
+            debug!("Using default value for issuer");
+        }
+        let issuer = self.issuer.unwrap_or_default();
+
+        if self.access_token_duration.is_none() {
+            debug!("Using default value for access_token_duration");
+        }
+        let access_token_duration = self.access_token_duration.unwrap_or_default();
+
+        Ok(BiomeRestConfig {
+            issuer,
+            access_token_duration,
+        })
+    }
+}

--- a/libsplinter/src/biome/rest_api/error.rs
+++ b/libsplinter/src/biome/rest_api/error.rs
@@ -20,14 +20,51 @@ use std::fmt;
 pub enum BiomeRestResourceManagerBuilderError {
     /// Returned if a required field is missing
     MissingRequiredField(String),
+    /// Returned if a required field is missing
+    BuildingError(Box<dyn Error>),
 }
 
-impl Error for BiomeRestResourceManagerBuilderError {}
+impl Error for BiomeRestResourceManagerBuilderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            BiomeRestResourceManagerBuilderError::MissingRequiredField(_) => None,
+            BiomeRestResourceManagerBuilderError::BuildingError(err) => Some(&**err),
+        }
+    }
+}
 
 impl fmt::Display for BiomeRestResourceManagerBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BiomeRestResourceManagerBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "failed to build BiomeRestResourceManager: {}", s)
+            }
+            BiomeRestResourceManagerBuilderError::BuildingError(ref s) => {
+                write!(f, "failed to build BiomeRestResourceManager: {}", s)
+            }
+        }
+    }
+}
+
+impl From<BiomeRestConfigBuilderError> for BiomeRestResourceManagerBuilderError {
+    fn from(err: BiomeRestConfigBuilderError) -> BiomeRestResourceManagerBuilderError {
+        BiomeRestResourceManagerBuilderError::BuildingError(Box::new(err))
+    }
+}
+
+/// Error for BiomeRestConfigBuilder
+#[derive(Debug)]
+pub enum BiomeRestConfigBuilderError {
+    /// Returned if a required field is missing
+    MissingRequiredField(String),
+}
+
+impl Error for BiomeRestConfigBuilderError {}
+
+impl fmt::Display for BiomeRestConfigBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BiomeRestConfigBuilderError::MissingRequiredField(ref s) => {
                 write!(f, "failed to build BiomeRestResourceManager: {}", s)
             }
         }

--- a/libsplinter/src/biome/rest_api/error.rs
+++ b/libsplinter/src/biome/rest_api/error.rs
@@ -57,6 +57,8 @@ impl From<BiomeRestConfigBuilderError> for BiomeRestResourceManagerBuilderError 
 pub enum BiomeRestConfigBuilderError {
     /// Returned if a required field is missing
     MissingRequiredField(String),
+    /// Returned if a value provided is not valid
+    InvalidValue(String),
 }
 
 impl Error for BiomeRestConfigBuilderError {}
@@ -65,6 +67,9 @@ impl fmt::Display for BiomeRestConfigBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             BiomeRestConfigBuilderError::MissingRequiredField(ref s) => {
+                write!(f, "failed to build BiomeRestResourceManager: {}", s)
+            }
+            BiomeRestConfigBuilderError::InvalidValue(ref s) => {
                 write!(f, "failed to build BiomeRestResourceManager: {}", s)
             }
         }

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -90,6 +90,7 @@ impl RestResourceProvider for BiomeRestResourceManager {
                 resources.push(make_register_route(
                     credentials_store.clone(),
                     self.user_store.clone(),
+                    self.rest_config.clone(),
                 ));
                 resources.push(make_login_route(
                     credentials_store.clone(),

--- a/libsplinter/src/biome/secrets/auto_secret_manager.rs
+++ b/libsplinter/src/biome/secrets/auto_secret_manager.rs
@@ -1,0 +1,50 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rand::{distributions::Alphanumeric, Rng};
+
+use super::{SecretManager, SecretManagerError};
+
+const SECRET_LENGTH: usize = 64;
+
+/// A SecretManager that generates a random string as a secret and keeps it in memory
+pub struct AutoSecretManager {
+    secret: String,
+}
+
+impl Default for AutoSecretManager {
+    fn default() -> Self {
+        AutoSecretManager {
+            secret: generate_random_secret(),
+        }
+    }
+}
+
+impl SecretManager for AutoSecretManager {
+    fn secret(&self) -> Result<String, SecretManagerError> {
+        Ok(self.secret.to_owned())
+    }
+
+    fn update_secret(&mut self) -> Result<(), SecretManagerError> {
+        self.secret = generate_random_secret();
+        Ok(())
+    }
+}
+
+fn generate_random_secret() -> String {
+    rand::thread_rng()
+        .sample_iter(Alphanumeric)
+        .take(SECRET_LENGTH)
+        .collect()
+}

--- a/libsplinter/src/biome/secrets/error.rs
+++ b/libsplinter/src/biome/secrets/error.rs
@@ -1,0 +1,45 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error for a SecretManager
+#[derive(Debug)]
+pub enum SecretManagerError {
+    /// Returned when the manager fails to update a secret
+    UpdateSecretError(Box<dyn Error>),
+    /// Returned when the manager fails to fetch a secret
+    SecretError(Box<dyn Error>),
+}
+
+impl Error for SecretManagerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SecretManagerError::UpdateSecretError(err) => Some(&**err),
+            SecretManagerError::SecretError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for SecretManagerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SecretManagerError::UpdateSecretError(ref s) => {
+                write!(f, "failed to update secret: {}", s)
+            }
+            SecretManagerError::SecretError(ref s) => write!(f, "failed to fetch secret: {}", s),
+        }
+    }
+}

--- a/libsplinter/src/biome/secrets/mod.rs
+++ b/libsplinter/src/biome/secrets/mod.rs
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides support for user management in splinter applications
-//!
-//! ## Features
-//!
-//! * `biome-credentials`: API to register and authenticate a user using an username and password.
-//!   Not recommend for use in production.
-//! * `biome-notifications`: API to create and manage user notifications.
+//! Provides an API for managing secrets
 
-#[cfg(feature = "biome-credentials")]
-pub mod credentials;
+mod error;
 
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
+pub use error::SecretManagerError;
 
-pub mod rest_api;
-pub mod secrets;
-pub mod users;
+/// Defines a manager for fetching and/or generating a secret.
+pub trait SecretManager: Sync + Send {
+    /// Returns the secret
+    fn secret(&self) -> Result<String, SecretManagerError>;
+
+    /// Updates the secret
+    fn update_secret(&mut self) -> Result<(), SecretManagerError>;
+}

--- a/libsplinter/src/biome/secrets/mod.rs
+++ b/libsplinter/src/biome/secrets/mod.rs
@@ -14,8 +14,10 @@
 
 //! Provides an API for managing secrets
 
+mod auto_secret_manager;
 mod error;
 
+pub use auto_secret_manager::AutoSecretManager;
 pub use error::SecretManagerError;
 
 /// Defines a manager for fetching and/or generating a secret.

--- a/libsplinter/src/biome/sessions/claims.rs
+++ b/libsplinter/src/biome/sessions/claims.rs
@@ -1,0 +1,127 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides a definition and a builder for the payload of a JWT Token
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use super::ClaimsBuildError;
+
+/// Defines payload of a JWT Token
+#[derive(Serialize, Deserialize)]
+pub struct Claims {
+    user_id: String,
+    iss: String,
+    exp: u64,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    custom_claims: HashMap<String, String>,
+}
+
+impl Claims {
+    /// Returns the user id
+    pub fn user_id(&self) -> String {
+        self.user_id.to_owned()
+    }
+
+    /// Returns the issuer of the token
+    pub fn iss(&self) -> String {
+        self.iss.to_owned()
+    }
+
+    /// Returns the expiration of the token
+    pub fn exp(&self) -> u64 {
+        self.exp
+    }
+
+    /// Returns custom claims
+    pub fn custom_claims(&self) -> HashMap<String, String> {
+        self.custom_claims.clone()
+    }
+}
+/// Builder for a claim
+#[derive(Default)]
+pub struct ClaimsBuilder {
+    user_id: Option<String>,
+    iss: Option<String>,
+    duration: Option<Duration>,
+    custom_claims: HashMap<String, String>,
+}
+
+impl ClaimsBuilder {
+    /// User id to be included in the claims
+    pub fn with_user_id(mut self, user_id: &str) -> Self {
+        self.user_id = Some(user_id.to_string());
+        self
+    }
+
+    /// Issuer to be included in the claims
+    pub fn with_issuer(mut self, iss: &str) -> Self {
+        self.iss = Some(iss.to_string());
+        self
+    }
+
+    /// Duration of the JWT token. The token expiration timestamp will be calculated based on
+    /// this value upon build.
+    pub fn with_duration(mut self, duration: Duration) -> Self {
+        self.duration = Some(duration);
+        self
+    }
+
+    /// Adds an custom claim. This method can be called multiple times.
+    pub fn with_custom_claim(mut self, key: &str, value: &str) -> Self {
+        self.custom_claims
+            .insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Consumes the builder and returns Claims. It calculates the expiration token by adding
+    /// the duration set in the builder to the current system time. The `exp` field in the claims
+    /// is set the resulting value.
+    pub fn build(self) -> Result<Claims, ClaimsBuildError> {
+        let user_id = self
+            .user_id
+            .ok_or_else(|| ClaimsBuildError::MissingRequiredField("Missing user_id".to_string()))?;
+
+        let iss = self
+            .iss
+            .ok_or_else(|| ClaimsBuildError::MissingRequiredField("Missing iss".to_string()))?;
+
+        let duration = self.duration.ok_or_else(|| {
+            ClaimsBuildError::MissingRequiredField("Missing claim duration".to_string())
+        })?;
+
+        let token_expiration_date = SystemTime::now().checked_add(duration).ok_or_else(|| {
+            ClaimsBuildError::InvalidValue(format!("Invalid duration for claim: {:?}", duration))
+        })?;
+
+        let token_expiration_timestamp = get_timestamp(token_expiration_date).map_err(|err| {
+            ClaimsBuildError::InvalidValue(format!("Invalid duration for claim: {}", err))
+        })?;
+
+        Ok(Claims {
+            user_id,
+            iss,
+            exp: token_expiration_timestamp,
+            custom_claims: self.custom_claims,
+        })
+    }
+}
+
+fn get_timestamp(time: SystemTime) -> Result<u64, SystemTimeError> {
+    Ok(time.duration_since(UNIX_EPOCH)?.as_secs())
+}

--- a/libsplinter/src/biome/sessions/error.rs
+++ b/libsplinter/src/biome/sessions/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error for ClaimsBuilder
+#[derive(Debug)]
+pub enum ClaimsBuildError {
+    /// Returned if a required field is missing
+    MissingRequiredField(String),
+    /// Returned if a invalid value was provided to the builder
+    InvalidValue(String),
+}
+
+impl Error for ClaimsBuildError {}
+
+impl fmt::Display for ClaimsBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ClaimsBuildError::MissingRequiredField(ref s) => {
+                write!(f, "failed to build claim: {}", s)
+            }
+            ClaimsBuildError::InvalidValue(ref s) => write!(f, "failed to build claim: {}", s),
+        }
+    }
+}

--- a/libsplinter/src/biome/sessions/error.rs
+++ b/libsplinter/src/biome/sessions/error.rs
@@ -17,6 +17,47 @@ use std::fmt;
 
 use jsonwebtoken::errors::{Error as JWTError, ErrorKind};
 
+use super::super::secrets::SecretManagerError;
+
+/// Error for TokenIssuer
+#[derive(Debug)]
+pub enum TokenIssuerError {
+    /// Returned when the TokenIssuer fails to encode a Token
+    EncodingError(Box<dyn Error>),
+    /// Returned when the TokenIssuer fails to get a valid secret
+    SecretError(Box<dyn Error>),
+}
+
+impl Error for TokenIssuerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            TokenIssuerError::EncodingError(err) => Some(&**err),
+            TokenIssuerError::SecretError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for TokenIssuerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TokenIssuerError::EncodingError(ref s) => write!(f, "failed to issue token: {}", s),
+            TokenIssuerError::SecretError(ref s) => write!(f, "failed to fetch secret: {}", s),
+        }
+    }
+}
+
+impl From<JWTError> for TokenIssuerError {
+    fn from(err: JWTError) -> TokenIssuerError {
+        TokenIssuerError::EncodingError(Box::new(err))
+    }
+}
+
+impl From<SecretManagerError> for TokenIssuerError {
+    fn from(err: SecretManagerError) -> TokenIssuerError {
+        TokenIssuerError::SecretError(Box::new(err))
+    }
+}
+
 /// Error for ClaimsBuilder
 #[derive(Debug)]
 pub enum ClaimsBuildError {

--- a/libsplinter/src/biome/sessions/mod.rs
+++ b/libsplinter/src/biome/sessions/mod.rs
@@ -16,11 +16,22 @@
 
 mod claims;
 mod error;
+mod token_issuer;
+
 use jsonwebtoken::{decode, Validation};
+use serde::Serialize;
 
 pub use claims::{Claims, ClaimsBuilder};
-pub use error::{ClaimsBuildError, TokenValidationError};
+pub use error::{ClaimsBuildError, TokenIssuerError, TokenValidationError};
+pub use token_issuer::AccessTokenIssuer;
+
 const DEFAULT_LEEWAY: i64 = 10; // default leeway in seconds.
+
+/// Implementers can issue JWT tokens
+pub trait TokenIssuer<T: Serialize> {
+    /// Issues a JWT token with the given claims
+    fn issue_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
+}
 
 /// Deserializes a JWT token, checks that a sigures is valid and checks that the claims are
 /// valid. It also and performs the extra validation provided by the caller.

--- a/libsplinter/src/biome/sessions/mod.rs
+++ b/libsplinter/src/biome/sessions/mod.rs
@@ -16,6 +16,60 @@
 
 mod claims;
 mod error;
+use jsonwebtoken::{decode, Validation};
 
 pub use claims::{Claims, ClaimsBuilder};
-pub use error::ClaimsBuildError;
+pub use error::{ClaimsBuildError, TokenValidationError};
+const DEFAULT_LEEWAY: i64 = 10; // default leeway in seconds.
+
+/// Deserializes a JWT token, checks that a sigures is valid and checks that the claims are
+/// valid. It also and performs the extra validation provided by the caller.
+///
+/// # Arguments
+///
+///  * `token` - The serialized token to be validated
+///  * `secret` - The secret to be used to validate the token signature
+///  * `issuer` - The expected value for the token issuer
+///  * `extra_validation` - Closure that performs extra validation, returns Ok(()) if the claims
+///  are valid or an error if they are not.
+///
+/// ```
+/// use splinter::biome::sessions::{validate_token, TokenValidationError};
+///
+/// let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
+///              eyJ1c2VyX2lkIjoiY2RmMTIwNzAtNjk1Mi00NTNmLWFiNmMtYjRlMzllZmM3YzA4IiwiZXhwIjo0MTMzO\
+///              Dk0NDAwLCJpc3MiOiJzZWxmLWlzc3VlZCIsImFkbWluIjoidHJ1ZSJ9.\
+///              km0hcHqWC7HFy02x2V-4QrKArNpzy4fXpBpqdL70e48";
+///
+/// validate_token(token, "super_secret", "self-issued", |claims| {
+///     let custom_claims = claims.custom_claims();
+///     let is_admin = custom_claims.get("admin").ok_or_else(|| {
+///         TokenValidationError::InvalidClaim("User is not an admin".to_string())
+///     })?;
+///     match is_admin.as_ref() {
+///         "true" => Ok(()),
+///         _ =>  Err(TokenValidationError::InvalidClaim("User is not an admin".to_string()))
+///     }
+/// }).unwrap();
+/// ```
+pub fn validate_token<F>(
+    token: &str,
+    secret: &str,
+    issuer: &str,
+    extra_validation: F,
+) -> Result<(), TokenValidationError>
+where
+    F: Fn(Claims) -> Result<(), TokenValidationError>,
+{
+    let validation = default_validation(DEFAULT_LEEWAY, issuer);
+    let claims = decode::<Claims>(&token, secret.as_ref(), &validation)?.claims;
+
+    extra_validation(claims)
+}
+
+fn default_validation(leeway: i64, issuer: &str) -> Validation {
+    let mut validation = Validation::default();
+    validation.leeway = leeway;
+    validation.iss = Some(issuer.to_string());
+    validation
+}

--- a/libsplinter/src/biome/sessions/mod.rs
+++ b/libsplinter/src/biome/sessions/mod.rs
@@ -12,21 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides support for user management in splinter applications
-//!
-//! ## Features
-//!
-//! * `biome-credentials`: API to register and authenticate a user using an username and password.
-//!   Not recommend for use in production.
-//! * `biome-notifications`: API to create and manage user notifications.
+//! Provides an API for managing user sessions, including issuing and validating JWT tokens
 
-#[cfg(feature = "biome-credentials")]
-pub mod credentials;
+mod claims;
+mod error;
 
-#[cfg(feature = "biome-notifications")]
-pub mod notifications;
-
-pub mod rest_api;
-pub mod secrets;
-pub mod sessions;
-pub mod users;
+pub use claims::{Claims, ClaimsBuilder};
+pub use error::ClaimsBuildError;

--- a/libsplinter/src/biome/sessions/token_issuer.rs
+++ b/libsplinter/src/biome/sessions/token_issuer.rs
@@ -1,0 +1,45 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides an implementation of a TokenIssuer
+
+use std::sync::Arc;
+
+use jsonwebtoken::{encode, Header};
+
+use super::super::secrets::SecretManager;
+use super::{Claims, TokenIssuer, TokenIssuerError};
+
+/// Issues JWT access tokens
+pub struct AccessTokenIssuer {
+    secret_manager: Arc<dyn SecretManager>,
+}
+
+impl AccessTokenIssuer {
+    /// Creates a new AccessTokenIssuer that will use the given secret manager for issuing tokens
+    pub fn new(secret_manager: Arc<dyn SecretManager>) -> AccessTokenIssuer {
+        AccessTokenIssuer { secret_manager }
+    }
+}
+
+impl TokenIssuer<Claims> for AccessTokenIssuer {
+    fn issue_token_with_claims(&self, claims: Claims) -> Result<String, TokenIssuerError> {
+        let token = encode(
+            &Header::default(),
+            &claims,
+            self.secret_manager.secret()?.as_ref(),
+        )?;
+        Ok(token)
+    }
+}


### PR DESCRIPTION
This PR implements a login route for biome. When it a client sends a request to the route with the payload:
```json
{ 
    "username": "my_username",
    "hashed_password": "D3912FA5639A37367C15814367069FE7798CFAF6"
}
```
 - The route handler verifies that username exists
 - Verifies that the password provided is correct
 - Issues a JWT token that the client can use to access other protected routes and the server will use to verify that the users have the permission to access such routes
- Returns the user_id and jwt token in the payload:
```json 
{
    "message": "Successful login",
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYzlhNTM0MjEtZTUzOS00NDMyLTkyYjktMTAzNTI5M2FkZWVlIiwiaXNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1NzU0MTk4Mjh9.97n-gSCjBTE7lcVNhkDt6WNL3-x_Z8VLz5fLfn8uCH8",
    "user_id": "c9a53421-e539-4432-92b9-1035293adeee"
}
```

To support that this PR implements:
- An API to pass configuration options for BiomeRestResources, such as how long the JWT access tokens should last and what the issuer field of the token payload should be set to.  
- A basic Biome API to manage server side secrets 
- A basic Biome API to issue JWT tokens
- A method to verify JWT tokens
