### PR TITLE
Connection Manager Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ members = [
     "examples/gameroom/database",
     "examples/gameroom/daemon",
     "examples/cm-repl/daemon",
+    "examples/cm-repl/cli",
     "services/health"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ members = [
     "examples/private_xo",
     "examples/gameroom/database",
     "examples/gameroom/daemon",
+    "examples/cm-repl/daemon",
     "services/health"
 ]

--- a/examples/cm-repl/cli/Cargo.toml
+++ b/examples/cm-repl/cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cmc"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+
+[dependencies]
+clap = "2"
+flexi_logger = "0.14"
+log = "0.4"
+reqwest = "0.9"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"

--- a/examples/cm-repl/cli/Dockerfile
+++ b/examples/cm-repl/cli/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM splintercommunity/splinter-dev as BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+COPY protos/ /build/protos
+
+# Build the project
+WORKDIR /build/examples/cm-repl/cli
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
+# -------------=== cm-repl docker build ===-------------
+FROM ubuntu:bionic
+
+COPY --from=BUILDER /build/target/debian/cmc*.deb /tmp
+
+RUN apt-get update \
+ && dpkg --unpack /tmp/cm-repl*.deb \
+ && apt-get -f -y install
+
+CMD ["cmc"]

--- a/examples/cm-repl/cli/src/actions.rs
+++ b/examples/cm-repl/cli/src/actions.rs
@@ -1,0 +1,66 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest;
+
+pub fn add_connection(url: &str, addr: &str) {
+    let response = reqwest::Client::new()
+        .post(&format!("{}/connections/create", url))
+        .json(&json!({
+            "url": addr.to_string()
+        }))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{:?}", err);
+        }
+    };
+}
+
+pub fn remove_connection(url: &str, addr: &str) {
+    let response = reqwest::Client::new()
+        .delete(&format!("{}/connections/delete", url))
+        .json(&json!({
+            "url": addr.to_string()
+        }))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{:?}", err);
+        }
+    };
+}
+
+pub fn list_connections(url: &str) {
+    let response = reqwest::Client::new()
+        .get(&format!("{}/connections/fetch", url))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{:?}", err);
+        }
+    };
+}

--- a/examples/cm-repl/cli/src/main.rs
+++ b/examples/cm-repl/cli/src/main.rs
@@ -1,0 +1,88 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate log;
+
+mod actions;
+
+use clap::{clap_app, crate_version};
+use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+
+use actions::{add_connection, list_connections, remove_connection};
+
+pub fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}
+
+fn main() {
+    let matches = clap_app!(cmc =>
+        (version: crate_version!())
+        (about: "Connection manager client (cmc)")
+        (@arg url: +takes_value "Rest api address")
+        (@arg verbose: -v --verbose +multiple "Increase output verbosity")
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand connection =>
+            (@setting SubcommandRequiredElseHelp)
+            (about: "Add, remove, and list connections")
+            (@subcommand add =>
+                (about: "Add a new connection")
+                (@arg address: +takes_value +required "Node address you want to add as a connection")
+            )
+            (@subcommand remove =>
+                (about: "remove connection")
+                (@arg address: +takes_value +required "Node address you want to add as a connection")
+            )
+            (@subcommand list =>
+                (about: "list active connections")
+            )
+         )
+    ).get_matches();
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("tokio", log::LevelFilter::Warn);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()
+        .expect("Failed to create logger");
+
+    let url = matches.value_of("url").unwrap_or("http://localhost:3030");
+
+    match matches.subcommand() {
+        ("connection", Some(m)) => match m.subcommand() {
+            ("add", Some(m)) => add_connection(url, m.value_of("address").unwrap()),
+            ("remove", Some(m)) => remove_connection(url, m.value_of("address").unwrap()),
+            ("list", Some(_)) => list_connections(url),
+            _ => panic!("Unknown command"),
+        },
+        _ => panic!("Unknown command"),
+    }
+}

--- a/examples/cm-repl/daemon/Cargo.toml
+++ b/examples/cm-repl/daemon/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cm-repl-daemon"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+
+[dependencies]
+splinter = { path = "../../../libsplinter", features = ["connection-manager", "matrix"]}
+serde = "1.0"
+serde_json = "1.0"
+log = "0.4"
+flexi_logger = "0.14"
+clap = "2.32"
+ctrlc = "3.0"

--- a/examples/cm-repl/daemon/Dockerfile
+++ b/examples/cm-repl/daemon/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM splintercommunity/splinter-dev as BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+COPY protos/ /build/protos
+
+# Build the project
+WORKDIR /build/examples/cm-repl/daemon
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
+# -------------=== cm-repl docker build ===-------------
+FROM ubuntu:bionic
+
+COPY --from=BUILDER /build/target/debian/cm-repl*.deb /tmp
+
+RUN apt-get update \
+ && dpkg --unpack /tmp/cm-repl*.deb \
+ && apt-get -f -y install
+
+CMD ["cm-repl-daemon"]

--- a/examples/cm-repl/daemon/Dockerfile
+++ b/examples/cm-repl/daemon/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev as BUILDER
+# -------------=== Build connection manager daemon ===-------------
+
+FROM splintercommunity/splinter-dev as DAEMON_BUILDER
 
 # Copy over source files
 COPY Cargo.toml /build/Cargo.toml
@@ -27,13 +29,32 @@ ARG REPO_VERSION
 RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION
 
+# -------------=== Build connection manager cli ===-------------
+
+FROM splintercommunity/splinter-dev as CLI_BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+COPY protos/ /build/protos
+
+# Build the project
+WORKDIR /build/examples/cm-repl/cli
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
 # -------------=== cm-repl docker build ===-------------
 FROM ubuntu:bionic
 
-COPY --from=BUILDER /build/target/debian/cm-repl*.deb /tmp
+COPY --from=DAEMON_BUILDER /build/target/debian/cm-repl*.deb /tmp
+COPY --from=CLI_BUILDER /build/target/debian/cmc*.deb /tmp
 
 RUN apt-get update \
  && dpkg --unpack /tmp/cm-repl*.deb \
+ && dpkg --unpack /tmp/cmc*.deb \
  && apt-get -f -y install
 
 CMD ["cm-repl-daemon"]

