### PR TITLE
Add command to list proposals to cli and add support to show for proposals

### DIFF
--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -201,22 +201,90 @@ impl Action for CircuitShowAction {
 fn show_circuit(url: &str, circuit_id: &str, format: &str) -> Result<(), CliError> {
     let client = api::SplinterRestClient::new(url);
     let circuit = client.fetch_circuit(circuit_id)?;
-    match format {
-        "json" => println!(
-            "{}",
-            serde_json::to_string(&circuit).map_err(|err| CliError::ActionError(format!(
-                "Cannot format circuit into json: {}",
-                err
-            )))?
-        ),
-        // default is yaml
-        _ => println!(
-            "{}",
-            serde_yaml::to_string(&circuit).map_err(|err| CliError::ActionError(format!(
-                "Cannot format circuit into yaml: {}",
-                err
-            )))?
-        ),
+    let mut print_circuit = false;
+    let mut print_proposal = false;
+    if let Some(circuit) = circuit {
+        print_circuit = true;
+        match format {
+            "json" => println!(
+                "\n {}",
+                serde_json::to_string(&circuit).map_err(|err| CliError::ActionError(format!(
+                    "Cannot format circuit into json: {}",
+                    err
+                )))?
+            ),
+            // default is yaml
+            _ => println!(
+                "{}",
+                serde_yaml::to_string(&circuit).map_err(|err| CliError::ActionError(format!(
+                    "Cannot format circuit into yaml: {}",
+                    err
+                )))?
+            ),
+        }
     }
+
+    let proposal = client.fetch_proposal(circuit_id)?;
+
+    if let Some(proposal) = proposal {
+        print_proposal = true;
+        match format {
+            "json" => println!(
+                "\n {}",
+                serde_json::to_string(&proposal).map_err(|err| CliError::ActionError(format!(
+                    "Cannot format proposal into json: {}",
+                    err
+                )))?
+            ),
+            // default is yaml
+            _ => println!(
+                "{}",
+                serde_yaml::to_string(&proposal).map_err(|err| CliError::ActionError(format!(
+                    "Cannot format proposal into yaml: {}",
+                    err
+                )))?
+            ),
+        }
+    }
+
+    if !print_circuit && !print_proposal {
+        return Err(CliError::ActionError(format!(
+            "Proposal for {} does not exist",
+            circuit_id
+        )));
+    }
+
+    Ok(())
+}
+
+pub struct CircuitProposalsAction;
+
+impl Action for CircuitProposalsAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let url = args.value_of("url").unwrap_or("http://127.0.0.1:8080");
+
+        let filter = args.value_of("management_type");
+
+        list_proposals(url, filter)
+    }
+}
+
+fn list_proposals(url: &str, filter: Option<&str>) -> Result<(), CliError> {
+    let client = api::SplinterRestClient::new(url);
+
+    let proposals = client.list_proposals(filter)?;
+    println!(
+        "{0: <80} | {1: <30}",
+        "CIRCUIT ID", "CIRCUIT MANAGEMENT TYPE",
+    );
+    println!("{}", "-".repeat(110));
+    proposals.data.iter().for_each(|proposal| {
+        println!(
+            "{0: <80} | {1: <30}",
+            proposal.circuit_id, proposal.circuit.circuit_management_type,
+        );
+    });
     Ok(())
 }

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -129,16 +129,23 @@ fn vote_on_circuit_proposal(
     let requester_node = client.fetch_node_id()?;
     let proposal = client.fetch_proposal(circuit_id)?;
 
-    let circuit_vote = CircuitVote {
-        circuit_id: circuit_id.into(),
-        circuit_hash: proposal.circuit_hash,
-        vote,
-    };
+    if let Some(proposal) = proposal {
+        let circuit_vote = CircuitVote {
+            circuit_id: circuit_id.into(),
+            circuit_hash: proposal.circuit_hash,
+            vote,
+        };
 
-    let signed_payload =
-        payload::make_signed_payload(&requester_node, &private_key_hex, circuit_vote)?;
+        let signed_payload =
+            payload::make_signed_payload(&requester_node, &private_key_hex, circuit_vote)?;
 
-    client.submit_admin_payload(signed_payload)
+        client.submit_admin_payload(signed_payload)
+    } else {
+        Err(CliError::ActionError(format!(
+            "Proposal for {} does not exist",
+            circuit_id
+        )))
+    }
 }
 
 pub struct CircuitListAction;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -227,7 +227,7 @@ fn run() -> Result<(), CliError> {
                 )
                 .subcommand(
                     SubCommand::with_name("show")
-                        .about("Show a specific circuit")
+                        .about("Show a specific circuit or proposal")
                         .arg(
                             Arg::with_name("url")
                                 .short("U")
@@ -247,6 +247,27 @@ fn run() -> Result<(), CliError> {
                                 .help("Format of the circuit")
                                 .possible_values(&["yaml", "json"])
                                 .default_value("yaml")
+                                .takes_value(true),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("proposals")
+                        .about("List the circuit proposals")
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .long("url")
+                                .help("The URL of the Splinter daemon REST API")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("management_type")
+                                .short("m")
+                                .long("management-type")
+                                .long_help(
+                                    "Filter the circuit proposals by the circuit \
+                                     management type of the circuits",
+                                )
                                 .takes_value(true),
                         ),
                 ),
@@ -309,7 +330,8 @@ fn run() -> Result<(), CliError> {
                 .with_command("create", circuit::CircuitCreateAction)
                 .with_command("vote", circuit::CircuitVoteAction)
                 .with_command("list", circuit::CircuitListAction)
-                .with_command("show", circuit::CircuitShowAction),
+                .with_command("show", circuit::CircuitShowAction)
+                .with_command("proposals", circuit::CircuitProposalsAction),
         );
     }
 

