### PR TITLE
Add newline to key files

### DIFF
--- a/cli/src/action/admin.rs
+++ b/cli/src/action/admin.rs
@@ -282,10 +282,7 @@ fn create_key_pair(
             .mode(0o640)
             .open(private_key_path.as_path())
             .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
-
-        private_key_file
-            .write(private_key.as_hex().as_bytes())
-            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+        write_hex_to_file(&private_key.as_hex(), &mut private_key_file)?;
     }
 
     {
@@ -301,10 +298,7 @@ fn create_key_pair(
             .mode(0o644)
             .open(public_key_path.as_path())
             .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
-
-        public_key_file
-            .write(public_key.as_hex().as_bytes())
-            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+        write_hex_to_file(&public_key.as_hex(), &mut public_key_file)?;
     }
     if change_permissions {
         chown(private_key_path.as_path(), key_dir_uid, key_dir_gid)?;
@@ -312,4 +306,9 @@ fn create_key_pair(
     }
 
     Ok(public_key.as_slice().to_vec())
+}
+
+/// Write the given hex string to the given file, appending a newline at the end.
+fn write_hex_to_file(hex: &str, file: &mut File) -> Result<(), CliError> {
+    writeln!(file, "{}", hex).map_err(|err| CliError::EnvironmentError(format!("{}", err)))
 }

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -73,12 +73,12 @@ pub fn read_private_key(file_name: &str) -> Result<String, CliError> {
     })?;
 
     let mut buf = String::new();
-
     file.read_to_string(&mut buf).map_err(|err| {
         CliError::EnvironmentError(format!("Unable to read {}: {}", file_name, err))
     })?;
+    let key = buf.trim();
 
-    Ok(buf)
+    Ok(key)
 }
 
 pub(self) enum Vote {


### PR DESCRIPTION
Add newline to key files generated by splinter CLI and trim whitespace when reading keys in circuit CLI.