--- a/examples/cm-repl/daemon/src/main.rs
+++ b/examples/cm-repl/daemon/src/main.rs
@@ -1,0 +1,135 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate clap;
+#[macro_use]
+extern crate log;
+
+mod rest_api;
+
+use clap::{clap_app, crate_version};
+use ctrlc;
+use flexi_logger::{style, DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+use rest_api::start_rest_api;
+use splinter::{
+    mesh::Mesh,
+    network::connection_manager::ConnectionManager,
+    transport::{raw::RawTransport, Incoming, Transport},
+};
+
+use std::thread;
+
+fn log_format(
+    w: &mut dyn std::io::Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    let level = record.level();
+    write!(
+        w,
+        "[{}] T[{:?}] {} [{}] {}",
+        now.now().format("%Y-%m-%d %H:%M:%S%.3f"),
+        thread::current().name().unwrap_or("<unnamed>"),
+        record.level(),
+        record.module_path().unwrap_or("<unnamed>"),
+        style(level, &record.args()),
+    )
+}
+
+fn main() {
+    let app = clap_app!(cm_poc =>
+        (version: crate_version!())
+        (about: "Proof of concept demostrating connection manager usage")
+        (@arg bind: +takes_value "Rest api address")
+        (@arg endpoint: +takes_value "Node endpoint")
+        (@arg verbose: -v --verbose +multiple "Increase output verbosity"));
+
+    let matches = app.get_matches();
+
+    let bind = matches.value_of("bind").unwrap_or("0.0.0.0:3030");
+    let endpoint = matches.value_of("endpoint").unwrap_or("tcp://0.0.0.0:3040");
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("tokio", log::LevelFilter::Warn);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()
+        .expect("Failed to create logger");
+
+    let mesh = Mesh::new(512, 512);
+
+    let mut transport = RawTransport::default();
+    let mut listener = transport
+        .listen(endpoint)
+        .expect("Failed to create listener");
+
+    let mut cm = ConnectionManager::new(
+        mesh.get_life_cycle(),
+        mesh.get_sender(),
+        Box::new(transport),
+    );
+
+    let mesh_clone = mesh.clone();
+    let _ = thread::spawn(move || {
+        for connection_result in listener.incoming() {
+            info!("Recieved connection");
+            let connection = match connection_result {
+                Ok(c) => c,
+                Err(err) => return error!("{:?}", err),
+            };
+
+            mesh_clone.add(connection).unwrap();
+        }
+    });
+
+    let mesh_incoming = mesh.incoming();
+    let _ = thread::spawn(move || loop {
+        match mesh_incoming.recv() {
+            Ok(msg) => {
+                info!("Received Message: {:?}", msg);
+            }
+            Err(err) => {
+                error!("{:?}", err);
+            }
+        }
+    });
+
+    let connector = cm.start().expect("Failed to create connection manager");
+
+    let shutdown_handle = cm.shutdown_handle().unwrap();
+    let (rest_api_shutdown_handle, join_handle) = start_rest_api(connector, &bind);
+
+    ctrlc::set_handler(move || {
+        info!("shutting down");
+        shutdown_handle.shutdown();
+        if let Err(err) = rest_api_shutdown_handle.shutdown() {
+            error!("Failed to shutdown rest api gracefully: {:?}", err);
+        }
+    })
+    .expect("Error setting up ctrl-c handler");
+
+    cm.await_shutdown();
+    join_handle.join().unwrap();
+}

--- a/examples/cm-repl/daemon/src/rest_api.rs
+++ b/examples/cm-repl/daemon/src/rest_api.rs
@@ -1,0 +1,136 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use splinter::{
+    actix_web::{web, Error, HttpResponse},
+    futures::{future::IntoFuture, stream::Stream, Future},
+    network::connection_manager::{
+        messages::{CmResponse, CmResponseStatus},
+        Connector,
+    },
+    rest_api::{Method, Resource, RestApiBuilder, RestApiShutdownHandle, RestResourceProvider},
+};
+
+pub struct Provider {
+    connector: Connector,
+}
+
+impl Provider {
+    pub fn new(connector: Connector) -> Self {
+        Self { connector }
+    }
+}
+
+impl RestResourceProvider for Provider {
+    fn resources(&self) -> Vec<Resource> {
+        vec![
+            make_add_connection(self.connector.clone()),
+            make_remove_connection(self.connector.clone()),
+            make_fetch_connections(self.connector.clone()),
+        ]
+    }
+}
+
+fn make_add_connection(connector: Connector) -> Resource {
+    Resource::build("/connections/create").add_method(Method::Post, move |_, payload| {
+        let connector = connector.clone();
+        Box::new(
+            payload
+                .from_err::<Error>()
+                .fold(web::BytesMut::new(), move |mut body, chunk| {
+                    body.extend_from_slice(&chunk);
+                    Ok::<_, Error>(body)
+                })
+                .and_then(move |body| match serde_json::from_slice::<Payload>(&body) {
+                    Ok(payload) => match connector.request_connection(&payload.url) {
+                        Ok(CmResponse::AddConnection {
+                            status,
+                            error_message,
+                        }) if status == CmResponseStatus::Error => {
+                            HttpResponse::InternalServerError().body(format!("{:?}", error_message))
+                        }
+                        Ok(res) => HttpResponse::Ok().body(format!("{:?}", res)),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                    },
+                    Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                })
+                .into_future(),
+        )
+    })
+}
+
+fn make_remove_connection(connector: Connector) -> Resource {
+    Resource::build("/connections/delete").add_method(Method::Delete, move |_, payload| {
+        let connector = connector.clone();
+        Box::new(
+            payload
+                .from_err::<Error>()
+                .fold(web::BytesMut::new(), move |mut body, chunk| {
+                    body.extend_from_slice(&chunk);
+                    Ok::<_, Error>(body)
+                })
+                .and_then(move |body| match serde_json::from_slice::<Payload>(&body) {
+                    Ok(payload) => match connector.remove_connection(&payload.url) {
+                        Ok(CmResponse::AddConnection {
+                            status,
+                            error_message,
+                        }) if status == CmResponseStatus::Error => {
+                            HttpResponse::InternalServerError().body(format!("{:?}", error_message))
+                        }
+                        Ok(res) => HttpResponse::Ok().body(format!("{:?}", res)),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                    },
+                    Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                })
+                .into_future(),
+        )
+    })
+}
+
+fn make_fetch_connections(connector: Connector) -> Resource {
+    Resource::build("/connections/fetch").add_method(Method::Get, move |_, _| {
+        match connector.list_connections() {
+            Ok(res) => Box::new(HttpResponse::Ok().body(format!("{:?}", res)).into_future()),
+            Err(err) => Box::new(
+                HttpResponse::InternalServerError()
+                    .body(format!("{:?}", err))
+                    .into_future(),
+            ),
+        }
+    })
+}
+
+#[derive(Serialize, Deserialize)]
+struct Payload {
+    url: String,
+}
+
+pub fn start_rest_api(
+    connector: Connector,
+    bind: &str,
+) -> (RestApiShutdownHandle, thread::JoinHandle<()>) {
+    let provider = Provider::new(connector);
+
+    let builder = RestApiBuilder::new();
+    builder
+        .with_bind(bind)
+        .add_resources(provider.resources())
+        .build()
+        .expect("Failed to build rest api")
+        .run()
+        .expect("Failed to start rest api")
+}

--- a/examples/cm-repl/docker-compose.yaml
+++ b/examples/cm-repl/docker-compose.yaml
@@ -1,0 +1,54 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3'
+
+services:
+  node-0:
+    image: cm-node
+    expose:
+      - 3030
+      - 3040
+    ports:
+      - 3030:3030
+      - 3040:3040
+    build:
+      context: ../..
+      dockerfile: examples/cm-repl/daemon/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    entrypoint: |
+      bash -c "
+        cm-repl-daemon -vvv
+      "
+
+  node-1:
+    image: cm-node
+    expose:
+      - 3030
+      - 3040
+    ports:
+      - 4030:3030
+      - 4040:3040
+    build:
+      context: ../..
+      dockerfile: examples/cm-repl/daemon/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    entrypoint: |
+      bash -c "
+        cm-repl-daemon -vvv
+      "
+
+

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -72,9 +72,10 @@ experimental = [
     "biome-notifications",
     "database",
     "connection-manager",
+    "matrix"
 ]
 
-connection-manager = []
+connection-manager = ["matrix"]
 zmq-transport = ["zmq"]
 ursa-compat = ["ursa"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
@@ -83,6 +84,7 @@ biome = ["database", "jsonwebtoken", "rand"]
 biome-credentials = ["biome", "database", "bcrypt"]
 biome-notifications = ["biome", "database"]
 database = ["diesel", "diesel_migrations"]
+matrix = []
 
 [package.metadata.docs.rs]
 features = [

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -68,6 +68,8 @@ pub mod database;
 pub mod events;
 mod hex;
 pub mod keys;
+#[cfg(feature = "matrix")]
+mod matrix;
 pub mod mesh;
 pub mod network;
 pub mod node_registry;

--- a/libsplinter/src/matrix.rs
+++ b/libsplinter/src/matrix.rs
@@ -1,0 +1,125 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::transport::Connection;
+
+/// MatrixLifeCycle trait abstracts out adding and removing connections to a
+/// connection handler without requiring knowledge about sending or receiving messges. 
+pub trait MatrixLifeCycle: Clone + Send {
+    fn add(&self, connection: Box<dyn Connection>) -> Result<usize, MatrixAddError>;
+    fn remove(&self, id: usize) -> Result<Box<dyn Connection>, MatrixRemoveError>;
+}
+
+pub trait MatrixSender: Clone + Send {
+    fn send(&self, id: usize, message: Vec<u8>) -> Result<(), MatrixSendError>;
+}
+
+#[derive(Debug)]
+pub struct MatrixAddError {
+    pub context: String,
+    pub source: Option<Box<dyn Error + Send>>,
+}
+
+impl MatrixAddError {
+    pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
+        Self { context, source }
+    }
+}
+
+impl Error for MatrixAddError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for MatrixAddError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MatrixRemoveError {
+    pub context: String,
+    pub source: Option<Box<dyn Error + Send>>,
+}
+
+impl MatrixRemoveError {
+    pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
+        Self { context, source }
+    }
+}
+
+impl Error for MatrixRemoveError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for MatrixRemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MatrixSendError {
+    pub context: String,
+    pub source: Option<Box<dyn Error + Send>>,
+}
+
+impl MatrixSendError {
+    pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
+        Self { context, source }
+    }
+}
+
+impl Error for MatrixSendError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(ref err) = self.source {
+            Some(&**err)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for MatrixSendError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}

