### PR TITLE
Add sapling style loader

### DIFF
--- a/canopy/app/saplings/configSaplings.yml
+++ b/canopy/app/saplings/configSaplings.yml
@@ -1,4 +1,5 @@
 - namespace: login
   runtimeFiles:
     - 0.0.0.0:8675/loginRegisterSapling.js
+  styleFiles: []
   workerFiles: []

--- a/canopy/app/saplings/userSaplings.yml
+++ b/canopy/app/saplings/userSaplings.yml
@@ -2,5 +2,6 @@
   namespace: vanilla
   runtimeFiles:
     - 0.0.0.0:8675/vanilla.js
+  styleFiles: []
   workerFiles: []
   icon: https://via.placeholder.com/48

--- a/canopy/app/src/styleLoader.js
+++ b/canopy/app/src/styleLoader.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function styleLoader(styleUrl) {
+  const url = new URL(styleUrl);
+  return new Promise((resolve, reject) => {
+    const head = document.querySelector('head');
+    const link = document.createElement('link');
+    link.href = url;
+    link.rel = 'stylesheet';
+    link.onload = resolve;
+    link.onerror = reject;
+    head.insertAdjacentElement('beforeend', link);
+  });
+}
+
+export default styleLoader;


### PR DESCRIPTION
Adds a style loader to load external sapling styles into the canopy
DOM.

Signed-off-by: Davey Newhall <newhall@bitwise.io>