### PR TITLE
Connection manager CLI example

### DIFF
--- a/examples/cm-repl/README.md
+++ b/examples/cm-repl/README.md
@@ -1,0 +1,30 @@
+# Connection Manager Example
+
+This is an example application meant to demonstrate the current functionality
+of the connection manager. It is split into two components, a cli tool and a
+server. The servier side is a very stripped down version of splinterd as it
+can only accept new connections and remove them. The cli tool simply 
+dispatches commands to the server.
+
+## Getting Started
+
+Run the following command to set up an environment with two nodes
+
+```
+$ docker-compose -f examples/cm-repl/docker-compose.yaml
+```
+
+## Using the connectin manager client
+
+The connection manager client (cmc) can add remove and list connections held by
+the two nodes.
+
+```
+$ docker exec -it cm-repl_node-0_1 bash
+
+# cmc connection add tcp://node-0:3040
+# cmc connection list
+# cmc connection remove tcp://node-0:3040
+```
+
+

--- a/examples/cm-repl/cli/Cargo.toml
+++ b/examples/cm-repl/cli/Cargo.toml
@@ -12,21 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "cmc"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
 
-members = [
-    "cli",
-    "client",
-    "libsplinter",
-    "splinterd",
-    "examples/cm-repl/cli",
-    "examples/cm-repl/daemon",
-    "examples/private_counter/cli",
-    "examples/private_counter/service",
-    "examples/private_xo",
-    "examples/gameroom/cli",
-    "examples/gameroom/database",
-    "examples/gameroom/daemon",
-    "services/health",
-    "services/scabbard",
-]
+[dependencies]
+clap = "2"
+flexi_logger = "0.14"
+log = "0.4"
+reqwest = "0.9"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"

--- a/examples/cm-repl/cli/Dockerfile
+++ b/examples/cm-repl/cli/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM splintercommunity/splinter-dev as BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+COPY protos/ /build/protos
+
+# Build the project
+WORKDIR /build/examples/cm-repl/cli
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
+# -------------=== cm-repl docker build ===-------------
+FROM ubuntu:bionic
+
+COPY --from=BUILDER /build/target/debian/cmc*.deb /tmp
+
+RUN apt-get update \
+ && dpkg --unpack /tmp/cm-repl*.deb \
+ && apt-get -f -y install
+
+CMD ["cmc"]

--- a/examples/cm-repl/cli/src/actions.rs
+++ b/examples/cm-repl/cli/src/actions.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest;
+
+pub fn add_connection(url: &str, addr: &str) {
+    let response = reqwest::Client::new()
+        .post(&format!("{}/connections/create", url))
+        .json(&json!({
+            "url": addr.to_string()
+        }))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{}", err);
+        }
+    };
+}
+
+pub fn remove_connection(url: &str, addr: &str) {
+    let response = reqwest::Client::new()
+        .delete(&format!("{}/connections/delete", url))
+        .json(&json!({
+            "url": addr.to_string()
+        }))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{}", err);
+        }
+    };
+}
+
+pub fn list_connections(url: &str) {
+    let response = reqwest::Client::new()
+        .get(&format!("{}/connections/fetch", url))
+        .send();
+
+    match response {
+        Ok(mut r) => {
+            println!("{}", r.text().unwrap());
+        }
+        Err(err) => {
+            error!("{}", err);
+        }
+    };
+}

