### PR TITLE
List connection message

### DIFF
--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -32,6 +32,7 @@ pub struct CmRequest {
 pub enum CmPayload {
     AddConnection { endpoint: String },
     RemoveConnection { endpoint: String },
+    ListConnections,
 }
 
 #[derive(Debug, PartialEq)]
@@ -43,6 +44,9 @@ pub enum CmResponse {
     RemoveConnection {
         status: CmResponseStatus,
         error_message: Option<String>,
+    },
+    ListConnections {
+        endpoints: Vec<String>,
     },
 }
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -389,13 +389,7 @@ fn notify_subscribers(
     subscribers: &mut Vec<SyncSender<ConnectionManagerNotification>>,
     notification: ConnectionManagerNotification,
 ) {
-    subscribers.retain(|sender| {
-        if sender.send(notification.clone()).is_err() {
-            false
-        } else {
-            true
-        }
-    });
+    subscribers.retain(|sender| !sender.send(notification.clone()).is_err());
 }
 
 fn send_heartbeats<T: MatrixLifeCycle, U: MatrixSender>(

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -168,6 +168,16 @@ impl Connector {
         }
     }
 
+    pub fn list_connections(&self) -> Result<Vec<String>, ConnectionManagerError> {
+        match self.send_payload(CmPayload::ListConnections) {
+            Ok(CmResponse::ListConnections { endpoints }) => Ok(endpoints),
+            Err(err) => Err(err),
+            _ => {
+                panic!("This cannot return a response type that is not CmResponse::ListConnections")
+            }
+        }
+    }
+
     fn send_payload(&self, payload: CmPayload) -> Result<CmResponse, ConnectionManagerError> {
         let (sender, recv) = sync_channel(1);
 
@@ -360,6 +370,13 @@ fn handle_request<T: MatrixLifeCycle, U: MatrixSender>(
                 status: CmResponseStatus::Error,
                 error_message: Some(format!("{:?}", err)),
             },
+        },
+        CmPayload::ListConnections => CmResponse::ListConnections {
+            endpoints: state
+                .connection_metadata()
+                .iter()
+                .map(|(key, _)| key.to_string())
+                .collect(),
         },
     };
 


### PR DESCRIPTION
Adds list connection message type, which is returns a list of endpoints
the connection manager is connected to. This is meant to be used for
debugging purposes.