### PR TITLE
Add commands to support circuit creation

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,7 +62,7 @@ experimental = [
     "keygen",
 ]
 
-circuit = ["reqwest", "serde_json", "splinter/sawtooth-signing-compat"]
+circuit = ["reqwest", "serde_json", "splinter/sawtooth-signing-compat", "dirs"]
 health = ["reqwest", "serde_json"]
 keygen = ["dirs", "whoami"]
 

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -22,6 +22,8 @@ pub mod database;
 pub mod health;
 #[cfg(feature = "keygen")]
 pub mod keygen;
+#[cfg(feature = "circuit")]
+pub mod node;
 
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/cli/src/action/node.rs
+++ b/cli/src/action/node.rs
@@ -51,6 +51,30 @@ impl Action for AddNodeAliasAction {
     }
 }
 
+pub struct GetNodeAliasAction;
+
+impl Action for GetNodeAliasAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let alias = match args.value_of("alias") {
+            Some(alias) => alias,
+            None => return Err(CliError::ActionError("Alias is required".into())),
+        };
+
+        let node_store = get_node_store();
+
+        let node = node_store.get_node(alias)?;
+
+        if let Some(node) = node {
+            println!("{} {}", node.alias(), node.endpoint())
+        } else {
+            println!("Alias not found {}", alias)
+        }
+
+        Ok(())
+    }
+}
+
 pub struct ListNodeAliasAction;
 
 impl Action for ListNodeAliasAction {

--- a/cli/src/action/node.rs
+++ b/cli/src/action/node.rs
@@ -94,6 +94,25 @@ impl Action for ListNodeAliasAction {
     }
 }
 
+pub struct DeleteNodeAliasAction;
+
+impl Action for DeleteNodeAliasAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let alias = match args.value_of("alias") {
+            Some(alias) => alias,
+            None => return Err(CliError::ActionError("Alias is required".into())),
+        };
+
+        let node_store = get_node_store();
+
+        node_store.delete_node(alias)?;
+
+        Ok(())
+    }
+}
+
 fn get_node_store() -> FileBackedNodeStore {
     FileBackedNodeStore::default()
 }

--- a/cli/src/action/node.rs
+++ b/cli/src/action/node.rs
@@ -1,0 +1,73 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Action;
+use crate::error::CliError;
+use crate::store::node::{FileBackedNodeStore, Node, NodeStore, NodeStoreError};
+
+use clap::ArgMatches;
+use reqwest::Url;
+
+pub struct AddNodeAliasAction;
+
+impl Action for AddNodeAliasAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let alias = match args.value_of("alias") {
+            Some(alias) => alias,
+            None => return Err(CliError::ActionError("Alias is required".into())),
+        };
+        let endpoint = match args.value_of("endpoint") {
+            Some(endpoint) => endpoint,
+            None => return Err(CliError::ActionError("Endpoint is required".into())),
+        };
+
+        validate_node_endpont(&endpoint)?;
+
+        let node_store = get_node_store();
+
+        if !args.is_present("force") && node_store.get_node(&alias)?.is_some() {
+            return Err(CliError::ActionError(format!(
+                "Alias {} is already in use",
+                alias
+            )));
+        }
+        let node = Node::new(alias, endpoint);
+
+        node_store.add_node(&node)?;
+
+        Ok(())
+    }
+}
+
+fn get_node_store() -> FileBackedNodeStore {
+    FileBackedNodeStore::default()
+}
+
+fn validate_node_endpont(endpoint: &str) -> Result<(), CliError> {
+    if let Err(err) = Url::parse(endpoint) {
+        Err(CliError::ActionError(format!(
+            "{} is not a valid url: {}",
+            endpoint, err
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+impl From<NodeStoreError> for CliError {
+    fn from(err: NodeStoreError) -> Self {
+        CliError::ActionError(format!("Failed to perform node operation: {}", err))
+    }
+}

--- a/cli/src/action/node.rs
+++ b/cli/src/action/node.rs
@@ -51,6 +51,25 @@ impl Action for AddNodeAliasAction {
     }
 }
 
+pub struct ListNodeAliasAction;
+
+impl Action for ListNodeAliasAction {
+    fn run<'a>(&mut self, _: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let node_store = get_node_store();
+
+        let nodes = node_store.list_nodes()?;
+
+        if nodes.is_empty() {
+            println!("No node alias have been set yet");
+        } else {
+            nodes.iter().for_each(|node| {
+                println!("{} {}", node.alias(), node.endpoint());
+            })
+        }
+        Ok(())
+    }
+}
+
 fn get_node_store() -> FileBackedNodeStore {
     FileBackedNodeStore::default()
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -331,7 +331,8 @@ fn run() -> Result<(), CliError> {
                                         .long("force")
                                         .help("Overwrite alias data if it already exists"),
                                 ),
-                        ),
+                        )
+                        .subcommand(SubCommand::with_name("list").about("List all node alias")),
                 ),
         );
     }
