### PR TITLE
Remove generate-certs from default features

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,10 +33,11 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
+        splinter cert generate && \
         splinterd \
-            --generate-certs \
             -c ./configs/splinterd-node-0-docker.toml \
             --registry-file ./node_registries/nodes.yaml \
+            --insecure \
             -vv
       "
 

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -144,10 +144,12 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          splinterd --generate-certs -c ./configs/splinterd-node-acme.toml -vv \
+          splinter cert generate && \
+          splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --bind 0.0.0.0:8085
+              --bind 0.0.0.0:8085 \
+              --insecure
         "
 
     db-bubba:
@@ -251,8 +253,10 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          splinterd --generate-certs -c ./configs/splinterd-node-bubba.toml -vv \
+          splinter cert generate && \
+          splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --bind 0.0.0.0:8085
+              --bind 0.0.0.0:8085 \
+              --insecure
         "

--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -40,3 +40,6 @@ registry_backend = "FILE"
 
 # Node Registry file
 registry_file = "/node_registry/nodes.yaml"
+
+# List of certificate authority certificates (*.pem files).
+ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -40,3 +40,6 @@ registry_backend = "FILE"
 
 # Node Registry file
 registry_file = "/node_registry/nodes.yaml"
+
+# List of certificate authority certificates (*.pem files).
+ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -100,7 +100,8 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        splinterd --generate-certs -c ./project/tests/splinterd-node-0-docker.toml -vv
+        splinter cert generate && \
+        splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
       "
 
   db-cypress-test:

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -52,7 +52,8 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        splinterd --generate-certs -c ./project/tests/splinterd-node-0-docker.toml -vv
+        splinter cert generate &&
+        splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
       "
 
   db-test:

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -40,3 +40,6 @@ registry_backend = "FILE"
 
 # Node Registry file
 registry_file = "/project/tests/sample_node_registry.yaml"
+
+# List of certificate authority certificates (*.pem files).
+ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -40,7 +40,7 @@ tempdir = "0.3"
 toml = "0.4.8"
 
 [features]
-default = ["generate-certs"]
+default = []
 
 stable = ["default"]
 

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -16,16 +16,26 @@
 
 FROM splintercommunity/splinter-dev as BUILDER
 
+COPY cli /build/cli
 COPY libsplinter /build/libsplinter
 COPY services/health /build/services/health
 COPY splinterd/ /build/splinterd
 
-# Build the package
+# Build splinterd
 WORKDIR /build/splinterd
 ARG REPO_VERSION
 ARG CARGO_ARGS
 RUN sed -i -e s/version.*$/version\ =\ \"${REPO_VERSION}\"/ Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN mv /build/target/debian/splinter-daemon*.deb /tmp
+
+# Build splinter-cli
+WORKDIR /build/cli
+ARG REPO_VERSION
+ARG CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN mv /build/target/debian/splinter-cli*.deb /tmp
 
 # -------------=== splinterd docker build ===-------------
 
@@ -34,8 +44,8 @@ FROM ubuntu:bionic
 ARG CARGO_ARGS
 RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS
 
-COPY --from=builder /build/target/debian/splinter-daemon*.deb /tmp
+COPY --from=builder /tmp/splinter-*.deb /tmp/
 
 RUN apt-get update \
- && dpkg --unpack /tmp/splinter-daemon*.deb \
+ && dpkg --unpack /tmp/splinter-*.deb \
  && apt-get -f -y install

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -34,3 +34,6 @@ transport = "tls"
 
 # Rest api address.
 bind = "0.0.0.0:8080"
+
+# List of certificate authority certificates (*.pem files).
+ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -35,7 +35,6 @@ use crate::config::{Config, ConfigError};
 #[cfg(feature = "config-toml")]
 use crate::config::{ConfigBuilder, TomlConfig};
 use crate::daemon::SplinterDaemonBuilder;
-#[cfg(feature = "generate-certs")]
 use clap::Arg;
 use clap::{clap_app, crate_version};
 use openssl::error::ErrorStack;


### PR DESCRIPTION
Refactor of https://github.com/Cargill/splinter/pull/359. Instead of using shared volumes to create and share certificates, this PR adds the splinter cli to the splinterd image so cert creation can happen locally.