### PR TITLE
Add database migration command to Splinter CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,9 +17,26 @@ default = []
 
 stable = ["default"]
 
-experimental = ["health"]
+experimental = [
+    "health",
+    "database",
+    "database-migrate-biome-credentials",
+    "database-migrate-biome-notifications",
+    "database-migrate-biome-users",
+]
 
 health = ["reqwest", "serde_json"]
+
+database = ["splinter/database", "diesel"]
+database-migrate-biome-users = ["splinter/biome", "database"]
+database-migrate-biome-credentials = [
+    "splinter/biome-credentials",
+    "database-migrate-biome-users",
+]
+database-migrate-biome-notifications = [
+    "splinter/biome-notifications",
+    "database-migrate-biome-users",
+]
 
 [package]
 name = "splinter-cli"
@@ -34,6 +51,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
+diesel = { version = "1.0", features = ["postgres"], optional = true }
 flexi_logger = "0.14"
 libc = "0.2"
 log = "0.4"

--- a/cli/src/action/database.rs
+++ b/cli/src/action/database.rs
@@ -1,0 +1,72 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+use flexi_logger::ReconfigurationHandle;
+
+use super::Action;
+use crate::error::CliError;
+use diesel::{connection::Connection as _, pg::PgConnection};
+#[cfg(feature = "database-migrate-biome-credentials")]
+use splinter::biome::credentials::database::run_migrations as run_biome_credentials_migrations;
+#[cfg(feature = "database-migrate-biome-notifications")]
+use splinter::biome::notifications::database::run_migrations as run_biome_notifications_migrations;
+#[cfg(feature = "database-migrate-biome-users")]
+use splinter::biome::users::database::run_migrations as run_biome_users_migrations;
+use splinter::database::run_migrations as run_setup_migrations;
+
+pub struct MigrateAction;
+
+impl Action for MigrateAction {
+    fn run<'a>(
+        &mut self,
+        arg_matches: Option<&ArgMatches<'a>>,
+        _logger_handle: &mut ReconfigurationHandle,
+    ) -> Result<(), CliError> {
+        let url = if let Some(args) = arg_matches {
+            args.value_of("connect")
+                .unwrap_or("postgres://admin:admin@localhost:5432/splinterd")
+        } else {
+            "postgres://admin:admin@localhost:5432/splinterd"
+        };
+
+        let connection =
+            PgConnection::establish(url).map_err(|err| CliError::DatabaseError(err.to_string()))?;
+
+        run_setup_migrations(&connection).map_err(|err| {
+            CliError::DatabaseError(format!("Unable to run Biome setup migrations: {}", err))
+        })?;
+
+        #[cfg(feature = "database-migrate-biome-users")]
+        run_biome_users_migrations(&connection).map_err(|err| {
+            CliError::DatabaseError(format!("Unable to run Biome users migrations: {}", err))
+        })?;
+        #[cfg(feature = "database-migrate-biome-credentials")]
+        run_biome_credentials_migrations(&connection).map_err(|err| {
+            CliError::DatabaseError(format!(
+                "Unable to run Biome credentials migrations: {}",
+                err
+            ))
+        })?;
+        #[cfg(feature = "database-migrate-biome-notifications")]
+        run_biome_notifications_migrations(&connection).map_err(|err| {
+            CliError::DatabaseError(format!(
+                "Unable to run Biome notifications migrations: {}",
+                err
+            ))
+        })?;
+
+        Ok(())
+    }
+}

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 pub mod admin;
 pub mod certs;
+#[cfg(feature = "database")]
+pub mod database;
 #[cfg(feature = "health")]
 pub mod health;
 

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -20,6 +20,8 @@ pub enum CliError {
     InvalidSubcommand,
     ActionError(String),
     EnvironmentError(String),
+    #[cfg(feature = "database")]
+    DatabaseError(String),
 }
 
 impl Error for CliError {}
@@ -33,6 +35,8 @@ impl fmt::Display for CliError {
             CliError::EnvironmentError(msg) => {
                 write!(f, "action encountered an environment error: {}", msg)
             }
+            #[cfg(feature = "database")]
+            CliError::DatabaseError(msg) => write!(f, "database error: {}", msg),
         }
     }
 }

