### PR TITLE
Add Biome users API routes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,9 @@ postgres = [
     "splinter/postgres",
 ]
 
+# Aliases - used to map libsplinter feature names to their CLI counterparts
+biome-credentials = ["database-migrate-biome-credentials"]
+
 [package]
 name = "splinter-cli"
 version = "0.3.9"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
       dockerfile: splinterd/Dockerfile-installed-${DISTRO}
       args:
         - REPO_VERSION=${REPO_VERSION}
+        - CARGO_ARGS=${CARGO_ARGS}
+        - SPLINTERD_ARGS=${SPLINTERD_ARGS}
     entrypoint: |
       bash -c "
         splinter cert generate --skip && \
@@ -38,6 +40,7 @@ services:
             -c ./configs/splinterd-node-0-docker.toml \
             --registry-file ./node_registries/nodes.yaml \
             --insecure \
+            $SPLINTERD_ARGS \
             -vv
       "
 

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -56,6 +56,7 @@ circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-builder = []
 config-toml = ["config-builder"]
+database = ["splinter/database"]
 generate-certs = []
 
 [package.metadata.deb]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -45,6 +45,8 @@ default = []
 stable = ["default"]
 
 experimental = [
+    "biome",
+    "biome-credentials",
     "circuit-read",
     "config-builder",
     "config-toml",
@@ -52,6 +54,8 @@ experimental = [
     "proposal-read"
 ]
 
+biome = ["splinter/biome", "database"]
+biome-credentials = ["splinter/biome-credentials", "biome"]
 circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-builder = []

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -25,6 +25,7 @@ COPY splinterd/ /build/splinterd
 WORKDIR /build/splinterd
 ARG REPO_VERSION
 ARG CARGO_ARGS
+ARG SPLINTERD_ARGS
 RUN sed -i -e s/version.*$/version\ =\ \"${REPO_VERSION}\"/ Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
 RUN mv /build/target/debian/splinter-daemon*.deb /tmp
@@ -43,6 +44,8 @@ FROM ubuntu:bionic
 
 ARG CARGO_ARGS
 RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS
+ARG SPLINTERD_ARGS
+RUN echo "SPLINTERD_ARGS = '$SPLINTERD_ARGS'" > SPLINTERD_ARGS
 
 COPY --from=builder /tmp/splinter-*.deb /tmp/
 

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -37,3 +37,5 @@ bind = "0.0.0.0:8080"
 
 # List of certificate authority certificates (*.pem files).
 ca_certs = "/etc/splinter/certs/generated_ca.pem"
+# db address
+database = "postgres://splinter_admin:splinter_test@127.0.0.1:5432/splinter"

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -28,6 +28,8 @@ pub struct ConfigBuilder {
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
+    #[cfg(feature = "database")]
+    database: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
@@ -49,6 +51,8 @@ impl ConfigBuilder {
             peers: None,
             node_id: None,
             bind: None,
+            #[cfg(feature = "database")]
+            database: None,
             registry_backend: None,
             registry_file: None,
             heartbeat_interval: None,
@@ -120,6 +124,12 @@ impl ConfigBuilder {
         self
     }
 
+    #[cfg(feature = "database")]
+    pub fn with_database(mut self, database: String) -> Self {
+        self.database = Some(database);
+        self
+    }
+
     pub fn with_registry_backend(mut self, registry_backend: String) -> Self {
         self.registry_backend = Some(registry_backend);
         self
@@ -150,6 +160,8 @@ impl ConfigBuilder {
             peers: self.peers,
             node_id: self.node_id,
             bind: self.bind,
+            #[cfg(feature = "database")]
+            database: self.database,
             registry_backend: self.registry_backend,
             registry_file: self.registry_file,
             heartbeat_interval: self.heartbeat_interval,

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -49,6 +49,8 @@ pub struct Config {
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
+    #[cfg(feature = "database")]
+    database: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
@@ -113,6 +115,11 @@ impl Config {
 
     pub fn bind(&self) -> Option<String> {
         self.bind.clone()
+    }
+
+    #[cfg(feature = "database")]
+    pub fn database(&self) -> Option<String> {
+        self.database.clone()
     }
 
     pub fn registry_backend(&self) -> Option<String> {

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -34,6 +34,8 @@ pub struct TomlConfig {
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
+    #[cfg(feature = "database")]
+    database: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
@@ -96,6 +98,11 @@ impl TomlConfig {
         self.bind.take()
     }
 
+    #[cfg(feature = "database")]
+    pub fn take_database(&mut self) -> Option<String> {
+        self.database.take()
+    }
+
     pub fn take_registry_backend(&mut self) -> Option<String> {
         self.registry_backend.take()
     }
@@ -147,6 +154,12 @@ impl TomlConfig {
         }
         if let Some(x) = self.take_bind() {
             builder = builder.with_bind(x);
+        }
+        #[cfg(feature = "database")]
+        {
+            if let Some(x) = self.take_database() {
+                builder = builder.with_database(x);
+            }
         }
         if let Some(x) = self.take_registry_backend() {
             builder = builder.with_registry_backend(x);

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -21,6 +21,8 @@ use crossbeam_channel;
 #[cfg(feature = "health")]
 use health::HealthService;
 use splinter::admin::service::{admin_service_id, AdminService};
+#[cfg(feature = "biome")]
+use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
 use splinter::circuit::directory::CircuitDirectory;
 use splinter::circuit::handlers::{
     AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
@@ -29,6 +31,8 @@ use splinter::circuit::handlers::{
 #[cfg(feature = "circuit-read")]
 use splinter::circuit::rest_api::CircuitResourceProvider;
 use splinter::circuit::SplinterState;
+#[cfg(feature = "biome")]
+use splinter::database::{self, ConnectionPool};
 use splinter::keys::{
     insecure::AllowAllKeyPermissionManager, rest_api::KeyRegistryManager,
     storage::StorageKeyRegistry,
@@ -384,6 +388,12 @@ impl SplinterDaemon {
             rest_api_builder = rest_api_builder.add_resources(circuit_resource.resources());
         }
 
+        #[cfg(feature = "biome")]
+        {
+            let biome_resources = build_biome_routes(&self.db_url)?;
+            rest_api_builder = rest_api_builder.add_resources(biome_resources.resources());
+        }
+
         let (rest_api_shutdown_handle, rest_api_join_handle) = rest_api_builder.build()?.run()?;
 
         let (admin_shutdown_handle, service_processor_join_handle) =
@@ -591,6 +601,31 @@ fn start_health_service(
             "unable to start health service, due to thread join error".into(),
         )
     })?
+}
+
+#[cfg(feature = "biome")]
+fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartError> {
+    info!("Adding biome routes");
+    let connection_pool: ConnectionPool =
+        database::create_connection_pool(db_url).map_err(|err| {
+            StartError::RestApiError(format!(
+                "Unable to connect to the splinter databaase: {}",
+                err
+            ))
+        })?;
+    let mut biome_rest_provider_builder: BiomeRestResourceManagerBuilder = Default::default();
+    biome_rest_provider_builder =
+        biome_rest_provider_builder.with_user_store(connection_pool.clone());
+    #[cfg(feature = "biome-credentials")]
+    {
+        biome_rest_provider_builder =
+            biome_rest_provider_builder.with_credentials_store(connection_pool.clone());
+    }
+    let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
+        StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))
+    })?;
+
+    Ok(biome_rest_provider)
 }
 
 #[derive(Default)]

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -98,6 +98,8 @@ pub struct SplinterDaemon {
     network: Network,
     node_id: String,
     rest_api_endpoint: String,
+    #[cfg(feature = "database")]
+    db_url: String,
     registry_config: RegistryConfig,
     storage_type: String,
 }
@@ -600,6 +602,8 @@ pub struct SplinterDaemonBuilder {
     initial_peers: Option<Vec<String>>,
     node_id: Option<String>,
     rest_api_endpoint: Option<String>,
+    #[cfg(feature = "database")]
+    db_url: Option<String>,
     registry_backend: Option<String>,
     registry_file: Option<String>,
     storage_type: Option<String>,
@@ -643,6 +647,12 @@ impl SplinterDaemonBuilder {
 
     pub fn with_rest_api_endpoint(mut self, value: String) -> Self {
         self.rest_api_endpoint = Some(value);
+        self
+    }
+
+    #[cfg(feature = "database")]
+    pub fn with_db_url(mut self, value: String) -> Self {
+        self.db_url = Some(value);
         self
     }
 
@@ -703,6 +713,11 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: rest_api_endpoint".to_string())
         })?;
 
+        #[cfg(feature = "database")]
+        let db_url = self.db_url.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: db_url".to_string())
+        })?;
+
         let storage_type = self.storage_type.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: storage_type".to_string())
         })?;
@@ -725,6 +740,8 @@ impl SplinterDaemonBuilder {
             network,
             node_id,
             rest_api_endpoint,
+            #[cfg(feature = "database")]
+            db_url,
             registry_config,
             key_registry_location,
             storage_type,


### PR DESCRIPTION
Adds the biome and biome-credentials API routes to splinterd behind the corresponding experimental features. This also, enables connecting to a database behind the database experimental feature.

This was tested with the changes to migrations introduced in PR #393 