### PR TITLE
Removes panics from Splinter daemon start up caused by user

### DIFF
--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -307,10 +307,7 @@ impl Network {
         let mesh_id = match rwlock_read_unwrap!(self.peers).get_mesh_id(peer_id) {
             Some(mesh_id) => *mesh_id,
             None => {
-                return Err(SendError::NoPeerError(format!(
-                    "Send Error: No peer with peer_id {} found",
-                    peer_id
-                )));
+                return Err(SendError::NoPeerError(peer_id.to_string()));
             }
         };
 
@@ -397,9 +394,20 @@ pub enum SendError {
     MeshError(String),
 }
 
+impl std::error::Error for SendError {}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            SendError::NoPeerError(msg) => write!(f, "no peer with peer_id {} found", msg),
+            SendError::MeshError(msg) => write!(f, "received error from mesh: {}", msg),
+        }
+    }
+}
+
 impl From<MeshSendError> for SendError {
-    fn from(recv_error: MeshSendError) -> Self {
-        SendError::MeshError(format!("Send Error: {:?}", recv_error))
+    fn from(send_error: MeshSendError) -> Self {
+        SendError::MeshError(send_error.to_string())
     }
 }
 

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -138,7 +138,10 @@ impl PeerMap {
 
             Ok(())
         } else {
-            Err(PeerUpdateError {})
+            Err(PeerUpdateError {
+                old_peer_id,
+                new_peer_id,
+            })
         }
     }
 
@@ -441,7 +444,22 @@ impl From<RemoveError> for ConnectionError {
 }
 
 #[derive(Debug)]
