### PR TITLE
Fix wait for batch status

### DIFF
--- a/libsplinter/src/service/scabbard/client/mod.rs
+++ b/libsplinter/src/service/scabbard/client/mod.rs
@@ -45,7 +45,7 @@ impl ScabbardClient {
     ) -> Result<(), Error> {
         let batch_link = submit_batches(&self.url, circuit_id, service_id, batches)?;
         if let Some(wait_secs) = wait {
-            wait_for_batches(&batch_link, wait_secs)
+            wait_for_batches(&self.url, &batch_link, wait_secs)
         } else {
             Ok(())
         }

--- a/libsplinter/src/service/scabbard/client/submit.rs
+++ b/libsplinter/src/service/scabbard/client/submit.rs
@@ -41,6 +41,7 @@ pub fn submit_batches(
 
     let body = batches.write_to_bytes()?;
 
+    debug!("Submitting batches via {}", url);
     let request = Client::new().post(url).body(body);
     let response = perform_request(request)?;
 
@@ -51,9 +52,14 @@ pub fn submit_batches(
     Ok(batch_link.link)
 }
 
-pub fn wait_for_batches(url: &str, wait: u64) -> Result<(), Error> {
-    let url = parse_http_url(&format!("{}&wait={}", url, wait))?;
+pub fn wait_for_batches(base_url: &str, batch_link: &str, wait: u64) -> Result<(), Error> {
+    let url = if batch_link.starts_with("http") || batch_link.starts_with("https") {
+        parse_http_url(&format!("{}&wait={}", batch_link, wait))?
+    } else {
+        parse_http_url(&format!("{}{}&wait={}", base_url, batch_link, wait))?
+    };
 
+    debug!("Checking batches via {}", url);
     let request = Client::new().get(url);
     let response = perform_request(request)?;
 


### PR DESCRIPTION
Scabbard does not prefix the batch link with the scheme and host.  This causes the batches to always fail as the batch link cannot be queried. This corrects the client such that the link will have the base url added if missing.

Additionally:

- Adds more debug statements