### PR TITLE
Fix style loader

### DIFF
--- a/canopy/app/saplings/canopyConfig.yml
+++ b/canopy/app/saplings/canopyConfig.yml
@@ -1,2 +1,16 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 canopyConfig:
   splinterEndpoint: ""

--- a/canopy/app/saplings/configSaplings.yml
+++ b/canopy/app/saplings/configSaplings.yml
@@ -7,3 +7,4 @@
   runtimeFiles:
     - 0.0.0.0:8675/profile.js
   workerFiles: []
+  styleFiles: []

--- a/canopy/app/saplings/configSaplings.yml
+++ b/canopy/app/saplings/configSaplings.yml
@@ -1,3 +1,17 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - namespace: login
   runtimeFiles:
     - 0.0.0.0:8675/loginRegisterSapling.js

--- a/canopy/app/saplings/loginRegisterSapling.js
+++ b/canopy/app/saplings/loginRegisterSapling.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 window.$CANOPY.registerConfigSapling('login', () => {
   console.log('Registering Login Sapling');
 });

--- a/canopy/app/saplings/userSaplings.yml
+++ b/canopy/app/saplings/userSaplings.yml
@@ -1,3 +1,17 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - displayName: Vanilla
   namespace: vanilla
   runtimeFiles:


### PR DESCRIPTION
The Profile sapling config was missing the styleFiles property, which was causing an error on startup. Also adds missing license headers.