### PR TITLE
Scabbard CLI

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -16,6 +16,16 @@ version: "3.7"
 
 services:
 
+  scabbard-cli:
+    build:
+      context: .
+      dockerfile: services/scabbard/Dockerfile-installed-${DISTRO}
+      args:
+      - CARGO_ARGS=${CARGO_ARGS}
+      - REPO_VERSION=${REPO_VERSION}
+    image: ${REGISTRY}${NAMESPACE}scabbard-cli:${ISOLATION_ID}
+    container_name: scabbard-cli
+
   splinter-cli:
     build:
       context: .

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -15,7 +15,6 @@
 FROM splintercommunity/splinter-dev as BUILDER
 
 # Copy over source files
-COPY Cargo.toml /build/Cargo.toml
 COPY examples/gameroom/cli /build/examples/gameroom/cli
 COPY examples/gameroom/database /build/examples/gameroom/database
 COPY examples/gameroom/daemon/ /build/examples/gameroom/daemon

--- a/services/scabbard/Cargo.toml
+++ b/services/scabbard/Cargo.toml
@@ -24,14 +24,45 @@ description = """\
     and transactions between organizations.
 """
 
+[[bin]]
+name = "scabbard"
+path = "src/cli/main.rs"
+
 [dependencies]
+clap = "2"
+dirs = "2.0"
+flexi_logger = "0.14"
+log = "0.4"
+protobuf = "2"
+rand = "0.7"
+sabre-sdk = "0.4"
+sawtooth-sdk = "0.3"
+splinter = { path = "../../libsplinter", features = ["sawtooth-signing-compat", "scabbard-client"] }
+
+[dev-dependencies]
+serial_test = "0.3"
+tempfile = "3.1"
 
 [features]
 default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+  "contract-registry",
+  "execute",
+  "namespace",
+  "namespace-permission",
+  "smart-permissions",
+  "upload",
+]
+
+contract-registry = []
+execute = []
+namespace = []
+namespace-permission = []
+smart-permissions = []
+upload = []
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/services/scabbard/Cargo.toml
+++ b/services/scabbard/Cargo.toml
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "scabbard"
+version = "0.3.11"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+license = "Apache-2.0"
+description = """\
+    Splinter is a privacy-focused platform for distributed applications that \
+    provides a blockchain-inspired networking environment for communication \
+    and transactions between organizations.
+"""
 
-members = [
-    "cli",
-    "client",
-    "libsplinter",
-    "splinterd",
-    "examples/private_counter/cli",
-    "examples/private_counter/service",
-    "examples/private_xo",
-    "examples/gameroom/cli",
-    "examples/gameroom/database",
-    "examples/gameroom/daemon",
-    "services/health",
-    "services/scabbard",
-]
+[dependencies]
+
+[features]
+default = []
+
+stable = ["default"]
+
+experimental = []

--- a/services/scabbard/Dockerfile-installed-bionic
+++ b/services/scabbard/Dockerfile-installed-bionic
@@ -1,0 +1,46 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM splintercommunity/splinter-dev as BUILDER
+
+# Copy over source files
+COPY Cargo.toml /build/Cargo.toml
+COPY libsplinter /build/libsplinter
+COPY services/scabbard /build/services/scabbard
+
+# Build the project
+WORKDIR /build/services/scabbard
+ARG REPO_VERSION
+ARG CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+
+# Log the commit hash
+COPY .git/ /tmp/.git/
+WORKDIR /tmp
+RUN git rev-parse HEAD > /commit-hash
+
+# -------------=== scabbard cli docker build ===-------------
+
+FROM ubuntu:bionic
+
+ARG CARGO_ARGS
+RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS
+
+COPY --from=builder /build/target/debian/scabbard_*.deb /tmp
+COPY --from=builder /commit-hash /commit-hash
+
+RUN apt-get update \
+ && dpkg --unpack /tmp/scabbard_*.deb \
+ && apt-get -f -y install

--- a/services/scabbard/packaging/ubuntu/postinst
+++ b/services/scabbard/packaging/ubuntu/postinst
@@ -11,29 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-[package]
-name = "scabbard"
-version = "0.3.11"
-authors = ["Cargill Incorporated"]
-edition = "2018"
-license = "Apache-2.0"
-description = """\
-    Splinter is a privacy-focused platform for distributed applications that \
-    provides a blockchain-inspired networking environment for communication \
-    and transactions between organizations.
-"""
-
-[dependencies]
-
-[features]
-default = []
-
-stable = ["default"]
-
-experimental = []
-
-[package.metadata.deb]
-maintainer = "The Splinter Team"
-depends = "$auto"
-maintainer-scripts = "packaging/ubuntu"