--- a/libsplinter/src/admin/service/open_proposals.rs
+++ b/libsplinter/src/admin/service/open_proposals.rs
@@ -147,7 +147,7 @@ impl ProposalRegistry {
     }
 }
 
-/// An iterator over CircuitPropoals and the time that each occurred.
+/// An iterator over CircuitProposals and the time that each occurred.
 pub struct Proposals {
     inner: Box<dyn Iterator<Item = (String, messages::CircuitProposal)>>,
     size: usize,


### PR DESCRIPTION
To test, run gameroom with experimental features and submit gameroom invitations but do not accept them.

To list circuits (from the cli directory) run:
`cargo run --features experimental -- circuit proposals --url http://0.0.0.0:8088`

The output will look like:
```
CIRCUIT ID                                                                       | CIRCUIT MANAGEMENT TYPE       
--------------------------------------------------------------------------------------------------------------
gameroom::bubba-node-000::acme-node-000::986c460b-d1f9-4c8e-8e53-566353fc38b8    | gameroom 
```

To show a proposal from the cli directory) run (replace circuit id with one from the list).

`cargo run --features experimental -- circuit show gameroom::bubba-node-000::acme-node-000::986c460b-d1f9-4c8e-8e53-566353fc38b8--url http://0.0.0.0:8088`

This will print the proposal in yaml by default (json is also supported):

```
---
proposal_type: Create
circuit_id: "gameroom::bubba-node-000::acme-node-000::986c460b-d1f9-4c8e-8e53-566353fc38b8"
circuit_hash: 27316a2d5fd6b971b59cedf04ca82cbb5f2e4e13c1aad1f5b51ce8929711cc93
circuit:
  circuit_id: "gameroom::bubba-node-000::acme-node-000::986c460b-d1f9-4c8e-8e53-566353fc38b8"
  authorization_type: Trust
  persistence: Any
  durability: NoDurability
  routes: Any
  circuit_management_type: gameroom
  members:
    - node_id: bubba-node-000
      endpoint: "tls://splinterd-node-bubba:8044"
    - node_id: acme-node-000
      endpoint: "tls://splinterd-node-acme:8044"
  roster:
    - service_id: gameroom_bubba-node-000
      service_type: scabbard
      allowed_nodes:
        - bubba-node-000
      arguments:
        - - admin_keys
          - "[\"03622e59d611726f6a7226de2384bdc53227c4b22d07506b2a9520264b1012461c\"]"
        - - peer_services
          - "[\"gameroom_acme-node-000\"]"
    - service_id: gameroom_acme-node-000
      service_type: scabbard
      allowed_nodes:
        - acme-node-000
      arguments:
        - - admin_keys
          - "[\"03622e59d611726f6a7226de2384bdc53227c4b22d07506b2a9520264b1012461c\"]"
        - - peer_services
          - "[\"gameroom_bubba-node-000\"]"
votes: []
requester: 03191ece38160fbc368caf806c7e5e6022cde7017bb86afb5f545a913c81e488e4
requester_node_id: acme-node-000

```
