### PR TITLE
Node registry validation

### DIFF
--- a/examples/gameroom/daemon/openapi.yml
+++ b/examples/gameroom/daemon/openapi.yml
@@ -46,8 +46,9 @@ paths:
         - name: filter
           in: query
           description: |
-            url-encodeded stringified JSON containing property filters in the format
-              {NODE_PROPERTY:[{"operator":OPERATOR,"value":VALUE}]}
+            url-encodeded stringified JSON containing property filters on the
+            node's metadata properties in the format
+              {METADATA_PROPERTY:[{"operator":OPERATOR,"value":VALUE}]}
           required: false
           schema:
             type: string
@@ -953,11 +954,19 @@ components:
       properties:
         identity:
           type: string
-      additionalProperties: true
+        endpoint:
+          type: string
+        display_name:
+          type: string
+        metadata:
+          type: object
       example:
         identity: node-123123-asdf
-        company: Cargill
-        status: Up
+        endpoint: tls://12.0.0.123:8431
+        display_name: Cargill - Node 1
+        metadata:
+          company: Cargill
+          status: Up
 
     Paging:
       type: object

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -122,21 +122,13 @@ pub fn propose_gameroom(
             .iter()
             .map(|node| SplinterNode {
                 node_id: node.identity.to_string(),
-                endpoint: node
-                    .metadata
-                    .get("endpoint")
-                    .unwrap_or(&"".to_string())
-                    .to_string(),
+                endpoint: node.endpoint.to_string(),
             })
             .collect::<Vec<SplinterNode>>();
 
         members.push(SplinterNode {
             node_id: node_info.identity.to_string(),
-            endpoint: node_info
-                .metadata
-                .get("endpoint")
-                .unwrap_or(&"".to_string())
-                .to_string(),
+            endpoint: node_info.endpoint.to_string(),
         });
         let partial_circuit_id = members.iter().fold(String::new(), |mut acc, member| {
             acc.push_str(&format!("::{}", member.node_id));

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -239,20 +239,22 @@ mod test {
 
     fn get_node_1() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "127.0.0.1:8080".to_string());
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
         Node {
             identity: "Node-123".to_string(),
+            endpoint: "tls://127.0.0.1:8080".to_string(),
+            display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
     }
 
     fn get_node_2() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "127.0.0.1:8082".to_string());
         metadata.insert("company".to_string(), "Cargill".to_string());
         Node {
             identity: "Node-456".to_string(),
+            endpoint: "tls://127.0.0.1:8082".to_string(),
+            display_name: "Cargill - Node 1".to_string(),
             metadata,
         }
     }

--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -231,8 +231,9 @@ async function getNode(id: string): Promise<Node> {
       console.warn(`Node with ID: ${id} not found. It may have been removed from the registry.`);
       return {
         identity: id,
+        endpoint: 'unknown',
+        display_name: 'unknown',
         metadata: {
-          endpoint: 'unknown',
           organization: id,
         },
       };

--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -43,9 +43,10 @@ export interface UserAuthResponse {
 
 export interface Node {
   identity: string;
+  endpoint: string;
+  display_name: string;
   metadata: {
     organization: string;
-    endpoint: string;
   };
 }
 

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -160,9 +160,9 @@ export default class Dashboard extends Vue {
   }
 
   getMemberLabel(node: Node) {
-    let endpoint = node.metadata.endpoint;
+    let endpoint = node.endpoint;
     if (process.env.VUE_APP_BRAND
-     && node.metadata.endpoint.includes(process.env.VUE_APP_BRAND)) {
+     && node.endpoint.includes(process.env.VUE_APP_BRAND)) {
       endpoint = 'local';
     }
 

--- a/examples/gameroom/node_registry/nodes.yaml
+++ b/examples/gameroom/node_registry/nodes.yaml
@@ -14,10 +14,12 @@
 # -----------------------------------------------------------------------------
 
 - identity: 'bubba-node-000'
+  endpoint: 'tls://splinterd-node-bubba:8044'
+  display_name: 'Bubba - Node 1'
   metadata:
     organization: 'Bubba Bakery'
-    endpoint: 'tls://splinterd-node-bubba:8044'
 - identity: 'acme-node-000'
+  endpoint: 'tls://splinterd-node-acme:8044'
+  display_name: 'Acme - Node 1'
   metadata:
     organization: 'ACME Corporation'
-    endpoint: 'tls://splinterd-node-acme:8044'

--- a/examples/gameroom/tests/sample_node_registry.yaml
+++ b/examples/gameroom/tests/sample_node_registry.yaml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 - identity: "Node-123"
+  endpoint: "tls://127.0.0.1:8080"
+  display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
-    url: "127.0.0.1:8080"
 - identity: "Node-456"
+  endpoint: "tls://127.0.0.1:8082"
+  display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"
-    url: "127.0.0.1:8082"

--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -70,6 +70,7 @@ pub enum InvalidNodeError {
     EmptyEndpoint,
     EmptyIdentity,
     EmptyDisplayName,
+    InvalidIdentity(String, String), // (identity, message)
 }
 
 impl Error for InvalidNodeError {
@@ -80,6 +81,7 @@ impl Error for InvalidNodeError {
             InvalidNodeError::EmptyEndpoint => None,
             InvalidNodeError::EmptyIdentity => None,
             InvalidNodeError::EmptyDisplayName => None,
+            InvalidNodeError::InvalidIdentity(..) => None,
         }
     }
 }
@@ -97,6 +99,9 @@ impl fmt::Display for InvalidNodeError {
             InvalidNodeError::EmptyIdentity => write!(f, "node must have non-empty identity"),
             InvalidNodeError::EmptyDisplayName => {
                 write!(f, "node must have non-empty display_name")
+            }
+            InvalidNodeError::InvalidIdentity(identity, msg) => {
+                write!(f, "identity {} is invalid: {}", identity, msg)
             }
         }
     }

--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -19,9 +19,7 @@ use std::fmt;
 pub enum NodeRegistryError {
     /// This error is returned when a node is not found.
     NotFoundError(String),
-    /// This error is returned when the user attempts to create a node with an identity that
-    /// already exists.
-    DuplicateNodeError(String),
+    InvalidNode(InvalidNodeError),
     /// This error is returned when an internal error occurred
     InternalError(Box<dyn Error + Send>),
     /// This error is returned when the user cannot create a node in the registry
@@ -32,7 +30,7 @@ impl Error for NodeRegistryError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             NodeRegistryError::NotFoundError(_) => None,
-            NodeRegistryError::DuplicateNodeError(_) => None,
+            NodeRegistryError::InvalidNode(err) => Some(err),
             NodeRegistryError::InternalError(err) => Some(err.as_ref()),
             // Unfortunately, have to match on both arms to return the expected result
             NodeRegistryError::UnableToAddNode(_, Some(err)) => Some(err.as_ref()),
@@ -45,7 +43,7 @@ impl fmt::Display for NodeRegistryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             NodeRegistryError::NotFoundError(e) => write!(f, "Node not found: {}", e),
-            NodeRegistryError::DuplicateNodeError(e) => write!(f, "Duplicate identity: {}", e),
+            NodeRegistryError::InvalidNode(e) => write!(f, "Invalid node: {}", e),
             NodeRegistryError::InternalError(e) => write!(f, "Internal error: {}", e),
             NodeRegistryError::UnableToAddNode(msg, err) => write!(
                 f,
@@ -55,6 +53,51 @@ impl fmt::Display for NodeRegistryError {
                     .map(|e| format!("; {}", e))
                     .unwrap_or_else(|| "".to_string())
             ),
+        }
+    }
+}
+
+impl From<InvalidNodeError> for NodeRegistryError {
+    fn from(err: InvalidNodeError) -> Self {
+        NodeRegistryError::InvalidNode(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum InvalidNodeError {
+    DuplicateEndpoint(String),
+    DuplicateIdentity(String),
+    EmptyEndpoint,
+    EmptyIdentity,
+    EmptyDisplayName,
+}
+
+impl Error for InvalidNodeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            InvalidNodeError::DuplicateEndpoint(_) => None,
+            InvalidNodeError::DuplicateIdentity(_) => None,
+            InvalidNodeError::EmptyEndpoint => None,
+            InvalidNodeError::EmptyIdentity => None,
+            InvalidNodeError::EmptyDisplayName => None,
+        }
+    }
+}
+
+impl fmt::Display for InvalidNodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidNodeError::DuplicateEndpoint(endpoint) => {
+                write!(f, "another node with endpoint {} exists", endpoint)
+            }
+            InvalidNodeError::DuplicateIdentity(identity) => {
+                write!(f, "another node with identity {} exists", identity)
+            }
+            InvalidNodeError::EmptyEndpoint => write!(f, "node must have non-empty endpoint"),
+            InvalidNodeError::EmptyIdentity => write!(f, "node must have non-empty identity"),
+            InvalidNodeError::EmptyDisplayName => {
+                write!(f, "node must have non-empty display_name")
+            }
         }
     }
 }

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -22,8 +22,12 @@ pub use error::NodeRegistryError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Node {
-    /// The Splinter identity of the node.
+    /// The Splinter identity of the node; must be unique in the registry.
     pub identity: String,
+    /// The endpoint the node can be reached at; must be unique in the registry.
+    pub endpoint: String,
+    /// A human-readable name for the node.
+    pub display_name: String,
     /// A map with node metadata.
     pub metadata: HashMap<String, String>,
 }

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -18,7 +18,7 @@ pub mod yaml;
 
 use std::collections::HashMap;
 
