### PR TITLE
Enable more than 2-party circuit creation

### DIFF
--- a/libsplinter/src/admin/service/consensus.rs
+++ b/libsplinter/src/admin/service/consensus.rs
@@ -112,6 +112,10 @@ impl AdminConsensusManager {
             .send(update)
             .map_err(|err| AdminConsensusManagerError(Box::new(err)))
     }
+
+    pub fn proposal_update_sender(&self) -> Sender<ProposalUpdate> {
+        self.proposal_update_tx.clone()
+    }
 }
 
 pub struct AdminProposalManager {

--- a/libsplinter/src/admin/service/messages.rs
+++ b/libsplinter/src/admin/service/messages.rs
@@ -369,6 +369,8 @@ impl CircuitProposalVote {
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct VoteRecord {
+    #[serde(serialize_with = "as_hex")]
+    #[serde(deserialize_with = "deserialize_hex")]
     pub public_key: Vec<u8>,
     pub vote: Vote,
     pub voter_node_id: String,

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -27,7 +27,7 @@ use openssl::hash::{hash, MessageDigest};
 use protobuf::{self, Message};
 
 use crate::circuit::SplinterState;
-use crate::consensus::{Proposal, ProposalUpdate};
+use crate::consensus::Proposal;
 use crate::hex::to_hex;
 use crate::keys::{KeyPermissionManager, KeyRegistry};
 use crate::network::{
@@ -155,7 +155,7 @@ impl AdminService {
             .auth_inquisitor()
             .register_callback(Box::new(
                 move |peer_id: &str, state: PeerAuthorizationState| {
-                    auth_callback_shared
+                    let result = auth_callback_shared
                         .lock()
                         .map_err(|_| {
                             AuthorizationCallbackError(
@@ -163,6 +163,9 @@ impl AdminService {
                             )
                         })?
                         .on_authorization_change(peer_id, state);
+                    if let Err(err) = result {
+                        error!("{}", err);
+                    }
 
                     Ok(())
                 },
@@ -307,24 +310,15 @@ impl Service for AdminService {
                     .into();
                 proposal.summary = expected_hash;
                 proposal.consensus_data = required_verifiers.to_vec();
-
                 let mut admin_service_shared = self.admin_service_shared.lock().map_err(|_| {
                     ServiceError::PoisonedLock("the admin shared lock was poisoned".into())
                 })?;
 
-                admin_service_shared.add_pending_consensus_proposal(
-                    proposal.id.clone(),
-                    (proposal.clone(), circuit_payload.clone()),
-                );
-
-                self.consensus
-                    .as_ref()
-                    .ok_or_else(|| ServiceError::NotStarted)?
-                    .send_update(ProposalUpdate::ProposalReceived(
-                        proposal,
-                        message_context.sender.as_bytes().into(),
-                    ))
-                    .map_err(|err| ServiceError::UnableToHandleMessage(Box::new(err)))
+                admin_service_shared.handle_proposed_circuit(
+                    proposal,
+                    circuit_payload.clone(),
+                    message_context.sender.to_string(),
+                )
             }
             AdminMessage_Type::MEMBER_READY => {
                 let member_ready = admin_message.get_member_ready();
@@ -558,7 +552,7 @@ mod tests {
             .admin_service_shared
             .lock()
             .unwrap()
-            .propose_circuit(payload)
+            .propose_circuit(payload, "test".to_string())
             .expect("The proposal was not handled correctly");
 
         // wait up to 1 second for the proposed circuit message

--- a/libsplinter/src/consensus/two_phase/mod.rs
+++ b/libsplinter/src/consensus/two_phase/mod.rs
@@ -60,8 +60,8 @@ use crate::protos::two_phase::{
 use self::timing::Timeout;
 
 const DEFAULT_COORDINATOR_TIMEOUT_MILLIS: u64 = 5000; // 5 seconds
-const MESSAGE_TIMEOUT_MILLIS: u64 = 100;
-const PROPOSAL_TIMEOUT_MILLIS: u64 = 100;
+const MESSAGE_RECV_TIMEOUT_MILLIS: u64 = 100;
+const PROPOSAL_RECV_TIMEOUT_MILLIS: u64 = 100;
 
 #[derive(Debug)]
 enum State {
@@ -649,8 +649,8 @@ impl ConsensusEngine for TwoPhaseEngine {
         proposal_manager: Box<dyn ProposalManager>,
         startup_state: StartupState,
     ) -> Result<(), ConsensusEngineError> {
-        let message_timeout = Duration::from_millis(MESSAGE_TIMEOUT_MILLIS);
-        let proposal_timeout = Duration::from_millis(PROPOSAL_TIMEOUT_MILLIS);
+        let message_timeout = Duration::from_millis(MESSAGE_RECV_TIMEOUT_MILLIS);
+        let proposal_timeout = Duration::from_millis(PROPOSAL_RECV_TIMEOUT_MILLIS);
 
         self.id = startup_state.id;
 


### PR DESCRIPTION
Update on_authorization_change to handle consensus proposals

Previously, only payloads coming from a rest api would check
if all members of in the circuit proposal where connected.
This caused issues with larger then 2 party circuits because
there was no guarantee that all members were connected.

This PR updates UnpeeredPendingPayload to keep track of
both circuit management payloads and consensus proposals
received over the splinter network. Now the consensus proposal
will only be handled once all members are authorized.

To test pull in 20fd0e7a1393b1d69fc0624e8e45572f3545cc71 from https://github.com/agunde406/splinter/tree/three-party-circuit-test and build gameroom with experimental features turned on. This commit adds another node to gameroom so there are 3.

Run the following command create a 3 party circuit

`docker exec -it splinterd-node-acme bash`

```
cat > circuit.yaml 

circuit_id: "test-all"
roster:
  - service_id: gameroom_bubba-node-000
    service_type: scabbard
    allowed_nodes:
      - bubba-node-000
    arguments:
      - - admin_keys
        - "[\"03e2ae056a29abfb896cee748a55829758227da437251aa67c7ec7afe16a8b27e9\"]"
      - - peer_services
        - "[\"gameroom_acme-node-000\", \"gameroom_generic-node-000\"]"
  - service_id: gameroom_acme-node-000
    service_type: scabbard
    allowed_nodes:
      - acme-node-000
    arguments:
      - - admin_keys
        - "[\"03e2ae056a29abfb896cee748a55829758227da437251aa67c7ec7afe16a8b27e9\"]"
      - - peer_services
        - "[\"gameroom_bubba-node-000\", \"gameroom_generic-node-000\"]"
  - service_id: gameroom_generic-node-000
    service_type: scabbard
    allowed_nodes:
      - generic-node-000
    arguments:
      - - admin_keys
        - "[\"03e2ae056a29abfb896cee748a55829758227da437251aa67c7ec7afe16a8b27e9\"]"
      - - peer_services
        - "[\"gameroom_acme-node-000\", \"gameroom_bubba-node-000\"]"
members:
  - node_id: bubba-node-000
    endpoint: "tls://splinterd-node-bubba:8044"
  - node_id: acme-node-000
    endpoint: "tls://splinterd-node-acme:8044"
  - node_id: generic-node-000
    endpoint: "tls://splinterd-node-generic:8044"
authorization_type: Trust
persistence: Any
durability: NoDurability
routes: Any
circuit_management_type: gameroom

```

`splinter circuit create circuit.yaml --url http://splinterd-node-acme:8085 -k key_registry_shared/alice.priv `

`splinter circuit list  --url http://splinterd-node-acme:8085  `

`splinter circuit vote  test-all --accept -k key_registry_shared/bob.priv  --url http://splinterd-node-bubba:8085`

`splinter circuit vote  test-all --accept -k key_registry_shared/gwen.priv  --url http://splinterd-node-generic:8085`

`splinter circuit list --url http://splinterd-node-acme:8085 `

And you should see a circuit listed on all 3 nodes.

Note: gameroomd will error on each step because the application_metadata is not included, but the circuit should still be created at the end.