--- a/libsplinter/src/biome/credentials/database/mod.rs
+++ b/libsplinter/src/biome/credentials/database/mod.rs
@@ -33,7 +33,7 @@ use crate::database::error::DatabaseError;
 pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
     embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
 
-    info!("Successfully applied migrations");
+    info!("Successfully applied biome credentials migrations");
 
     Ok(())
 }

--- a/libsplinter/src/biome/notifications/database/mod.rs
+++ b/libsplinter/src/biome/notifications/database/mod.rs
@@ -27,7 +27,7 @@ pub use crate::database::error::DatabaseError;
 pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
     embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
 
-    info!("Successfully applied migrations");
+    info!("Successfully applied biome notifications migrations");
 
     Ok(())
 }

--- a/libsplinter/src/biome/users/database/mod.rs
+++ b/libsplinter/src/biome/users/database/mod.rs
@@ -33,7 +33,7 @@ use crate::database::error::DatabaseError;
 pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
     embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
 
-    info!("Successfully applied migrations");
+    info!("Successfully applied biome users migrations");
 
     Ok(())
 }

--- a/libsplinter/src/database/mod.rs
+++ b/libsplinter/src/database/mod.rs
@@ -40,7 +40,7 @@ pub fn create_connection_pool(database_url: &str) -> Result<ConnectionPool, Data
 pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
     embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
 
-    info!("Successfully applied migrations");
+    info!("Successfully applied setup migrations");
 
     Ok(())
 }


### PR DESCRIPTION
Adds a new subcommand, `$ splinter database migrate`, to the Splinter CLI. Also adds Rust features that correspond to the libsplinter Rust features for database-requiring modules.

To test I used this compose file:

```
# test-migrations.yaml

version: "3.7"

services:
  splinter-cli:
    build:
      context: .
      dockerfile: cli/Dockerfile-installed-${DISTRO}
      args:
        - CARGO_ARGS=${CARGO_ARGS}
        - REPO_VERSION=${REPO_VERSION}
    image: ${REGISTRY}${NAMESPACE}splinter-cli:${ISOLATION_ID}
    container_name: splinter-cli
    command: bash -c "tail -f /dev/null"

  splinterd-db:
    image: postgres
    environment:
      POSTGRES_USER: admin
      POSTGRES_PASSWORD: admin
      POSTGRES_DB: splinterd
    expose:
      - 5432
    ports:
      - "5432:5432"
    restart: unless-stopped

  adminer:
    image: adminer
    container_name: splinterd-db-adminer
    restart: always
    ports:
      - "8080:8080"
```
First set some cargo args for the features you want enabled:
`$ export 'CARGO_ARGS=-- --features database'`

Start up the compose file:
`$ docker-compose -f test-migrations up`

Exec into the CLI and run the migrations:
`$ docker exec -it splinter-cli bash`
`# splinter database migrate -C postgres://admin:admin@splinterd-db:5432/splinterd`

You should see the message: "Successfully applied setup migrations". None of the other migrations were run because we only had the `database` feature enabled.

You can inspect the database using adminer (instructions at the bottom) or another method of your choosing to see that the ` __diesel_schema_migrations` table was created.

To run other migrations, down your docker-compose network and set some more CLI args:
`$ export 'CARGO_ARGS=-- --features database-migrate-biome-credentials'`
`$ docker-compose -f test-migrations.yaml build splinter-cli`
 (This would build the cli with `database`, `database-migrate-biome-users`, and `database-migrate-biome-credentials` features)

Reup your compose network, exec into the CLI and run the migrations again:
`$ docker-compose -f test-migrations up`
`$ docker exec -it splinter-cli bash`
`# splinter database migrate -C postgres://admin:admin@splinterd-db:5432/splinterd`

Now you should see:
"""
Successfully applied setup migrations
Successfully applied biome users migrations
Successfully applied biome credentials migrations
"""

Adminer:
You can also go to localhost:8080 to view Adminer (GUI for postgres) and see that proper migrations have been run

Server:
splinterd-db

Username:
admin

Password:
admin

Database:
splinterd