@@ -403,7 +404,9 @@ fn run() -> Result<(), CliError> {
             "node",
             SubcommandActions::new().with_command(
                 "alias",
-                SubcommandActions::new().with_command("add", node::AddNodeAliasAction),
+                SubcommandActions::new()
+                    .with_command("add", node::AddNodeAliasAction)
+                    .with_command("list", node::ListNodeAliasAction),
             ),
         )
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -341,6 +341,15 @@ fn run() -> Result<(), CliError> {
                                         .takes_value(true)
                                         .help("Alias for the node"),
                                 ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("delete")
+                                .about("Delete alias for a node")
+                                .arg(
+                                    Arg::with_name("alias")
+                                        .takes_value(true)
+                                        .help("Alias for the node"),
+                                ),
                         ),
                 ),
         );
@@ -416,7 +425,8 @@ fn run() -> Result<(), CliError> {
                 SubcommandActions::new()
                     .with_command("add", node::AddNodeAliasAction)
                     .with_command("get", node::GetNodeAliasAction)
-                    .with_command("list", node::ListNodeAliasAction),
+                    .with_command("list", node::ListNodeAliasAction)
+                    .with_command("delete", node::DeleteNodeAliasAction),
             ),
         )
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -303,6 +303,37 @@ fn run() -> Result<(), CliError> {
                         ),
                 ),
         );
+
+        app = app.subcommand(
+            SubCommand::with_name("node")
+                .about("Provides node management functionality")
+                .setting(AppSettings::SubcommandRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name("alias")
+                        .about("Manage node alias")
+                        .setting(AppSettings::SubcommandRequiredElseHelp)
+                        .subcommand(
+                            SubCommand::with_name("add")
+                                .about("Add a new node alias")
+                                .arg(
+                                    Arg::with_name("alias")
+                                        .takes_value(true)
+                                        .help("Alias for the node"),
+                                )
+                                .arg(
+                                    Arg::with_name("endpoint")
+                                        .takes_value(true)
+                                        .help("Endpoint for the node"),
+                                )
+                                .arg(
+                                    Arg::with_name("force")
+                                        .short("f")
+                                        .long("force")
+                                        .help("Overwrite alias data if it already exists"),
+                                ),
+                        ),
+                ),
+        );
     }
 
     let matches = app.get_matches();
@@ -358,7 +389,7 @@ fn run() -> Result<(), CliError> {
 
     #[cfg(feature = "circuit")]
     {
-        use action::circuit;
+        use action::{circuit, node};
         subcommands = subcommands.with_command(
             "circuit",
             SubcommandActions::new()
@@ -368,6 +399,13 @@ fn run() -> Result<(), CliError> {
                 .with_command("show", circuit::CircuitShowAction)
                 .with_command("proposals", circuit::CircuitProposalsAction),
         );
+        subcommands = subcommands.with_command(
+            "node",
+            SubcommandActions::new().with_command(
+                "alias",
+                SubcommandActions::new().with_command("add", node::AddNodeAliasAction),
+            ),
+        )
     }
 
     #[cfg(feature = "keygen")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,8 @@ extern crate diesel;
 
 mod action;
 mod error;
+#[cfg(feature = "circuit")]
+mod store;
 
 use clap::clap_app;
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -332,7 +332,16 @@ fn run() -> Result<(), CliError> {
                                         .help("Overwrite alias data if it already exists"),
                                 ),
                         )
-                        .subcommand(SubCommand::with_name("list").about("List all node alias")),
+                        .subcommand(SubCommand::with_name("list").about("List all node alias"))
+                        .subcommand(
+                            SubCommand::with_name("get")
+                                .about("Get endpoint for a alias")
+                                .arg(
+                                    Arg::with_name("alias")
+                                        .takes_value(true)
+                                        .help("Alias for the node"),
+                                ),
+                        ),
                 ),
         );
     }
