### PR TITLE
Key management routes to biome rest api

### DIFF
--- a/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
@@ -30,3 +30,14 @@ pub fn list_keys_with_user_id(conn: &PgConnection, user_id: &str) -> QueryResult
 pub fn list_keys(conn: &PgConnection) -> QueryResult<Vec<KeyModel>> {
     keys::table.load::<KeyModel>(conn)
 }
+
+pub fn update_key(
+    conn: &PgConnection,
+    user_id: &str,
+    public_key: &str,
+    display_name: &str,
+) -> QueryResult<usize> {
+    diesel::update(keys::table.find((public_key, user_id)))
+        .set((keys::display_name.eq(display_name),))
+        .execute(conn)
+}

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
@@ -17,6 +17,6 @@ use super::super::schema::keys;
 
 use diesel::{dsl::insert_into, pg::PgConnection, prelude::*, QueryResult};
 
-pub fn insert_key(conn: &PgConnection, key: KeyModel) -> QueryResult<usize> {
-    insert_into(keys::table).values(&vec![key]).execute(conn)
+pub fn insert_key(conn: &PgConnection, key: &KeyModel) -> QueryResult<usize> {
+    insert_into(keys::table).values(vec![key]).execute(conn)
 }

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/keys.rs
@@ -20,3 +20,13 @@ use diesel::{dsl::insert_into, pg::PgConnection, prelude::*, QueryResult};
 pub fn insert_key(conn: &PgConnection, key: &KeyModel) -> QueryResult<usize> {
     insert_into(keys::table).values(vec![key]).execute(conn)
 }
+
+pub fn list_keys_with_user_id(conn: &PgConnection, user_id: &str) -> QueryResult<Vec<KeyModel>> {
+    keys::table
+        .filter(keys::user_id.eq(user_id))
+        .load::<KeyModel>(conn)
+}
+
+pub fn list_keys(conn: &PgConnection) -> QueryResult<Vec<KeyModel>> {
+    keys::table.load::<KeyModel>(conn)
+}

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
@@ -14,4 +14,4 @@
 
 mod keys;
 
-pub use keys::insert_key;
+pub use keys::{insert_key, list_keys, list_keys_with_user_id};

--- a/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/helpers/mod.rs
@@ -14,4 +14,4 @@
 
 mod keys;
 
-pub use keys::{insert_key, list_keys, list_keys_with_user_id};
+pub use keys::{insert_key, list_keys, list_keys_with_user_id, update_key};

--- a/libsplinter/src/biome/key_management/database/postgres/migrations/2020-01-10-204453_add_foreign_key_constraint/down.sql
+++ b/libsplinter/src/biome/key_management/database/postgres/migrations/2020-01-10-204453_add_foreign_key_constraint/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE keys DROP CONSTRAINT biome_user;

--- a/libsplinter/src/biome/key_management/database/postgres/migrations/2020-01-10-204453_add_foreign_key_constraint/up.sql
+++ b/libsplinter/src/biome/key_management/database/postgres/migrations/2020-01-10-204453_add_foreign_key_constraint/up.sql
@@ -1,0 +1,17 @@
+-- Copyright 2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE keys
+ ADD CONSTRAINT biome_user FOREIGN KEY (user_id) REFERENCES splinter_user(id);

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -24,6 +24,7 @@ pub(in crate::biome) mod store;
 use database::postgres::models::KeyModel;
 
 // Represents a public and private key pair
+#[derive(Serialize)]
 pub struct Key {
     public_key: String,
     encrypted_private_key: String,

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -15,6 +15,10 @@
 //! Provides an API for storing key pairs and associating them with users.
 
 pub mod database;
+
+#[cfg(feature = "rest-api")]
+pub(in crate::biome) mod rest_resources;
+
 pub(in crate::biome) mod store;
 
 use database::postgres::models::KeyModel;

--- a/libsplinter/src/biome/key_management/rest_resources.rs
+++ b/libsplinter/src/biome/key_management/rest_resources.rs
@@ -1,0 +1,176 @@
+// Copyright 2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::{HttpRequest, HttpResponse};
+use crate::futures::{Future, IntoFuture};
+use crate::rest_api::{
+    get_authorization_token, into_bytes, ErrorResponse, HandlerFunction, Method, Resource,
+};
+
+use super::super::rest_api::BiomeRestConfig;
+use super::super::secrets::SecretManager;
+use super::super::sessions::{validate_token, TokenValidationError};
+
+use super::{
+    store::{KeyStore, KeyStoreError},
+    Key,
+};
+
+#[derive(Deserialize)]
+struct NewKey {
+    public_key: String,
+    encrypted_private_key: String,
+    display_name: String,
+}
+/// Defines a REST endpoint for managing keys
+pub fn make_key_management_route(
+    rest_config: Arc<BiomeRestConfig>,
+    key_store: Arc<dyn KeyStore<Key>>,
+    secret_manager: Arc<dyn SecretManager>,
+) -> Resource {
+    Resource::build("/biome/users/{user_id}/keys").add_method(
+        Method::Post,
+        handle_post(
+            rest_config.clone(),
+            key_store.clone(),
+            secret_manager.clone(),
+        ),
+    )
+}
+
+fn handle_post(
+    rest_config: Arc<BiomeRestConfig>,
+    key_store: Arc<dyn KeyStore<Key>>,
+    secret_manager: Arc<dyn SecretManager>,
+) -> HandlerFunction {
+    Box::new(move |request, payload| {
+        let key_store = key_store.clone();
+        let user_id = match request.match_info().get("user_id") {
+            Some(id) => id.to_owned(),
+            None => {
+                error!("User ID is not in path request");
+                return Box::new(
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                );
+            }
+        };
+
+        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
+            AuthorizationResult::Authorized => (),
+            AuthorizationResult::Unauthorized(msg) => {
+                return Box::new(
+                    HttpResponse::Unauthorized()
+                        .json(ErrorResponse::unauthorized(&msg))
+                        .into_future(),
+                )
+            }
+            AuthorizationResult::Failed => {
+                return Box::new(
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                );
+            }
+        }
+
+        Box::new(into_bytes(payload).and_then(move |bytes| {
+            let new_key = match serde_json::from_slice::<NewKey>(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload: {}",
+                            err
+                        )))
+                        .into_future();
+                }
+            };
+            let key = Key::new(
+                &new_key.public_key,
+                &new_key.encrypted_private_key,
+                &user_id,
+                &new_key.display_name,
+            );
+
+            match key_store.add_key(key) {
+                Ok(()) => HttpResponse::Ok()
+                    .json(json!({ "message": "Key added successfully" }))
+                    .into_future(),
+                Err(err) => {
+                    debug!("Failed to add new key to database {}", err);
+                    match err {
+                        KeyStoreError::DuplicateKeyError(msg) => HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&msg))
+                            .into_future(),
+                        KeyStoreError::UserDoesNotExistError(msg) => HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&msg))
+                            .into_future(),
+                        _ => HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future(),
+                    }
+                }
+            }
+        }))
+    })
+}
+
+enum AuthorizationResult {
+    Authorized,
+    Unauthorized(String),
+    Failed,
+}
+
+fn authorize_user(
+    request: &HttpRequest,
+    user_id: &str,
+    secret_manager: &Arc<dyn SecretManager>,
+    rest_config: &BiomeRestConfig,
+) -> AuthorizationResult {
+    let auth_token = match get_authorization_token(&request) {
+        Ok(token) => token,
+        Err(err) => {
+            debug!("Failed to get token: {}", err);
+            return AuthorizationResult::Unauthorized("User is not authorized".to_string());
+        }
+    };
+
+    let secret = match secret_manager.secret() {
+        Ok(secret) => secret,
+        Err(err) => {
+            debug!("Failed to fetch secret {}", err);
+            return AuthorizationResult::Failed;
+        }
+    };
+
+    if let Err(err) = validate_token(&auth_token, &secret, &rest_config.issuer(), |claim| {
+        if user_id != claim.user_id() {
+            return Err(TokenValidationError::InvalidClaim(format!(
+                "User is not update keys for user {}",
+                user_id
+            )));
+        }
+        Ok(())
+    }) {
+        debug!("Invalid token: {}", err);
+        return AuthorizationResult::Unauthorized("User is not authorized".to_string());
+    };
+
+    AuthorizationResult::Authorized
+}

