### PR TITLE
Implement "circuit vote" splinter CLI command

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -72,6 +72,25 @@ impl<'a> SplinterRestClient<'a> {
                 ))),
             })
     }
+
+    pub fn fetch_proposal(&self, circuit_id: &str) -> Result<CircuitProposal, CliError> {
+        Client::new()
+            .get(&format!("{}/admin/proposals/{}", self.url, circuit_id))
+            .send()
+            .and_then(|res| res.json())
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to fetch circuit proposal {}: {}",
+                    circuit_id, err
+                ))
+            })
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CircuitProposal {
+    pub circuit_id: String,
+    pub circuit_hash: String,
 }
 
 #[derive(Deserialize)]

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -81,9 +81,15 @@ pub fn read_private_key(file_name: &str) -> Result<String, CliError> {
     Ok(buf)
 }
 
-enum Vote {
+pub(self) enum Vote {
     Accept,
     Reject,
+}
+
+pub(self) struct CircuitVote {
+    circuit_id: String,
+    circuit_hash: String,
+    vote: Vote,
 }
 
 pub struct CircuitVoteAction;

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -118,10 +118,25 @@ impl Action for CircuitVoteAction {
 }
 
 fn vote_on_circuit_proposal(
-    _url: &str,
-    _key: &str,
-    _path: &str,
-    _vote: Vote,
+    url: &str,
+    key: &str,
+    circuit_id: &str,
+    vote: Vote,
 ) -> Result<(), CliError> {
-    unimplemented!()
+    let client = api::SplinterRestClient::new(url);
+    let private_key_hex = read_private_key(key)?;
+
+    let requester_node = client.fetch_node_id()?;
+    let proposal = client.fetch_proposal(circuit_id)?;
+
+    let circuit_vote = CircuitVote {
+        circuit_id: circuit_id.into(),
+        circuit_hash: proposal.circuit_hash,
+        vote,
+    };
+
+    let signed_payload =
+        payload::make_signed_payload(&requester_node, &private_key_hex, circuit_vote)?;
+
+    client.submit_admin_payload(signed_payload)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -196,7 +196,6 @@ fn run() -> Result<(), CliError> {
                                 .required(true)
                                 .long("accept")
                                 .conflicts_with("reject")
-                                .possible_values(&["accept", "reject"])
                                 .help("Accept the proposal"),
                         )
                         .arg(
@@ -204,7 +203,6 @@ fn run() -> Result<(), CliError> {
                                 .required(true)
                                 .long("reject")
                                 .conflicts_with("accept")
-                                .possible_values(&["accept", "reject"])
                                 .help("Reject the proposal"),
                         ),
                 ),


### PR DESCRIPTION
~**NOTE: This PR depends on the functionality of #416, in order to test**~ 

To test:  Follow the create instructions in #410, but start  the gameroom with 

```
$ 'CARGO_ARGS=-- --features experimental' docker-compose -f examples/gameroom/docker-compose.yaml up --build
```

With the keys copied, submit the vote to the Bubba Bakery node with Bob's key:

```
$ cargo run --manifest-path cli/Cargo.toml --features circuit -- circuit vote -k <some local dir>/key_registry_shared/bob.priv -U http://localhost:8089 --accept
```

This will initiate creating the circuit, but will fail creating the services (due to the parameters for the services in the example circuit being incorrect.