### PR TITLE
Add circuit list/show commands

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ experimental = [
     "postgres",
 ]
 
-circuit = ["reqwest", "splinter/sawtooth-signing-compat"]
+circuit = ["reqwest", "serde_json", "splinter/sawtooth-signing-compat"]
 health = ["reqwest", "serde_json"]
 
 database = ["splinter/database", "diesel", "postgres"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,11 +136,12 @@ fn run() -> Result<(), CliError> {
 
     #[cfg(feature = "circuit")]
     {
-        use clap::{Arg, SubCommand};
+        use clap::{AppSettings, Arg, SubCommand};
 
         app = app.subcommand(
             SubCommand::with_name("circuit")
                 .about("Provides circuit management functionality")
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     SubCommand::with_name("create")
                         .about("Propose that a new circuit is created")
@@ -205,6 +206,49 @@ fn run() -> Result<(), CliError> {
                                 .conflicts_with("accept")
                                 .help("Reject the proposal"),
                         ),
+                )
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List the circuits")
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .long("url")
+                                .help("The URL of the Splinter daemon REST API")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("member")
+                                .short("m")
+                                .long("member")
+                                .help("Filter the circuits by a node ID in the member list")
+                                .takes_value(true),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("show")
+                        .about("Show a specific circuit")
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .long("url")
+                                .help("The URL of the Splinter daemon REST API")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("circuit")
+                                .help("The circuit ID of the circuit to be shown")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("format")
+                                .short("f")
+                                .long("format")
+                                .help("Format of the circuit")
+                                .possible_values(&["yaml", "json"])
+                                .default_value("yaml")
+                                .takes_value(true),
+                        ),
                 ),
         );
     }
@@ -263,7 +307,9 @@ fn run() -> Result<(), CliError> {
             "circuit",
             SubcommandActions::new()
                 .with_command("create", circuit::CircuitCreateAction)
-                .with_command("vote", circuit::CircuitVoteAction),
+                .with_command("vote", circuit::CircuitVoteAction)
+                .with_command("list", circuit::CircuitListAction)
+                .with_command("show", circuit::CircuitShowAction),
         );
     }
 


### PR DESCRIPTION
This is a draft PR for listing/showing circuits. 

To test, run gameroom with experimental features and create some gamerooms.

To list circuits (from the cli directory) run:
`cargo run --features experimental -- circuit list --url http://0.0.0.0:8088`

The output will look like:
```
CIRCUIT ID                                                                       | CIRCUIT MANAGEMENT TYPE  
--------------------------------------------------------------------------------------------------------------     
gameroom::bubba-node-000::acme-node-000::304dc30c-cc27-45eb-a389-ce34af32a6e8    | gameroom                      
gameroom::bubba-node-000::acme-node-000::aed2b597-d126-4fdf-9893-3f4c18cb1f21    | gameroom  
```

To show a circuit (from the cli directory) run (replace circuit id with one from the list).

`cargo run --features experimental -- circuit show gameroom::bubba-node-000::acme-node-000::304dc30c-cc27-45eb-a389-ce34af32a6e8  --url http://0.0.0.0:8088`

This will print the circuit definition in yaml by default (json is also supported)
```
---
id: "gameroom::bubba-node-000::acme-node-000::304dc30c-cc27-45eb-a389-ce34af32a6e8"
auth: Trust
persistence: Any
durability: NoDurability
routes: Any
circuit_management_type: gameroom
members:
  - bubba-node-000
  - acme-node-000
roster:
  - service_id: gameroom_bubba-node-000
    service_type: scabbard
    allowed_nodes:
      - bubba-node-000
    arguments:
      admin_keys: "[\"027de322207f6be687ae0f1b8b26d6547154662a92068431114055944fde81bf37\"]"
      peer_services: "[\"gameroom_acme-node-000\"]"
  - service_id: gameroom_acme-node-000
    service_type: scabbard
    allowed_nodes:
      - acme-node-000
    arguments:
      admin_keys: "[\"027de322207f6be687ae0f1b8b26d6547154662a92068431114055944fde81bf37\"]"
      peer_services: "[\"gameroom_bubba-node-000\"]"
```

Please let me know what you think list should look like. And what other supported show formats should be included. 


