### PR TITLE
Node registry list simplification

### DIFF
--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -22,9 +22,6 @@ pub enum NodeRegistryError {
     /// This error is returned when the user attempts to create a node with an identity that
     /// already exists.
     DuplicateNodeError(String),
-    /// This error is returned when the user attempts to filter the nodes list using an invalid
-    /// filter.
-    InvalidFilterError(String),
     /// This error is returned when an internal error occurred
     InternalError(Box<dyn Error + Send>),
     /// This error is returned when the user cannot create a node in the registry
@@ -36,7 +33,6 @@ impl Error for NodeRegistryError {
         match self {
             NodeRegistryError::NotFoundError(_) => None,
             NodeRegistryError::DuplicateNodeError(_) => None,
-            NodeRegistryError::InvalidFilterError(_) => None,
             NodeRegistryError::InternalError(err) => Some(err.as_ref()),
             // Unfortunately, have to match on both arms to return the expected result
             NodeRegistryError::UnableToAddNode(_, Some(err)) => Some(err.as_ref()),
@@ -50,7 +46,6 @@ impl fmt::Display for NodeRegistryError {
         match self {
             NodeRegistryError::NotFoundError(e) => write!(f, "Node not found: {}", e),
             NodeRegistryError::DuplicateNodeError(e) => write!(f, "Duplicate identity: {}", e),
-            NodeRegistryError::InvalidFilterError(e) => write!(f, "Invalid filter: {}", e),
             NodeRegistryError::InternalError(e) => write!(f, "Internal error: {}", e),
             NodeRegistryError::UnableToAddNode(msg, err) => write!(
                 f,

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -28,24 +28,71 @@ pub struct Node {
     pub metadata: HashMap<String, String>,
 }
 
+/// A predicate on a key/value pair in a Node's metadata table.
+///
+/// Each variant is an operator, and supplies a tuple representing a key/value pair. It is applied
+/// by the comparison operator on the value found at the given key (the first item in the tuple)
+/// against the predicate's value (the second item in the tuple).
+///
+/// If the item is missing in a node's metadata table, the predicate returns false.
+#[derive(Clone)]
+pub enum MetadataPredicate {
+    /// Applies the `==` operator.
+    Eq(String, String),
+    /// Applies the `!=` operator.
+    Ne(String, String),
+    /// Applies the `>` operator.
+    Gt(String, String),
+    /// Applies the `>=` operator.
+    Ge(String, String),
+    /// Applies the `<` operator.
+    Lt(String, String),
+    /// Applies the `<=` operator.
+    Le(String, String),
+}
+
+impl MetadataPredicate {
+    /// Apply this predicate against a given node.
+    pub fn apply(&self, node: &Node) -> bool {
+        match self {
+            MetadataPredicate::Eq(key, val) => {
+                node.metadata.get(key).map(|v| v == val).unwrap_or(false)
+            }
+            MetadataPredicate::Ne(key, val) => {
+                node.metadata.get(key).map(|v| v != val).unwrap_or(false)
+            }
+            MetadataPredicate::Gt(key, val) => {
+                node.metadata.get(key).map(|v| v > val).unwrap_or(false)
+            }
+            MetadataPredicate::Ge(key, val) => {
+                node.metadata.get(key).map(|v| v >= val).unwrap_or(false)
+            }
+            MetadataPredicate::Lt(key, val) => {
+                node.metadata.get(key).map(|v| v < val).unwrap_or(false)
+            }
+            MetadataPredicate::Le(key, val) => {
+                node.metadata.get(key).map(|v| v <= val).unwrap_or(false)
+            }
+        }
+    }
+}
+
 /// Provides Node Registry read capabilities.
 pub trait NodeRegistryReader: Send + Sync {
     /// Returns a list of nodes.
     ///
     /// # Arguments
     ///
-    /// * `filters` - A map that defines list filters. The key is the property to be filtered by
-    /// and the value is a tuple. The first item of the tuple defines the operator "=", "<", ">",
-    /// "<=" or "<=". The second item in the tuple is the value to compare the node property
-    /// against. If the filters map has more than one key-value pair, this function should return
-    /// only nodes that match all the provided filters.
+    /// * `predicates` - A list of of predicates to be applied to the resulting list. These are
+    /// applied as an AND, from a query perspective. If the list is empty, it is the equivalent of
+    /// no predicates (i.e. return all).
     ///
     /// * `limit` - The maximum number of items to return
     ///
     /// * `offset` - The index of the resource to start the resulting array
     fn list_nodes(
         &self,
-        filters: Option<HashMap<String, (String, String)>>,
+        predicates: &[MetadataPredicate],
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Node>, NodeRegistryError>;
@@ -118,7 +165,7 @@ where
 {
     fn list_nodes(
         &self,
-        filters: Option<HashMap<String, (String, String)>>,
+        filters: &[MetadataPredicate],
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Node>, NodeRegistryError> {

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -16,8 +16,9 @@ pub mod error;
 pub mod noop;
 pub mod yaml;
 
-pub use error::NodeRegistryError;
 use std::collections::HashMap;
+
+pub use error::NodeRegistryError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Node {

--- a/libsplinter/src/node_registry/noop.rs
+++ b/libsplinter/src/node_registry/noop.rs
@@ -16,7 +16,10 @@
 
 use std::collections::HashMap;
 
-use super::{Node, NodeRegistryError, NodeRegistryReader, NodeRegistryWriter, RwNodeRegistry};
+use super::{
+    MetadataPredicate, Node, NodeRegistryError, NodeRegistryReader, NodeRegistryWriter,
+    RwNodeRegistry,
+};
 
 /// The NoOpNodeRegistry is an empty-list implementation of the NodeRegistry trait.
 ///
@@ -27,7 +30,7 @@ pub struct NoOpNodeRegistry;
 impl NodeRegistryReader for NoOpNodeRegistry {
     fn list_nodes(
         &self,
-        _filters: Option<HashMap<String, (String, String)>>,
+        _filters: &[MetadataPredicate],
         _limit: Option<usize>,
         _offset: Option<usize>,
     ) -> Result<Vec<Node>, NodeRegistryError> {

--- a/libsplinter/src/node_registry/noop.rs
+++ b/libsplinter/src/node_registry/noop.rs
@@ -28,17 +28,19 @@ use super::{
 pub struct NoOpNodeRegistry;
 
 impl NodeRegistryReader for NoOpNodeRegistry {
-    fn list_nodes(
-        &self,
-        _filters: &[MetadataPredicate],
-        _limit: Option<usize>,
-        _offset: Option<usize>,
-    ) -> Result<Vec<Node>, NodeRegistryError> {
-        Ok(vec![])
+    fn list_nodes<'a, 'b: 'a>(
+        &'b self,
+        _predicates: &'a [MetadataPredicate],
+    ) -> Result<Box<dyn Iterator<Item = Node> + Send + 'a>, NodeRegistryError> {
+        Ok(Box::new(std::iter::empty()))
     }
 
     fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
         Err(NodeRegistryError::NotFoundError(identity.to_string()))
+    }
+
+    fn count_nodes(&self, _predicates: &[MetadataPredicate]) -> Result<u32, NodeRegistryError> {
+        Ok(0)
     }
 }
 

--- a/splinterd/src/routes/node.rs
+++ b/splinterd/src/routes/node.rs
@@ -284,14 +284,9 @@ where
                     paging: get_response_paging_info(limit, offset, &link, total_count),
                 }))
             }
-            Err(err) => match err {
-                BlockingError::Error(err) => match err {
-                    NodeRegistryError::InvalidFilterError(err) => {
-                        Ok(HttpResponse::BadRequest().json(err))
-                    }
-                    _ => Ok(HttpResponse::InternalServerError().into()),
-                },
-                _ => Ok(HttpResponse::InternalServerError().into()),
+            Err(err) => {
+                error!("Unable to list nodes: {}", err);
+                Ok(HttpResponse::InternalServerError().into())
             },
         }),
     )


### PR DESCRIPTION
This PR pushes the parsing of the predicate operations and the limit/offset parameters to the REST API layer.  This simplifies the API for the Node registry and removes the need for implementers of the traits to parse the predicate operations.