### PR TITLE
Add Shared Config to CanopyJS

### DIFF
--- a/canopy/app/src/App.js
+++ b/canopy/app/src/App.js
@@ -19,6 +19,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import { useUserState, UserProvider } from 'UserStore';
 import SideNav from 'components/navigation/SideNav';
 import { loadAllSaplings } from './loadSaplings';
+import { loadSharedConfig } from './loadSharedConfig';
 
 import 'App.scss';
 
@@ -28,6 +29,7 @@ function App() {
   const saplingDomNode = useRef(null);
   const [userSaplingManifests, setUserSaplingManifests] = useState([]);
   const [user, setUser] = useUserState();
+  const [sharedConfig, setSharedConfig] = useState({});
 
   const appSapling = useRef(null);
   const configSaplings = useRef({});
@@ -43,11 +45,18 @@ function App() {
 
   window.$CANOPY.setUser = setUser;
   window.$CANOPY.getUser = () => user;
+  window.$CANOPY.getSharedConfig = () => sharedConfig;
 
   // This useEffect with zero dependencies will run only when the component first loads.
   useEffect(() => {
     (async () => {
-      const { userSaplingsResponse } = await loadAllSaplings();
+      // handle all (simulated) HTTP requests concurrently
+      const [
+        { userSaplingsResponse },
+        sharedConfigResponse
+      ] = await Promise.all([loadAllSaplings(), loadSharedConfig()]);
+
+      setSharedConfig(sharedConfigResponse);
       setUserSaplingManifests(userSaplingsResponse);
 
       // Load the config saplings

--- a/canopy/app/src/loadSharedConfig.js
+++ b/canopy/app/src/loadSharedConfig.js
@@ -1,0 +1,3 @@
+import { getSharedConfig } from './getSaplings.macro';
+
+export const loadSharedConfig = async () => getSharedConfig();

--- a/canopy/canopyjs/src/index.spec.ts
+++ b/canopy/canopyjs/src/index.spec.ts
@@ -27,7 +27,10 @@ const minimalUser = { userId: 'MINIMAL' };
   registerConfigSapling: jest.fn(),
   registerApp: jest.fn(),
   getUser: jest.fn(() => completeUser),
-  setUser: jest.fn()
+  setUser: jest.fn(),
+  getSharedConfig: jest.fn(() => ({
+    mock: true
+  }))
 };
 
 interface MockCanopy {
@@ -35,6 +38,7 @@ interface MockCanopy {
   registerApp: jest.Mock;
   getUser: jest.Mock;
   setUser: jest.Mock;
+  getSharedConfig: jest.Mock;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -88,6 +92,13 @@ describe('CanopyJS', () => {
       const { setUser } = await import('./index');
       setUser(minimalUser);
       expect($CANOPY.setUser.mock.calls[0][0]).toEqual(minimalUser);
+    });
+  });
+
+  describe('getSharedConfig', () => {
+    it('should call getSharedConfig from window object', async () => {
+      const { getSharedConfig } = await import('./index');
+      expect(getSharedConfig()).toEqual({ mock: true });
     });
   });
 });

--- a/canopy/canopyjs/src/index.ts
+++ b/canopy/canopyjs/src/index.ts
@@ -23,6 +23,16 @@ interface SetUser {
   (user: User): void;
 }
 
+interface SharedConfig {
+  canopyConfig: {
+    splinterEndpoint: string;
+  };
+}
+
+interface GetSharedConfig {
+  (): SharedConfig;
+}
+
 interface GetUser {
   (): User;
 }
@@ -42,6 +52,7 @@ interface Canopy {
   registerConfigSapling: RegisterConfigSapling;
   getUser: GetUser;
   setUser: SetUser;
+  getSharedConfig: GetSharedConfig;
 }
 
 function assertAndGetWindowCanopy(): Canopy {
@@ -63,5 +74,6 @@ export const {
   registerApp,
   registerConfigSapling,
   getUser,
-  setUser
+  setUser,
+  getSharedConfig
 }: Canopy = canopy;


### PR DESCRIPTION
While previously, shared config was made available to the Canopy app, it was not invoked.

This change brings the shared config into the Canopy app and exposes it to Saplings via CanopyJS