### PR TITLE
Key Add key mangement module to biome

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -75,6 +75,7 @@ stable = [
 experimental = [
     "biome",
     "biome-credentials",
+    "biome-key-management",
     "biome-notifications",
     "connection-manager",
     "connection-manager-notification-iter-try-next",
@@ -84,6 +85,7 @@ experimental = [
 
 biome = ["database", "jsonwebtoken", "rand"]
 biome-credentials = ["biome", "database", "bcrypt"]
+biome-key-management = ["biome", "database"]
 biome-notifications = ["biome", "database"]
 connection-manager = []
 connection-manager-notification-iter-try-next = ["connection-manager"]
@@ -102,6 +104,7 @@ ursa-compat = ["ursa"]
 features = [
     "biome",
     "biome-credentials",
+    "biome-key-management",
     "biome-notifications",
     "connection-manager",
     "connection-manager-notification-iter-try-next",

--- a/libsplinter/src/biome/key_management/database/mod.rs
+++ b/libsplinter/src/biome/key_management/database/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod postgres;

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
@@ -1,0 +1,22 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::models::KeyModel;
+use super::super::schema::keys;
+
+use diesel::{dsl::insert_into, pg::PgConnection, prelude::*, QueryResult};
+
+pub fn insert_key(conn: &PgConnection, key: KeyModel) -> QueryResult<usize> {
+    insert_into(keys::table).values(&vec![key]).execute(conn)
+}

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod keys;
+
+pub use keys::insert_key;

--- a/libsplinter/src/biome/key_management/database/postgres/migrations/2019-12-12-200956_create-keys/down.sql
+++ b/libsplinter/src/biome/key_management/database/postgres/migrations/2019-12-12-200956_create-keys/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE keys;

--- a/libsplinter/src/biome/key_management/database/postgres/migrations/2019-12-12-200956_create-keys/up.sql
+++ b/libsplinter/src/biome/key_management/database/postgres/migrations/2019-12-12-200956_create-keys/up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2019 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS keys (
+    public_key            TEXT NOT NULL,
+    encrypted_private_key TEXT NOT NULL,
+    user_id               TEXT NOT NULL,
+    display_name          TEXT NOT NULL,
+    PRIMARY KEY(public_key, user_id)
+);

--- a/libsplinter/src/biome/key_management/database/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines methods and utilities to interact with key management tables in the database.
+
+pub(in crate::biome) mod helpers;
+pub(in crate::biome) mod models;
+pub(super) mod schema;
+
+embed_migrations!("./src/biome/key_management/database/postgres/migrations");
+
+use diesel::pg::PgConnection;
+
+use crate::database::error::DatabaseError;
+
+/// Run database migrations to create tables defined in the key management module
+///
+/// # Arguments
+///
+/// * `conn` - Connection to database
+///
+pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
+    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+
+    info!("Successfully applied key management migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/biome/key_management/database/postgres/models.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/models.rs
@@ -1,0 +1,25 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::schema::*;
+
+#[derive(Insertable, Queryable, Identifiable, PartialEq, Debug)]
+#[table_name = "keys"]
+#[primary_key(public_key, user_id)]
+pub struct KeyModel {
+    pub public_key: String,
+    pub encrypted_private_key: String,
+    pub user_id: String,
+    pub display_name: String,
+}

--- a/libsplinter/src/biome/key_management/database/postgres/schema.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/schema.rs
@@ -1,0 +1,22 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    keys (public_key, user_id) {
+        public_key -> Text,
+        encrypted_private_key -> Text,
+        user_id -> Text,
+        display_name -> Text,
+    }
+}

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -1,0 +1,50 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides an API for storing key pairs and associating them with users.
+
+// Represents a public and private key pair
+pub struct Key {
+    public_key: String,
+    encrypted_private_key: String,
+    user_id: String,
+    display_name: String,
+}
+
+impl Key {
+    /// Creates a new Key
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key`: The public key of the key pair.
+    /// * `encrypted_private_key`: The private key of the key pair. This key
+    ///     should be encrypted by the client before being sent to the key
+    ///     management module
+    /// * `user_id`: The identity of the Biome user who owns the key.
+    /// * `display_name`: A human readable name for the key.
+    ///
+    pub fn new(
+        public_key: &str,
+        encrypted_private_key: &str,
+        user_id: &str,
+        display_name: &str,
+    ) -> Self {
+        Key {
+            public_key: public_key.to_string(),
+            encrypted_private_key: encrypted_private_key.to_string(),
+            user_id: user_id.to_string(),
+            display_name: display_name.to_string(),
+        }
+    }
+}

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -14,6 +14,10 @@
 
 //! Provides an API for storing key pairs and associating them with users.
 
+pub mod database;
+
+use database::postgres::models::KeyModel;
+
 // Represents a public and private key pair
 pub struct Key {
     public_key: String,
@@ -45,6 +49,27 @@ impl Key {
             encrypted_private_key: encrypted_private_key.to_string(),
             user_id: user_id.to_string(),
             display_name: display_name.to_string(),
+        }
+    }
+}
+
+impl From<KeyModel> for Key {
+    fn from(key: KeyModel) -> Self {
+        Key {
+            public_key: key.public_key,
+            encrypted_private_key: key.encrypted_private_key,
+            user_id: key.user_id,
+            display_name: key.display_name,
+        }
+    }
+}
+impl Into<KeyModel> for Key {
+    fn into(self) -> KeyModel {
+        KeyModel {
+            public_key: self.public_key,
+            encrypted_private_key: self.encrypted_private_key,
+            user_id: self.user_id,
+            display_name: self.display_name,
         }
     }
 }

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -15,6 +15,7 @@
 //! Provides an API for storing key pairs and associating them with users.
 
 pub mod database;
+pub(in crate::biome) mod store;
 
 use database::postgres::models::KeyModel;
 

--- a/libsplinter/src/biome/key_management/store/error.rs
+++ b/libsplinter/src/biome/key_management/store/error.rs
@@ -1,0 +1,86 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::database::error::DatabaseError;
+
+/// Represents KeyStore errors
+#[derive(Debug)]
+pub enum KeyStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents database query failures
+    /// Disable warning, this will be used for any database fetch helpers
+    #[allow(dead_code)]
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+}
+
+impl Error for KeyStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            KeyStoreError::OperationError { source, .. } => Some(&**source),
+            KeyStoreError::QueryError { source, .. } => Some(&**source),
+            KeyStoreError::StorageError { source, .. } => Some(&**source),
+            KeyStoreError::ConnectionError(err) => Some(&**err),
+        }
+    }
+}
+
+impl fmt::Display for KeyStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KeyStoreError::OperationError { context, source } => {
+                write!(f, "failed to perform operation: {}: {}", context, source)
+            }
+            KeyStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            KeyStoreError::StorageError { context, source } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            KeyStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+        }
+    }
+}
+
+impl From<DatabaseError> for KeyStoreError {
+    fn from(err: DatabaseError) -> KeyStoreError {
+        match err {
+            DatabaseError::ConnectionError(_) => KeyStoreError::ConnectionError(Box::new(err)),
+            _ => KeyStoreError::StorageError {
+                context: "The database returned an error".to_string(),
+                source: Box::new(err),
+            },
+        }
+    }
+}

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -1,0 +1,65 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;
+pub mod postgres;
+
+use error::KeyStoreError;
+
+/// Defines methods for CRUD operations and fetching and listing keys
+/// without defining a storage strategy
+pub trait KeyStore<T> {
+    /// Adds a key to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `key` - The key to be added
+    ///
+    ///
+    fn add_key(&self, key: T) -> Result<(), KeyStoreError>;
+
+    /// Updates a key information in the underling storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `key` - The key with the updated information
+    ///
+    fn update_key(&self, updated_key: T) -> Result<(), KeyStoreError>;
+
+    /// Removes a key from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key`: The public key of the key record to be removed.
+    /// * `user_id`: The ID owner of the key record to be removed.
+    ///
+    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<T, KeyStoreError>;
+
+    /// Fetches a key from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    /// * `public_key`: The public key of the key record to be removed.
+    /// * `user_id`: The ID owner of the key record to be removed.
+    ///
+    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<T, KeyStoreError>;
+
+    /// List all keys from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id`: The ID owner of the key records to list.
+    ///
+    fn list_keys(&self, user_id: Option<&str>) -> Result<Vec<T>, KeyStoreError>;
+}

--- a/libsplinter/src/biome/key_management/store/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/postgres/mod.rs
@@ -1,0 +1,64 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WI()HOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::database::postgres::helpers::insert_key;
+use super::super::store::{KeyStore, KeyStoreError};
+use super::super::Key;
+use crate::database::ConnectionPool;
+
+/// Manages creating, updating and fetching keys from a PostgreSQL database.
+pub struct PostgresKeyStore {
+    connection_pool: ConnectionPool,
+}
+
+impl PostgresKeyStore {
+    /// Creates a new PostgresKeyStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the PostgreSQL database
+    ///
+    pub fn new(connection_pool: ConnectionPool) -> Self {
+        PostgresKeyStore { connection_pool }
+    }
+}
+
+impl KeyStore<Key> for PostgresKeyStore {
+    fn add_key(&self, key: Key) -> Result<(), KeyStoreError> {
+        let key_model = key.into();
+        insert_key(&*self.connection_pool.get()?, key_model).map_err(|err| {
+            KeyStoreError::OperationError {
+                context: "Failed to add key".to_string(),
+                source: Box::new(err),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn update_key(&self, _updated_key: Key) -> Result<(), KeyStoreError> {
+        unimplemented!()
+    }
+
+    fn remove_key(&self, _public_key: &str, _user_id: &str) -> Result<Key, KeyStoreError> {
+        unimplemented!()
+    }
+
+    fn fetch_key(&self, _public_key: &str, _user_id: &str) -> Result<Key, KeyStoreError> {
+        unimplemented!()
+    }
+
+    fn list_keys(&self, _user_id: Option<&str>) -> Result<Vec<Key>, KeyStoreError> {
+        unimplemented!()
+    }
+}

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -18,10 +18,14 @@
 //!
 //! * `biome-credentials`: API to register and authenticate a user using an username and password.
 //!   Not recommend for use in production.
+//! * `biome-key-management`: API to store and retrieve encrypted private keys.
 //! * `biome-notifications`: API to create and manage user notifications.
 
 #[cfg(feature = "biome-credentials")]
 pub mod credentials;
+
+#[cfg(feature = "biome-key-management")]
+pub mod key_management;
 
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;


### PR DESCRIPTION
This module will an API for storing key pairs and associating them with users.

This PR also implements the `add_key()` function, but leaves the other unimplemented (will be in the next PR)