--- a/examples/cm-repl/cli/src/main.rs
+++ b/examples/cm-repl/cli/src/main.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate log;
+
+mod actions;
+
+use clap::{clap_app, crate_version};
+use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+
+use actions::{add_connection, list_connections, remove_connection};
+
+pub fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}
+
+fn main() {
+    let matches = clap_app!(cmc =>
+        (version: crate_version!())
+        (about: "Connection manager client (cmc)")
+        (@arg url: +takes_value "Connection Manager Repl REST API address")
+        (@arg verbose: -v --verbose +multiple "Increase output verbosity")
+        (@setting SubcommandRequiredElseHelp)
+        (@subcommand connection =>
+            (@setting SubcommandRequiredElseHelp)
+            (about: "Add, remove, and list connections")
+            (@subcommand add =>
+                (about: "Add a new connection")
+                (@arg address: +takes_value +required "Node address you want to add as a connection")
+            )
+            (@subcommand remove =>
+                (about: "Remove connection")
+                (@arg address: +takes_value +required "Node address you want to add as a connection")
+            )
+            (@subcommand list =>
+                (about: "List active connections")
+            )
+         )
+    ).get_matches();
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("tokio", log::LevelFilter::Warn);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()
+        .expect("Failed to create logger");
+
+    let url = matches.value_of("url").unwrap_or("http://localhost:3030");
+
+    match matches.subcommand() {
+        ("connection", Some(m)) => match m.subcommand() {
+            ("add", Some(m)) => add_connection(url, m.value_of("address").unwrap()),
+            ("remove", Some(m)) => remove_connection(url, m.value_of("address").unwrap()),
+            ("list", Some(_)) => list_connections(url),
+            _ => panic!("Unknown command"),
+        },
+        _ => panic!("Unknown command"),
+    }
+}

--- a/examples/cm-repl/daemon/Cargo.toml
+++ b/examples/cm-repl/daemon/Cargo.toml
@@ -12,20 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "cm-repl-daemon"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
 
-members = [
-    "cli",
-    "client",
-    "libsplinter",
-    "splinterd",
-    "examples/cm-repl/daemon",
-    "examples/private_counter/cli",
-    "examples/private_counter/service",
-    "examples/private_xo",
-    "examples/gameroom/cli",
-    "examples/gameroom/database",
-    "examples/gameroom/daemon",
-    "services/health",
-    "services/scabbard",
-]
+[dependencies]
+clap = "2.32"
+ctrlc = "3.0"
+flexi_logger = "0.14"
+serde = "1.0"
+serde_json = "1.0"
+splinter = { path = "../../../libsplinter", features = ["connection-manager", "matrix", "rest-api"]}
+log = "0.4"

--- a/examples/cm-repl/daemon/Dockerfile
+++ b/examples/cm-repl/daemon/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -------------=== Build connection manager daemon ===-------------
+
+FROM splintercommunity/splinter-dev as DAEMON_BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY libsplinter/protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+
+# Build the project
+WORKDIR /build/examples/cm-repl/daemon
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
+# -------------=== Build connection manager cli ===-------------
+
+FROM splintercommunity/splinter-dev as CLI_BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY libsplinter/protos /build/protos
+COPY examples/cm-repl /build/examples/cm-repl
+COPY libsplinter /build/libsplinter
+
+# Build the project
+WORKDIR /build/examples/cm-repl/cli
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION
+
+# -------------=== cm-repl docker build ===-------------
+FROM ubuntu:bionic
+
+COPY --from=DAEMON_BUILDER /build/target/debian/cm-repl*.deb /tmp
+COPY --from=CLI_BUILDER /build/target/debian/cmc*.deb /tmp
+
+RUN apt-get update \
+ && dpkg --unpack /tmp/cm-repl*.deb \
+ && dpkg --unpack /tmp/cmc*.deb \
+ && apt-get -f -y install
+
+CMD ["cm-repl-daemon"]

