### PR TITLE
Gameroom DB migrations

### DIFF
--- a/examples/gameroom/cli/Cargo.toml
+++ b/examples/gameroom/cli/Cargo.toml
@@ -12,18 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "gameroom-cli"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+license = "Apache-2.0"
 
-members = [
-    "cli",
-    "client",
-    "libsplinter",
-    "splinterd",
-    "examples/private_counter/cli",
-    "examples/private_counter/service",
-    "examples/private_xo",
-    "examples/gameroom/cli",
-    "examples/gameroom/database",
-    "examples/gameroom/daemon",
-    "services/health"
-]
+[[bin]]
+name = "gameroom"
+path = "src/main.rs"
+
+[dependencies]
+clap = "2"
+flexi_logger = "0.14"
+log = "0.4"
+
+[features]
+default = []
+
+stable = ["default"]
+
+experimental = []
+
+[package.metadata.deb]
+maintainer = "The Splinter Team"
+depends = "$auto"

--- a/examples/gameroom/cli/Cargo.toml
+++ b/examples/gameroom/cli/Cargo.toml
@@ -25,6 +25,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
+diesel = { version = "1.0", features = ["postgres"] }
+diesel_migrations = "1.4"
 flexi_logger = "0.14"
 log = "0.4"
 

--- a/examples/gameroom/cli/src/action/database.rs
+++ b/examples/gameroom/cli/src/action/database.rs
@@ -1,0 +1,63 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use diesel::{connection::Connection as _, pg::PgConnection};
+
+use crate::error::CliError;
+
+embed_migrations!("../database/migrations");
+
+pub fn get_subcommand<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("database")
+        .about("Manage Gameroom database")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(
+            Arg::with_name("database-url")
+                .help("database connection URL")
+                .long("database-url")
+                .global(true)
+                .default_value("postgres://gameroom:gameroom_example@postgres:5432/gameroom")
+                .takes_value(true),
+        )
+        .subcommand(
+            SubCommand::with_name("migrate")
+                .about("Run database migrations for the Gameroom database"),
+        )
+}
+
+pub fn handle_database_subcommand(matches: &ArgMatches) -> Result<(), CliError> {
+    match matches.subcommand() {
+        ("migrate", Some(matches)) => migrate_database(matches),
+        (unknown_subcmd, _) => Err(CliError::InvalidSubcommand(unknown_subcmd.into())),
+    }
+}
+
+fn migrate_database(matches: &ArgMatches) -> Result<(), CliError> {
+    let url = matches
+        .value_of("database-url")
+        .ok_or_else(|| CliError::MissingArgument("database-url".into()))?;
+
+    let conn = PgConnection::establish(url).map_err(|err| {
+        CliError::CommandFailed(format!("failed to establish database connection: {}", err))
+    })?;
+
+    embedded_migrations::run(&conn).map_err(|err| {
+        CliError::CommandFailed(format!("failed to run database migrations: {}", err))
+    })?;
+
+    info!("Database migrations applied successfully");
+
+    Ok(())
+}

--- a/examples/gameroom/cli/src/action/mod.rs
+++ b/examples/gameroom/cli/src/action/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+

--- a/examples/gameroom/cli/src/action/mod.rs
+++ b/examples/gameroom/cli/src/action/mod.rs
@@ -12,3 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod database;

--- a/examples/gameroom/cli/src/error.rs
+++ b/examples/gameroom/cli/src/error.rs
@@ -1,0 +1,35 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum CliError {
+    CommandFailed(String),
+    InvalidSubcommand(String),
+    MissingArgument(String),
+}
+
+impl Error for CliError {}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::CommandFailed(err) => write!(f, "command failed to execute: {}", err),
+            Self::InvalidSubcommand(subcmd) => write!(f, "invalid subcommand provided: {}", subcmd),
+            Self::MissingArgument(arg) => write!(f, "missing required argument: {}", arg),
+        }
+    }
+}