--- a/services/scabbard/src/cli/error.rs
+++ b/services/scabbard/src/cli/error.rs
@@ -1,0 +1,146 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use flexi_logger::FlexiLoggerError;
+use protobuf::error::ProtobufError;
+use sabre_sdk::{
+    protocol::payload::{
+        CreateContractActionBuildError, CreateContractRegistryActionBuildError,
+        CreateNamespaceRegistryActionBuildError, CreateNamespaceRegistryPermissionActionBuildError,
+        CreateSmartPermissionActionBuildError, DeleteContractActionBuildError,
+        DeleteContractRegistryActionBuildError, DeleteNamespaceRegistryActionBuildError,
+        DeleteNamespaceRegistryPermissionActionBuildError, DeleteSmartPermissionActionBuildError,
+        ExecuteContractActionBuildError, SabrePayloadBuildError,
+        UpdateContractRegistryOwnersActionBuildError,
+        UpdateNamespaceRegistryOwnersActionBuildError, UpdateSmartPermissionActionBuildError,
+    },
+    protos::ProtoConversionError,
+};
+use splinter::{service::scabbard::client::Error as ClientError, signing::Error as SigningError};
+
+#[derive(Debug)]
+pub enum CliError {
+    ActionError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    InvalidArgument(String),
+    InvalidSubcommand,
+    LoggingSetupError(String),
+    MissingArgument(String),
+}
+
+impl CliError {
+    pub fn action_error(context: &str) -> Self {
+        CliError::ActionError {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn action_error_with_source(context: &str, err: Box<dyn Error>) -> Self {
+        CliError::ActionError {
+            context: context.into(),
+            source: Some(err),
+        }
+    }
+}
+
+impl Error for CliError {}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CliError::ActionError { context, source } => {
+                if let Some(ref err) = source {
+                    write!(f, "{}: {}", context, err)
+                } else {
+                    f.write_str(&context)
+                }
+            }
+            CliError::InvalidArgument(msg) => write!(f, "invalid argument: {}", msg),
+            CliError::InvalidSubcommand => write!(f, "specified subcommand invalid"),
+            CliError::LoggingSetupError(msg) => write!(f, "error setting up logging: {}", msg),
+            CliError::MissingArgument(arg) => write!(f, "missing required argument: {}", arg),
+        }
+    }
+}
+
+impl From<FlexiLoggerError> for CliError {
+    fn from(err: FlexiLoggerError) -> Self {
+        Self::LoggingSetupError(err.to_string())
+    }
+}
+
+impl From<ProtobufError> for CliError {
+    fn from(err: ProtobufError) -> Self {
+        Self::action_error_with_source("protobuf serialization failed", err.into())
+    }
+}
+
+impl From<SabrePayloadBuildError> for CliError {
+    fn from(err: SabrePayloadBuildError) -> Self {
+        Self::action_error_with_source("failed to build Sabre payload", err.into())
+    }
+}
+
+impl From<ProtoConversionError> for CliError {
+    fn from(err: ProtoConversionError) -> Self {
+        Self::action_error_with_source("failed to convert Sabre protobuf", err.into())
+    }
+}
+
+impl From<SigningError> for CliError {
+    fn from(err: SigningError) -> Self {
+        Self::action_error_with_source("signing failed", err.into())
+    }
+}
+
+impl From<ClientError> for CliError {
+    fn from(err: ClientError) -> Self {
+        Self::action_error_with_source("scabbard client encountered an error", err.into())
+    }
+}
+
+macro_rules! impl_sabre_action_builder_errors {
+    ($($x:ty),*) => {
+        $(
+            impl From<$x> for CliError {
+                fn from(e: $x) -> Self {
+                    CliError::action_error_with_source("failed to build Sabre action", Box::new(e))
+                }
+            }
+        )*
+    };
+}
+
+impl_sabre_action_builder_errors!(
+    CreateContractActionBuildError,
+    DeleteContractActionBuildError,
+    ExecuteContractActionBuildError,
+    CreateContractRegistryActionBuildError,
+    DeleteContractRegistryActionBuildError,
+    UpdateContractRegistryOwnersActionBuildError,
+    CreateNamespaceRegistryActionBuildError,
+    DeleteNamespaceRegistryActionBuildError,
+    UpdateNamespaceRegistryOwnersActionBuildError,
+    CreateNamespaceRegistryPermissionActionBuildError,
+    DeleteNamespaceRegistryPermissionActionBuildError,
+    CreateSmartPermissionActionBuildError,
+    UpdateSmartPermissionActionBuildError,
+    DeleteSmartPermissionActionBuildError
+);