-pub use error::NodeRegistryError;
+pub use error::{InvalidNodeError, NodeRegistryError};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Node {

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -123,29 +123,13 @@ pub trait NodeRegistryReader: Send + Sync {
 
 /// Provides Node Registry write capabilities.
 pub trait NodeRegistryWriter: Send + Sync {
-    /// Registers a new node.
+    /// Adds a new node to the registry, or replaces an existing node with the same identity.
     ///
     /// # Arguments
     ///
-    /// * `node` - The node to be added to the registry.
+    /// * `node` - The node to be added to or updated in the registry.
     ///
-    fn add_node(&self, node: Node) -> Result<(), NodeRegistryError>;
-
-    /// Updates a node with the given identity.
-    /// The node's exiting metadata properties that are not in the updates map will not be
-    /// changed. New properties that are not already in the nodes's metadata will be added to
-    /// the metadata.
-    ///
-    /// # Arguments
-    ///
-    ///  * `identity` - The Splinter identity of the node.
-    ///  * `updates` - A map containing the updated properties.
-    ///
-    fn update_node(
-        &self,
-        identity: &str,
-        updates: HashMap<String, String>,
-    ) -> Result<(), NodeRegistryError>;
+    fn insert_node(&self, node: Node) -> Result<(), NodeRegistryError>;
 
     /// Deletes a node with the given identity.
     ///
@@ -202,16 +186,8 @@ impl<NW> NodeRegistryWriter for Box<NW>
 where
     NW: NodeRegistryWriter + ?Sized,
 {
-    fn add_node(&self, node: Node) -> Result<(), NodeRegistryError> {
-        (**self).add_node(node)
-    }
-
-    fn update_node(
-        &self,
-        identity: &str,
-        updates: HashMap<String, String>,
-    ) -> Result<(), NodeRegistryError> {
-        (**self).update_node(identity, updates)
+    fn insert_node(&self, node: Node) -> Result<(), NodeRegistryError> {
+        (**self).insert_node(node)
     }
 
     fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -111,6 +111,14 @@ pub trait NodeRegistryReader: Send + Sync {
     ///  * `identity` - The Splinter identity of the node.
     ///
     fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError>;
+
+    fn has_node(&self, identity: &str) -> Result<bool, NodeRegistryError> {
+        match self.fetch_node(identity) {
+            Ok(_) => Ok(true),
+            Err(NodeRegistryError::NotFoundError(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
 }
 
 /// Provides Node Registry write capabilities.
@@ -183,6 +191,10 @@ where
 
     fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
         (**self).fetch_node(identity)
+    }
+
+    fn has_node(&self, identity: &str) -> Result<bool, NodeRegistryError> {
+        (**self).has_node(identity)
     }
 }
 

--- a/libsplinter/src/node_registry/noop.rs
+++ b/libsplinter/src/node_registry/noop.rs
@@ -14,8 +14,6 @@
 
 //! Provides an empty-list implemenation of the NodeRegistry trait.
 
-use std::collections::HashMap;
-
 use super::{
     MetadataPredicate, Node, NodeRegistryError, NodeRegistryReader, NodeRegistryWriter,
     RwNodeRegistry,
@@ -45,19 +43,11 @@ impl NodeRegistryReader for NoOpNodeRegistry {
 }
 
 impl NodeRegistryWriter for NoOpNodeRegistry {
-    fn add_node(&self, _node: Node) -> Result<(), NodeRegistryError> {
+    fn insert_node(&self, _node: Node) -> Result<(), NodeRegistryError> {
         Err(NodeRegistryError::UnableToAddNode(
             "operation not supported".into(),
             None,
         ))
-    }
-
-    fn update_node(
-        &self,
-        identity: &str,
-        _updates: HashMap<String, String>,
-    ) -> Result<(), NodeRegistryError> {
-        Err(NodeRegistryError::NotFoundError(identity.to_string()))
     }
 
     fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {

--- a/libsplinter/src/node_registry/yaml/error.rs
+++ b/libsplinter/src/node_registry/yaml/error.rs
@@ -15,13 +15,14 @@
 use std::error::Error;
 use std::fmt;
 
+use crate::node_registry::InvalidNodeError;
+
 #[derive(Debug)]
 pub enum YamlNodeRegistryError {
     PoisonLockError(String),
-
     SerdeError(serde_yaml::Error),
-
     IoError(std::io::Error),
+    InvalidNode(InvalidNodeError),
 }
 
 impl Error for YamlNodeRegistryError {
@@ -30,6 +31,7 @@ impl Error for YamlNodeRegistryError {
             YamlNodeRegistryError::PoisonLockError(_) => None,
             YamlNodeRegistryError::SerdeError(err) => Some(err),
             YamlNodeRegistryError::IoError(err) => Some(err),
+            YamlNodeRegistryError::InvalidNode(err) => Some(err),
         }
     }
 }
@@ -40,6 +42,7 @@ impl fmt::Display for YamlNodeRegistryError {
             YamlNodeRegistryError::PoisonLockError(e) => write!(f, "Error locking file: {}", e),
             YamlNodeRegistryError::SerdeError(e) => write!(f, "Serde error: {}", e),
             YamlNodeRegistryError::IoError(e) => write!(f, "IO error: {}", e),
+            YamlNodeRegistryError::InvalidNode(e) => write!(f, "invalid node in YAML file: {}", e),
         }
     }
 }
@@ -53,5 +56,11 @@ impl From<std::io::Error> for YamlNodeRegistryError {
 impl From<serde_yaml::Error> for YamlNodeRegistryError {
     fn from(err: serde_yaml::Error) -> YamlNodeRegistryError {
         YamlNodeRegistryError::SerdeError(err)
+    }
+}
+
+impl From<InvalidNodeError> for YamlNodeRegistryError {
+    fn from(err: InvalidNodeError) -> Self {
+        YamlNodeRegistryError::InvalidNode(err)
     }
 }

--- a/libsplinter/src/node_registry/yaml/mod.rs
+++ b/libsplinter/src/node_registry/yaml/mod.rs
@@ -153,6 +153,8 @@ impl NodeRegistryWriter for YamlNodeRegistry {
                 updated_metadata.extend(updates);
                 let updated_node = Node {
                     identity: node.identity.clone(),
+                    endpoint: node.endpoint.clone(),
+                    display_name: node.display_name.clone(),
                     metadata: updated_metadata,
                 };
                 nodes[i] = updated_node;
@@ -334,8 +336,8 @@ mod test {
                     get_node_3().metadata.get("company").unwrap().to_string(),
                 ),
                 MetadataPredicate::Eq(
-                    "url".to_string(),
-                    get_node_3().metadata.get("url").unwrap().to_string(),
+                    "admin".to_string(),
+                    get_node_3().metadata.get("admin").unwrap().to_string(),
                 ),
             ];
 
@@ -361,8 +363,8 @@ mod test {
                 .expect("Failed to create YamlNodeRegistry");
 
             let filter = vec![MetadataPredicate::Eq(
-                "url".to_string(),
-                get_node_3().metadata.get("url").unwrap().to_string(),
+                "admin".to_string(),
+                get_node_3().metadata.get("admin").unwrap().to_string(),
             )];
 
             let nodes = registry
@@ -528,30 +530,36 @@ mod test {
 
     fn get_node_1() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "12.0.0.123:8431".to_string());
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
+        metadata.insert("admin".to_string(), "Bob".to_string());
         Node {
             identity: "Node-123".to_string(),
+            endpoint: "tls://12.0.0.123:8431".to_string(),
+            display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
     }
 
     fn get_node_2() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "13.0.0.123:8434".to_string());
         metadata.insert("company".to_string(), "Cargill".to_string());
+        metadata.insert("admin".to_string(), "Carol".to_string());
         Node {
             identity: "Node-456".to_string(),
+            endpoint: "tls://12.0.0.123:8434".to_string(),
+            display_name: "Cargill - Node 1".to_string(),
             metadata,
         }
     }
 
     fn get_node_3() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "13.0.0.123:8435".to_string());
         metadata.insert("company".to_string(), "Cargill".to_string());
+        metadata.insert("admin".to_string(), "Charlie".to_string());
         Node {
             identity: "Node-789".to_string(),
+            endpoint: "tls://12.0.0.123:8435".to_string(),
+            display_name: "Cargill - Node 2".to_string(),
             metadata,
         }
     }

--- a/libsplinter/src/node_registry/yaml/mod.rs
+++ b/libsplinter/src/node_registry/yaml/mod.rs
@@ -377,7 +377,7 @@ mod test {
     /// Verifies that add_node successfully adds a new node to the yaml file.
     ///
     #[test]
-    fn test_list_add_node_ok() {
+    fn test_add_node_ok() {
         run_test(|test_yaml_file_path| {
             write_to_file(&vec![], test_yaml_file_path);
 
@@ -406,7 +406,7 @@ mod test {
     /// exists in the yaml file.
     ///
     #[test]
-    fn test_list_add_node_duplicate_error() {
+    fn test_add_node_duplicate_error() {
         run_test(|test_yaml_file_path| {
             write_to_file(&vec![get_node_1()], test_yaml_file_path);
 

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -320,8 +320,9 @@ paths:
         - name: filter
           in: query
           description: |
-            url-encodeded stringified JSON containing property filters in the format
-              {NODE_PROPERTY:[{"operator":OPERATOR,"value":VALUE}]}
+            url-encodeded stringified JSON containing property filters on the
+            node's metadata properties in the format
+              {METADATA_PROPERTY:[{"operator":OPERATOR,"value":VALUE}]}
           required: false
           schema:
             type: string
@@ -565,11 +566,19 @@ components:
       properties:
         identity:
           type: string
-      additionalProperties: true
+        endpoint:
+          type: string
+        display_name:
+          type: string
+        metadata:
+          type: object
       example:
         identity: node-123123-asdf
-        company: Cargill
-        status: Up
+        endpoint: tls://12.0.0.123:8431
+        display_name: Cargill - Node 1
+        metadata:
+          company: Cargill
+          status: Up
 
     PublicKeyInfo:
       type: object

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -286,7 +286,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
-          description: The node already exists
+          description: The node already exists or is invalid
           content:
             application/json:
               schema:
@@ -383,14 +383,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-    patch:
+    put:
       tags:
         - Node Registry
-      description: Update a node in the Node Registry
+      description: Add a node to or replace a node in the Node Registry. This action is idempotent.
       parameters:
         - name: identity
           in: path
-          description: identity of node to update
+          description: identity of node to add/replace
           required: true
           schema:
             type: string
@@ -399,18 +399,18 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/RegisteredNode'
       responses:
         200:
-          description: The node in the registry has been updated
+          description: The node in the registry has been replaced
         400:
           description: The request was malformed
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        404:
-          description: The node with {identity} was not found
+        403:
+          description: The node was invalid
           content:
             application/json:
               schema:

--- a/splinterd/sample_node_registries/nodes.yaml
+++ b/splinterd/sample_node_registries/nodes.yaml
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 - identity: "Node-123"
+  endpoint: "tls://123.0.0.123:8080"
+  display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
-    url: "123.0.0.123:8080"
 - identity: "Node-456"
+  endpoint: "tls://456.0.0.456:8080"
+  display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"
-    url: "456.0.0.456:8080"
-

--- a/splinterd/src/routes/node.rs
+++ b/splinterd/src/routes/node.rs
@@ -337,10 +337,8 @@ where
                         Ok(_) => HttpResponse::Ok().finish(),
                         Err(err) => match err {
                             BlockingError::Error(err) => match err {
-                                NodeRegistryError::DuplicateNodeError(id) => {
-                                    HttpResponse::Forbidden()
-                                        .json(format!("node with with ID ({}) already exists", id))
-                                }
+                                NodeRegistryError::InvalidNode(err) => HttpResponse::Forbidden()
+                                    .json(format!("node is invalid: {}", err)),
                                 _ => HttpResponse::InternalServerError().json(format!("{}", err)),
                             },
                             _ => HttpResponse::InternalServerError().json(format!("{}", err)),

--- a/splinterd/src/routes/node.rs
+++ b/splinterd/src/routes/node.rs
@@ -18,7 +18,8 @@ use splinter::actix_web::{error::BlockingError, web, Error, HttpRequest, HttpRes
 use splinter::futures::{future::IntoFuture, stream::Stream, Future};
 use splinter::{
     node_registry::{
-        error::NodeRegistryError, MetadataPredicate, Node, NodeRegistryReader, NodeRegistryWriter,
+        error::{InvalidNodeError, NodeRegistryError},
+        MetadataPredicate, Node, NodeRegistryReader, NodeRegistryWriter,
     },
     rest_api::{Method, Resource},
 };
@@ -42,8 +43,8 @@ where
         .add_method(Method::Get, move |r, _| {
             fetch_node(r, web::Data::new(registry.clone()))
         })
-        .add_method(Method::Patch, move |r, p| {
-            update_node(r, p, web::Data::new(registry1.clone()))
+        .add_method(Method::Put, move |r, p| {
+            put_node(r, p, web::Data::new(registry1.clone()))
         })
         .add_method(Method::Delete, move |r, _| {
             delete_node(r, web::Data::new(registry2.clone()))
@@ -90,7 +91,7 @@ where
     )
 }
 
-fn update_node<NW>(
+fn put_node<NW>(
     request: HttpRequest,
     payload: web::Payload,
     registry: web::Data<NW>,
@@ -98,7 +99,7 @@ fn update_node<NW>(
 where
     NW: NodeRegistryWriter + 'static,
 {
-    let identity = request
+    let path_identity = request
         .match_info()
         .get("identity")
         .unwrap_or("")
@@ -111,35 +112,45 @@ where
                 Ok::<_, Error>(body)
             })
             .into_future()
-            .and_then(
-                move |body| match serde_json::from_slice::<HashMap<String, String>>(&body) {
-                    Ok(updates) => Box::new(
-                        web::block(move || registry.update_node(&identity, updates)).then(|res| {
-                            Ok(match res {
-                                Ok(_) => HttpResponse::Ok().finish(),
-                                Err(err) => match err {
-                                    BlockingError::Error(err) => match err {
-                                        NodeRegistryError::NotFoundError(err) => {
-                                            HttpResponse::NotFound().json(err)
-                                        }
-                                        _ => HttpResponse::InternalServerError()
-                                            .json(format!("{}", err)),
-                                    },
+            .and_then(move |body| match serde_json::from_slice::<Node>(&body) {
+                Ok(node) => Box::new(
+                    web::block(move || {
+                        if node.identity != path_identity {
+                            Err(NodeRegistryError::InvalidNode(
+                                InvalidNodeError::InvalidIdentity(
+                                    node.identity,
+                                    "node identity cannot be changed".into(),
+                                ),
+                            ))
+                        } else {
+                            registry.insert_node(node)
+                        }
+                    })
+                    .then(|res| {
+                        Ok(match res {
+                            Ok(_) => HttpResponse::Ok().finish(),
+                            Err(err) => match err {
+                                BlockingError::Error(err) => match err {
+                                    NodeRegistryError::InvalidNode(err) => {
+                                        HttpResponse::Forbidden()
+                                            .json(format!("node is invalid: {}", err))
+                                    }
                                     _ => {
                                         HttpResponse::InternalServerError().json(format!("{}", err))
                                     }
                                 },
-                            })
-                        }),
-                    )
-                        as Box<dyn Future<Item = HttpResponse, Error = Error>>,
-                    Err(err) => Box::new(
-                        HttpResponse::BadRequest()
-                            .json(format!("invalid updates: {}", err))
-                            .into_future(),
-                    ),
-                },
-            ),
+                                _ => HttpResponse::InternalServerError().json(format!("{}", err)),
+                            },
+                        })
+                    }),
+                )
+                    as Box<dyn Future<Item = HttpResponse, Error = Error>>,
+                Err(err) => Box::new(
+                    HttpResponse::BadRequest()
+                        .json(format!("invalid node: {}", err))
+                        .into_future(),
+                ),
+            }),
     )
 }
 
@@ -321,7 +332,7 @@ fn add_node<NW>(
     registry: web::Data<NW>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>>
 where
-    NW: NodeRegistryWriter + 'static,
+    NW: NodeRegistryReader + NodeRegistryWriter + 'static,
 {
     Box::new(
         payload
@@ -332,19 +343,34 @@ where
             })
             .into_future()
             .and_then(move |body| match serde_json::from_slice::<Node>(&body) {
-                Ok(node) => Box::new(web::block(move || registry.add_node(node)).then(|res| {
-                    Ok(match res {
-                        Ok(_) => HttpResponse::Ok().finish(),
-                        Err(err) => match err {
-                            BlockingError::Error(err) => match err {
-                                NodeRegistryError::InvalidNode(err) => HttpResponse::Forbidden()
-                                    .json(format!("node is invalid: {}", err)),
+                Ok(node) => Box::new(
+                    web::block(move || {
+                        if registry.has_node(&node.identity)? {
+                            Err(NodeRegistryError::InvalidNode(
+                                InvalidNodeError::DuplicateIdentity(node.identity),
+                            ))
+                        } else {
+                            registry.insert_node(node)
+                        }
+                    })
+                    .then(|res| {
+                        Ok(match res {
+                            Ok(_) => HttpResponse::Ok().finish(),
+                            Err(err) => match err {
+                                BlockingError::Error(err) => match err {
+                                    NodeRegistryError::InvalidNode(err) => {
+                                        HttpResponse::Forbidden()
+                                            .json(format!("node is invalid: {}", err))
+                                    }
+                                    _ => {
+                                        HttpResponse::InternalServerError().json(format!("{}", err))
+                                    }
+                                },
                                 _ => HttpResponse::InternalServerError().json(format!("{}", err)),
                             },
-                            _ => HttpResponse::InternalServerError().json(format!("{}", err)),
-                        },
-                    })
-                }))
+                        })
+                    }),
+                )
                     as Box<dyn Future<Item = HttpResponse, Error = Error>>,
                 Err(err) => Box::new(
                     HttpResponse::BadRequest()
@@ -428,24 +454,25 @@ mod tests {
     }
 
     #[test]
-    /// Test the PATCH /nodes/{identity} route for updating the metadata of a node in the registry.
-    fn test_update_node() {
+    /// Test the PUT /nodes/{identity} route for adding or updating a node in the registry.
+    fn test_put_node() {
         run_test(|test_yaml_file_path| {
-            write_to_file(&test_yaml_file_path, &[get_node_1()]);
+            let mut node = get_node_1();
+            write_to_file(&test_yaml_file_path, &[node.clone()]);
 
             let node_registry = new_yaml_node_registry(test_yaml_file_path);
 
             let mut app = test::init_service(
                 App::new().data(node_registry.clone()).service(
                     web::resource("/nodes/{identity}")
-                        .route(web::patch().to_async(update_node::<YamlNodeRegistry>))
+                        .route(web::patch().to_async(put_node::<YamlNodeRegistry>))
                         .route(web::get().to_async(fetch_node::<YamlNodeRegistry>)),
                 ),
             );
 
-            // Verify invalid updates (e.g. no updates) gets a BAD_REQUEST response
+            // Verify no body (e.g. no updated Node) gets a BAD_REQUEST response
             let req = test::TestRequest::patch()
-                .uri(&format!("/nodes/{}", get_node_1().identity))
+                .uri(&format!("/nodes/{}", &node.identity))
                 .to_request();
 
             let resp = test::call_service(&mut app, req);
@@ -453,16 +480,15 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
             // Verify that updating an existing node gets an OK response and the fetched node has
-            // the updated metadata
-            let updated_key = "location".to_string();
-            let updated_value = "Minneapolis".to_string();
-            let mut updates = HashMap::new();
-            updates.insert(updated_key.clone(), updated_value.clone());
+            // the updated values
+            node.endpoint = "12.0.0.123:8432".to_string();
+            node.metadata
+                .insert("location".to_string(), "Minneapolis".to_string());
 
             let req = test::TestRequest::patch()
-                .uri(&format!("/nodes/{}", get_node_1().identity))
+                .uri(&format!("/nodes/{}", &node.identity))
                 .header(header::CONTENT_TYPE, "application/json")
-                .set_json(&updates)
+                .set_json(&node)
                 .to_request();
 
             let resp = test::call_service(&mut app, req);
@@ -470,30 +496,28 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::OK);
 
             let req = test::TestRequest::get()
-                .uri(&format!("/nodes/{}", get_node_1().identity))
+                .uri(&format!("/nodes/{}", &node.identity))
                 .to_request();
 
             let resp = test::call_service(&mut app, req);
 
             assert_eq!(resp.status(), StatusCode::OK);
-            let node: Node = serde_yaml::from_slice(&test::read_body(resp)).unwrap();
-            assert_eq!(
-                node.metadata
-                    .get(&updated_key)
-                    .expect("updated value doesn't exist"),
-                &updated_value
-            );
+            let updated_node: Node = serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+            assert_eq!(updated_node, node);
 
-            // Verify that updating a non-existent node gets a NOT_FOUND response
+            // Verify that attempting to change the node identity gets a FORBIDDEN response
+            let old_identity = node.identity.clone();
+            node.identity = "Node-789".into();
+
             let req = test::TestRequest::patch()
-                .uri(&format!("/nodes/{}", get_node_2().identity))
+                .uri(&format!("/nodes/{}", &old_identity))
                 .header(header::CONTENT_TYPE, "application/json")
-                .set_json(&updates)
+                .set_json(&node)
                 .to_request();
 
             let resp = test::call_service(&mut app, req);
 
-            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         })
     }
 
@@ -627,9 +651,13 @@ mod tests {
 
             let node_registry = new_yaml_node_registry(test_yaml_file_path);
 
-            let mut app = test::init_service(App::new().data(node_registry.clone()).service(
-                web::resource("/nodes").route(web::post().to_async(add_node::<YamlNodeRegistry>)),
-            ));
+            let mut app = test::init_service(
+                App::new().data(node_registry.clone()).service(
+                    web::resource("/nodes")
+                        .route(web::post().to_async(add_node::<YamlNodeRegistry>))
+                        .route(web::get().to_async(fetch_node::<YamlNodeRegistry>)),
+                ),
+            );
 
             // Verify an invalid node gets a BAD_REQUEST response
             let req = test::TestRequest::post()

--- a/splinterd/src/routes/node.rs
+++ b/splinterd/src/routes/node.rs
@@ -702,20 +702,22 @@ mod tests {
 
     fn get_node_1() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "12.0.0.123:8431".to_string());
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
         Node {
             identity: "Node-123".to_string(),
+            endpoint: "12.0.0.123:8431".to_string(),
+            display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
     }
 
     fn get_node_2() -> Node {
         let mut metadata = HashMap::new();
-        metadata.insert("url".to_string(), "13.0.0.123:8434".to_string());
         metadata.insert("company".to_string(), "Cargill".to_string());
         Node {
             identity: "Node-456".to_string(),
+            endpoint: "13.0.0.123:8434".to_string(),
+            display_name: "Cargill - Node 1".to_string(),
             metadata,
         }
     }


### PR DESCRIPTION
- Update the definition of a `Node` in the node registry to have required `endpoint` and `display_name` fields
- Update the YAML node registry to verify that all nodes' required fields are not empty
- Update the YAML node registry to verify that all node identities and endpoints are unique
- Change `NodeRegistry.update_node` to take a new node definition rather than just updated fields