--- a/examples/gameroom/cli/src/main.rs
+++ b/examples/gameroom/cli/src/main.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+
+mod action;
+mod error;
+
+use clap::{App, AppSettings, Arg};
+use flexi_logger::{LogSpecBuilder, Logger};
+
+use error::CliError;
+
+fn main() {
+    if let Err(e) = run() {
+        error!("ERROR: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), CliError> {
+    let app = App::new(env!("CARGO_PKG_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Cargill")
+        .about("Command line for Gameroom")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(
+            Arg::with_name("verbose")
+                .help("log verbosely")
+                .short("v")
+                .multiple(true),
+        );
+
+    let matches = app.get_matches();
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Info,
+        1 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+
+    setup_logging(log_level);
+
+    Ok(())
+}
+
+fn setup_logging(log_level: log::LevelFilter) {
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()
+        .expect("Failed to create logger");
+}
+
+// log format for cli that will only show the log message
+pub fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut flexi_logger::DeferredNow,
+    record: &log::Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}

--- a/examples/gameroom/cli/src/main.rs
+++ b/examples/gameroom/cli/src/main.rs
@@ -14,6 +14,8 @@
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate diesel_migrations;
 
 mod action;
 mod error;
@@ -41,7 +43,8 @@ fn run() -> Result<(), CliError> {
                 .help("log verbosely")
                 .short("v")
                 .multiple(true),
-        );
+        )
+        .subcommand(action::database::get_subcommand());
 
     let matches = app.get_matches();
 
@@ -53,7 +56,10 @@ fn run() -> Result<(), CliError> {
 
     setup_logging(log_level);
 
-    Ok(())
+    match matches.subcommand() {
+        ("database", Some(matches)) => action::database::handle_database_subcommand(matches),
+        (unknown_subcmd, _) => Err(CliError::InvalidSubcommand(unknown_subcmd.into())),
+    }
 }
 
 fn setup_logging(log_level: log::LevelFilter) {

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -15,12 +15,21 @@
 FROM splintercommunity/splinter-dev as BUILDER
 
 # Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY examples/gameroom/cli /build/examples/gameroom/cli
 COPY examples/gameroom/database /build/examples/gameroom/database
 COPY examples/gameroom/daemon/ /build/examples/gameroom/daemon
 COPY libsplinter /build/libsplinter
 
-# Build the project
+# Build the gameroomd package
 WORKDIR /build/examples/gameroom/daemon
+ARG REPO_VERSION
+ARG CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+
+# Build the gameroom-cli package
+WORKDIR /build/examples/gameroom/cli
 ARG REPO_VERSION
 ARG CARGO_ARGS
 RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
@@ -43,7 +52,7 @@ RUN apt-get update \
     postgresql-client \
     unzip
 
-COPY --from=BUILDER /build/target/debian/gameroom*.deb /tmp
+COPY --from=BUILDER /build/target/debian/gameroom*.deb /tmp/
 COPY --from=BUILDER /commit-hash /commit-hash
 
 RUN apt-get update \

--- a/examples/gameroom/database/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/examples/gameroom/database/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/examples/gameroom/database/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/examples/gameroom/database/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/examples/gameroom/database/migrations/2020-01-15-180145_gameroom_last_event/down.sql
+++ b/examples/gameroom/database/migrations/2020-01-15-180145_gameroom_last_event/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE gameroom_service DROP COLUMN last_event;

--- a/examples/gameroom/database/migrations/2020-01-15-180145_gameroom_last_event/up.sql
+++ b/examples/gameroom/database/migrations/2020-01-15-180145_gameroom_last_event/up.sql
@@ -1,0 +1,17 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE gameroom_service ADD COLUMN IF NOT EXISTS
+  last_event TEXT NOT NULL DEFAULT '';

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -111,6 +111,7 @@ services:
                sleep 1
             done
 
+            gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom \
               -b gameroomd-acme:8000 --splinterd-url http://splinterd-node-acme:8085
           "
@@ -219,6 +220,7 @@ services:
                sleep 1
             done
 
+            gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom \
               -b gameroomd-bubba:8000 --splinterd-url http://splinterd-node-bubba:8085
           "


### PR DESCRIPTION
Add migrations for the gameroom database and add a migration for the addition of the gameroom_service.last_event column.

To test:
- Pull https://github.com/ltseeley/splinter/tree/gameroom-db-migration-test (same as this branch, but with an additional commit that contains docker compose files for testing)
- Run `docker-compose -f examples/gameroom/docker-compose-36.yaml up`
- Create a gameroom
- `docker-compose -f examples/gameroom/docker-compose-36.yaml down`
- `docker-compose -f examples/gameroom/docker-compose-dockerhub.yaml up`
- Verify that the database containers exit with error `column gameroom_service.last_event does not exist`
- `docker-compose -f examples/gameroom/docker-compose-dockerhub.yaml down`
- `docker-compose -f examples/gameroom/docker-compose.yaml up`
- Verify that the containers start without error and the gameroom still exists in the UI