--- a/services/scabbard/src/cli/key.rs
+++ b/services/scabbard/src/cli/key.rs
@@ -1,0 +1,200 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use sawtooth_sdk::signing::secp256k1::Secp256k1PrivateKey;
+
+use super::error::CliError;
+
+/// Load a private key from the local filesystem.
+///
+/// If the argument is a file path (contains a '/'), this will attempt to load the key file from
+/// the specified location. If the argument is not a file path, this will attempt to load the
+/// file from the $HOME/.splinter/keys directory; when loading from this directory, the '.prive'
+/// file extension is optional.
+pub fn load_signing_key(key: &str) -> Result<Secp256k1PrivateKey, CliError> {
+    let file_path = determine_key_file_path(key)?;
+
+    let key_file = File::open(file_path).map_err(|err| {
+        CliError::action_error_with_source("failed to open private key file", err.into())
+    })?;
+    let mut key_file_reader = BufReader::new(key_file);
+
+    let mut raw_key_string = String::new();
+    key_file_reader
+        .read_line(&mut raw_key_string)
+        .map_err(|err| {
+            CliError::action_error_with_source("failed to read private key file", err.into())
+        })?;
+
+    let key_string = raw_key_string.trim();
+    if key_string.is_empty() {
+        return Err(CliError::action_error("private key file is empty"));
+    }
+
+    let signing_key = Secp256k1PrivateKey::from_hex(key_string).map_err(|err| {
+        CliError::action_error_with_source("failed to read valid private key from file", err.into())
+    })?;
+
+    Ok(signing_key)
+}
+
+fn determine_key_file_path(key: &str) -> Result<PathBuf, CliError> {
+    if key.contains('/') {
+        Ok(PathBuf::from(key))
+    } else {
+        let mut path = dirs::home_dir().ok_or_else(|| {
+            CliError::action_error("failed to load signing key: unable to determine home directory")
+        })?;
+        path.push(".splinter");
+        path.push("keys");
+        path.push(key);
+
+        if path.exists() {
+            Ok(path)
+        } else {
+            path.set_extension("priv");
+            if path.exists() {
+                Ok(path)
+            } else {
+                Err(CliError::action_error(
+                    "failed to load signing key: could not be found",
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::create_dir_all;
+    use std::io::Write;
+    use std::path::Path;
+
+    use sawtooth_sdk::signing::PrivateKey;
+    use serial_test::serial;
+    use tempfile::{tempdir, NamedTempFile};
+
+    const MOCK_PRIV_KEY_HEX: &str =
+        "d31e395bed0d9b2277b25d57523063d7d6b9db802d80549bc1362875cdcb83c6";
+
+    /// Verify that an error is returned when the key file is not found.
+    #[test]
+    fn file_not_found() {
+        assert!(load_signing_key("non_existent_file.priv").is_err());
+    }
+
+    /// Verify that an error is returned when the key file is empty.
+    #[test]
+    fn file_empty() {
+        let (_file, path) = temp_key_file("");
+        assert!(load_signing_key(&path).is_err());
+    }
+
+    /// Verify that an error is returned when the file does not contain a valid key.
+    #[test]
+    fn key_in_file_invalid() {
+        let (_file, path) = temp_key_file("not_valid_hex");
+        assert!(load_signing_key(&path).is_err());
+    }
+
+    /// Verify that a key is successfully loaded from a valid key file that is specified with a
+    /// full path.
+    #[test]
+    fn successful_with_path() {
+        let (_file, path) = temp_key_file(MOCK_PRIV_KEY_HEX);
+        let signing_key = load_signing_key(&path).expect("failed to get key from file");
+        assert_eq!(&signing_key.as_hex(), MOCK_PRIV_KEY_HEX);
+    }
+
+    /// Verify that a key is successfully loaded from a valid key file in the $HOME/.splinter/keys
+    /// directory when the key's file name, without the file extension, is specified.
+    #[test]
+    #[serial(home_dir)]
+    fn successful_from_home_without_extension() {
+        run_test_for_key_in_home(MOCK_PRIV_KEY_HEX, |key_path| {
+            let file_stem = key_path
+                .file_stem()
+                .expect("failed to get file stem")
+                .to_string_lossy()
+                .into_owned();
+            let signing_key = load_signing_key(&file_stem).expect("failed to get key");
+            assert_eq!(&signing_key.as_hex(), MOCK_PRIV_KEY_HEX);
+        })
+    }
+
+    /// Verify that a key is successfully loaded from a valid key file in the $HOME/.splinter/keys
+    /// directory when the key's file name with the file extension is specified.
+    #[test]
+    #[serial(home_dir)]
+    fn successful_from_home_with_extension() {
+        run_test_for_key_in_home(MOCK_PRIV_KEY_HEX, |key_path| {
+            let file_name = key_path
+                .file_name()
+                .expect("failed to get file name")
+                .to_string_lossy()
+                .into_owned();
+            let signing_key = load_signing_key(&file_name).expect("failed to get key");
+            assert_eq!(&signing_key.as_hex(), MOCK_PRIV_KEY_HEX);
+        })
+    }
+
+    /// Create a temporary key file with the given key; return the temp file's handle and the file
+    /// path.
+    fn temp_key_file(key: &str) -> (NamedTempFile, String) {
+        let mut file = NamedTempFile::new().expect("failed to create temp key file");
+        writeln!(&mut file, "{}", key).expect("failed to write key to temp file");
+        let path = file.path().to_string_lossy().into_owned();
+        (file, path)
+    }
+
+    /// Create a temporary home directory, write the given key to a temporary file in
+    /// $HOME/.splinter/keys, and run the given test, passing in the key file's path. When the test
+    /// has been run, reset the home directory to its original value and check the test's result.
+    ///
+    /// NOTE: the tests that use this method must be run serially because they modify the same
+    /// environment variable. This is accomplished by annotating each test with
+    /// `#[serial(scar_path)]`.
+    fn run_test_for_key_in_home<F>(key: &str, test: F)
+    where
+        F: Fn(&Path) -> () + std::panic::UnwindSafe,
+    {
+        let original_home = std::env::var("HOME").expect("failed to get original home dir");
+
+        let temp_home = tempdir().expect("failed to create temp home dir");
+        std::env::set_var("HOME", temp_home.path());
+
+        let result = std::panic::catch_unwind(move || {
+            let mut keys_dir_path = temp_home.path().to_path_buf();
+            keys_dir_path.push(".splinter");
+            keys_dir_path.push("keys");
+            create_dir_all(&keys_dir_path).expect("failed to create $HOME/.splinter/keys dir");
+
+            let key_file =
+                NamedTempFile::new_in(&keys_dir_path).expect("failed to create temp key file");
+            writeln!(&key_file, "{}", key).expect("failed to write key to temp file");
+
+            test(key_file.path())
+        });
+
+        std::env::set_var("HOME", original_home);
+
+        assert!(result.is_ok())
+    }
+}

--- a/services/scabbard/src/cli/main.rs
+++ b/services/scabbard/src/cli/main.rs
@@ -1,0 +1,1337 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+
+mod error;
+mod key;
+mod transaction;
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+
+#[cfg(any(
+    feature = "upload",
+    feature = "exec",
+    feature = "namespace",
+    feature = "namespace-permission",
+    feature = "contract-registry",
+    feature = "smart-permissions"
+))]
+use clap::SubCommand;
+use clap::{App, AppSettings, Arg};
+use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+use sabre_sdk::protocol::payload::{
+    Action, CreateContractActionBuilder, CreateContractRegistryActionBuilder,
+    CreateNamespaceRegistryActionBuilder, CreateNamespaceRegistryPermissionActionBuilder,
+    CreateSmartPermissionActionBuilder, DeleteContractRegistryActionBuilder,
+    DeleteNamespaceRegistryActionBuilder, DeleteNamespaceRegistryPermissionActionBuilder,
+    DeleteSmartPermissionActionBuilder, ExecuteContractActionBuilder, SabrePayloadBuilder,
+    UpdateContractRegistryOwnersActionBuilder, UpdateNamespaceRegistryOwnersActionBuilder,
+    UpdateSmartPermissionActionBuilder,
+};
+use sawtooth_sdk::signing::secp256k1::Secp256k1Context;
+use splinter::{
+    service::scabbard::client::{SabreSmartContractDefinition, ScabbardClient},
+    signing::sawtooth::SawtoothSecp256k1RefSigner,
+};
+
+use error::CliError;
+
+fn main() {
+    if let Err(e) = run() {
+        error!("ERROR: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), CliError> {
+    let mut app = App::new("scabbard");
+
+    app = app
+        .version(env!("CARGO_PKG_VERSION"))
+        .author("Cargill")
+        .about("Command line for scabbard")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(
+            Arg::with_name("verbose")
+                .help("Log verbosely")
+                .short("v")
+                .global(true)
+                .multiple(true),
+        );
+
+    #[cfg(feature = "upload")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("upload")
+                .about("Upload a Sabre contract")
+                .args(&[
+                    Arg::with_name("scar")
+                        .long_help(
+                            "The .scar to upload (either a file path or the name of a .scar in \
+                             SCAR_PATH)",
+                        )
+                        .required(true),
+                    Arg::with_name("key")
+                        .long_help(
+                            "Key for signing transactions (either a file path or the name of a \
+                             .priv file in $HOME/.splinter/keys)",
+                        )
+                        .short("k")
+                        .long("key")
+                        .required(true)
+                        .takes_value(true),
+                    Arg::with_name("url")
+                        .help("URL to the scabbard REST API")
+                        .short("U")
+                        .long("url")
+                        .takes_value(true)
+                        .default_value("http://localhost:8008"),
+                    Arg::with_name("service-id")
+                        .long_help(
+                            "Fully-qualified service ID of the scabbard service (must be of the \
+                             form 'circuit_id::service_id')",
+                        )
+                        .long("service-id")
+                        .takes_value(true)
+                        .required(true),
+                    Arg::with_name("wait")
+                        .help("Time (in seconds) to wait for batches to be committed")
+                        .long("wait")
+                        .takes_value(true)
+                        .default_value("300"),
+                ]),
+        );
+    }
+
+    #[cfg(feature = "exec")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("exec")
+                .about("Execute a Sabre contract")
+                .args(&[
+                    Arg::with_name("contract")
+                        .help("Name:version of a Sabre contract")
+                        .short("C")
+                        .long("contract")
+                        .required(true)
+                        .takes_value(true),
+                    Arg::with_name("payload")
+                        .help("Path to Sabre contract payload")
+                        .short("p")
+                        .long("payload")
+                        .required(true)
+                        .takes_value(true),
+                    Arg::with_name("inputs")
+                        .help("Input addresses used by the contract")
+                        .long("inputs")
+                        .required(true)
+                        .takes_value(true)
+                        .multiple(true),
+                    Arg::with_name("outputs")
+                        .help("Output addresses used by the contract")
+                        .long("outputs")
+                        .required(true)
+                        .takes_value(true)
+                        .multiple(true),
+                    Arg::with_name("key")
+                        .long_help(
+                            "Key for signing transactions (either a file path or the name of a \
+                             .priv file in $HOME/.splinter/keys)",
+                        )
+                        .short("k")
+                        .long("key")
+                        .required(true)
+                        .takes_value(true),
+                    Arg::with_name("url")
+                        .help("URL to the scabbard REST API")
+                        .short("U")
+                        .long("url")
+                        .takes_value(true)
+                        .default_value("http://localhost:8008"),
+                    Arg::with_name("service-id")
+                        .long_help(
+                            "Fully-qualified service ID of the scabbard service (must be of the \
+                             form 'circuit_id::service_id')",
+                        )
+                        .long("service-id")
+                        .takes_value(true)
+                        .required(true),
+                    Arg::with_name("wait")
+                        .help("Time (in seconds) to wait for batches to be committed")
+                        .long("wait")
+                        .takes_value(true)
+                        .default_value("300"),
+                ]),
+        );
+    }
+
+    #[cfg(feature = "namespace")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("ns")
+                .about("Create, update, or delete a Sabre namespace")
+                .subcommand(
+                    SubCommand::with_name("create")
+                        .about("Create a Sabre namespace")
+                        .args(&[
+                            Arg::with_name("namespace")
+                                .help("A global state address prefix (namespace)")
+                                .required(true),
+                            Arg::with_name("owner")
+                                .help("Owner of this namespace")
+                                .short("O")
+                                .long("owner")
+                                .required(true)
+                                .takes_value(true)
+                                .multiple(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("update")
+                        .about("Update an existing Sabre namespace")
+                        .args(&[
+                            Arg::with_name("namespace")
+                                .help("A global state address prefix (namespace)")
+                                .required(true),
+                            Arg::with_name("owner")
+                                .help("Owner of this namespace")
+                                .short("O")
+                                .long("owner")
+                                .required(true)
+                                .takes_value(true)
+                                .multiple(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("delete")
+                        .about("Delete a Sabre namespace")
+                        .args(&[
+                            Arg::with_name("namespace")
+                                .help("A global state address prefix (namespace)")
+                                .required(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                ),
+        );
+    }
+
+    #[cfg(feature = "namespace-permission")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("perm")
+                .about("Set or delete a Sabre namespace permission")
+                .args(&[
+                    Arg::with_name("namespace")
+                        .help("A global state address prefix (namespace)")
+                        .required(true),
+                    Arg::with_name("contract")
+                        .help("Name of the contract")
+                        .required(true)
+                        .conflicts_with("delete"),
+                    Arg::with_name("read")
+                        .help("Set read permission")
+                        .short("r")
+                        .long("read")
+                        .conflicts_with("delete"),
+                    Arg::with_name("write")
+                        .help("Set write permission")
+                        .short("w")
+                        .long("write")
+                        .conflicts_with("delete"),
+                    Arg::with_name("delete")
+                        .help("Remove all permissions")
+                        .short("d")
+                        .long("delete"),
+                    Arg::with_name("key")
+                        .long_help(
+                            "Key for signing transactions (either a file path or the name of a \
+                             .priv file in $HOME/.splinter/keys)",
+                        )
+                        .short("k")
+                        .long("key")
+                        .required(true)
+                        .takes_value(true),
+                    Arg::with_name("url")
+                        .help("URL to the scabbard REST API")
+                        .short("U")
+                        .long("url")
+                        .takes_value(true)
+                        .default_value("http://localhost:8008"),
+                    Arg::with_name("service-id")
+                        .long_help(
+                            "Fully-qualified service ID of the scabbard service (must be of the \
+                             form 'circuit_id::service_id')",
+                        )
+                        .long("service-id")
+                        .takes_value(true)
+                        .required(true),
+                    Arg::with_name("wait")
+                        .help("Time (in seconds) to wait for batches to be committed")
+                        .long("wait")
+                        .takes_value(true)
+                        .default_value("300"),
+                ]),
+        );
+    }
+
+    #[cfg(feature = "contract-registry")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("cr")
+                .about("Create, update, or delete a Sabre contract registry")
+                .subcommand(
+                    SubCommand::with_name("create")
+                        .about("Create a Sabre contract registry")
+                        .args(&[
+                            Arg::with_name("name")
+                                .help("Name of the contracts in the registry")
+                                .required(true),
+                            Arg::with_name("owner")
+                                .help("Owner of this contract registry")
+                                .short("O")
+                                .long("owner")
+                                .required(true)
+                                .takes_value(true)
+                                .multiple(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("update")
+                        .about("Update an existing Sabre contract registry")
+                        .args(&[
+                            Arg::with_name("name")
+                                .help("Name of the contracts in the registry")
+                                .required(true),
+                            Arg::with_name("owner")
+                                .help("Owner of this contract registry")
+                                .short("O")
+                                .long("owner")
+                                .required(true)
+                                .takes_value(true)
+                                .multiple(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("delete")
+                        .about("Delete a Sabre contract registry")
+                        .args(&[
+                            Arg::with_name("name")
+                                .help("name of the contracts in the registry")
+                                .required(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                ),
+        );
+    }
+
+    #[cfg(feature = "smart-permissions")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("sp")
+                .about("Create, update or delete smart permissions")
+                .subcommand(
+                    SubCommand::with_name("create")
+                        .about("Create a smart permission")
+                        .args(&[
+                            Arg::with_name("org_id")
+                                .help("Organization ID")
+                                .required(true),
+                            Arg::with_name("name")
+                                .help("Name of the smart permission")
+                                .required(true),
+                            Arg::with_name("filename")
+                                .help("Path to smart permission")
+                                .short("f")
+                                .long("filename")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("update")
+                        .about("Update an existing a smart permission")
+                        .args(&[
+                            Arg::with_name("org_id")
+                                .help("Organization ID")
+                                .required(true),
+                            Arg::with_name("name")
+                                .help("Name of the smart permission")
+                                .required(true),
+                            Arg::with_name("filename")
+                                .help("Path to smart permission")
+                                .short("f")
+                                .long("filename")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                )
+                .subcommand(
+                    SubCommand::with_name("delete")
+                        .about("Delete a smart permission")
+                        .args(&[
+                            Arg::with_name("org_id")
+                                .help("Organization ID")
+                                .required(true),
+                            Arg::with_name("name")
+                                .help("Name of the smart permission")
+                                .required(true),
+                            Arg::with_name("key")
+                                .long_help(
+                                    "Key for signing transactions (either a file path or the name \
+                                     of a .priv file in $HOME/.splinter/keys)",
+                                )
+                                .short("k")
+                                .long("key")
+                                .required(true)
+                                .takes_value(true),
+                            Arg::with_name("url")
+                                .help("URL to the scabbard REST API")
+                                .short("U")
+                                .long("url")
+                                .takes_value(true)
+                                .default_value("http://localhost:8008"),
+                            Arg::with_name("service-id")
+                                .long_help(
+                                    "Fully-qualified service ID of the scabbard service (must be \
+                                     of the  form 'circuit_id::service_id')",
+                                )
+                                .long("service-id")
+                                .takes_value(true)
+                                .required(true),
+                            Arg::with_name("wait")
+                                .help("Time (in seconds) to wait for batches to be committed")
+                                .long("wait")
+                                .takes_value(true)
+                                .default_value("300"),
+                        ]),
+                ),
+        );
+    }
+
+    let matches = app.get_matches();
+
+    let log_level = match matches.occurrences_of("verbose") {
+        0 => log::LevelFilter::Warn,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
+        _ => log::LevelFilter::Trace,
+    };
+    setup_logging(log_level)?;
+
+    match matches.subcommand() {
+        ("upload", Some(matches)) => {
+            let url = matches.value_of("url").expect("default not set for --url");
+            let client = ScabbardClient::new(url);
+
+            let full_service_id = matches
+                .value_of("service-id")
+                .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+            let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+            let wait = matches
+                .value_of("wait")
+                .expect("default not set for --wait")
+                .parse::<u64>()
+                .map_err(|_| {
+                    CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                })?;
+
+            let key = matches
+                .value_of("key")
+                .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+            let signing_key = key::load_signing_key(key)?;
+            let context = Secp256k1Context::new();
+            let signer = SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                CliError::action_error_with_source("failed to create signer", err.into())
+            })?;
+
+            let scar = matches
+                .value_of("scar")
+                .ok_or_else(|| CliError::MissingArgument("scar".into()))?;
+            let sc_definition = SabreSmartContractDefinition::new_from_scar(scar)?;
+
+            let action = CreateContractActionBuilder::new()
+                .with_name(sc_definition.metadata.name)
+                .with_version(sc_definition.metadata.version)
+                .with_inputs(sc_definition.metadata.inputs)
+                .with_outputs(sc_definition.metadata.outputs)
+                .with_contract(sc_definition.contract)
+                .build()?;
+            let payload = SabrePayloadBuilder::new()
+                .with_action(Action::CreateContract(action))
+                .build()?;
+
+            let txn = transaction::create_transaction(payload, &signer)?;
+            let batch = transaction::create_batch(vec![txn], &signer)?;
+            let batch_list = transaction::create_batch_list_from_one(batch);
+
+            Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+        }
+        ("exec", Some(matches)) => {
+            let url = matches.value_of("url").expect("default not set for --url");
+            let client = ScabbardClient::new(url);
+
+            let full_service_id = matches
+                .value_of("service-id")
+                .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+            let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+            let wait = matches
+                .value_of("wait")
+                .expect("default not set for --wait")
+                .parse::<u64>()
+                .map_err(|_| {
+                    CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                })?;
+
+            let key = matches
+                .value_of("key")
+                .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+            let signing_key = key::load_signing_key(key)?;
+            let context = Secp256k1Context::new();
+            let signer = SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                CliError::action_error_with_source("failed to create signer", err.into())
+            })?;
+
+            let contract = matches
+                .value_of("contract")
+                .ok_or_else(|| CliError::MissingArgument("contract".into()))?;
+            let (name, version) = match contract.splitn(2, ':').collect::<Vec<_>>() {
+                v if v.len() == 2 => Ok((v[0], v[1])),
+                _ => Err(CliError::InvalidArgument(
+                    "--contract must be of the form 'name:version'".into(),
+                )),
+            }?;
+
+            let inputs = matches
+                .values_of("inputs")
+                .ok_or_else(|| CliError::MissingArgument("inputs".into()))?
+                .map(String::from)
+                .collect();
+
+            let outputs = matches
+                .values_of("outputs")
+                .ok_or_else(|| CliError::MissingArgument("outputs".into()))?
+                .map(String::from)
+                .collect();
+
+            let payload_file = matches
+                .value_of("payload")
+                .ok_or_else(|| CliError::MissingArgument("payload".into()))?;
+            let contract_payload = load_file_into_bytes(payload_file)?;
+
+            let action = ExecuteContractActionBuilder::new()
+                .with_name(name.into())
+                .with_version(version.into())
+                .with_inputs(inputs)
+                .with_outputs(outputs)
+                .with_payload(contract_payload)
+                .build()?;
+            let payload = SabrePayloadBuilder::new()
+                .with_action(Action::ExecuteContract(action))
+                .build()?;
+
+            let txn = transaction::create_transaction(payload, &signer)?;
+            let batch = transaction::create_batch(vec![txn], &signer)?;
+            let batch_list = transaction::create_batch_list_from_one(batch);
+
+            Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+        }
+        ("ns", Some(matches)) => match matches.subcommand() {
+            ("create", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let namespace = matches
+                    .value_of("namespace")
+                    .ok_or_else(|| CliError::MissingArgument("namespace".into()))?;
+                let owners = matches
+                    .values_of("owner")
+                    .ok_or_else(|| CliError::MissingArgument("owner".into()))?
+                    .map(String::from)
+                    .collect();
+
+                let action = CreateNamespaceRegistryActionBuilder::new()
+                    .with_namespace(namespace.into())
+                    .with_owners(owners)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::CreateNamespaceRegistry(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("update", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let namespace = matches
+                    .value_of("namespace")
+                    .ok_or_else(|| CliError::MissingArgument("namespace".into()))?;
+                let owners = matches
+                    .values_of("owner")
+                    .ok_or_else(|| CliError::MissingArgument("owner".into()))?
+                    .map(String::from)
+                    .collect();
+
+                let action = UpdateNamespaceRegistryOwnersActionBuilder::new()
+                    .with_namespace(namespace.into())
+                    .with_owners(owners)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::UpdateNamespaceRegistryOwners(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("delete", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let namespace = matches
+                    .value_of("namespace")
+                    .ok_or_else(|| CliError::MissingArgument("namespace".into()))?;
+
+                let action = DeleteNamespaceRegistryActionBuilder::new()
+                    .with_namespace(namespace.into())
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::DeleteNamespaceRegistry(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            _ => Err(CliError::InvalidSubcommand),
+        },
+        ("perm", Some(matches)) => {
+            let url = matches.value_of("url").expect("default not set for --url");
+            let client = ScabbardClient::new(url);
+
+            let full_service_id = matches
+                .value_of("service-id")
+                .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+            let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+            let wait = matches
+                .value_of("wait")
+                .expect("default not set for --wait")
+                .parse::<u64>()
+                .map_err(|_| {
+                    CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                })?;
+
+            let key = matches
+                .value_of("key")
+                .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+            let signing_key = key::load_signing_key(key)?;
+            let context = Secp256k1Context::new();
+            let signer = SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                CliError::action_error_with_source("failed to create signer", err.into())
+            })?;
+
+            let namespace = matches
+                .value_of("namespace")
+                .ok_or_else(|| CliError::MissingArgument("namespace".into()))?;
+
+            let payload = if matches.is_present("delete") {
+                let action = DeleteNamespaceRegistryPermissionActionBuilder::new()
+                    .with_namespace(namespace.into())
+                    .build()?;
+                SabrePayloadBuilder::new()
+                    .with_action(Action::DeleteNamespaceRegistryPermission(action))
+                    .build()?
+            } else {
+                let contract = matches
+                    .value_of("contract")
+                    .ok_or_else(|| CliError::MissingArgument("contract".into()))?;
+                let read = matches.is_present("read");
+                let write = matches.is_present("write");
+
+                let action = CreateNamespaceRegistryPermissionActionBuilder::new()
+                    .with_namespace(namespace.into())
+                    .with_contract_name(contract.into())
+                    .with_read(read)
+                    .with_write(write)
+                    .build()?;
+                SabrePayloadBuilder::new()
+                    .with_action(Action::CreateNamespaceRegistryPermission(action))
+                    .build()?
+            };
+
+            let txn = transaction::create_transaction(payload, &signer)?;
+            let batch = transaction::create_batch(vec![txn], &signer)?;
+            let batch_list = transaction::create_batch_list_from_one(batch);
+
+            Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+        }
+        ("cr", Some(matches)) => match matches.subcommand() {
+            ("create", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+                let owners = matches
+                    .values_of("owner")
+                    .ok_or_else(|| CliError::MissingArgument("owner".into()))?
+                    .map(String::from)
+                    .collect();
+
+                let action = CreateContractRegistryActionBuilder::new()
+                    .with_name(name.into())
+                    .with_owners(owners)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::CreateContractRegistry(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("update", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+                let owners = matches
+                    .values_of("owner")
+                    .ok_or_else(|| CliError::MissingArgument("owner".into()))?
+                    .map(String::from)
+                    .collect();
+
+                let action = UpdateContractRegistryOwnersActionBuilder::new()
+                    .with_name(name.into())
+                    .with_owners(owners)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::UpdateContractRegistryOwners(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("delete", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+
+                let action = DeleteContractRegistryActionBuilder::new()
+                    .with_name(name.into())
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::DeleteContractRegistry(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            _ => Err(CliError::InvalidSubcommand),
+        },
+        ("sp", Some(matches)) => match matches.subcommand() {
+            ("create", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let org_id = matches
+                    .value_of("org_id")
+                    .ok_or_else(|| CliError::MissingArgument("org_id".into()))?;
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+                let sp_filename = matches
+                    .value_of("filename")
+                    .ok_or_else(|| CliError::MissingArgument("filename".into()))?;
+                let function = load_file_into_bytes(sp_filename)?;
+
+                let action = CreateSmartPermissionActionBuilder::new()
+                    .with_name(name.to_string())
+                    .with_org_id(org_id.to_string())
+                    .with_function(function)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::CreateSmartPermission(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("update", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let org_id = matches
+                    .value_of("org_id")
+                    .ok_or_else(|| CliError::MissingArgument("org_id".into()))?;
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+                let sp_filename = matches
+                    .value_of("filename")
+                    .ok_or_else(|| CliError::MissingArgument("filename".into()))?;
+                let function = load_file_into_bytes(sp_filename)?;
+
+                let action = UpdateSmartPermissionActionBuilder::new()
+                    .with_name(name.to_string())
+                    .with_org_id(org_id.to_string())
+                    .with_function(function)
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::UpdateSmartPermission(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            ("delete", Some(matches)) => {
+                let url = matches.value_of("url").expect("default not set for --url");
+                let client = ScabbardClient::new(url);
+
+                let full_service_id = matches
+                    .value_of("service-id")
+                    .ok_or_else(|| CliError::MissingArgument("service-id".into()))?;
+                let (circuit_id, service_id) = split_full_service_id(full_service_id)?;
+
+                let wait = matches
+                    .value_of("wait")
+                    .expect("default not set for --wait")
+                    .parse::<u64>()
+                    .map_err(|_| {
+                        CliError::InvalidArgument("'wait' argument must be a valid integer".into())
+                    })?;
+
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+                let signing_key = key::load_signing_key(key)?;
+                let context = Secp256k1Context::new();
+                let signer =
+                    SawtoothSecp256k1RefSigner::new(&context, signing_key).map_err(|err| {
+                        CliError::action_error_with_source("failed to create signer", err.into())
+                    })?;
+
+                let org_id = matches
+                    .value_of("org_id")
+                    .ok_or_else(|| CliError::MissingArgument("org_id".into()))?;
+                let name = matches
+                    .value_of("name")
+                    .ok_or_else(|| CliError::MissingArgument("name".into()))?;
+
+                let action = DeleteSmartPermissionActionBuilder::new()
+                    .with_name(name.to_string())
+                    .with_org_id(org_id.to_string())
+                    .build()?;
+                let payload = SabrePayloadBuilder::new()
+                    .with_action(Action::DeleteSmartPermission(action))
+                    .build()?;
+
+                let txn = transaction::create_transaction(payload, &signer)?;
+                let batch = transaction::create_batch(vec![txn], &signer)?;
+                let batch_list = transaction::create_batch_list_from_one(batch);
+
+                Ok(client.submit(circuit_id, service_id, batch_list, Some(wait))?)
+            }
+            _ => Err(CliError::InvalidSubcommand),
+        },
+        _ => Err(CliError::InvalidSubcommand),
+    }
+}
+
+/// Convert a fully-qualified service ID into its separate (circuit_id, service_id) components.
+fn split_full_service_id(arg: &str) -> Result<(&str, &str), CliError> {
+    let ids = arg.splitn(2, "::").collect::<Vec<_>>();
+    let circuit_id = ids
+        .get(0)
+        .ok_or_else(|| CliError::InvalidArgument("service-id invalid: cannot be empty".into()))?;
+    let service_id = ids.get(1).ok_or_else(|| {
+        CliError::InvalidArgument(
+            "service-id invalid: must be of the form 'circuit_id::service_id'".into(),
+        )
+    })?;
+    Ok((circuit_id, service_id))
+}
+
+fn setup_logging(log_level: log::LevelFilter) -> Result<(), CliError> {
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+
+    Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .start()?;
+
+    Ok(())
+}
+
+// log format for cli that will only show the log message
+fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}
+
+/// Load the contents of a file into a bytes vector.
+fn load_file_into_bytes(payload_file: &str) -> Result<Vec<u8>, CliError> {
+    let file = File::open(payload_file)
+        .map_err(|err| CliError::action_error_with_source("failed to load file", err.into()))?;
+    let mut buf_reader = BufReader::new(file);
+    let mut contents = Vec::new();
+    buf_reader
+        .read_to_end(&mut contents)
+        .map_err(|err| CliError::action_error_with_source("failed to read file", err.into()))?;
+    Ok(contents)
+}

--- a/services/scabbard/src/cli/transaction.rs
+++ b/services/scabbard/src/cli/transaction.rs
@@ -1,0 +1,407 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Write;
+use std::iter::FromIterator;
+
+use protobuf::{self, Message};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use sabre_sdk::{
+    protocol::{
+        payload::{Action, SabrePayload},
+        ADMINISTRATORS_SETTING_ADDRESS,
+    },
+    protos::IntoBytes,
+};
+use sawtooth_sdk::messages::{
+    batch::{Batch, BatchHeader, BatchList},
+    transaction::{Transaction, TransactionHeader},
+};
+use splinter::signing::{hash::HashSigner, Signer};
+
+use super::error::CliError;
+
+const DEFAULT_NONCE_SIZE: usize = 32;
+
+/// Returns a Transaction for the given Payload and Signer
+///
+/// # Arguments
+///
+/// * `payload` - a fully populated identity payload
+/// * `signer` - the signer to be used to sign the transaction
+///
+/// # Errors
+///
+/// An error is returned if it occurs during serialization of the provided payload or internally
+/// created `TransactionHeader`, or if a signing error occurs.
+pub fn create_transaction(
+    payload: SabrePayload,
+    signer: &dyn Signer,
+) -> Result<Transaction, CliError> {
+    let public_key = to_hex(signer.public_key());
+
+    let mut txn = Transaction::new();
+    let mut txn_header = TransactionHeader::new();
+
+    txn_header.set_family_name(String::from("sabre"));
+    txn_header.set_family_version(String::from("0.4"));
+    txn_header.set_nonce(create_nonce());
+    txn_header.set_signer_public_key(public_key.clone());
+    txn_header.set_batcher_public_key(public_key.clone());
+
+    let (input_addresses, output_addresses) = match payload.action() {
+        Action::CreateContract(create_contract) => {
+            let name = create_contract.name();
+            let version = create_contract.version();
+
+            let addresses = vec![
+                compute_contract_registry_address(name)?,
+                compute_contract_address(name, version)?,
+            ];
+
+            (addresses.clone(), addresses)
+        }
+        Action::DeleteContract(delete_contract) => {
+            let name = delete_contract.name();
+            let version = delete_contract.version();
+
+            let addresses = vec![
+                compute_contract_registry_address(name)?,
+                compute_contract_address(name, version)?,
+            ];
+
+            (addresses.clone(), addresses)
+        }
+        Action::ExecuteContract(execute_contract) => {
+            let name = execute_contract.name();
+            let version = execute_contract.version();
+
+            let mut input_addresses = vec![
+                compute_contract_registry_address(name)?,
+                compute_contract_address(name, version)?,
+            ];
+            for input in execute_contract.inputs() {
+                let namespace = match input.get(..6) {
+                    Some(namespace) => namespace,
+                    None => {
+                        return Err(CliError::action_error(&format!(
+                            "invalid input: '{}' is less than 6 characters long",
+                            input,
+                        )));
+                    }
+                };
+
+                input_addresses.push(compute_namespace_registry_address(namespace)?);
+            }
+            input_addresses.append(&mut execute_contract.inputs().to_vec());
+
+            let mut output_addresses = vec![
+                compute_contract_registry_address(name)?,
+                compute_contract_address(name, version)?,
+            ];
+
+            for output in execute_contract.outputs() {
+                let namespace = match output.get(..6) {
+                    Some(namespace) => namespace,
+                    None => {
+                        return Err(CliError::action_error(&format!(
+                            "invalid output: '{}' is less than 6 characters long",
+                            output
+                        )));
+                    }
+                };
+
+                output_addresses.push(compute_namespace_registry_address(namespace)?);
+            }
+            output_addresses.append(&mut execute_contract.outputs().to_vec());
+
+            (input_addresses, output_addresses)
+        }
+        Action::CreateContractRegistry(create_contract_registry) => {
+            let name = create_contract_registry.name();
+            let addresses = vec![
+                compute_contract_registry_address(name)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::DeleteContractRegistry(delete_contract_registry) => {
+            let name = delete_contract_registry.name();
+            let addresses = vec![
+                compute_contract_registry_address(name)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::UpdateContractRegistryOwners(update_contract_registry_owners) => {
+            let name = update_contract_registry_owners.name();
+            let addresses = vec![
+                compute_contract_registry_address(name)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::CreateNamespaceRegistry(create_namespace_registry) => {
+            let namespace = create_namespace_registry.namespace();
+            let addresses = vec![
+                compute_namespace_registry_address(namespace)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::DeleteNamespaceRegistry(delete_namespace_registry) => {
+            let namespace = delete_namespace_registry.namespace();
+            let addresses = vec![
+                compute_namespace_registry_address(namespace)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::UpdateNamespaceRegistryOwners(update_namespace_registry_owners) => {
+            let namespace = update_namespace_registry_owners.namespace();
+            let addresses = vec![
+                compute_namespace_registry_address(namespace)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::CreateNamespaceRegistryPermission(create_namespace_registry_permission) => {
+            let namespace = create_namespace_registry_permission.namespace();
+            let addresses = vec![
+                compute_namespace_registry_address(namespace)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::DeleteNamespaceRegistryPermission(delete_namespace_registry_permission) => {
+            let namespace = delete_namespace_registry_permission.namespace();
+            let addresses = vec![
+                compute_namespace_registry_address(namespace)?,
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
+            ];
+            (addresses.clone(), addresses)
+        }
+        Action::CreateSmartPermission(create_smart_permission) => {
+            let org_id = create_smart_permission.org_id();
+            let name = create_smart_permission.name();
+            let addresses = vec![
+                compute_smart_permission_address(org_id, name)?,
+                compute_org_address(org_id)?,
+                compute_agent_address(&public_key)?,
+            ];
+
+            (addresses.clone(), addresses)
+        }
+        Action::UpdateSmartPermission(update_smart_permission) => {
+            let org_id = update_smart_permission.org_id();
+            let name = update_smart_permission.name();
+            let addresses = vec![
+                compute_smart_permission_address(org_id, name)?,
+                compute_org_address(org_id)?,
+                compute_agent_address(&public_key)?,
+            ];
+
+            (addresses.clone(), addresses)
+        }
+        Action::DeleteSmartPermission(delete_smart_permission) => {
+            let org_id = delete_smart_permission.org_id();
+            let name = delete_smart_permission.name();
+            let addresses = vec![
+                compute_smart_permission_address(org_id, name)?,
+                compute_org_address(org_id)?,
+                compute_agent_address(&public_key)?,
+            ];
+
+            (addresses.clone(), addresses)
+        }
+    };
+
+    txn_header.set_inputs(protobuf::RepeatedField::from_vec(input_addresses));
+    txn_header.set_outputs(protobuf::RepeatedField::from_vec(output_addresses));
+
+    let payload_bytes = payload.into_bytes()?;
+    let hash = HashSigner.sign(&payload_bytes).map_err(|err| {
+        CliError::action_error_with_source("failed to hash payload bytes", err.into())
+    })?;
+    txn_header.set_payload_sha512(to_hex(&hash));
+    txn.set_payload(payload_bytes);
+
+    let txn_header_bytes = txn_header.write_to_bytes()?;
+    txn.set_header(txn_header_bytes.clone());
+
+    let b: &[u8] = &txn_header_bytes;
+    let signature = signer.sign(b)?;
+    txn.set_header_signature(to_hex(&signature));
+
+    Ok(txn)
+}
+
+/// Returns a Batch for the given Transactions and Signer
+///
+/// # Arguments
+///
+/// * `txns` - transaction to put in the batch
+/// * `signer` - the signer to be used to sign the batch
+///
+/// # Errors
+///
+/// An error is returned if it occurs during serialization of the provided transactions or
+/// internally created `BatchHeader`, or if a signing error occurs.
+pub fn create_batch(txns: Vec<Transaction>, signer: &dyn Signer) -> Result<Batch, CliError> {
+    let public_key = to_hex(signer.public_key());
+
+    let mut batch = Batch::new();
+    let mut batch_header = BatchHeader::new();
+
+    batch_header.set_transaction_ids(protobuf::RepeatedField::from_iter(
+        txns.iter().map(|txn| txn.header_signature.clone()),
+    ));
+    batch_header.set_signer_public_key(public_key);
+    batch.set_transactions(txns.into());
+
+    let batch_header_bytes = batch_header.write_to_bytes()?;
+    batch.set_header(batch_header_bytes.clone());
+
+    let b: &[u8] = &batch_header_bytes;
+    let signature = signer.sign(b)?;
+    batch.set_header_signature(to_hex(&signature));
+
+    Ok(batch)
+}
+
+/// Returns a BatchList containing the provided Batch
+///
+/// # Arguments
+///
+/// * `batch` - a Batch
+pub fn create_batch_list_from_one(batch: Batch) -> BatchList {
+    let mut batch_list = BatchList::new();
+    batch_list.set_batches(protobuf::RepeatedField::from_vec(vec![batch]));
+    batch_list
+}
+
+/// Creates a nonce appropriate for a TransactionHeader
+fn create_nonce() -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(DEFAULT_NONCE_SIZE)
+        .collect::<String>()
+}
+
+/// Returns a state address for a given namespace registry
+///
+/// # Arguments
+///
+/// * `namespace` - the address prefix for this namespace
+fn compute_namespace_registry_address(namespace: &str) -> Result<String, CliError> {
+    let prefix = match namespace.get(..6) {
+        Some(x) => x,
+        None => {
+            return Err(CliError::action_error(&format!(
+                "invalid namespace: '{}' is less than 6 characters long",
+                namespace,
+            )));
+        }
+    };
+
+    let hash = HashSigner.sign(prefix.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash namespace registry address", err.into())
+    })?;
+
+    Ok(String::from("00ec00") + &to_hex(&hash)[..64])
+}
+
+/// Returns a state address for a given contract registry
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract registry
+fn compute_contract_registry_address(name: &str) -> Result<String, CliError> {
+    let hash = HashSigner.sign(name.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash contract registry address", err.into())
+    })?;
+
+    Ok(String::from("00ec01") + &to_hex(&hash)[..64])
+}
+
+/// Returns a state address for a given contract
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract
+/// * `version` - the version of the contract
+fn compute_contract_address(name: &str, version: &str) -> Result<String, CliError> {
+    let s = String::from(name) + "," + version;
+
+    let hash = HashSigner.sign(s.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash contract address", err.into())
+    })?;
+
+    Ok(String::from("00ec02") + &to_hex(&hash)[..64])
+}
+
+/// Returns a state address for a given agent name
+///
+/// # Arguments
+///
+/// * `name` - the agent's name
+fn compute_agent_address(name: &str) -> Result<String, CliError> {
+    let hash = HashSigner.sign(name.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash pike agent address", err.into())
+    })?;
+
+    Ok(String::from("cad11d00") + &to_hex(&hash)[..62])
+}
+
+/// Returns a state address for a given organization id
+///
+/// # Arguments
+///
+/// * `id` - the organization's id
+fn compute_org_address(id: &str) -> Result<String, CliError> {
+    let hash = HashSigner.sign(id.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash pike org address", err.into())
+    })?;
+
+    Ok(String::from("cad11d01") + &to_hex(&hash)[..62])
+}
+
+/// Returns a state address for a given smart permission
+///
+/// # Arguments
+///
+/// * `org_id` - the organization's id
+/// * `name` - smart permission name
+fn compute_smart_permission_address(org_id: &str, name: &str) -> Result<String, CliError> {
+    let org_id_hash = HashSigner.sign(org_id.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash pike org id", err.into())
+    })?;
+
+    let name_hash = HashSigner.sign(name.as_bytes()).map_err(|err| {
+        CliError::action_error_with_source("failed to hash pike org id", err.into())
+    })?;
+
+    Ok(String::from("00ec03") + &to_hex(&org_id_hash)[..6] + &to_hex(&name_hash)[..58])
+}
+
+/// Convert bytes to a hex string.
+fn to_hex(bytes: &[u8]) -> String {
+    let mut buf = String::new();
+    for b in bytes {
+        write!(&mut buf, "{:02x}", b).expect("Unable to write to string");
+    }
+
+    buf
+}

--- a/services/scabbard/src/lib.rs
+++ b/services/scabbard/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
To test:
- Run the Grid on Splinter example and setup a circuit
- Download the xo smart contract (https://build.sawtooth.me/job/Sawtooth-Hyperledger/job/sawtooth-sdk-rust/job/master/lastSuccessfulBuild/artifact/build/scar/xo_0.4.1.scar)
- Add the xo smart contract's directory as a volume for the scabbard-cli service in docker-compose-installed.yaml (mapped to `/usr/share/scar`)
- Run the scabbard-cli image using `docker-compose -f docker-compose-installed.yaml run scabbard-cli bash`
- In the scabbard-cli container:
  - `mkdir -p /root/.splinter/keys`
  - `echo "<alpha-gridd-pub-key>" > /root/.splinter/keys/gridd.pub`
  - `echo "<alpha-gridd-priv-key>" > /root/.splinter/keys/gridd.priv`
  - `scabbard cr create sawtooth_xo --owner $(cat /root/.splinter/keys/gridd.pub) -k gridd -U 'http://splinterd-alpha:8085' --service-id 'my-grid-circuit::grid-scabbard-a'`
  - `scabbard upload /usr/share/scar/xo_0.4.1.scar -k gridd -U 'http://splinterd-alpha:8085' --service-id 'my-grid-circuit::grid-scabbard-a'`
  - `scabbard ns create 5b7349 --owner $(cat /root/.splinter/keys/gridd.pub) -k gridd -U 'http://splinterd-alpha:8085' --service-id 'my-grid-circuit::grid-scabbard-a'`
  - `scabbard perm 5b7349 sawtooth_xo -r -w -k gridd -U 'http://splinterd-alpha:8085' --service-id 'my-grid-circuit::grid-scabbard-a'`
  - `scabbard perm cad11d sawtooth_xo -r -k gridd -U 'http://splinterd-alpha:8085' --service-id 'my-grid-circuit::grid-scabbard-a'`

There is currently no way to verify the success of these actions besides the proposals being committed (seen in the logs).