### PR TITLE
Remove stable from experimental feature tests

### DIFF
--- a/tests/test-splinter.yaml
+++ b/tests/test-splinter.yaml
@@ -31,9 +31,9 @@ services:
             echo \"Running stable feature tests...\" && \
             (cd libsplinter && cargo test --features stable) &&
             (cd splinterd && cargo test --features stable) &&
-            echo \"Running stable+experimental feature tests...\" && \
-            (cd libsplinter && cargo test --features stable experimental) &&
-            (cd splinterd && cargo test --features stable experimental)
+            echo \"Running experimental feature tests...\" && \
+            (cd libsplinter && cargo test --features experimental) &&
+            (cd splinterd && cargo test --features experimental)
         "
     stop_signal: SIGKILL
 


### PR DESCRIPTION
We want to test experimental features in isolation from the stable
features.

Signed-off-by: Logan Seeley <seeley@bitwise.io>