### PR TITLE
Initial tests for the Config module.

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -69,6 +69,10 @@ impl ConfigBuilder {
         self
     }
 
+    // In testing for the ConfigBuilder module behind the config-builder feature, this method is
+    // not used in order to produce a None option in the resulting ConfigBuilder object. This
+    // method is required to compile and test the ConfigToml module behind the config-toml feature.
+    #[cfg(feature = "config-toml")]
     pub fn with_cert_dir(mut self, cert_dir: String) -> Self {
         self.cert_dir = Some(cert_dir);
         self
@@ -119,6 +123,10 @@ impl ConfigBuilder {
         self
     }
 
+    // In testing for the ConfigBuilder module behind the config-builder feature, this method is
+    // not used in order to produce a None option in the resulting ConfigBuilder object. This
+    // method is required to compile and test the ConfigToml module behind the config-toml feature.
+    #[cfg(feature = "config-toml")]
     pub fn with_bind(mut self, bind: String) -> Self {
         self.bind = Some(bind);
         self
@@ -130,16 +138,28 @@ impl ConfigBuilder {
         self
     }
 
+    // In testing for the ConfigBuilder module behind the config-builder feature, this method is
+    // not used in order to produce a None option in the resulting ConfigBuilder object. This
+    // method is required to compile and test the ConfigToml module behind the config-toml feature.
+    #[cfg(feature = "config-toml")]
     pub fn with_registry_backend(mut self, registry_backend: String) -> Self {
         self.registry_backend = Some(registry_backend);
         self
     }
 
+    // In testing for the ConfigBuilder module behind the config-builder feature, this method is
+    // not used in order to produce a None option in the resulting ConfigBuilder object. This
+    // method is required to compile and test the ConfigToml module behind the config-toml feature.
+    #[cfg(feature = "config-toml")]
     pub fn with_registry_file(mut self, registry_file: String) -> Self {
         self.registry_file = Some(registry_file);
         self
     }
 
+    // In testing for the ConfigBuilder module behind the config-builder feature, this method is
+    // not used in order to produce a None option in the resulting ConfigBuilder object. This
+    // method is required to compile and test the ConfigToml module behind the config-toml feature.
+    #[cfg(feature = "config-toml")]
     pub fn with_heartbeat_interval(mut self, heartbeat_interval: u64) -> Self {
         self.heartbeat_interval = Some(heartbeat_interval);
         self

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -134,3 +134,305 @@ impl Config {
         self.heartbeat_interval
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    /// Paths to existing example config toml files from the top-level Splinterd directory.
+    static TEST_TOML1: &str = "sample_configs/splinterd.toml.example";
+    // This toml file is only used in testing the TomlConfig module and therefore only used with
+    // the `toml-config` feature.
+    #[cfg(feature = "config-toml")]
+    static TEST_TOML2: &str = "sample_configs/splinterd.toml.example2";
+
+    /// Values present in the existing example config toml files.
+    static STORAGE: &str = "yaml";
+    static TRANSPORT: &str = "tls";
+    static CA_CERTS: &str = "certs/ca.pem";
+    static CLIENT_CERT: &str = "certs/client.crt";
+    static CLIENT_KEY: &str = "certs/client.key";
+    static SERVER_CERT: &str = "certs/server.crt";
+    static SERVER_KEY: &str = "certs/server.key";
+
+    /// Config values unique to the TEST_TOML1 file.
+    static SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
+    static NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static NODE_ID: &str = "012";
+
+    /// Config values unique to the TEST_TOML2 file.
+    // These values are only used in testing the TomlConfig module and therefore only used with
+    // the `toml-config` feature.
+    #[cfg(feature = "config-toml")]
+    static SERVICE_ENDPOINT2: &str = "127.0.0.1:8045";
+    #[cfg(feature = "config-toml")]
+    static NETWORK_ENDPOINT2: &str = "127.0.0.1:8046";
+    #[cfg(feature = "config-toml")]
+    static NODE_ID2: &str = "345";
+
+    /// Creates a Config struct based on the values from the TEST_TOML1 file.
+    fn construct_config_example() -> Config {
+        Config {
+            storage: Some(STORAGE.to_string()),
+            transport: Some(TRANSPORT.to_string()),
+            cert_dir: None,
+            ca_certs: Some(CA_CERTS.to_string()),
+            client_cert: Some(CLIENT_CERT.to_string()),
+            client_key: Some(CLIENT_KEY.to_string()),
+            server_cert: Some(SERVER_CERT.to_string()),
+            server_key: Some(SERVER_KEY.to_string()),
+            service_endpoint: Some(SERVICE_ENDPOINT.to_string()),
+            network_endpoint: Some(NETWORK_ENDPOINT.to_string()),
+            peers: Some(vec![]),
+            node_id: Some(NODE_ID.to_string()),
+            bind: None,
+            #[cfg(feature = "database")]
+            database: None,
+            registry_backend: None,
+            registry_file: None,
+            heartbeat_interval: None,
+        }
+    }
+
+    /// Creates a Config struct based on the values from the TEST_TOML2 file.
+    // This function is only used in testing the TomlConfig module and therefore only used with
+    // the `toml-config` feature.
+    #[cfg(feature = "config-toml")]
+    fn construct_config_example2() -> Config {
+        Config {
+            storage: Some(STORAGE.to_string()),
+            transport: Some(TRANSPORT.to_string()),
+            cert_dir: None,
+            ca_certs: Some(CA_CERTS.to_string()),
+            client_cert: Some(CLIENT_CERT.to_string()),
+            client_key: Some(CLIENT_KEY.to_string()),
+            server_cert: Some(SERVER_CERT.to_string()),
+            server_key: Some(SERVER_KEY.to_string()),
+            service_endpoint: Some(SERVICE_ENDPOINT2.to_string()),
+            network_endpoint: Some(NETWORK_ENDPOINT2.to_string()),
+            peers: Some(vec![NETWORK_ENDPOINT.to_string()]),
+            node_id: Some(NODE_ID2.to_string()),
+            bind: None,
+            #[cfg(feature = "database")]
+            database: None,
+            registry_backend: None,
+            registry_file: None,
+            heartbeat_interval: None,
+        }
+    }
+
+    /// Directly compares two Config structs.
+    fn compare_configs(config1: Config, config2: Config) {
+        assert_eq!(config1.storage, config2.storage);
+        assert_eq!(config1.transport, config2.transport);
+        assert_eq!(config1.cert_dir, config2.cert_dir);
+        assert_eq!(config1.ca_certs, config2.ca_certs);
+        assert_eq!(config1.client_cert, config2.client_cert);
+        assert_eq!(config1.client_key, config2.client_key);
+        assert_eq!(config1.server_cert, config2.server_cert);
+        assert_eq!(config1.server_key, config2.server_key);
+        assert_eq!(config1.service_endpoint, config2.service_endpoint);
+        assert_eq!(config1.network_endpoint, config2.network_endpoint);
+        assert_eq!(config1.peers, config2.peers);
+        assert_eq!(config1.node_id, config2.node_id);
+        assert_eq!(config1.bind, config2.bind);
+        #[cfg(feature = "database")]
+        assert_eq!(config1.database, config2.database);
+        assert_eq!(config1.registry_backend, config2.registry_backend);
+        assert_eq!(config1.registry_file, config2.registry_file);
+        assert_eq!(config1.heartbeat_interval, config2.heartbeat_interval);
+    }
+
+    #[cfg(not(feature = "config-toml"))]
+    #[test]
+    /// This test verifies that a Config object, constructed from the TEST_TOML1 file using the
+    /// Config module's `from_file` method, contains the correct values using the following
+    /// steps:
+    ///
+    /// 1. The example config toml file, TEST_TOML1, is opened.
+    /// 2. A Config object is created by passing the opened file into the `from_file` function
+    ///    defined in the Config module.
+    /// 3. Construct a Config object with the values manually set to the values from the TEST_TOML1
+    ///    file using the `construct_config_example.` This object will be used to verify the values
+    ///    in the Config object created in step 2.
+    ///
+    /// This test then verifies the Config object generated from the `from_file` method in step 2
+    /// contains the correct values by comparing it against the example Config object using the
+    /// `compare_configs` function.
+    fn test_config_from_file() {
+        // Opening the toml file using the TEST_TOML1 path
+        let config_file =
+            fs::File::open(TEST_TOML1).expect(&format!("Unable to load {}", TEST_TOML1));
+        // Use the config module's `from_file` method to construct a Config object from the
+        // config_file previously opened.
+        let generated_config = Config::from_file(config_file).unwrap();
+        // Construct an example Config object.
+        let example_config = construct_config_example();
+        // Compare the generated Config object against a manually constructed example Config object.
+        compare_configs(generated_config, example_config);
+    }
+
+    #[cfg(feature = "config-builder")]
+    #[test]
+    /// This test verifies that a Config object is accurately constructed by chaining the builder
+    /// methods from a new ConfigBuilder object. The following steps are performed in this test:
+    ///
+    /// 1. An empty ConfigBuilder object is constructed.
+    /// 2. The fields of the ConfigBuilder object are populated by chaining the builder methods.
+    ///    Note: The values used are from an example Config object constructed in the
+    ///    `construct_config_example` function.
+    /// 3. Construct a Config object with the values manually set in the `construct_config_example.`
+    ///    This object will be used to verify the values in the Config object created in step 2.
+    ///
+    /// This test then verifies the Config object built from chaining the builder methods in step
+    /// 2 contains the correct values by comparing it against the example Config object using the
+    /// `compare_configs` function.
+    fn test_config_builder_chain() {
+        // Create a new ConfigBuilder object.
+        let config_builder = ConfigBuilder::new();
+        // Populate the Config fields by chaining the ConfigBuilder methods. The final method,
+        // `build` converts the ConfigBuilder object to a Config object.
+        let built_config = config_builder
+            .with_storage(STORAGE.to_string())
+            .with_transport(TRANSPORT.to_string())
+            .with_ca_certs(CA_CERTS.to_string())
+            .with_client_cert(CLIENT_CERT.to_string())
+            .with_client_key(CLIENT_KEY.to_string())
+            .with_server_cert(SERVER_CERT.to_string())
+            .with_server_key(SERVER_KEY.to_string())
+            .with_service_endpoint(SERVICE_ENDPOINT.to_string())
+            .with_network_endpoint(NETWORK_ENDPOINT.to_string())
+            .with_peers(vec![])
+            .with_node_id(NODE_ID.to_string())
+            .build();
+        // Construct an example Config object.
+        let example_config = construct_config_example();
+        // Compare the generated Config object against a manually constructed example Config object.
+        compare_configs(built_config, example_config);
+    }
+
+    #[cfg(feature = "config-builder")]
+    #[test]
+    /// This test verifies that a Config object is accurately constructed by separately applying
+    /// the builder methods to a new ConfigBuilder object. The following steps are performed in
+    /// this test:
+    ///
+    /// 1. An empty ConfigBuilder object is constructed.
+    /// 2. The fields of the ConfigBuilder object are populated by separately applying the builder
+    ///    methods. Note: The values used are from an example Config object constructed in the
+    ///    `construct_config_example` function.
+    /// 3. Construct an example Config object with values manually set in `construct_config_example.`
+    ///    This object will be used to verify the values in the Config object created in step 2.
+    ///
+    /// This test then verifies the Config object built from chaining the builder methods in step
+    /// 2 contains the correct values by comparing it against the example Config object using the
+    /// `compare_configs` function.
+    fn test_config_builder_separate() {
+        // Create a new ConfigBuilder object.
+        let mut config_builder = ConfigBuilder::new();
+        // Populate the Config fields by separately applying the ConfigBuilder methods.
+        // `build` converts the ConfigBuilder object to a Config object.
+        config_builder = config_builder.with_storage(STORAGE.to_string());
+        config_builder = config_builder.with_transport(TRANSPORT.to_string());
+        config_builder = config_builder.with_ca_certs(CA_CERTS.to_string());
+        config_builder = config_builder.with_client_cert(CLIENT_CERT.to_string());
+        config_builder = config_builder.with_client_key(CLIENT_KEY.to_string());
+        config_builder = config_builder.with_server_cert(SERVER_CERT.to_string());
+        config_builder = config_builder.with_server_key(SERVER_KEY.to_string());
+        config_builder = config_builder.with_service_endpoint(SERVICE_ENDPOINT.to_string());
+        config_builder = config_builder.with_network_endpoint(NETWORK_ENDPOINT.to_string());
+        config_builder = config_builder.with_peers(vec![]);
+        config_builder = config_builder.with_node_id(NODE_ID.to_string());
+        // The `build` method converts the ConfigBuilder object to a Config object.
+        let built_config = config_builder.build();
+        // Construct an example Config object.
+        let example_config = construct_config_example();
+        // Compare the generated Config object against a manually constructed example Config object.
+        compare_configs(built_config, example_config);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    /// This test verifies that a Config object, constructed from the TomlConfig module, contains
+    /// the correct values using the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is constructed.
+    /// 2. The example config toml file, TEST_TOML1, is read and converted to a string.
+    /// 3. A TomlConfig object is constructed by passing in the toml string created in the previous
+    ///    step.
+    /// 4. Apply the TomlConfig object created in the previous step to the ConfigBuilder created.
+    ///    Note: The TomlConfig object's values should have precedence, so populated values in the
+    ///    TomlConfig object should overwrite existing ones.
+    /// 5. Construct a Config object with the values manually set to the values from the TEST_TOML1
+    ///    file using the `construct_config_example.` This object will be used to verify the values
+    ///    in the Config object created in step 4.
+    ///
+    /// This test then verifies the built Config object contains the correct values by comparing
+    /// it against the example Config object using the `compare_configs` function.
+    fn test_toml_builder() {
+        // Create a new ConfigBuilder object, with all empty fields.
+        let empty_builder = ConfigBuilder::new();
+        // Read the TEST_TOML1 example file to a string.
+        let toml_string =
+            fs::read_to_string(TEST_TOML1).expect(&format!("Unable to load {}", TEST_TOML1));
+        // Create a TomlConfig object from the toml string.
+        let toml_builder = TomlConfig::new(toml_string)
+            .expect(&format!("Unable to create TomlConfig from: {}", TEST_TOML1));
+        // Apply the TomlConfig object to the empty builder initially created.
+        let built_config = toml_builder.apply_to_builder(empty_builder).build();
+        // Construct an example Config object with values from the TEST_TOML1 file.
+        let example_config = construct_config_example();
+        // Compare the generated Config object against a manually constructed example Config object.
+        compare_configs(built_config, example_config);
+    }
+
+    #[cfg(feature = "config-toml")]
+    #[test]
+    /// This test verifies that a Config object, constructed from the TomlConfig module's
+    /// `apply_to_builder` method overwrites the correct values from a ConfigBuilder object.
+    ///
+    /// 1. A ConfigBuilder is constructed using preset values.
+    /// 2. An example config toml file, TEST_TOML2, is read and converted to a string. Note:
+    ///    This toml file contains some values different from the values used to construct the
+    ///    ConfigBuilder in step 1.
+    /// 3. A TomlConfig object is constructed by passing in the toml string created in the previous
+    ///    step.
+    /// 4. Apply the TomlConfig object created in the previous step to the ConfigBuilder created.
+    ///    Note: The TomlConfig object's values should have precedence, so populated values in the
+    ///    TomlConfig object should overwrite existing ones.
+    /// 5. Construct a Config object with the values manually set to the values from the TEST_TOML2
+    ///    file using the `construct_config_example2.` This object will be used to verify the values
+    ///    in the Config object created in step 4.
+    ///
+    /// This test then verifies the built Config object contains the correct values by comparing
+    /// it against the example Config object using the `compare_configs` function.
+    fn test_toml_builder_precedence() {
+        // Create a ConfigBuilder with populated fields.
+        let populated_builder = ConfigBuilder::new()
+            .with_storage(STORAGE.to_string())
+            .with_transport(TRANSPORT.to_string())
+            .with_ca_certs(CA_CERTS.to_string())
+            .with_client_cert(CLIENT_CERT.to_string())
+            .with_client_key(CLIENT_KEY.to_string())
+            .with_server_cert(SERVER_CERT.to_string())
+            .with_server_key(SERVER_KEY.to_string())
+            .with_service_endpoint(SERVICE_ENDPOINT.to_string())
+            .with_network_endpoint(NETWORK_ENDPOINT.to_string())
+            .with_peers(vec![])
+            .with_node_id(NODE_ID.to_string());
+        // Read the TEST_TOML2 example file to a string.
+        let toml_string =
+            fs::read_to_string(TEST_TOML2).expect(&format!("Unable to load {}", TEST_TOML2));
+        // Create a TomlConfig object from the toml string.
+        let toml_builder = TomlConfig::new(toml_string)
+            .expect(&format!("Unable to create TomlConfig from: {}", TEST_TOML1));
+        // Apply the TomlConfig object to the builder initially created.
+        let built_config = toml_builder.apply_to_builder(populated_builder).build();
+        // Construct an example Config object with values from the TEST_TOML2 file.
+        let example_config = construct_config_example2();
+        // Compare the generated Config object against a manually constructed example Config object.
+        compare_configs(built_config, example_config);
+    }
+}


### PR DESCRIPTION
Adds some initial tests for the Config module. This includes tests for the Config, ConfigBuilder and TomlConfig objects.

In order to run all tests (which are all from various features) run each of the following: 
- `cargo test` should result in only the first test being run 
- `cargo test --features config-builder` should run the first 3 tests
- `cargo test --features config-toml` should run the last 4 tests 
