### PR TITLE
Split Node Registry into -Reader and -Writer traits 

### DIFF
--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -27,15 +27,8 @@ pub struct Node {
     pub metadata: HashMap<String, String>,
 }
 
-pub trait NodeRegistry: Send + Sync {
-    /// Registers a new node.
-    ///
-    /// # Arguments
-    ///
-    /// * `node` - The node to be added to the registry.
-    ///
-    fn add_node(&self, node: Node) -> Result<(), NodeRegistryError>;
-
+/// Provides Node Registry read capabilities.
+pub trait NodeRegistryReader: Send + Sync {
     /// Returns a list of nodes.
     ///
     /// # Arguments
@@ -63,6 +56,17 @@ pub trait NodeRegistry: Send + Sync {
     ///  * `identity` - The Splinter identity of the node.
     ///
     fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError>;
+}
+
+/// Provides Node Registry write capabilities.
+pub trait NodeRegistryWriter: Send + Sync {
+    /// Registers a new node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The node to be added to the registry.
+    ///
+    fn add_node(&self, node: Node) -> Result<(), NodeRegistryError>;
 
     /// Updates a node with the given identity.
     /// The node's exiting metadata properties that are not in the updates map will not be
@@ -87,7 +91,10 @@ pub trait NodeRegistry: Send + Sync {
     ///  * `identity` - The Splinter identity of the node.
     ///
     fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError>;
+}
 
+/// Provides a marker trait for a clonable, readable and writable Node Registry.
+pub trait RwNodeRegistry: NodeRegistryWriter + NodeRegistryReader {
     /// Clone implementation for Box<NodeRegistry>.
     /// The implementation of Clone for NodeRegistry calls this method.
     ///
@@ -95,11 +102,11 @@ pub trait NodeRegistry: Send + Sync {
     ///  fn clone_box(&self) -> Box<NodeRegistry> {
     ///     Box::new(Clone::clone(self))
     ///  }
-    fn clone_box(&self) -> Box<dyn NodeRegistry>;
+    fn clone_box(&self) -> Box<dyn RwNodeRegistry>;
 }
 
-impl Clone for Box<dyn NodeRegistry> {
-    fn clone(&self) -> Box<dyn NodeRegistry> {
+impl Clone for Box<dyn RwNodeRegistry> {
+    fn clone(&self) -> Box<dyn RwNodeRegistry> {
         self.clone_box()
     }
 }

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -110,3 +110,42 @@ impl Clone for Box<dyn RwNodeRegistry> {
         self.clone_box()
     }
 }
+
+impl<NR> NodeRegistryReader for Box<NR>
+where
+    NR: NodeRegistryReader + ?Sized,
+{
+    fn list_nodes(
+        &self,
+        filters: Option<HashMap<String, (String, String)>>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<Vec<Node>, NodeRegistryError> {
+        (**self).list_nodes(filters, limit, offset)
+    }
+
+    fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
+        (**self).fetch_node(identity)
+    }
+}
+
+impl<NW> NodeRegistryWriter for Box<NW>
+where
+    NW: NodeRegistryWriter + ?Sized,
+{
+    fn add_node(&self, node: Node) -> Result<(), NodeRegistryError> {
+        (**self).add_node(node)
+    }
+
+    fn update_node(
+        &self,
+        identity: &str,
+        updates: HashMap<String, String>,
+    ) -> Result<(), NodeRegistryError> {
+        (**self).update_node(identity, updates)
+    }
+
+    fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {
+        (**self).delete_node(identity)
+    }
+}

--- a/libsplinter/src/node_registry/noop.rs
+++ b/libsplinter/src/node_registry/noop.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 
-use super::{Node, NodeRegistry, NodeRegistryError};
+use super::{Node, NodeRegistryError, NodeRegistryReader, NodeRegistryWriter, RwNodeRegistry};
 
 /// The NoOpNodeRegistry is an empty-list implementation of the NodeRegistry trait.
 ///
@@ -24,14 +24,7 @@ use super::{Node, NodeRegistry, NodeRegistryError};
 /// nodes.  It does not allow node creation.
 pub struct NoOpNodeRegistry;
 
-impl NodeRegistry for NoOpNodeRegistry {
-    fn add_node(&self, _node: Node) -> Result<(), NodeRegistryError> {
-        Err(NodeRegistryError::UnableToAddNode(
-            "operation not supported".into(),
-            None,
-        ))
-    }
-
+impl NodeRegistryReader for NoOpNodeRegistry {
     fn list_nodes(
         &self,
         _filters: Option<HashMap<String, (String, String)>>,
@@ -43,6 +36,15 @@ impl NodeRegistry for NoOpNodeRegistry {
 
     fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
         Err(NodeRegistryError::NotFoundError(identity.to_string()))
+    }
+}
+
+impl NodeRegistryWriter for NoOpNodeRegistry {
+    fn add_node(&self, _node: Node) -> Result<(), NodeRegistryError> {
+        Err(NodeRegistryError::UnableToAddNode(
+            "operation not supported".into(),
+            None,
+        ))
     }
 
     fn update_node(
@@ -56,8 +58,10 @@ impl NodeRegistry for NoOpNodeRegistry {
     fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {
         Err(NodeRegistryError::NotFoundError(identity.to_string()))
     }
+}
 
-    fn clone_box(&self) -> Box<dyn NodeRegistry> {
+impl RwNodeRegistry for NoOpNodeRegistry {
+    fn clone_box(&self) -> Box<dyn RwNodeRegistry> {
         Box::new(NoOpNodeRegistry)
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -38,7 +38,7 @@ use splinter::network::handlers::{NetworkEchoHandler, NetworkHeartbeatHandler};
 use splinter::network::peer::PeerConnector;
 use splinter::network::sender::{NetworkMessageSender, SendRequest};
 use splinter::network::{ConnectionError, Network, PeerUpdateError, RecvTimeoutError, SendError};
-use splinter::node_registry::{self, NodeRegistry};
+use splinter::node_registry::{self, RwNodeRegistry};
 use splinter::orchestrator::{NewOrchestratorError, ServiceOrchestrator};
 use splinter::protos::authorization::AuthorizationMessageType;
 use splinter::protos::circuit::CircuitMessageType;
@@ -810,7 +810,7 @@ fn set_up_circuit_dispatcher(
 
 fn create_node_registry(
     registry_config: &RegistryConfig,
-) -> Result<Box<dyn NodeRegistry>, RestApiServerError> {
+) -> Result<Box<dyn RwNodeRegistry>, RestApiServerError> {
     match registry_config {
         RegistryConfig::File { registry_file } => Ok(Box::new(
             node_registry::yaml::YamlNodeRegistry::new(&registry_file).map_err(|err| {


### PR DESCRIPTION
This PR splits the `NodeRegistry` trait into a `NodeRegistryReader` and a `NodeRegistryWriter`.  It renames the remaining `NodeRegistry` trait to `RwNodeRegistry` which requires both traits, and some clonability.