--- a/libsplinter/src/biome/key_management/store/error.rs
+++ b/libsplinter/src/biome/key_management/store/error.rs
@@ -39,6 +39,12 @@ pub enum KeyStoreError {
     },
     /// Represents an issue connecting to the database
     ConnectionError(Box<dyn Error>),
+    /// Returned when a key is not found by the provided ID
+    NotFoundError(String),
+    /// Returned when a key with the same ID is already in the database
+    DuplicateKeyError(String),
+    /// Returned when a user is not found with the provided ID
+    UserDoesNotExistError(String),
 }
 
 impl Error for KeyStoreError {
@@ -48,6 +54,9 @@ impl Error for KeyStoreError {
             KeyStoreError::QueryError { source, .. } => Some(&**source),
             KeyStoreError::StorageError { source, .. } => Some(&**source),
             KeyStoreError::ConnectionError(err) => Some(&**err),
+            KeyStoreError::NotFoundError(_) => None,
+            KeyStoreError::DuplicateKeyError(_) => None,
+            KeyStoreError::UserDoesNotExistError(_) => None,
         }
     }
 }
@@ -69,6 +78,9 @@ impl fmt::Display for KeyStoreError {
             KeyStoreError::ConnectionError(err) => {
                 write!(f, "failed to connect to underlying storage: {}", err)
             }
+            KeyStoreError::NotFoundError(msg) => write!(f, "key not found: {}", msg),
+            KeyStoreError::DuplicateKeyError(msg) => write!(f, "key already exists: {}", msg),
+            KeyStoreError::UserDoesNotExistError(msg) => write!(f, "user does not exist: {}", msg),
         }
     }
 }

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -33,9 +33,16 @@ pub trait KeyStore<T> {
     ///
     /// # Arguments
     ///
-    ///  * `key` - The key with the updated information
+    /// * `public_key`: The public key of the key record to be updated.
+    /// * `user_id`: The ID owner of the key record to be updated.
+    /// * `new_display_name`: The new display name of the key record.
     ///
-    fn update_key(&self, updated_key: T) -> Result<(), KeyStoreError>;
+    fn update_key(
+        &self,
+        public_key: &str,
+        user_id: &str,
+        new_display_name: &str,
+    ) -> Result<(), KeyStoreError>;
 
     /// Removes a key from the underlying storage
     ///

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -15,7 +15,7 @@
 pub mod error;
 pub mod postgres;
 
-use error::KeyStoreError;
+pub use error::KeyStoreError;
 
 /// Defines methods for CRUD operations and fetching and listing keys
 /// without defining a storage strategy

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -19,7 +19,7 @@ pub use error::KeyStoreError;
 
 /// Defines methods for CRUD operations and fetching and listing keys
 /// without defining a storage strategy
-pub trait KeyStore<T> {
+pub trait KeyStore<T>: Sync + Send {
     /// Adds a key to the underlying storage
     ///
     /// # Arguments

--- a/libsplinter/src/biome/key_management/store/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/postgres/mod.rs
@@ -70,7 +70,12 @@ impl KeyStore<Key> for PostgresKeyStore {
         Ok(())
     }
 
-    fn update_key(&self, _updated_key: Key) -> Result<(), KeyStoreError> {
+    fn update_key(
+        &self,
+        _public_key: &str,
+        _user_id: &str,
+        _new_display_name: &str,
+    ) -> Result<(), KeyStoreError> {
         unimplemented!()
     }
 

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -50,7 +50,9 @@ use crate::database::ConnectionPool;
 use crate::rest_api::{Resource, RestResourceProvider};
 
 #[cfg(feature = "biome-key-management")]
-use super::key_management::store::postgres::PostgresKeyStore;
+use super::key_management::{
+    rest_resources::make_key_management_route, store::postgres::PostgresKeyStore,
+};
 use super::secrets::{AutoSecretManager, SecretManager};
 use super::user::store::diesel::SplinterUserStore;
 
@@ -109,6 +111,12 @@ impl RestResourceProvider for BiomeRestResourceManager {
                 );
             }
         };
+        #[cfg(feature = "biome-key-management")]
+        resources.push(make_key_management_route(
+            self.rest_config.clone(),
+            self.key_store.clone(),
+            self.token_secret_manager.clone(),
+        ));
         resources
     }
 }

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -86,3 +86,20 @@ impl From<ActixError> for ResponseError {
         ResponseError::ActixError(err)
     }
 }
