### PR TITLE
Localize the Key Registries

### DIFF
--- a/examples/gameroom/README.md
+++ b/examples/gameroom/README.md
@@ -31,17 +31,18 @@ and [Docker Compose](https://docs.docker.com/compose).
      docker-compose -f examples/gameroom/docker-compose.yaml up
      ```
 1. To extract private keys to use in the web application, run bash using the
-   `generate-key-registry` image and read the private key.  For example, to get
-   Alice's private key:
+   associated splinter node image and read the private key.  For example, to
+   get Alice's private key for use with the Acme node:
 
     ```
-    $ docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash
-    root@<container-id>:/# cat /key_registry/alice.priv; echo ""
+    $ docker-compose -f examples/gameroom/docker-compose.yaml exec splinterd-node-acme bash
+    root@<container-id>:/# cat /var/lib/splinter/alice.priv; echo ""
     <the private key value>
     root@<container-id>:/#
     ```
 
-    The keys available are `alice` and `bob`.
+    The private key for Bob and the Bubba node is similarly available in the
+    `splinterd-node-bubba` image.
 
 1. In a browser, navigate to the web application UI for each organization:
 

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -16,33 +16,10 @@ version: '3'
 
 volumes:
   cargo-registry:
-  key-registry:
   acme-var:
   bubba-var:
 
 services:
-
-    generate-key-registry:
-        image: splinter-cli
-        build:
-          context: ../..
-          dockerfile: ./cli/Dockerfile-installed-${DISTRO}
-          args:
-            - CARGO_ARGS=${CARGO_ARGS}
-            - REPO_VERSION=${REPO_VERSION}
-        volumes:
-          - key-registry:/key_registry
-          - ./key_registry:/input
-        command: |
-          bash -c "
-            if [ ! -f /key_registry/keys.yaml ]
-            then
-              splinter admin keyregistry \
-                -i /input/key_registry_spec.yaml \
-                -d /key_registry \
-                --force
-            fi
-          "
 
     db-acme:
       image: gameroom-database
@@ -131,19 +108,19 @@ services:
       ports:
         - 8088:8085
       volumes:
-        - key-registry:/key_registry_shared
+        - ./key_registry:/input
         - acme-var:/var/lib/splinter
         - ./splinterd-config:/configs
         - ./node_registry:/node_registry
       entrypoint: |
         bash -c "
-          # We need to wait for the generated key registry to be available
-          while [ ! -f /key_registry_shared/keys.yaml ]; do \
-            echo 'waiting for key registry'; \
-            sleep 1; \
-          done && \
-          # Copy the generated key registry to its expected location
-          cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
+          if [ ! -f /var/lib/splinter/keys.yaml ]
+          then
+            splinter admin keyregistry \
+              -i /input/key_registry_spec_acme.yaml \
+              --force
+          fi
+
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
@@ -240,19 +217,19 @@ services:
       ports:
         - 8089:8085
       volumes:
-        - key-registry:/key_registry_shared
+        - ./key_registry:/input
         - ./splinterd-config:/configs
         - ./node_registry:/node_registry
         - bubba-var:/var/lib/splinter
       entrypoint: |
         bash -c "
-          # We need to wait for the generated key registry to be available
-          while [ ! -f /key_registry_shared/keys.yaml ]; do \
-            echo 'waiting for key registry'; \
-            sleep 1; \
-          done && \
-          # Copy the generated key registry to its expected location
-          cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
+          if [ ! -f /var/lib/splinter/keys.yaml ]
+          then
+            splinter admin keyregistry \
+              -i /input/key_registry_spec_bubba.yaml \
+              --force
+          fi
+
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint 0.0.0.0:8043 \

--- a/examples/gameroom/gameroom-app/src/store/modules/proposals.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/proposals.ts
@@ -45,6 +45,7 @@ const actions = {
       const response = await submitPayload(signedPayload);
       return response;
     } catch (err) {
+      await dispatch('votes/clearVote', vote.proposalID, {root: true});
       console.error(err);
       throw err;
     }

--- a/examples/gameroom/gameroom-app/src/store/modules/votes.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/votes.ts
@@ -30,12 +30,18 @@ const actions = {
   vote({ commit }: any, id: number) {
     commit('setVote', id);
   },
+  clearVote({ commit}: any, id: number) {
+      commit('clearVote', id)
+  }
 };
 
 const mutations = {
   setVote(state: VoteState, id: number) {
     state.votes[id] = true;
   },
+  clearVote(state: VoteState, id: number) {
+    delete state.votes[id];
+  }
 };
 
 export default {

--- a/examples/gameroom/key_registry/key_registry_spec_acme.yaml
+++ b/examples/gameroom/key_registry/key_registry_spec_acme.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+alice:
+  node_id: acme-node-000
+  metadata:
+    gameroom/first-name: alice
+    gameroom/organization: Acme

--- a/examples/gameroom/key_registry/key_registry_spec_bubba.yaml
+++ b/examples/gameroom/key_registry/key_registry_spec_bubba.yaml
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 ---
-alice:
-  node_id: acme-node-000
-  metadata:
-    gameroom/first-name: alice
-    gameroom/organization: Acme
 bob:
   node_id: bubba-node-000
   metadata:

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -48,11 +48,14 @@ fn make_submit_route<A: AdminCommands + Clone + 'static>(admin_commands: A) -> R
                     Ok(()) => HttpResponse::Accepted().finish().into_future(),
                     Err(AdminServiceError::ServiceError(ServiceError::UnableToHandleMessage(
                         err,
-                    ))) => HttpResponse::BadRequest()
-                        .json(json!({
-                            "message": format!("Unable to handle message: {}", err)
-                        }))
-                        .into_future(),
+                    ))) => {
+                        debug!("Unable to process message: {}", err);
+                        HttpResponse::BadRequest()
+                            .json(json!({
+                                "message": format!("Unable to handle message: {}", err)
+                            }))
+                            .into_future()
+                    }
                     Err(AdminServiceError::ServiceError(ServiceError::InvalidMessageFormat(
                         err,
                     ))) => HttpResponse::BadRequest()

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -515,7 +515,7 @@ mod tests {
             .admin_service_shared
             .lock()
             .unwrap()
-            .propose_circuit(payload)
+            .propose_circuit(&header, payload)
             .expect("The proposal was not handled correctly");
 
         // wait up to 1 second for the proposed circuit message


### PR DESCRIPTION
This PR changes the way the key registry is utilized by removing the assumption that the key registry is shared between the nodes.  Keys are now considered a local concern of a splinter node.

When a circuit proposal or vote is submitted, the signer is first checked to see if they are allowed to make that change on the nodes behalf.  If not, the request is rejected.   Likewise, if a node receives a proposal or vote via consensus, and it pertains to itself, the signer is checked.  If the signer is unknown or does not have permissions, the change is marked as invalid and fails consensus.

The docker-compose file for the Gameroom example has been updated to generate key registries for each node individually.  Note that to retrieve these private keys, the user must follow slightly different instructions:

```
$ docker-compose -f examples/gameroom/docker-compose.yaml exec splinterd-node-acme bash
root@<container-id>:/# cat /var/lib/splinter/alice.priv; echo ""
<the private key value>
root@<container-id>:/#
```

and likewise for bubba and bob's key.