### PR TITLE
Update verbose and quiet flags to be global

### DIFF
--- a/cli/src/action/admin.rs
+++ b/cli/src/action/admin.rs
@@ -26,7 +26,6 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::MetadataExt;
 
 use clap::ArgMatches;
-use flexi_logger::ReconfigurationHandle;
 use sawtooth_sdk::signing;
 use serde::{Deserialize, Serialize};
 use splinter::keys::{storage::StorageKeyRegistry, KeyInfo, KeyRegistry};
@@ -41,20 +40,6 @@ const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 pub struct KeyGenAction;
 
 impl Action for KeyGenAction {
-    fn reconfigure_logging<'a>(
-        &self,
-        arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &mut ReconfigurationHandle,
-    ) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        if args.is_present("quiet") {
-            logger_handle.parse_new_spec("error");
-        }
-
-        Ok(())
-    }
-
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
@@ -83,20 +68,6 @@ impl Action for KeyGenAction {
 pub struct KeyRegistryGenerationAction;
 
 impl Action for KeyRegistryGenerationAction {
-    fn reconfigure_logging<'a>(
-        &self,
-        arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &mut ReconfigurationHandle,
-    ) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        if args.is_present("quiet") {
-            logger_handle.parse_new_spec("error");
-        }
-
-        Ok(())
-    }
-
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 

--- a/cli/src/action/certs.rs
+++ b/cli/src/action/certs.rs
@@ -25,7 +25,6 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::MetadataExt;
 
 use clap::ArgMatches;
-use flexi_logger::ReconfigurationHandle;
 use openssl::asn1::Asn1Time;
 use openssl::bn::{BigNum, MsbOption};
 use openssl::error::ErrorStack;
@@ -52,20 +51,6 @@ const CA_CERT: &str = "generated_ca.pem";
 const CA_KEY: &str = "generated_ca.key";
 
 impl Action for CertGenAction {
-    fn reconfigure_logging<'a>(
-        &self,
-        arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &mut ReconfigurationHandle,
-    ) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        if args.is_present("quiet") {
-            logger_handle.parse_new_spec("error");
-        }
-
-        Ok(())
-    }
-
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -26,7 +26,6 @@ use std::ffi::CString;
 use std::path::Path;
 
 use clap::ArgMatches;
-use flexi_logger::ReconfigurationHandle;
 use libc;
 
 use super::error::CliError;
@@ -35,15 +34,6 @@ use super::error::CliError;
 ///
 /// An Action is a single subcommand for CLI operations.
 pub trait Action {
-    /// Modify logging for the subcommand, if necessary.  Default implementation is a no-op.
-    fn reconfigure_logging<'a>(
-        &self,
-        _arg_matches: Option<&ArgMatches<'a>>,
-        _logger_handle: &mut ReconfigurationHandle,
-    ) -> Result<(), CliError> {
-        Ok(())
-    }
-
     /// Run a CLI Action with the given args
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError>;
 }
@@ -71,22 +61,6 @@ impl<'a> SubcommandActions<'a> {
 }
 
 impl<'s> Action for SubcommandActions<'s> {
-    fn reconfigure_logging<'a>(
-        &self,
-        arg_matches: Option<&ArgMatches<'a>>,
-        logger_handle: &mut ReconfigurationHandle,
-    ) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        let (subcommand, args) = args.subcommand();
-
-        if let Some(action) = self.actions.get(subcommand) {
-            action.reconfigure_logging(args, logger_handle)
-        } else {
-            Err(CliError::InvalidSubcommand)
-        }
-    }
-
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,7 +47,7 @@ fn run() -> Result<(), CliError> {
         (version: VERSION)
         (author: "Cargill")
         (about: "Command line for Splinter")
-        (@arg verbose: -v +multiple "Log verbosely")
+        (@arg verbose: -v +multiple +global "Log verbosely")
         (@setting SubcommandRequiredElseHelp)
         (@subcommand admin =>
             (about: "Administrative commands")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,6 +48,7 @@ fn run() -> Result<(), CliError> {
         (author: "Cargill")
         (about: "Command line for Splinter")
         (@arg verbose: -v +multiple +global "Log verbosely")
+        (@arg quiet: -q --quiet +global "Do not display output")
         (@setting SubcommandRequiredElseHelp)
         (@subcommand admin =>
             (about: "Administrative commands")
@@ -57,7 +58,6 @@ fn run() -> Result<(), CliError> {
                 (@arg key_dir: -d --("key-dir") +takes_value
                  "Name of the directory in which to create the keys; defaults to current working directory")
                 (@arg force: --force "Overwrite files if they exist")
-                (@arg quiet: -q --quiet "Do not display output")
             )
             (@subcommand keyregistry =>
                 (about: "Generates a key registry yaml file and keys, based on a registry \
@@ -73,7 +73,6 @@ fn run() -> Result<(), CliError> {
                  "Name of the input key registry specification; \
                  defaults to \"./key_registry_spec.yaml\"")
                 (@arg force: --force "Overwrite files if they exist")
-                (@arg quiet: -q --quiet "Do not display output")
             )
         )
         (@subcommand cert =>
@@ -86,7 +85,6 @@ fn run() -> Result<(), CliError> {
                   "Name of the directory in which to create the certificates")
                 (@arg force: --force  conflicts_with[skip] "Overwrite files if they exist")
                 (@arg skip: --skip conflicts_with[force] "Check if files exists, generate if missing")
-                (@arg quiet: -q --quiet "Do not display output")
             )
         )
     );
@@ -277,16 +275,20 @@ fn run() -> Result<(), CliError> {
     let matches = app.get_matches();
 
     // set default to info
-    let log_level = match matches.occurrences_of("verbose") {
-        0 => log::LevelFilter::Info,
-        1 => log::LevelFilter::Debug,
-        _ => log::LevelFilter::Trace,
+    let log_level = if matches.is_present("quiet") {
+        log::LevelFilter::Error
+    } else {
+        match matches.occurrences_of("verbose") {
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        }
     };
 
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);
 
-    let mut logger_handle = Logger::with(log_spec_builder.build())
+    Logger::with(log_spec_builder.build())
         .format(log_format)
         .start()
         .expect("Failed to create logger");
@@ -335,7 +337,6 @@ fn run() -> Result<(), CliError> {
         );
     }
 
-    subcommands.reconfigure_logging(Some(&matches), &mut logger_handle)?;
     subcommands.run(Some(&matches))
 }
 


### PR DESCRIPTION
This allows verbose and quiet flags to be used within any of the CLI subcommands. 