@@ -406,6 +415,7 @@ fn run() -> Result<(), CliError> {
                 "alias",
                 SubcommandActions::new()
                     .with_command("add", node::AddNodeAliasAction)
+                    .with_command("get", node::GetNodeAliasAction)
                     .with_command("list", node::ListNodeAliasAction),
             ),
         )

--- a/cli/src/store/mod.rs
+++ b/cli/src/store/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod node;

--- a/cli/src/store/node/error.rs
+++ b/cli/src/store/node/error.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::io::Error as IoError;
+
+use serde_yaml::Error as SerdeError;
+
+#[derive(Debug)]
+pub enum NodeStoreError {
+    NotFound(String),
+    IoError(IoError),
+    SerdeError(SerdeError),
+}
+
+impl Error for NodeStoreError {}
+
+impl fmt::Display for NodeStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NodeStoreError::NotFound(msg) => write!(f, "Node not found: {}", msg),
+            NodeStoreError::IoError(err) => {
+                write!(f, "Node store encountered an IO error: {}", err)
+            }
+            NodeStoreError::SerdeError(err) => write!(
+                f,
+                "Node store encountered and serialization/deserialization error  {}",
+                err
+            ),
+        }
+    }
+}
+
+impl From<IoError> for NodeStoreError {
+    fn from(err: IoError) -> NodeStoreError {
+        NodeStoreError::IoError(err)
+    }
+}
+
+impl From<SerdeError> for NodeStoreError {
+    fn from(err: SerdeError) -> NodeStoreError {
+        NodeStoreError::SerdeError(err)
+    }
+}

--- a/cli/src/store/node/mod.rs
+++ b/cli/src/store/node/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 mod error;
+mod yaml_store;
 
 pub use error::NodeStoreError;