-pub struct PeerUpdateError {}
+pub struct PeerUpdateError {
+    pub old_peer_id: String,
+    pub new_peer_id: String,
+}
+
+impl std::error::Error for PeerUpdateError {}
+
+impl std::fmt::Display for PeerUpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "unable to update peer {} to {}",
+            self.old_peer_id, self.new_peer_id
+        )
+    }
+}
 
 #[cfg(test)]
 pub mod tests {

--- a/libsplinter/src/transport/tls.rs
+++ b/libsplinter/src/transport/tls.rs
@@ -20,6 +20,8 @@ use openssl::ssl::{
 };
 use url::{ParseError, Url};
 
+use std::error::Error;
+use std::fmt;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -243,6 +245,16 @@ impl Evented for TlsConnection {
 #[derive(Debug)]
 pub enum TlsInitError {
     ProtocolError(String),
+}
+
+impl Error for TlsInitError {}
+
+impl fmt::Display for TlsInitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TlsInitError::ProtocolError(msg) => write!(f, "unable to initialize TLS: {}", msg),
+        }
+    }
 }
 
 impl From<ErrorStack> for TlsInitError {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -36,7 +36,7 @@ ctrlc = "3.0"
 flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 protobuf = "2"
 serde = "1.0.80"
 serde_derive = "1.0.80"
@@ -66,7 +66,7 @@ proposal-read = ["splinter/proposal-read"]
 config-builder = []
 config-toml = ["config-builder"]
 database = ["splinter/database"]
-generate-certs = []
+generate-certs = ["openssl"]
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -26,7 +26,7 @@ WORKDIR /build/splinterd
 ARG REPO_VERSION
 ARG CARGO_ARGS
 ARG SPLINTERD_ARGS
-RUN sed -i -e s/version.*$/version\ =\ \"${REPO_VERSION}\"/ Cargo.toml
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
 RUN mv /build/target/debian/splinter-daemon*.deb /tmp
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -896,6 +896,20 @@ pub enum CreateError {
     NetworkError(String),
 }
 
+impl Error for CreateError {}
+
+impl fmt::Display for CreateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CreateError::MissingRequiredField(msg) => write!(f, "missing required field: {}", msg),
+            CreateError::NodeRegistryError(msg) => {
+                write!(f, "node registry raised an error: {}", msg)
+            }
+            CreateError::NetworkError(msg) => write!(f, "network raised an error: {}", msg),
+        }
+    }
+}
+
 impl From<RegistryConfigError> for CreateError {
     fn from(err: RegistryConfigError) -> Self {
         CreateError::NodeRegistryError(format!("Error configuring Node Registry: {}", err))

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -34,9 +34,9 @@ use crate::certs::{make_ca_cert, make_ca_signed_cert, write_file, CertError};
 use crate::config::{Config, ConfigError};
 #[cfg(feature = "config-toml")]
 use crate::config::{ConfigBuilder, TomlConfig};
-use crate::daemon::SplinterDaemonBuilder;
-use clap::Arg;
+use crate::daemon::{SplinterDaemonBuilder, StartError};
 use clap::{clap_app, crate_version};
+use clap::{Arg, ArgMatches};
 #[cfg(feature = "generate-certs")]
 use openssl::error::ErrorStack;
 use splinter::transport::raw::RawTransport;
@@ -227,6 +227,13 @@ fn main() {
         .start()
         .expect("Failed to create logger");
 
+    if let Err(err) = start_daemon(matches) {
+        error!("Failed to start daemon, {}", err);
+        std::process::exit(1);
+    }
+}
+
+fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     debug!("Loading configuration file");
 
     // get provided config file or search default location
@@ -236,41 +243,35 @@ fn main() {
 
     let config = load_toml_config(config_file_path);
 
-    // Currently only YamlStorage is supported
-
     let node_id = matches
         .value_of("node_id")
         .map(String::from)
         .or_else(|| config.node_id())
-        .expect("Must provide a unique node ID");
+        .ok_or_else(|| UserError::MissingArgument("node_id".into()))?;
 
     let storage_type = matches
         .value_of("storage")
         .map(String::from)
         .or_else(|| config.storage())
-        .or_else(|| Some(String::from("yaml")))
-        .expect("No Storage Provided");
+        .unwrap_or_else(|| String::from("yaml"));
 
     let transport_type = matches
         .value_of("transport")
         .map(String::from)
         .or_else(|| config.transport())
-        .or_else(|| Some(String::from("raw")))
-        .expect("No Transport Provided");
+        .unwrap_or_else(|| String::from("raw"));
 
     let service_endpoint = matches
         .value_of("service_endpoint")
         .map(String::from)
         .or_else(|| config.service_endpoint())
-        .or_else(|| Some("127.0.0.1:8043".to_string()))
-        .expect("Must provide a valid service endpoint");
+        .unwrap_or_else(|| "127.0.0.1:8043".to_string());
 
     let network_endpoint = matches
         .value_of("network_endpoint")
         .map(String::from)
         .or_else(|| config.network_endpoint())
-        .or_else(|| Some("127.0.0.1:8044".to_string()))
-        .expect("Must provide a valid network endpoint");
+        .unwrap_or_else(|| "127.0.0.1:8044".to_string());
 
     let initial_peers = matches
         .values_of("peers")
@@ -281,13 +282,7 @@ fn main() {
     let heartbeat_interval = value_t!(matches.value_of("heartbeat_interval"), u64)
         .unwrap_or_else(|_| config.heartbeat_interval().unwrap_or(HEARTBEAT_DEFAULT));
 
-    let (transport, transport_log) = match get_transport(&transport_type, &matches, &config) {
-        Ok(transport) => transport,
-        Err(err) => {
-            error!("An error occurred while getting transport {:?}", err);
-            std::process::exit(1);
-        }
-    };
+    let (transport, transport_log) = get_transport(&transport_type, &matches, &config)?;
 
     let location = {
         if let Ok(s) = env::var(STATE_DIR_ENV) {
@@ -300,29 +295,37 @@ fn main() {
     let storage_location = match &storage_type as &str {
         "yaml" => format!("{}{}", location, "circuits.yaml"),
         "memory" => "memory".to_string(),
-        _ => panic!("Storage type is not supported: {}", storage_type),
+        _ => {
+            return Err(UserError::InvalidArgument(format!(
+                "storage type is not supported: {}",
+                storage_type
+            )))
+        }
     };
 
     let key_registry_location = match &storage_type as &str {
         "yaml" => format!("{}{}", location, "keys.yaml"),
         "memory" => "memory".to_string(),
-        _ => panic!("Storage type is not supported: {}", storage_type),
+        _ => {
+            return Err(UserError::InvalidArgument(format!(
+                "storage type is not supported: {}",
+                storage_type
+            )))
+        }
     };
 
     let rest_api_endpoint = matches
         .value_of("bind")
         .map(String::from)
         .or_else(|| config.bind())
-        .or_else(|| Some("127.0.0.1:8080".to_string()))
-        .expect("Must provide a URL for the REST API endpoint");
+        .unwrap_or_else(|| "127.0.0.1:8080".to_string());
 
     #[cfg(feature = "database")]
     let db_url = matches
         .value_of("database")
         .map(String::from)
         .or_else(|| config.database())
-        .or_else(|| Some("127.0.0.1:5432".to_string()))
-        .expect("Must provide a URL for the database");
+        .unwrap_or_else(|| "127.0.0.1:5432".to_string());
 
     let registry_backend = matches
         .value_of("registry_backend")
@@ -384,18 +387,11 @@ fn main() {
         daemon_builder = daemon_builder.with_registry_file(registry_file);
     }
 
-    let mut node = match daemon_builder.build() {
-        Ok(node) => node,
-        Err(err) => {
-            error!("An error occurred while creating daemon {:?}", err);
-            std::process::exit(1);
-        }
-    };
-
-    if let Err(err) = node.start(transport) {
-        error!("Failed to start daemon {:?}", err);
-        std::process::exit(1);
-    }
+    let mut node = daemon_builder.build().map_err(|err| {
+        UserError::daemon_err_with_source("unable to build the Splinter daemon", Box::new(err))
+    })?;
+    node.start(transport)?;
+    Ok(())
 }
 
 fn get_transport(
@@ -484,8 +480,7 @@ fn get_transport(
                 .value_of("cert_dir")
                 .map(String::from)
                 .or_else(|| config.cert_dir())
-                .or_else(|| Some(cert_location))
-                .expect("Must provide a valid client certificate");
+                .unwrap_or(cert_location);
 
             let client_cert = matches
                 .value_of("client_cert")
@@ -501,7 +496,9 @@ fn get_transport(
                     let client_cert: Option<String> = client_cert.to_str().map(ToOwned::to_owned);
                     client_cert
                 })
-                .expect("Must provide a valid client certificate");
+                .ok_or_else(|| {
+                    GetTransportError::CertError("must provide a valid client certificate".into())
+                })?;
 
             let server_cert = matches
                 .value_of("server_cert")
@@ -517,7 +514,9 @@ fn get_transport(
                     let server_cert: Option<String> = server_cert.to_str().map(ToOwned::to_owned);
                     server_cert
                 })
-                .expect("Must provide a valid server certificate");
+                .ok_or_else(|| {
+                    GetTransportError::CertError("must provide a valid server certificate".into())
+                })?;
 
             let server_key_file = matches
                 .value_of("server_key")
@@ -533,7 +532,9 @@ fn get_transport(
                     let server_key: Option<String> = server_key.to_str().map(ToOwned::to_owned);
                     server_key
                 })
-                .expect("Must provide a valid key path");
+                .ok_or_else(|| {
+                    GetTransportError::CertError("must provide a valid server key path".into())
+                })?;
 
             let client_key_file = matches
                 .value_of("client_key")
@@ -549,7 +550,9 @@ fn get_transport(
                     let client_key: Option<String> = client_key.to_str().map(ToOwned::to_owned);
                     client_key
                 })
-                .expect("Must provide a valid key path");
+                .ok_or_else(|| {
+                    GetTransportError::CertError("must provide a valid client key path".into())
+                })?;
 
             let ca_file = {
                 if matches.is_present("insecure") {
@@ -571,7 +574,11 @@ fn get_transport(
                                 cert_dir_path.join(CA_PEM).to_str().map(ToOwned::to_owned);
                             ca_file
                         })
-                        .expect("Must provide a valid file containing ca certs");
+                        .ok_or_else(|| {
+                            GetTransportError::CertError(
+                                "must provide a valid file containing ca certs".into(),
+                            )
+                        })?;
                     Some(ca_file)
                 }
             };

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -37,6 +37,7 @@ use crate::config::{ConfigBuilder, TomlConfig};
 use crate::daemon::SplinterDaemonBuilder;
 use clap::Arg;
 use clap::{clap_app, crate_version};
+#[cfg(feature = "generate-certs")]
 use openssl::error::ErrorStack;
 use splinter::transport::raw::RawTransport;
 use splinter::transport::tls::{TlsInitError, TlsTransport};
@@ -624,6 +625,7 @@ pub enum GetTransportError {
     CertError(String),
     NotSupportedError(String),
     TlsTransportError(TlsInitError),
+    #[cfg(feature = "generate-certs")]
     OpensslError(ErrorStack),
     IoError(io::Error),
 }
@@ -641,6 +643,7 @@ impl From<TlsInitError> for GetTransportError {
     }
 }
 
+#[cfg(feature = "generate-certs")]
 impl From<ErrorStack> for GetTransportError {
     fn from(error_stack: ErrorStack) -> Self {
         GetTransportError::OpensslError(error_stack)


### PR DESCRIPTION
Instead an error will be returned, logged and the program will be exited.

Also makes openssl optional as it is only required if generate-certs feature is enabled. 