--- a/examples/cm-repl/daemon/src/main.rs
+++ b/examples/cm-repl/daemon/src/main.rs
@@ -1,0 +1,135 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate clap;
+#[macro_use]
+extern crate log;
+
+mod rest_api;
+
+use clap::{clap_app, crate_version};
+use ctrlc;
+use flexi_logger::{style, DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+use rest_api::start_rest_api;
+use splinter::{
+    mesh::Mesh,
+    network::connection_manager::ConnectionManager,
+    transport::{raw::RawTransport, Incoming, Transport},
+};
+
+use std::thread;
+
+fn log_format(
+    w: &mut dyn std::io::Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    let level = record.level();
+    write!(
+        w,
+        "[{}] T[{:?}] {} [{}] {}",
+        now.now().format("%Y-%m-%d %H:%M:%S%.3f"),
+        thread::current().name().unwrap_or("<unnamed>"),
+        record.level(),
+        record.module_path().unwrap_or("<unnamed>"),
+        style(level, &record.args()),
+    )
+}
+
+fn main() {
+    let app = clap_app!(cm_poc =>
+        (version: crate_version!())
+        (about: "Proof of concept demonstrating connection manager usage")
+        (@arg bind: +takes_value "Rest api address")
+        (@arg endpoint: +takes_value "Node endpoint")
+        (@arg verbose: -v --verbose +multiple "Increase output verbosity"));
+
+    let matches = app.get_matches();
+
+    let bind = matches.value_of("bind").unwrap_or("0.0.0.0:3030");
+    let endpoint = matches.value_of("endpoint").unwrap_or("tcp://0.0.0.0:3040");
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("tokio", log::LevelFilter::Warn);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()
+        .expect("Failed to create logger");
+
+    let mesh = Mesh::new(512, 512);
+
+    let mut transport = RawTransport::default();
+    let mut listener = transport
+        .listen(endpoint)
+        .expect("Failed to create listener");
+
+    let mut cm = ConnectionManager::new(
+        mesh.get_life_cycle(),
+        mesh.get_sender(),
+        Box::new(transport),
+    );
+
+    let mesh_clone = mesh.clone();
+    let _ = thread::spawn(move || {
+        for connection_result in listener.incoming() {
+            info!("Received connection");
+            let connection = match connection_result {
+                Ok(c) => c,
+                Err(err) => return error!("{:?}", err),
+            };
+
+            mesh_clone.add(connection).unwrap();
+        }
+    });
+
+    let mesh_incoming = mesh.incoming();
+    let _ = thread::spawn(move || loop {
+        match mesh_incoming.recv() {
+            Ok(msg) => {
+                info!("Received Message: {:?}", msg);
+            }
+            Err(err) => {
+                error!("{:?}", err);
+            }
+        }
+    });
+
+    let connector = cm.start().expect("Failed to create connection manager");
+
+    let shutdown_handle = cm.shutdown_handle().unwrap();
+    let (rest_api_shutdown_handle, join_handle) = start_rest_api(connector, &bind);
+
+    ctrlc::set_handler(move || {
+        info!("shutting down");
+        shutdown_handle.shutdown();
+        if let Err(err) = rest_api_shutdown_handle.shutdown() {
+            error!("Failed to shutdown rest api gracefully: {:?}", err);
+        }
+    })
+    .expect("Error setting up ctrl-c handler");
+
+    cm.await_shutdown();
+    join_handle.join().unwrap();
+}

--- a/examples/cm-repl/daemon/src/rest_api.rs
+++ b/examples/cm-repl/daemon/src/rest_api.rs
@@ -1,0 +1,136 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use splinter::{
+    actix_web::{web, Error, HttpResponse},
+    futures::{future::IntoFuture, stream::Stream, Future},
+    network::connection_manager::{
+        messages::{CmResponse, CmResponseStatus},
+        Connector,
+    },
+    rest_api::{Method, Resource, RestApiBuilder, RestApiShutdownHandle, RestResourceProvider},
+};
+
+pub struct Provider {
+    connector: Connector,
+}
+
+impl Provider {
+    pub fn new(connector: Connector) -> Self {
+        Self { connector }
+    }
+}
+
+impl RestResourceProvider for Provider {
+    fn resources(&self) -> Vec<Resource> {
+        vec![
+            make_add_connection(self.connector.clone()),
+            make_remove_connection(self.connector.clone()),
+            make_fetch_connections(self.connector.clone()),
+        ]
+    }
+}
+
+fn make_add_connection(connector: Connector) -> Resource {
+    Resource::build("/connections/create").add_method(Method::Post, move |_, payload| {
+        let connector = connector.clone();
+        Box::new(
+            payload
+                .from_err::<Error>()
+                .fold(web::BytesMut::new(), move |mut body, chunk| {
+                    body.extend_from_slice(&chunk);
+                    Ok::<_, Error>(body)
+                })
+                .and_then(move |body| match serde_json::from_slice::<Payload>(&body) {
+                    Ok(payload) => match connector.request_connection(&payload.url) {
+                        Ok(CmResponse::AddConnection {
+                            status,
+                            error_message,
+                        }) if status == CmResponseStatus::Error => {
+                            HttpResponse::InternalServerError().body(format!("{:?}", error_message))
+                        }
+                        Ok(res) => HttpResponse::Ok().body(format!("{:?}", res)),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                    },
+                    Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                })
+                .into_future(),
+        )
+    })
+}
+
+fn make_remove_connection(connector: Connector) -> Resource {
+    Resource::build("/connections/delete").add_method(Method::Delete, move |_, payload| {
+        let connector = connector.clone();
+        Box::new(
+            payload
+                .from_err::<Error>()
+                .fold(web::BytesMut::new(), move |mut body, chunk| {
+                    body.extend_from_slice(&chunk);
+                    Ok::<_, Error>(body)
+                })
+                .and_then(move |body| match serde_json::from_slice::<Payload>(&body) {
+                    Ok(payload) => match connector.remove_connection(&payload.url) {
+                        Ok(CmResponse::AddConnection {
+                            status,
+                            error_message,
+                        }) if status == CmResponseStatus::Error => {
+                            HttpResponse::InternalServerError().body(format!("{:?}", error_message))
+                        }
+                        Ok(res) => HttpResponse::Ok().body(format!("{:?}", res)),
+                        Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                    },
+                    Err(err) => HttpResponse::InternalServerError().body(format!("{:?}", err)),
+                })
+                .into_future(),
+        )
+    })
+}
+
+fn make_fetch_connections(connector: Connector) -> Resource {
+    Resource::build("/connections/fetch").add_method(Method::Get, move |_, _| {
+        match connector.list_connections() {
+            Ok(res) => Box::new(HttpResponse::Ok().body(format!("{:?}", res)).into_future()),
+            Err(err) => Box::new(
+                HttpResponse::InternalServerError()
+                    .body(format!("{:?}", err))
+                    .into_future(),
+            ),
+        }
+    })
+}
+
+#[derive(Serialize, Deserialize)]
+struct Payload {
+    url: String,
+}
+
+pub fn start_rest_api(
+    connector: Connector,
+    bind: &str,
+) -> (RestApiShutdownHandle, thread::JoinHandle<()>) {
+    let provider = Provider::new(connector);
+
+    let builder = RestApiBuilder::new();
+    builder
+        .with_bind(bind)
+        .add_resources(provider.resources())
+        .build()
+        .expect("Failed to build rest api")
+        .run()
+        .expect("Failed to start rest api")
+}

--- a/examples/cm-repl/docker-compose.yaml
+++ b/examples/cm-repl/docker-compose.yaml
@@ -1,0 +1,54 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3'
+
+services:
+  node-0:
+    image: cm-node
+    expose:
+      - 3030
+      - 3040
+    ports:
+      - 3030:3030
+      - 3040:3040
+    build:
+      context: ../..
+      dockerfile: examples/cm-repl/daemon/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    entrypoint: |
+      bash -c "
+        cm-repl-daemon -vvv
+      "
+
+  node-1:
+    image: cm-node
+    expose:
+      - 3030
+      - 3040
+    ports:
+      - 4030:3030
+      - 4040:3040
+    build:
+      context: ../..
+      dockerfile: examples/cm-repl/daemon/Dockerfile
+      args:
+        - REPO_VERSION=${REPO_VERSION}
+    entrypoint: |
+      bash -c "
+        cm-repl-daemon -vvv
+      "
+
+

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod error;
-mod messages;
+pub mod messages;
 mod pacemaker;
 
 use std;


### PR DESCRIPTION
Adds `cm-repl`, an example daemon using the connection manger and refactors notifications API

### Testing

1) Build with docker
```
docker-compose -f examples/cm-repl/docker-compose.yaml
```
2) Exec into one of the node containers
```
docker exec -it cm-repl_node-0_1 bash
```
3) Run connection manager client commands
```
cmc connection add tcp://node-0:3040
cmc connection list
cmc connection remove tcp://node-0:3040
```