### PR TITLE
Add "derive" as a serde feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -59,8 +59,7 @@ openssl = "0.10"
 protobuf = "2"
 reqwest = { version = "0.9", optional = true }
 sawtooth-sdk = "0.3"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version ="1.0", optional = true }
 serde_yaml = "0.8"
 splinter = { path = "../libsplinter" }


### PR DESCRIPTION
Replaces the serde_derive dependency by enabling serde's "derive"
feature. This fixes a compilation error related to derive statements.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>