### PR TITLE
Add key management routes to splinterd

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ experimental = [
     "health",
     "database",
     "database-migrate-biome-credentials",
+    "database-migrate-biome-key-management",
     "database-migrate-biome-notifications",
     "database-migrate-biome-user",
     "postgres",
@@ -34,6 +35,10 @@ database = ["splinter/database", "diesel", "postgres"]
 database-migrate-biome-user = ["splinter/biome-user", "database"]
 database-migrate-biome-credentials = [
     "splinter/biome-credentials",
+    "database-migrate-biome-user",
+]
+database-migrate-biome-key-management = [
+    "splinter/biome-key-management",
     "database-migrate-biome-user",
 ]
 database-migrate-biome-notifications = [

--- a/cli/src/action/database.rs
+++ b/cli/src/action/database.rs
@@ -19,6 +19,8 @@ use crate::error::CliError;
 use diesel::{connection::Connection as _, pg::PgConnection};
 #[cfg(feature = "database-migrate-biome-credentials")]
 use splinter::biome::credentials::database::run_migrations as run_biome_credentials_migrations;
+#[cfg(feature = "database-migrate-biome-key-management")]
+use splinter::biome::key_management::database::postgres::run_migrations as run_biome_key_management_migrations;
 #[cfg(feature = "database-migrate-biome-notifications")]
 use splinter::biome::notifications::database::run_migrations as run_biome_notifications_migrations;
 #[cfg(feature = "database-migrate-biome-user")]
@@ -51,6 +53,13 @@ impl Action for MigrateAction {
         run_biome_credentials_migrations(&connection).map_err(|err| {
             CliError::DatabaseError(format!(
                 "Unable to run Biome credentials migrations: {}",
+                err
+            ))
+        })?;
+        #[cfg(feature = "database-migrate-biome-key-management")]
+        run_biome_key_management_migrations(&connection).map_err(|err| {
+            CliError::DatabaseError(format!(
+                "Unable to run Biome key management migrations: {}",
                 err
             ))
         })?;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,11 +35,18 @@ services:
         - SPLINTERD_ARGS=${SPLINTERD_ARGS}
     entrypoint: |
       bash -c "
+        until PGPASSWORD=splinter_test psql -h splinter-db -U splinter_admin -d splinter -c '\q'; do
+          >&2 echo \"Database is unavailable - sleeping\"
+          sleep 1
+        done
+        splinter database migrate -C postgres://splinter_admin:splinter_test@splinter-db:5432/splinter && \
         splinter cert generate --skip && \
         splinterd \
             -c ./configs/splinterd-node-0-docker.toml \
             --registry-file ./node_registries/nodes.yaml \
             --insecure \
+            --enable-biome \
+            --database postgres://splinter_admin:splinter_test@splinter-db:5432/splinter \
             $SPLINTERD_ARGS \
             -vv
       "

--- a/libsplinter/src/biome/key_management/database/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/database/postgres/mod.rs
@@ -33,7 +33,7 @@ use crate::database::error::DatabaseError;
 pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
     embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
 
-    info!("Successfully applied key management migrations");
+    info!("Successfully applied Biome key management migrations");
 
     Ok(())
 }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -52,6 +52,7 @@ stable = ["default"]
 experimental = [
     "biome",
     "biome-credentials",
+    "biome-key-management",
     "circuit-read",
     "config-builder",
     "config-toml",
@@ -61,6 +62,7 @@ experimental = [
 
 biome = ["splinter/biome", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
+biome-key-management = ["splinter/biome-key-management", "biome"]
 circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-builder = []

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -56,5 +56,7 @@ COPY --from=builder /tmp/splinter-*.deb /tmp/
 COPY --from=builder /commit-hash /commit-hash
 
 RUN apt-get update \
+ && apt-get install -y -q \
+    postgresql-client \
  && dpkg --unpack /tmp/splinter-*.deb \
  && apt-get -f -y install

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -630,7 +630,11 @@ fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartErr
     #[cfg(feature = "biome-credentials")]
     {
         biome_rest_provider_builder =
-            biome_rest_provider_builder.with_credentials_store(connection_pool);
+            biome_rest_provider_builder.with_credentials_store(connection_pool.clone());
+    }
+    #[cfg(feature = "biome-key-management")]
+    {
+        biome_rest_provider_builder = biome_rest_provider_builder.with_key_store(connection_pool)
     }
     let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
         StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))


### PR DESCRIPTION
Adds the `biome/<user>/keys` routes to splinterd. Also adds the migrations to the Splinter CLI.

This adds the `database-migrate-biome-key-management` feature to the Splinter CLI.