### PR TITLE
Handle case where removed nodes broke invitations and notifications lists

### DIFF
--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -224,8 +224,19 @@ export async function listProposals(): Promise<GameroomProposal[]> {
 }
 
 async function getNode(id: string): Promise<Node> {
-    const response = await gameroomAPI.get(`/nodes/${id}`);
-    return response.data.data as Node;
+    try {
+      const response = await gameroomAPI.get(`/nodes/${id}`);
+      return response.data.data as Node;
+    } catch (e) {
+      console.warn(`Node with ID: ${id} not found. It may have been removed from the registry.`);
+      return {
+        identity: id,
+        metadata: {
+          endpoint: 'unknown',
+          organization: id,
+        },
+      };
+    }
 }
 
 export async function proposalVote(ballot: Ballot, proposalID: string,


### PR DESCRIPTION
When listing proposals, gamerooms, or notifications from the UI, we have to make a separate call to the /nodes endpoint to get information from the node registry. If one of the nodes referenced in a list of resources was removed or renamed, this would cause an error and none of the items would be displayed.

This PR adds a step that catches the error and logs a warning so that it does not break other resources. It also replaces the missing node info with some default values.

Fixes [1570](https://zenhub.cglcloud.com/app/workspaces/product-core-5d37298b0add7306b30efde2/issues/digitalsupplychain/product-core/1570) and [1563](https://zenhub.cglcloud.com/app/workspaces/product-core-5d37298b0add7306b30efde2/issues/digitalsupplychain/product-core/1563)

Signed-off-by: Darian Plumb <dplumb@bitwise.io>