### PR TITLE
Add initial subcommands for creating and voting on circuit proposals in the splinter cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 stable = ["default"]
 
 experimental = [
+    "circuit",
     "health",
     "database",
     "database-migrate-biome-credentials",
@@ -25,6 +26,7 @@ experimental = [
     "database-migrate-biome-users",
 ]
 
+circuit = ["reqwest"]
 health = ["reqwest", "serde_json"]
 
 database = ["splinter/database", "diesel"]

--- a/cli/src/action/circuit.rs
+++ b/cli/src/action/circuit.rs
@@ -1,0 +1,87 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+use flexi_logger::ReconfigurationHandle;
+
+use crate::error::CliError;
+
+use super::Action;
+
+pub struct CircuitCreateAction;
+
+impl Action for CircuitCreateAction {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &mut ReconfigurationHandle,
+    ) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let url = args.value_of("url").unwrap_or("http://localhost:8085");
+        let key = args.value_of("private_key_file").unwrap_or("splinter");
+        let path = match args.value_of("path") {
+            Some(path) => path,
+            None => return Err(CliError::ActionError("Path is required".into())),
+        };
+
+        create_circuit_proposal(url, key, path)
+    }
+}
+
+fn create_circuit_proposal(_url: &str, _key: &str, _path: &str) -> Result<(), CliError> {
+    unimplemented!()
+}
+
+enum Vote {
+    Accept,
+    Reject,
+}
+
+pub struct CircuitVoteAction;
+
+impl Action for CircuitVoteAction {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &mut ReconfigurationHandle,
+    ) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let url = args.value_of("url").unwrap_or("http://localhost:8085");
+        let key = args.value_of("private_key_file").unwrap_or("splinter");
+        let circuit_id = match args.value_of("circuit_id") {
+            Some(circuit_id) => circuit_id,
+            None => return Err(CliError::ActionError("Circuit id is required".into())),
+        };
+
+        // accept or reject must be present
+        let vote = {
+            if args.is_present("accept") {
+                Vote::Accept
+            } else {
+                Vote::Reject
+            }
+        };
+
+        vote_on_circuit_proposal(url, key, circuit_id, vote)
+    }
+}
+
+fn vote_on_circuit_proposal(
+    _url: &str,
+    _key: &str,
+    _path: &str,
+    _vote: Vote,
+) -> Result<(), CliError> {
+    unimplemented!()
+}

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 pub mod admin;
 pub mod certs;
+#[cfg(feature = "circuit")]
+pub mod circuit;
 #[cfg(feature = "database")]
 pub mod database;
 #[cfg(feature = "health")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,8 +20,8 @@ extern crate diesel;
 mod action;
 mod error;
 
+use crate::action::{admin, certs, Action, SubcommandActions};
 use crate::error::CliError;
-use action::{admin, certs, Action, SubcommandActions};
 
 use clap::clap_app;
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -134,6 +134,79 @@ fn run() -> Result<(), CliError> {
         )
     }
 
+    #[cfg(feature = "circuit")]
+    {
+        use clap::{Arg, SubCommand};
+
+        app = app.subcommand(
+            SubCommand::with_name("circuit")
+                .about("Provides circuit management functionality")
+                .subcommand(
+                    SubCommand::with_name("create")
+                        .about("Propose that a new circuit is created")
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .takes_value(true)
+                                .help("URL of Splinter Daemon"),
+                        )
+                        .arg(
+                            Arg::with_name("private_key_file")
+                                .value_name("private-key-file")
+                                .short("k")
+                                .takes_value(true)
+                                .help("Path to private key file"),
+                        )
+                        .arg(
+                            Arg::with_name("path")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Path to a yaml file that defines the circuit proposal"),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("vote")
+                        .about("Vote on a new circuit proposal")
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .takes_value(true)
+                                .help("URL of Splinter Daemon"),
+                        )
+                        .arg(
+                            Arg::with_name("private_key_file")
+                                .value_name("private-key-file")
+                                .short("k")
+                                .takes_value(true)
+                                .help("Path to private key file"),
+                        )
+                        .arg(
+                            Arg::with_name("circuit_id")
+                                .value_name("circuit-id")
+                                .takes_value(true)
+                                .required(true)
+                                .help("The circuit id of the proposed circuit"),
+                        )
+                        .arg(
+                            Arg::with_name("accept")
+                                .required(true)
+                                .long("accept")
+                                .conflicts_with("reject")
+                                .possible_values(&["accept", "reject"])
+                                .help("Accept the proposal"),
+                        )
+                        .arg(
+                            Arg::with_name("reject")
+                                .required(true)
+                                .long("reject")
+                                .conflicts_with("accept")
+                                .possible_values(&["accept", "reject"])
+                                .help("Reject the proposal"),
+                        ),
+                ),
+        );
+    }
+
     let matches = app.get_matches();
 
     // set default to info
@@ -180,6 +253,18 @@ fn run() -> Result<(), CliError> {
             SubcommandActions::new().with_command("migrate", database::MigrateAction),
         )
     }
+
+    #[cfg(feature = "circuit")]
+    {
+        use action::circuit;
+        subcommands = subcommands.with_command(
+            "circuit",
+            SubcommandActions::new()
+                .with_command("create", circuit::CircuitCreateAction)
+                .with_command("vote", circuit::CircuitVoteAction),
+        );
+    }
+
     subcommands.run(Some(&matches), &mut logger_handle)
 }
 


### PR DESCRIPTION
This includes the subcommands being added to the splinter cli and the argument parsing in the Actions for create and vote. The actions themselves are not yet implemented. This is hidden behind an experimental feature called "circuit".

```
splinter-cli 0.3.8
Cargill
Command line for Splinter

USAGE:
    splinter [FLAGS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
    -v               Log verbosely

SUBCOMMANDS:
    admin      Administrative commands
    cert       Generate certificates that can be used for development
    circuit    Provides circuit management functionality
    health     Displays information about network health
    help       Prints this message or the help of the given subcommand(s)
```

```
splinter-circuit 
Provides circuit management functionality

USAGE:
    splinter circuit [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    create    Propose that a new circuit is created
    help      Prints this message or the help of the given subcommand(s)
    vote      Vote on a new circuit proposal
```

```
splinter-circuit-create 
Propose that a new circuit is created

USAGE:
    splinter circuit create [OPTIONS] <path>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -k <private-key-file>        Path to private key file
    -U <url>                     URL of Splinter Daemon

ARGS:
    <path>    Path to a yaml file that defines the circuit proposal
```

``` 
splinter-circuit-vote 
Vote on a new circuit proposal

USAGE:
    splinter circuit vote [FLAGS] [OPTIONS] <circuit-id> --accept --reject

FLAGS:
        --accept     Accept the proposal
    -h, --help       Prints help information
        --reject     Reject the proposal
    -V, --version    Prints version information

OPTIONS:
    -k <private-key-file>        Path to private key file
    -U <url>                     URL of Splinter Daemon

ARGS:
    <circuit-id>    The circuit id of the proposed circuit
```