+pub use yaml_store::FileBackedNodeStore;
 
 pub struct Node {
     alias: String,

--- a/cli/src/store/node/mod.rs
+++ b/cli/src/store/node/mod.rs
@@ -1,0 +1,53 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+pub use error::NodeStoreError;
+
+pub struct Node {
+    alias: String,
+    endpoint: String,
+}
+
+impl Node {
+    pub fn new(alias: &str, endpoint: &str) -> Node {
+        Node {
+            alias: alias.to_owned(),
+            endpoint: endpoint.to_owned(),
+        }
+    }
+
+    pub fn alias(&self) -> String {
+        self.alias.to_owned()
+    }
+
+    pub fn endpoint(&self) -> String {
+        self.endpoint.to_owned()
+    }
+}
+
+pub trait NodeStore {
+    /// Get node from the store
+    fn get_node(&self, alias: &str) -> Result<Option<Node>, NodeStoreError>;
+
+    /// List nodes from the store
+    fn list_nodes(&self) -> Result<Vec<Node>, NodeStoreError>;
+
+    /// Add nodes to the store
+    fn add_node(&self, node: &Node) -> Result<(), NodeStoreError>;
+
+    /// Delete node from the store
+    fn delete_node(&self, alias: &str) -> Result<(), NodeStoreError>;
+}

--- a/cli/src/store/node/yaml_store.rs
+++ b/cli/src/store/node/yaml_store.rs
@@ -1,0 +1,179 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Error as IoError, ErrorKind};
+use std::path::PathBuf;
+
+use super::{Node, NodeStore, NodeStoreError};
+
+const DEFAULT_FILE_NAME: &str = "node_alias.yaml";
+const DEFAULTS_PATH: &str = ".splinter";
+
+#[derive(Serialize, Deserialize)]
+pub struct SerdeNode {
+    alias: String,
+    endpoint: String,
+}
+
+impl Into<Node> for SerdeNode {
+    fn into(self) -> Node {
+        Node {
+            alias: self.alias,
+            endpoint: self.endpoint,
+        }
+    }
+}
+
+impl From<&Node> for SerdeNode {
+    fn from(node: &Node) -> SerdeNode {
+        SerdeNode {
+            alias: node.alias.clone(),
+            endpoint: node.endpoint.clone(),
+        }
+    }
+}
+
+pub struct FileBackedNodeStore {
+    file_name: String,
+}
+
+impl Default for FileBackedNodeStore {
+    fn default() -> Self {
+        FileBackedNodeStore {
+            file_name: DEFAULT_FILE_NAME.to_owned(),
+        }
+    }
+}
+
+impl NodeStore for FileBackedNodeStore {
+    fn get_node(&self, alias: &str) -> Result<Option<Node>, NodeStoreError> {
+        let nodes = self.load()?;
+
+        let node = nodes.into_iter().find_map(|node| {
+            if node.alias == alias {
+                return Some(node.into());
+            }
+            None
+        });
+
+        Ok(node)
+    }
+
+    fn list_nodes(&self) -> Result<Vec<Node>, NodeStoreError> {
+        let serde_nodes = self.load()?;
+        let nodes = serde_nodes
+            .into_iter()
+            .map(|node| node.into())
+            .collect::<Vec<Node>>();
+        Ok(nodes)
+    }
+
+    fn add_node(&self, new_node: &Node) -> Result<(), NodeStoreError> {
+        let mut serde_nodes = self.load()?;
+        let existing_node_index = serde_nodes.iter().enumerate().find_map(|(index, node)| {
+            if new_node.alias() == node.alias {
+                Some(index)
+            } else {
+                None
+            }
+        });
+        if let Some(index) = existing_node_index {
+            serde_nodes.remove(index);
+        }
+        serde_nodes.push(SerdeNode::from(new_node));
+
+        self.save(&serde_nodes)?;
+
+        Ok(())
+    }
+
+    fn delete_node(&self, alias: &str) -> Result<(), NodeStoreError> {
+        let mut serde_nodes = self.load()?;
+        let existing_node_index = serde_nodes.iter().enumerate().find_map(|(index, node)| {
+            if node.alias == alias {
+                Some(index)
+            } else {
+                None
+            }
+        });
+
+        match existing_node_index {
+            Some(index) => {
+                serde_nodes.remove(index);
+                self.save(&serde_nodes)?;
+            }
+            None => {
+                return Err(NodeStoreError::NotFound(format!(
+                    "Node with alias {} was not found",
+                    alias
+                )))
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FileBackedNodeStore {
+    fn load(&self) -> Result<Vec<SerdeNode>, NodeStoreError> {
+        let file = open_file(false, &self.file_name)?;
+
+        if file.metadata()?.len() == 0 {
+            return Ok(vec![]);
+        }
+
+        let nodes = serde_yaml::from_reader(file)?;
+        Ok(nodes)
+    }
+
+    fn save(&self, nodes: &[SerdeNode]) -> Result<(), NodeStoreError> {
+        let temp_file_name = format!("{}.tmp", self.file_name);
+        let file = open_file(true, &temp_file_name)?;
+
+        serde_yaml::to_writer(file, &nodes)?;
+
+        let temp_file_path = build_file_path(&temp_file_name)?;
+        let perm_file_path = build_file_path(&self.file_name)?;
+        fs::rename(temp_file_path, perm_file_path)?;
+        Ok(())
+    }
+}
+
+fn build_file_path(file_name: &str) -> Result<PathBuf, NodeStoreError> {
+    let mut path = get_file_path()?;
+    path.push(file_name);
+    Ok(path)
+}
+
+fn open_file(truncate: bool, file_name: &str) -> Result<File, NodeStoreError> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(truncate)
+        .open(&build_file_path(file_name)?)?;
+    Ok(file)
+}
+
+fn get_file_path() -> Result<PathBuf, NodeStoreError> {
+    let mut path = dirs::home_dir().ok_or_else(|| {
+        let err = IoError::new(ErrorKind::NotFound, "Home directory not found");
+        NodeStoreError::IoError(err)
+    })?;
+    path.push(DEFAULTS_PATH);
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}


### PR DESCRIPTION
PR adds the commands bellow that will support creating circuits via cli
- `splinter node alias`:
   -  `add <node-alias> <node-endpoint>`: add new alias to an node endpoint
   -  `get <node-alias>`: see endpoint for alias
   -  `list`: list all aliases and endpoints
   -  `delete <node-alias>`: delete an alias

For more context on how these command can be used refer to [Shawn's comment](https://zenhub.cglcloud.com/app/workspaces/product-core-5d37298b0add7306b30efde2/issues/digitalsupplychain/product-core/1743#issuecomment-110397).