--- a/libsplinter/src/matrix.rs
+++ b/libsplinter/src/matrix.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use crate::transport::Connection;
 
 /// MatrixLifeCycle trait abstracts out adding and removing connections to a
-/// connection handler without requiring knowledge about sending or receiving messges. 
+/// connection handler without requiring knowledge about sending or receiving messges.
 pub trait MatrixLifeCycle: Clone + Send {
     fn add(&self, connection: Box<dyn Connection>) -> Result<usize, MatrixAddError>;
     fn remove(&self, id: usize) -> Result<Box<dyn Connection>, MatrixRemoveError>;

--- a/libsplinter/src/mesh/control.rs
+++ b/libsplinter/src/mesh/control.rs
@@ -141,6 +141,34 @@ pub enum RemoveError {
     ReceiverDisconnected,
 }
 
+impl Error for RemoveError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RemoveError::Io(err) => Some(err),
+            RemoveError::NotFound => None,
+            RemoveError::SenderDisconnected(_) => None,
+            RemoveError::ReceiverDisconnected => None,
+        }
+    }
+}
+
+impl fmt::Display for RemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RemoveError::Io(ref err) => {
+                write!(f, "io error while trying to remove connection {}", err)
+            }
+            RemoveError::NotFound => write!(f, "unable to remove connection, connection not found"),
+            RemoveError::SenderDisconnected(_) => {
+                write!(f, "unable to remove connection, sender disconnected")
+            }
+            RemoveError::ReceiverDisconnected => {
+                write!(f, "unable to remove connection, receiver disconnected")
+            }
+        }
+    }
+}
+
 impl From<mio_channel::SendError<ControlRequest>> for RemoveError {
     fn from(err: mio_channel::SendError<ControlRequest>) -> Self {
         match err {

--- a/libsplinter/src/mesh/matrix.rs
+++ b/libsplinter/src/mesh/matrix.rs
@@ -1,0 +1,74 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::matrix::{
+    MatrixAddError, MatrixLifeCycle, MatrixRemoveError, MatrixSendError, MatrixSender,
+};
+use crate::transport::Connection;
+
+use super::{Envelope, Mesh};
+
+#[derive(Clone)]
+pub struct MeshLifeCycle {
+    mesh: Mesh,
+}
+
+impl MeshLifeCycle {
+    pub fn new(mesh: Mesh) -> Self {
+        MeshLifeCycle { mesh }
+    }
+}
+
+impl MatrixLifeCycle for MeshLifeCycle {
+    fn add(&self, connection: Box<dyn Connection>) -> Result<usize, MatrixAddError> {
+        self.mesh.add(connection).map_err(|err| {
+            MatrixAddError::new(
+                "Unable to add connection to Matrix.".to_string(),
+                Some(Box::new(err)),
+            )
+        })
+    }
+
+    fn remove(&self, id: usize) -> Result<Box<dyn Connection>, MatrixRemoveError> {
+        self.mesh.remove(id).map_err(|err| {
+            MatrixRemoveError::new(
+                "Unable to remove connection from Matrix.".to_string(),
+                Some(Box::new(err)),
+            )
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct MeshMatrixSender {
+    mesh: Mesh,
+}
+
+impl MeshMatrixSender {
+    pub fn new(mesh: Mesh) -> Self {
+        MeshMatrixSender { mesh }
+    }
+}
+
+impl MatrixSender for MeshMatrixSender {
+    fn send(&self, id: usize, message: Vec<u8>) -> Result<(), MatrixSendError> {
+        let envelope = Envelope::new(id, message);
+        self.mesh.send(envelope).map_err(|err| {
+            MatrixSendError::new(
+                "Unable to send message to connection.".to_string(),
+                Some(Box::new(err)),
+            )
+        })
+    }
+}

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -51,6 +51,8 @@
 
 mod control;
 mod incoming;
+#[cfg(feature = "matrix")]
+mod matrix;
 mod outgoing;
 mod pool;
 mod reactor;
@@ -63,6 +65,8 @@ use std::time::Duration;
 
 pub use crate::mesh::control::{AddError, Control, RemoveError};
 pub use crate::mesh::incoming::Incoming;
+#[cfg(feature = "matrix")]
+pub use crate::mesh::matrix::{MeshLifeCycle, MeshMatrixSender};
 pub use crate::mesh::outgoing::Outgoing;
 
 use crate::mesh::reactor::Reactor;
@@ -173,6 +177,18 @@ impl Mesh {
     /// This is useful if an object only needs to receive and doesn't need to send.
     pub fn incoming(&self) -> Incoming {
         self.incoming.clone()
+    }
+
+    #[cfg(feature = "matrix")]
+    pub fn get_life_cycle(&self) -> MeshLifeCycle {
+        let mesh = self.clone();
+        MeshLifeCycle::new(mesh)
+    }
+
+    #[cfg(feature = "matrix")]
+    pub fn get_sender(&self) -> MeshMatrixSender {
+        let mesh = self.clone();
+        MeshMatrixSender::new(mesh)
     }
 }
 

--- a/libsplinter/src/network/connection_manager/heartbeat_monitor.rs
+++ b/libsplinter/src/network/connection_manager/heartbeat_monitor.rs
@@ -1,0 +1,100 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc::SyncSender,
+    Arc,
+};
+use std::thread;
+use std::time::Duration;
+
+use crate::network::connection_manager::{error::ConnectionManagerError, messages::CmMessage};
+
+pub struct HeartbeatMonitor {
+    interval: u64,
+    join_handle: Option<thread::JoinHandle<()>>,
+    shutdown_handle: Option<HbShutdownHandle>,
+}
+
+impl HeartbeatMonitor {
+    pub fn new(interval: u64) -> Self {
+        Self {
+            interval,
+            join_handle: None,
+            shutdown_handle: None,
+        }
+    }
+
+    pub fn start(&mut self, cm_sender: SyncSender<CmMessage>) -> Result<(), ConnectionManagerError> {
+        if self.join_handle.is_some() {
+            return Ok(());
+        }
+
+        let running = Arc::new(AtomicBool::new(true));
+
+        let running_clone = running.clone();
+        let interval = self.interval;
+        let join_handle = thread::Builder::new()
+            .name("Heartbeat Monitor".into())
+            .spawn(move || {
+                info!("Starting heartbeat manager");
+
+                while running_clone.load(Ordering::SeqCst) {
+                    thread::sleep(Duration::from_secs(interval));
+                    if let Err(err) = cm_sender.send(CmMessage::SendHeartbeats) {
+                        error!(
+                            "Connection manager has disconnected before 
+                            shutting down heartbeat monitor {:?}",
+                            err
+                        );
+                        break;
+                    }
+                }
+            })?;
+
+        self.join_handle = Some(join_handle);
+        self.shutdown_handle = Some(HbShutdownHandle { running });
+
+        Ok(())
+    }
+
+    pub fn shutdown_handle(&self) -> Option<HbShutdownHandle> {
+        self.shutdown_handle.clone()
+    }
+
+    pub fn await_shutdown(self) {
+        let join_handle = if let Some(jh) = self.join_handle {
+            jh
+        } else {
+            return;
+        };
+
+        if let Err(err) = join_handle.join() {
+            error!("Failed to shutdown heartbeat monitor gracefully: {:?}", err);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HbShutdownHandle {
+    running: Arc<AtomicBool>,
+}
+
+impl HbShutdownHandle {
+    pub fn shutdown(&self) {
+        self.running.store(false, Ordering::SeqCst)
+    }
+}

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -18,7 +18,7 @@ use crate::network::connection_manager::error::ConnectionManagerError;
 
 pub enum CmMessage {
     Shutdown,
-    Subscribe(String, SyncSender<Vec<CmNotification>>),
+    Subscribe(String, SyncSender<CmNotification>),
     UnSubscribe(String),
     Request(CmRequest),
     SendHeartbeats,

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crossbeam_channel::Sender;
+use std::sync::mpsc::SyncSender;
 
 use crate::network::connection_manager::error::ConnectionManagerError;
 
 pub enum CmMessage {
     Shutdown,
-    Subscribe(String, Sender<Vec<CmNotification>>),
+    Subscribe(String, SyncSender<Vec<CmNotification>>),
     UnSubscribe(String),
     Request(CmRequest),
     HeartbeatNotifications(Vec<CmNotification>),
 }
 
 pub struct CmRequest {
-    pub sender: Sender<CmResponse>,
+    pub sender: SyncSender<CmResponse>,
     pub payload: CmPayload,
 }
 

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -21,7 +21,7 @@ pub enum CmMessage {
     Subscribe(String, SyncSender<Vec<CmNotification>>),
     UnSubscribe(String),
     Request(CmRequest),
-    HeartbeatNotifications(Vec<CmNotification>),
+    SendHeartbeats,
 }
 
 pub struct CmRequest {

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -32,6 +32,7 @@ pub struct CmRequest {
 pub enum CmPayload {
     AddConnection { endpoint: String },
     RemoveConnection { endpoint: String },
+    ListConnections,
 }
 
 #[derive(Debug, PartialEq)]
@@ -43,6 +44,9 @@ pub enum CmResponse {
     RemoveConnection {
         status: CmResponseStatus,
         error_message: Option<String>,
+    },
+    ListConnections {
+        endpoints: Vec<String>,
     },
 }
 

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -18,8 +18,7 @@ use crate::network::connection_manager::error::ConnectionManagerError;
 
 pub enum CmMessage {
     Shutdown,
-    Subscribe(String, SyncSender<CmNotification>),
-    UnSubscribe(String),
+    Subscribe(SyncSender<CmNotification>),
     Request(CmRequest),
     SendHeartbeats,
 }

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -32,11 +32,16 @@ pub struct CmRequest {
 #[derive(Debug, PartialEq)]
 pub enum CmPayload {
     AddConnection { endpoint: String },
+    RemoveConnection { endpoint: String },
 }
 
 #[derive(Debug, PartialEq)]
 pub enum CmResponse {
     AddConnection {
+        status: CmResponseStatus,
+        error_message: Option<String>,
+    },
+    RemoveConnection {
         status: CmResponseStatus,
         error_message: Option<String>,
     },
@@ -46,6 +51,7 @@ pub enum CmResponse {
 pub enum CmResponseStatus {
     OK,
     Error,
+    ConnectionNotFound,
 }
 
 /// Messages that will be dispatched to all

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -198,7 +198,7 @@ impl ShutdownHandle {
     pub fn shutdown(&self) {
         self.hb_shutdown_handle.shutdown();
 
-        if let Err(_) = self.sender.send(CmMessage::Shutdown) {
+        if self.sender.send(CmMessage::Shutdown).is_err() {
             warn!("Connection manager is no longer running");
         }
     }
@@ -255,7 +255,7 @@ impl ConnectionState {
 
     fn add_connection(&mut self, endpoint: &str) -> Result<(), ConnectionManagerError> {
         if let Some(meta) = self.connections.get_mut(endpoint) {
-            meta.ref_count = meta.ref_count + 1;
+            meta.ref_count += 1;
         } else {
             let connection = self.transport.connect(endpoint).map_err(|err| {
                 ConnectionManagerError::ConnectionCreationError(format!("{:?}", err))
@@ -283,7 +283,7 @@ impl ConnectionState {
         endpoint: &str,
     ) -> Result<Option<ConnectionMetadata>, ConnectionManagerError> {
         let meta = if let Some(meta) = self.connections.get_mut(endpoint) {
-            meta.ref_count = meta.ref_count - 1;
+            meta.ref_count -= 1;
             meta.clone()
         } else {
             return Ok(None);
@@ -344,7 +344,7 @@ fn handle_request(req: CmRequest, state: &mut ConnectionState) {
         },
     };
 
-    if let Err(_) = req.sender.send(response) {
+    if req.sender.send(response).is_err() {
         error!("Requester has dropped its connection to connection manager");
     }
 }
@@ -354,7 +354,7 @@ fn notify_subscribers(
     notifications: Vec<CmNotification>,
 ) {
     for (id, sender) in subscribers.clone() {
-        if let Err(_) = sender.send(notifications.clone()) {
+        if sender.send(notifications.clone()).is_err() {
             warn!("subscriber has dropped its connection to connection manager");
             subscribers.remove(&id);
         }

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -571,7 +571,7 @@ pub mod tests {
     #[test]
     fn test_heartbeat_notifications_raw_tcp() {
         let mut transport = Box::new(RawTransport::default());
-        let mut listener = transport.listen("tcp://localhost:8080").unwrap();
+        let mut listener = transport.listen("tcp://localhost:3030").unwrap();
         let mesh = Mesh::new(512, 128);
         let mesh_clone = mesh.clone();
 
@@ -584,7 +584,7 @@ pub mod tests {
         let connector = cm.start().unwrap();
 
         let response = connector
-            .request_connection("tcp://localhost:8080")
+            .request_connection("tcp://localhost:3030")
             .unwrap();
 
         assert_eq!(
@@ -601,7 +601,7 @@ pub mod tests {
 
         assert!(notifications.iter().any(|x| *x
             == CmNotification::HeartbeatSent {
-                endpoint: "tcp://localhost:8080".to_string(),
+                endpoint: "tcp://localhost:3030".to_string(),
             }));
 
         // Verify mesh received heartbeat
@@ -617,7 +617,7 @@ pub mod tests {
     #[test]
     fn test_remove_connection() {
         let mut transport = Box::new(RawTransport::default());
-        let mut listener = transport.listen("tcp://localhost:8080").unwrap();
+        let mut listener = transport.listen("tcp://localhost:3030").unwrap();
         let mesh = Mesh::new(512, 128);
         let mesh_clone = mesh.clone();
 
@@ -630,7 +630,7 @@ pub mod tests {
         let connector = cm.start().unwrap();
 
         let add_response = connector
-            .request_connection("tcp://localhost:8080")
+            .request_connection("tcp://localhost:3030")
             .unwrap();
 
         assert_eq!(
@@ -641,7 +641,7 @@ pub mod tests {
             }
         );
 
-        let remove_response = connector.remove_connection("tcp://localhost:8080").unwrap();
+        let remove_response = connector.remove_connection("tcp://localhost:3030").unwrap();
 
         assert_eq!(
             remove_response,
@@ -655,7 +655,7 @@ pub mod tests {
     #[test]
     fn test_remove_nonexistent_connection() {
         let mut transport = Box::new(RawTransport::default());
-        let mut listener = transport.listen("tcp://localhost:8080").unwrap();
+        let mut listener = transport.listen("tcp://localhost:3030").unwrap();
         let mesh = Mesh::new(512, 128);
         let mesh_clone = mesh.clone();
 
@@ -667,7 +667,7 @@ pub mod tests {
         let mut cm = ConnectionManager::new(mesh.clone(), transport);
         let connector = cm.start().unwrap();
 
-        let remove_response = connector.remove_connection("tcp://localhost:8080").unwrap();
+        let remove_response = connector.remove_connection("tcp://localhost:3030").unwrap();
 
         assert_eq!(
             remove_response,

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -25,7 +25,6 @@ pub use error::ConnectionManagerError;
 pub use messages::{CmMessage, CmNotification, CmPayload, CmRequest, CmResponse, CmResponseStatus};
 use pacemaker::Pacemaker;
 use protobuf::Message;
-use uuid::Uuid;
 
 use crate::mesh::{Envelope, Mesh};
 use crate::protos::network::{NetworkHeartbeat, NetworkMessage, NetworkMessageType};
@@ -69,15 +68,12 @@ impl ConnectionManager {
         let join_handle = thread::Builder::new()
             .name("Connection Manager".into())
             .spawn(move || {
-                let mut subscribers = HashMap::new();
+                let mut subscribers = Vec::new();
                 loop {
                     match recv.recv() {
                         Ok(CmMessage::Shutdown) => break,
-                        Ok(CmMessage::Subscribe(id, sender)) => {
-                            subscribers.insert(id, sender);
-                        }
-                        Ok(CmMessage::UnSubscribe(ref id)) => {
-                            subscribers.remove(id);
+                        Ok(CmMessage::Subscribe(sender)) => {
+                            subscribers.push(sender);
                         }
                         Ok(CmMessage::Request(req)) => {
                             handle_request(req, &mut state);
@@ -155,14 +151,9 @@ impl Connector {
     }
 
     pub fn subscribe(&self) -> Result<NotificationHandler, ConnectionManagerError> {
-        let id = Uuid::new_v4().to_string();
-        let (send, recv) = sync_channel(1);
-        match self.sender.send(CmMessage::Subscribe(id.clone(), send)) {
-            Ok(()) => Ok(NotificationHandler {
-                id,
-                recv,
-                sender: self.sender.clone(),
-            }),
+        let (send, recv) = sync_channel(CHANNEL_CAPACITY);
+        match self.sender.send(CmMessage::Subscribe(send)) {
+            Ok(()) => Ok(NotificationHandler { recv }),
             Err(_) => Err(ConnectionManagerError::SendMessageError(
                 "The connection manager is no longer running".into(),
             )),
@@ -205,8 +196,6 @@ impl ShutdownHandle {
 }
 
 pub struct NotificationHandler {
-    id: String,
-    sender: SyncSender<CmMessage>,
     recv: Receiver<CmNotification>,
 }
 
@@ -217,16 +206,6 @@ impl NotificationHandler {
             Err(TryRecvError::Empty) => Ok(None),
             Err(TryRecvError::Disconnected) => Err(ConnectionManagerError::SendMessageError(
                 "The connection manager is no longer running".into(),
-            )),
-        }
-    }
-
-    pub fn unsubscribe(&self) -> Result<(), ConnectionManagerError> {
-        let message = CmMessage::UnSubscribe(self.id.clone());
-        match self.sender.send(message) {
-            Ok(()) => Ok(()),
-            Err(_) => Err(ConnectionManagerError::SendMessageError(
-                "Unsubscribe request timed out".into(),
             )),
         }
     }
@@ -365,21 +344,20 @@ fn handle_request(req: CmRequest, state: &mut ConnectionState) {
 }
 
 fn notify_subscribers(
-    subscribers: &mut HashMap<String, SyncSender<CmNotification>>,
+    subscribers: &mut Vec<SyncSender<CmNotification>>,
     notification: CmNotification,
 ) {
-    for (id, sender) in subscribers.clone() {
-        if let Err(_) = sender.send(notification.clone()) {
+    subscribers.retain(|sender| {
+        if sender.send(notification.clone()).is_err() {
             warn!("subscriber has dropped its connection to connection manager");
-            subscribers.remove(&id);
+            false
+        } else {
+            true
         }
-    }
+    });
 }
 
-fn send_heartbeats(
-    state: &mut ConnectionState,
-    subscribers: &mut HashMap<String, SyncSender<CmNotification>>,
-) {
+fn send_heartbeats(state: &mut ConnectionState, subscribers: &mut Vec<SyncSender<CmNotification>>) {
     for (endpoint, metadata) in state.connection_metadata() {
         info!("Sending heartbeat to {}", endpoint);
         if let Err(err) = state
@@ -452,22 +430,6 @@ pub mod tests {
         let mut cm = ConnectionManager::new(mesh, transport);
 
         cm.start().unwrap();
-        cm.shutdown_and_wait();
-    }
-
-    #[test]
-    fn test_notification_handler_subscribe_unsubscribe() {
-        let mut transport = Box::new(InprocTransport::default());
-        transport.listen("inproc://test").unwrap();
-        let mesh = Mesh::new(512, 128);
-
-        let mut cm = ConnectionManager::new(mesh, transport);
-
-        let connector = cm.start().unwrap();
-
-        let subscriber = connector.subscribe().unwrap();
-        subscriber.unsubscribe().unwrap();
-
         cm.shutdown_and_wait();
     }
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -26,24 +26,32 @@ pub use messages::{CmMessage, CmNotification, CmPayload, CmRequest, CmResponse, 
 use pacemaker::Pacemaker;
 use protobuf::Message;
 
-use crate::mesh::{Envelope, Mesh};
+use crate::matrix::{MatrixLifeCycle, MatrixSender};
 use crate::protos::network::{NetworkHeartbeat, NetworkMessage, NetworkMessageType};
 use crate::transport::Transport;
 
 const DEFAULT_HEARTBEAT_INTERVAL: u64 = 10;
 const CHANNEL_CAPACITY: usize = 15;
 
-pub struct ConnectionManager {
+pub struct ConnectionManager<T: 'static, U: 'static>
+where
+    T: MatrixLifeCycle,
+    U: MatrixSender,
+{
     pacemaker: Pacemaker,
-    connection_state: Option<ConnectionState>,
+    connection_state: Option<ConnectionState<T, U>>,
     join_handle: Option<thread::JoinHandle<()>>,
     sender: Option<SyncSender<CmMessage>>,
     shutdown_handle: Option<ShutdownHandle>,
 }
 
-impl ConnectionManager {
-    pub fn new(mesh: Mesh, transport: Box<dyn Transport + Send>) -> Self {
-        let connection_state = Some(ConnectionState::new(mesh, transport));
+impl<T, U> ConnectionManager<T, U>
+where
+    T: MatrixLifeCycle,
+    U: MatrixSender,
+{
+    pub fn new(life_cycle: T, matrix_sender: U, transport: Box<dyn Transport + Send>) -> Self {
+        let connection_state = Some(ConnectionState::new(life_cycle, matrix_sender, transport));
         let pacemaker = Pacemaker::new(DEFAULT_HEARTBEAT_INTERVAL);
 
         Self {
@@ -232,16 +240,26 @@ struct ConnectionMetadata {
     ref_count: u64,
 }
 
-struct ConnectionState {
+struct ConnectionState<T, U>
+where
+    T: MatrixLifeCycle,
+    U: MatrixSender,
+{
     connections: HashMap<String, ConnectionMetadata>,
-    mesh: Mesh,
+    life_cycle: T,
+    matrix_sender: U,
     transport: Box<dyn Transport>,
 }
 
-impl ConnectionState {
-    fn new(mesh: Mesh, transport: Box<dyn Transport + Send>) -> Self {
+impl<T, U> ConnectionState<T, U>
+where
+    T: MatrixLifeCycle,
+    U: MatrixSender,
+{
+    fn new(life_cycle: T, matrix_sender: U, transport: Box<dyn Transport + Send>) -> Self {
         Self {
-            mesh,
+            life_cycle,
+            matrix_sender,
             transport,
             connections: HashMap::new(),
         }
@@ -255,7 +273,7 @@ impl ConnectionState {
                 ConnectionManagerError::ConnectionCreationError(format!("{:?}", err))
             })?;
 
-            let id = self.mesh.add(connection).map_err(|err| {
+            let id = self.life_cycle.add(connection).map_err(|err| {
                 ConnectionManagerError::ConnectionCreationError(format!("{:?}", err))
             })?;
 
@@ -285,7 +303,7 @@ impl ConnectionState {
 
         if meta.ref_count < 1 {
             self.connections.remove(endpoint);
-            self.mesh.remove(meta.id).map_err(|err| {
+            self.life_cycle.remove(meta.id).map_err(|err| {
                 ConnectionManagerError::ConnectionRemovalError(format!("{:?}", err))
             })?;
         }
@@ -302,12 +320,15 @@ impl ConnectionState {
         self.connections.clone()
     }
 
-    fn mesh(&self) -> Mesh {
-        self.mesh.clone()
+    fn matrix_sender(&self) -> U {
+        self.matrix_sender.clone()
     }
 }
 
-fn handle_request(req: CmRequest, state: &mut ConnectionState) {
+fn handle_request<T: MatrixLifeCycle, U: MatrixSender>(
+    req: CmRequest,
+    state: &mut ConnectionState<T, U>,
+) {
     let response = match req.payload {
         CmPayload::AddConnection { ref endpoint } => {
             if let Err(err) = state.add_connection(endpoint) {
@@ -357,13 +378,13 @@ fn notify_subscribers(
     });
 }
 
-fn send_heartbeats(state: &mut ConnectionState, subscribers: &mut Vec<SyncSender<CmNotification>>) {
+fn send_heartbeats<T: MatrixLifeCycle, U: MatrixSender>(
+    state: &mut ConnectionState<T, U>,
+    subscribers: &mut Vec<SyncSender<CmNotification>>,
+) {
     for (endpoint, metadata) in state.connection_metadata() {
         info!("Sending heartbeat to {}", endpoint);
-        if let Err(err) = state
-            .mesh()
-            .send(Envelope::new(metadata.id, create_heartbeat()))
-        {
+        if let Err(err) = state.matrix_sender().send(metadata.id, create_heartbeat()) {
             error!(
                 "failed to send heartbeat: {:?} attempting reconnection",
                 err
@@ -418,6 +439,7 @@ fn create_heartbeat() -> Vec<u8> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::mesh::Mesh;
     use crate::transport::inproc::InprocTransport;
     use crate::transport::raw::RawTransport;
 
@@ -427,7 +449,7 @@ pub mod tests {
         transport.listen("inproc://test").unwrap();
         let mesh = Mesh::new(512, 128);
 
-        let mut cm = ConnectionManager::new(mesh, transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
 
         cm.start().unwrap();
         cm.shutdown_and_wait();
@@ -443,7 +465,7 @@ pub mod tests {
         });
 
         let mesh = Mesh::new(512, 128);
-        let mut cm = ConnectionManager::new(mesh, transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let response = connector.request_connection("inproc://test").unwrap();
@@ -470,7 +492,7 @@ pub mod tests {
         });
 
         let mesh = Mesh::new(512, 128);
-        let mut cm = ConnectionManager::new(mesh, transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let response = connector.request_connection("inproc://test").unwrap();
@@ -511,7 +533,7 @@ pub mod tests {
             mesh_clone.add(conn).unwrap();
         });
 
-        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let response = connector.request_connection("inproc://test").unwrap();
@@ -557,7 +579,7 @@ pub mod tests {
             mesh_clone.add(conn).unwrap();
         });
 
-        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let response = connector
@@ -605,7 +627,7 @@ pub mod tests {
             mesh_clone.add(conn).unwrap();
         });
 
-        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let add_response = connector
@@ -643,7 +665,7 @@ pub mod tests {
             mesh_clone.add(conn).unwrap();
         });
 
-        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let mut cm = ConnectionManager::new(mesh.get_life_cycle(), mesh.get_sender(), transport);
         let connector = cm.start().unwrap();
 
         let remove_response = connector.remove_connection("tcp://localhost:3030").unwrap();

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -39,7 +39,7 @@ const CHANNEL_CAPACITY: usize = 15;
 
 pub struct ConnectionManager {
     hb_monitor: HeartbeatMonitor,
-    connection_state: ConnectionState,
+    connection_state: Option<ConnectionState>,
     join_handle: Option<thread::JoinHandle<()>>,
     sender: Option<SyncSender<CmMessage>>,
     shutdown_handle: Option<ShutdownHandle>,
@@ -47,9 +47,8 @@ pub struct ConnectionManager {
 
 impl ConnectionManager {
     pub fn new(mesh: Mesh, transport: Box<dyn Transport + Send>) -> Self {
-        let connection_state = ConnectionState::new(mesh, transport);
-        let hb_monitor =
-            HeartbeatMonitor::new(DEFAULT_HEARTBEAT_INTERVAL);
+        let connection_state = Some(ConnectionState::new(mesh, transport));
+        let hb_monitor = HeartbeatMonitor::new(DEFAULT_HEARTBEAT_INTERVAL);
 
         Self {
             hb_monitor,
@@ -62,7 +61,13 @@ impl ConnectionManager {
 
     pub fn start(&mut self) -> Result<Connector, ConnectionManagerError> {
         let (sender, recv) = sync_channel(CHANNEL_CAPACITY);
-        let mut state = self.connection_state.clone();
+        let mut state = if let Some(state) = self.connection_state.take() {
+            state
+        } else {
+            return Err(ConnectionManagerError::StartUpError(
+                "Service was already started".into(),
+            ));
+        };
 
         let join_handle = thread::Builder::new()
             .name("Connection Manager".into())
@@ -301,7 +306,6 @@ struct ConnectionMetadata {
     ref_count: u64,
 }
 
-#[derive(Clone)]
 struct ConnectionState {
     connections: HashMap<String, ConnectionMetadata>,
     mesh: Mesh,

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 mod error;
-mod heartbeat_monitor;
 mod messages;
+mod pacemaker;
 
 use std;
 use std::collections::HashMap;
@@ -22,8 +22,8 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::thread;
 
 pub use error::ConnectionManagerError;
-use heartbeat_monitor::{HbShutdownHandle, HeartbeatMonitor};
 pub use messages::{CmMessage, CmNotification, CmPayload, CmRequest, CmResponse, CmResponseStatus};
+use pacemaker::Pacemaker;
 use protobuf::Message;
 use uuid::Uuid;
 
@@ -35,7 +35,7 @@ const DEFAULT_HEARTBEAT_INTERVAL: u64 = 10;
 const CHANNEL_CAPACITY: usize = 15;
 
 pub struct ConnectionManager {
-    hb_monitor: HeartbeatMonitor,
+    pacemaker: Pacemaker,
     connection_state: Option<ConnectionState>,
     join_handle: Option<thread::JoinHandle<()>>,
     sender: Option<SyncSender<CmMessage>>,
@@ -45,10 +45,10 @@ pub struct ConnectionManager {
 impl ConnectionManager {
     pub fn new(mesh: Mesh, transport: Box<dyn Transport + Send>) -> Self {
         let connection_state = Some(ConnectionState::new(mesh, transport));
-        let hb_monitor = HeartbeatMonitor::new(DEFAULT_HEARTBEAT_INTERVAL);
+        let pacemaker = Pacemaker::new(DEFAULT_HEARTBEAT_INTERVAL);
 
         Self {
-            hb_monitor,
+            pacemaker,
             connection_state,
             join_handle: None,
             sender: None,
@@ -93,11 +93,11 @@ impl ConnectionManager {
                 }
             })?;
 
-        self.hb_monitor.start(sender.clone())?;
+        self.pacemaker.start(sender.clone())?;
         self.join_handle = Some(join_handle);
         self.shutdown_handle = Some(ShutdownHandle {
             sender: sender.clone(),
-            hb_shutdown_handle: self.hb_monitor.shutdown_handle().unwrap(),
+            pacemaker_shutdown_handle: self.pacemaker.shutdown_handle().unwrap(),
         });
         self.sender = Some(sender.clone());
 
@@ -109,7 +109,7 @@ impl ConnectionManager {
     }
 
     pub fn await_shutdown(self) {
-        self.hb_monitor.await_shutdown();
+        self.pacemaker.await_shutdown();
 
         let join_handle = if let Some(jh) = self.join_handle {
             jh
@@ -191,12 +191,12 @@ impl Connector {
 #[derive(Clone)]
 pub struct ShutdownHandle {
     sender: SyncSender<CmMessage>,
-    hb_shutdown_handle: HbShutdownHandle,
+    pacemaker_shutdown_handle: pacemaker::ShutdownHandle,
 }
 
 impl ShutdownHandle {
     pub fn shutdown(&self) {
-        self.hb_shutdown_handle.shutdown();
+        self.pacemaker_shutdown_handle.shutdown();
 
         if self.sender.send(CmMessage::Shutdown).is_err() {
             warn!("Connection manager is no longer running");

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -13,19 +13,16 @@
 // limitations under the License.
 
 mod error;
+mod heartbeat_monitor;
 mod messages;
 
 use std;
 use std::collections::HashMap;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    mpsc::{sync_channel, Receiver, SyncSender},
-    Arc,
-};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::thread;
-use std::time::Duration;
 
 pub use error::ConnectionManagerError;
+use heartbeat_monitor::{HbShutdownHandle, HeartbeatMonitor};
 pub use messages::{CmMessage, CmNotification, CmPayload, CmRequest, CmResponse, CmResponseStatus};
 use protobuf::Message;
 use uuid::Uuid;
@@ -139,67 +136,6 @@ impl ConnectionManager {
     }
 }
 
-struct HeartbeatMonitor {
-    interval: u64,
-    join_handle: Option<thread::JoinHandle<()>>,
-    shutdown_handle: Option<HbShutdownHandle>,
-}
-
-impl HeartbeatMonitor {
-    fn new(interval: u64) -> Self {
-        Self {
-            interval,
-            join_handle: None,
-            shutdown_handle: None,
-        }
-    }
-
-    fn start(&mut self, cm_sender: SyncSender<CmMessage>) -> Result<(), ConnectionManagerError> {
-        if self.join_handle.is_some() {
-            return Ok(());
-        }
-
-        let running = Arc::new(AtomicBool::new(true));
-
-        let running_clone = running.clone();
-        let interval = self.interval;
-        let join_handle = thread::Builder::new()
-            .name("Heartbeat Monitor".into())
-            .spawn(move || {
-                info!("Starting heartbeat manager");
-
-                while running_clone.load(Ordering::SeqCst) {
-                    thread::sleep(Duration::from_secs(interval));
-                    if let Err(err) = cm_sender.send(CmMessage::SendHeartbeats) {
-                        error!("Connection manager has disconnected before shutting down heartbeat monitor {:?}", err);
-                        break;
-                    }
-                }
-            })?;
-
-        self.join_handle = Some(join_handle);
-        self.shutdown_handle = Some(HbShutdownHandle { running });
-
-        Ok(())
-    }
-
-    fn shutdown_handle(&self) -> Option<HbShutdownHandle> {
-        self.shutdown_handle.clone()
-    }
-
-    fn await_shutdown(self) {
-        let join_handle = if let Some(jh) = self.join_handle {
-            jh
-        } else {
-            return;
-        };
-
-        if let Err(err) = join_handle.join() {
-            error!("Failed to shutdown heartbeat monitor gracefully: {:?}", err);
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Connector {
     sender: SyncSender<CmMessage>,
@@ -258,17 +194,6 @@ impl ShutdownHandle {
         if let Err(_) = self.sender.send(CmMessage::Shutdown) {
             warn!("Connection manager is no longer running");
         }
-    }
-}
-
-#[derive(Clone)]
-struct HbShutdownHandle {
-    running: Arc<AtomicBool>,
-}
-
-impl HbShutdownHandle {
-    pub fn shutdown(&self) {
-        self.running.store(false, Ordering::SeqCst)
     }
 }
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -158,6 +158,10 @@ impl Connector {
         })
     }
 
+    pub fn list_connections(&self) -> Result<CmResponse, ConnectionManagerError> {
+        self.send_payload(CmPayload::ListConnections)
+    }
+
     pub fn subscribe(&self) -> Result<Notifier, ConnectionManagerError> {
         let (send, recv) = sync_channel(CHANNEL_CAPACITY);
         match self.sender.send(CmMessage::Subscribe(send)) {
@@ -356,6 +360,13 @@ fn handle_request<T: MatrixLifeCycle, U: MatrixSender>(
                 status: CmResponseStatus::Error,
                 error_message: Some(format!("{:?}", err)),
             },
+        },
+        CmPayload::ListConnections => CmResponse::ListConnections {
+            endpoints: state
+                .connection_metadata()
+                .iter()
+                .map(|(key, _)| key.to_string())
+                .collect(),
         },
     };
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -207,11 +207,11 @@ impl ShutdownHandle {
 pub struct NotificationHandler {
     id: String,
     sender: SyncSender<CmMessage>,
-    recv: Receiver<Vec<CmNotification>>,
+    recv: Receiver<CmNotification>,
 }
 
 impl NotificationHandler {
-    pub fn listen(&self) -> Result<Vec<CmNotification>, ConnectionManagerError> {
+    pub fn listen(&self) -> Result<CmNotification, ConnectionManagerError> {
         match self.recv.recv() {
             Ok(notifications) => Ok(notifications),
             Err(_) => Err(ConnectionManagerError::SendMessageError(
@@ -350,11 +350,11 @@ fn handle_request(req: CmRequest, state: &mut ConnectionState) {
 }
 
 fn notify_subscribers(
-    subscribers: &mut HashMap<String, SyncSender<Vec<CmNotification>>>,
-    notifications: Vec<CmNotification>,
+    subscribers: &mut HashMap<String, SyncSender<CmNotification>>,
+    notification: CmNotification,
 ) {
     for (id, sender) in subscribers.clone() {
-        if sender.send(notifications.clone()).is_err() {
+        if let Err(_) = sender.send(notification.clone()) {
             warn!("subscriber has dropped its connection to connection manager");
             subscribers.remove(&id);
         }
@@ -363,10 +363,8 @@ fn notify_subscribers(
 
 fn send_heartbeats(
     state: &mut ConnectionState,
-    subscribers: &mut HashMap<String, SyncSender<Vec<CmNotification>>>,
+    subscribers: &mut HashMap<String, SyncSender<CmNotification>>,
 ) {
-    let mut notifications = Vec::new();
-
     for (endpoint, metadata) in state.connection_metadata() {
         info!("Sending heartbeat to {}", endpoint);
         if let Err(err) = state
@@ -378,30 +376,40 @@ fn send_heartbeats(
                 err
             );
 
-            notifications.push(CmNotification::HeartbeatSendFail {
-                endpoint: endpoint.clone(),
-                message: format!("{:?}", err),
-            });
+            notify_subscribers(
+                subscribers,
+                CmNotification::HeartbeatSendFail {
+                    endpoint: endpoint.clone(),
+                    message: format!("{:?}", err),
+                },
+            );
 
             if let Err(err) = state.reconnect(&endpoint) {
                 error!("Connection reattempt failed: {:?}", err);
-                notifications.push(CmNotification::ReconnectAttemptFailed {
-                    endpoint: endpoint.clone(),
-                    message: format!("{:?}", err),
-                });
+                notify_subscribers(
+                    subscribers,
+                    CmNotification::ReconnectAttemptFailed {
+                        endpoint: endpoint.clone(),
+                        message: format!("{:?}", err),
+                    },
+                );
             } else {
-                notifications.push(CmNotification::ReconnectAttemptSuccess {
-                    endpoint: endpoint.clone(),
-                });
+                notify_subscribers(
+                    subscribers,
+                    CmNotification::ReconnectAttemptSuccess {
+                        endpoint: endpoint.clone(),
+                    },
+                );
             }
         } else {
-            notifications.push(CmNotification::HeartbeatSent {
-                endpoint: endpoint.clone(),
-            });
+            notify_subscribers(
+                subscribers,
+                CmNotification::HeartbeatSent {
+                    endpoint: endpoint.clone(),
+                },
+            );
         }
     }
-
-    notify_subscribers(subscribers, notifications);
 }
 
 fn create_heartbeat() -> Vec<u8> {
@@ -541,12 +549,14 @@ pub mod tests {
 
         let subscriber = connector.subscribe().unwrap();
 
-        let notifications = subscriber.listen().unwrap();
+        let notification = subscriber.listen().unwrap();
 
-        assert!(notifications.iter().any(|x| *x
-            == CmNotification::HeartbeatSent {
-                endpoint: "inproc://test".to_string(),
-            }));
+        assert!(
+            notification
+                == CmNotification::HeartbeatSent {
+                    endpoint: "inproc://test".to_string(),
+                }
+        );
 
         // Verify mesh received heartbeat
 
@@ -587,12 +597,14 @@ pub mod tests {
 
         let subscriber = connector.subscribe().unwrap();
 
-        let notifications = subscriber.listen().unwrap();
+        let notification = subscriber.listen().unwrap();
 
-        assert!(notifications.iter().any(|x| *x
-            == CmNotification::HeartbeatSent {
-                endpoint: "tcp://localhost:3030".to_string(),
-            }));
+        assert!(
+            notification
+                == CmNotification::HeartbeatSent {
+                    endpoint: "tcp://localhost:3030".to_string(),
+                }
+        );
 
         // Verify mesh received heartbeat
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod error;
-mod messages;
+pub mod messages;
 mod pacemaker;
 
 use std;

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -143,26 +143,15 @@ pub struct Connector {
 
 impl Connector {
     pub fn request_connection(&self, endpoint: &str) -> Result<CmResponse, ConnectionManagerError> {
-        let (sender, recv) = sync_channel(1);
+        self.send_payload(CmPayload::AddConnection {
+            endpoint: endpoint.to_string(),
+        })
+    }
 
-        let message = CmMessage::Request(CmRequest {
-            sender,
-            payload: CmPayload::AddConnection {
-                endpoint: endpoint.to_string(),
-            },
-        });
-
-        match self.sender.send(message) {
-            Ok(()) => (),
-            Err(_) => {
-                return Err(ConnectionManagerError::SendMessageError(
-                    "The connection manager is no longer running".into(),
-                ))
-            }
-        };
-
-        recv.recv()
-            .map_err(|err| ConnectionManagerError::SendMessageError(format!("{:?}", err)))
+    pub fn remove_connection(&self, endpoint: &str) -> Result<CmResponse, ConnectionManagerError> {
+        self.send_payload(CmPayload::RemoveConnection {
+            endpoint: endpoint.to_string(),
+        })
     }
 
     pub fn subscribe(&self) -> Result<NotificationHandler, ConnectionManagerError> {
@@ -178,6 +167,24 @@ impl Connector {
                 "The connection manager is no longer running".into(),
             )),
         }
+    }
+
+    fn send_payload(&self, payload: CmPayload) -> Result<CmResponse, ConnectionManagerError> {
+        let (sender, recv) = sync_channel(1);
+
+        let message = CmMessage::Request(CmRequest { sender, payload });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(ConnectionManagerError::SendMessageError(
+                    "The connection manager is no longer running".into(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| ConnectionManagerError::SendMessageError(format!("{:?}", err)))
     }
 }
 
@@ -307,18 +314,33 @@ impl ConnectionState {
 }
 
 fn handle_request(req: CmRequest, state: &mut ConnectionState) {
-    let result = match req.payload {
-        CmPayload::AddConnection { ref endpoint } => state.add_connection(endpoint),
-    };
-
-    let response = match result {
-        Ok(()) => CmResponse::AddConnection {
-            status: CmResponseStatus::OK,
-            error_message: None,
-        },
-        Err(err) => CmResponse::AddConnection {
-            status: CmResponseStatus::Error,
-            error_message: Some(format!("{:?}", err)),
+    let response = match req.payload {
+        CmPayload::AddConnection { ref endpoint } => {
+            if let Err(err) = state.add_connection(endpoint) {
+                CmResponse::AddConnection {
+                    status: CmResponseStatus::Error,
+                    error_message: Some(format!("{:?}", err)),
+                }
+            } else {
+                CmResponse::AddConnection {
+                    status: CmResponseStatus::OK,
+                    error_message: None,
+                }
+            }
+        }
+        CmPayload::RemoveConnection { ref endpoint } => match state.remove_connection(endpoint) {
+            Ok(Some(_)) => CmResponse::RemoveConnection {
+                status: CmResponseStatus::OK,
+                error_message: None,
+            },
+            Ok(None) => CmResponse::RemoveConnection {
+                status: CmResponseStatus::ConnectionNotFound,
+                error_message: None,
+            },
+            Err(err) => CmResponse::RemoveConnection {
+                status: CmResponseStatus::Error,
+                error_message: Some(format!("{:?}", err)),
+            },
         },
     };
 
@@ -589,6 +611,70 @@ pub mod tests {
         assert_eq!(
             heartbeat.get_message_type(),
             NetworkMessageType::NETWORK_HEARTBEAT
+        );
+    }
+
+    #[test]
+    fn test_remove_connection() {
+        let mut transport = Box::new(RawTransport::default());
+        let mut listener = transport.listen("tcp://localhost:8080").unwrap();
+        let mesh = Mesh::new(512, 128);
+        let mesh_clone = mesh.clone();
+
+        thread::spawn(move || {
+            let conn = listener.accept().unwrap();
+            mesh_clone.add(conn).unwrap();
+        });
+
+        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let connector = cm.start().unwrap();
+
+        let add_response = connector
+            .request_connection("tcp://localhost:8080")
+            .unwrap();
+
+        assert_eq!(
+            add_response,
+            CmResponse::AddConnection {
+                status: CmResponseStatus::OK,
+                error_message: None
+            }
+        );
+
+        let remove_response = connector.remove_connection("tcp://localhost:8080").unwrap();
+
+        assert_eq!(
+            remove_response,
+            CmResponse::RemoveConnection {
+                status: CmResponseStatus::OK,
+                error_message: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_remove_nonexistent_connection() {
+        let mut transport = Box::new(RawTransport::default());
+        let mut listener = transport.listen("tcp://localhost:8080").unwrap();
+        let mesh = Mesh::new(512, 128);
+        let mesh_clone = mesh.clone();
+
+        thread::spawn(move || {
+            let conn = listener.accept().unwrap();
+            mesh_clone.add(conn).unwrap();
+        });
+
+        let mut cm = ConnectionManager::new(mesh.clone(), transport);
+        let connector = cm.start().unwrap();
+
+        let remove_response = connector.remove_connection("tcp://localhost:8080").unwrap();
+
+        assert_eq!(
+            remove_response,
+            CmResponse::RemoveConnection {
+                status: CmResponseStatus::ConnectionNotFound,
+                error_message: None,
+            }
         );
     }
 }

--- a/libsplinter/src/network/connection_manager/pacemaker.rs
+++ b/libsplinter/src/network/connection_manager/pacemaker.rs
@@ -23,13 +23,13 @@ use std::time::Duration;
 
 use crate::network::connection_manager::{error::ConnectionManagerError, messages::CmMessage};
 
-pub struct HeartbeatMonitor {
+pub struct Pacemaker {
     interval: u64,
     join_handle: Option<thread::JoinHandle<()>>,
-    shutdown_handle: Option<HbShutdownHandle>,
+    shutdown_handle: Option<ShutdownHandle>,
 }
 
-impl HeartbeatMonitor {
+impl Pacemaker {
     pub fn new(interval: u64) -> Self {
         Self {
             interval,
@@ -38,7 +38,10 @@ impl HeartbeatMonitor {
         }
     }
 
-    pub fn start(&mut self, cm_sender: SyncSender<CmMessage>) -> Result<(), ConnectionManagerError> {
+    pub fn start(
+        &mut self,
+        cm_sender: SyncSender<CmMessage>,
+    ) -> Result<(), ConnectionManagerError> {
         if self.join_handle.is_some() {
             return Ok(());
         }
@@ -66,12 +69,12 @@ impl HeartbeatMonitor {
             })?;
 
         self.join_handle = Some(join_handle);
-        self.shutdown_handle = Some(HbShutdownHandle { running });
+        self.shutdown_handle = Some(ShutdownHandle { running });
 
         Ok(())
     }
 
-    pub fn shutdown_handle(&self) -> Option<HbShutdownHandle> {
+    pub fn shutdown_handle(&self) -> Option<ShutdownHandle> {
         self.shutdown_handle.clone()
     }
 
@@ -89,11 +92,11 @@ impl HeartbeatMonitor {
 }
 
 #[derive(Clone)]
-pub struct HbShutdownHandle {
+pub struct ShutdownHandle {
     running: Arc<AtomicBool>,
 }
 
-impl HbShutdownHandle {
+impl ShutdownHandle {
     pub fn shutdown(&self) {
         self.running.store(false, Ordering::SeqCst)
     }

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -80,7 +80,7 @@ impl Incoming for dyn Listener {
 }
 
 /// Factory-pattern based type for creating connections
-pub trait Transport {
+pub trait Transport: Send {
     /// Indicates whether or not a given address can be used to create a conneciton or listener.
     fn accepts(&self, address: &str) -> bool;
     fn connect(&mut self, endpoint: &str) -> Result<Box<dyn Connection>, ConnectError>;


### PR DESCRIPTION
Adds `cm-repl`, an example daemon using the connection manger and refactors notifications API

### Testing

1) Build with docker
```
docker-compose -f examples/cm-repl/docker-compose.yaml
```
2) Exec into one of the node containers
```
docker exec -it cm-repl_node-0_1 bash
```
3) Run connection manager client commands
```
cmc connection add tcp://node-0:3040
cmc connection list
cmc connection remove tcp://node-0:3040
```