+
+#[derive(Debug)]
+pub enum RequestError {
+    MissingHeader(String),
+    InvalidHeaderValue(String),
+}
+
+impl Error for RequestError {}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RequestError::MissingHeader(msg) => f.write_str(&msg),
+            RequestError::InvalidHeaderValue(msg) => f.write_str(&msg),
+        }
+    }
+}

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -193,8 +193,7 @@ impl Resource {
             ) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
             + Send
             + Sync
-            + 'static
-            + Clone,
+            + 'static,
     {
         Self::build(route).add_method(method, handle)
     }
@@ -214,8 +213,7 @@ impl Resource {
             ) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
             + Send
             + Sync
-            + 'static
-            + Clone,
+            + 'static,
     {
         self.methods.push((method, Arc::new(Box::new(handle))));
         self

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -93,7 +93,7 @@ pub trait RestResourceProvider {
     fn resources(&self) -> Vec<Resource>;
 }
 
-type HandlerFunction = Box<
+pub type HandlerFunction = Box<
     dyn Fn(HttpRequest, web::Payload) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
         + Send
         + Sync

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -67,7 +67,7 @@ use std::boxed::Box;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use errors::{ResponseError, RestApiServerError};
+pub use errors::{RequestError, ResponseError, RestApiServerError};
 
 pub use events::{new_websocket_event_sender, EventSender};
 
@@ -378,6 +378,29 @@ pub fn into_bytes(payload: web::Payload) -> impl Future<Item = Vec<u8>, Error = 
 
 pub fn percent_encode_filter_query(input: &str) -> String {
     percent_encoding::utf8_percent_encode(input, QUERY_ENCODE_SET).to_string()
+}
+
+pub fn require_header(header_key: &str, request: &HttpRequest) -> Result<String, RequestError> {
+    let header = request.headers().get(header_key).ok_or_else(|| {
+        RequestError::MissingHeader(format!("Header {} not included in Request", header_key))
+    })?;
+    Ok(header
+        .to_str()
+        .map_err(|err| RequestError::InvalidHeaderValue(format!("Invalid header value: {}", err)))?
+        .to_string())
+}
+
+pub fn get_authorization_token(request: &HttpRequest) -> Result<String, RequestError> {
+    let auth_header = require_header("Authorization", &request)?;
+    Ok(auth_header
+        .split_whitespace()
+        .last()
+        .ok_or_else(|| {
+            RequestError::InvalidHeaderValue(
+                "Authorization token not included in request".to_string(),
+            )
+        })?
+        .to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a POST, GET and PATCH `/biome/users/{user_id}/keys` to the key management feature in biome. 