### PR TITLE
Initial register/login sapling

### DIFF
--- a/canopy/app/saplings/configSaplings.yml
+++ b/canopy/app/saplings/configSaplings.yml
@@ -1,7 +1,6 @@
 - namespace: login
   runtimeFiles:
-    - 0.0.0.0:8675/loginRegisterSapling.js
-  styleFiles: []
+    - 0.0.0.0:8675/register-login.js
   workerFiles: []
 - namespace: profile
   runtimeFiles:

--- a/canopy/app/src/App.js
+++ b/canopy/app/src/App.js
@@ -33,8 +33,8 @@ function App() {
   const saplingDomNode = useRef(null);
   const [userSaplingManifests, setUserSaplingManifests] = useState([]);
   const [user, setUser] = useUserState();
-  const [sharedConfig, setSharedConfig] = useState({});
 
+  const sharedConfig = useRef(null);
   const appSapling = useRef(null);
   const configSaplings = useRef({});
 
@@ -49,7 +49,7 @@ function App() {
 
   window.$CANOPY.setUser = setUser;
   window.$CANOPY.getUser = () => user;
-  window.$CANOPY.getSharedConfig = () => sharedConfig;
+  window.$CANOPY.getSharedConfig = () => sharedConfig.current;
 
   // This useEffect with zero dependencies will run only when the component first loads.
   useEffect(() => {
@@ -60,7 +60,7 @@ function App() {
         sharedConfigResponse
       ] = await Promise.all([loadAllSaplings(), loadSharedConfig()]);
 
-      setSharedConfig(sharedConfigResponse);
+      sharedConfig.current = sharedConfigResponse;
       setUserSaplingManifests(userSaplingsResponse);
 
       // Load the config saplings

--- a/canopy/saplings/register-login/.eslintrc
+++ b/canopy/saplings/register-login/.eslintrc
@@ -1,0 +1,28 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".ts"]
+      }
+    }
+  },
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "rules": {
+    "import/no-default-export": 2,
+    "import/prefer-default-export": 0
+  },
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "airbnb",
+    "plugin:prettier/recommended"
+  ]
+}

--- a/canopy/saplings/register-login/.prettierrc
+++ b/canopy/saplings/register-login/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/canopy/saplings/register-login/jest.config.js
+++ b/canopy/saplings/register-login/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom'
+};

--- a/canopy/saplings/register-login/package.json
+++ b/canopy/saplings/register-login/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "register-login-sapling",
+  "private": true,
+  "version": "0.0.0-alpha",
+  "license": "Apache-2.0",
+  "author": "Cargill Incorporated",
+  "main": "dist/index.js",
+  "dependencies": {
+    "axios": "^0.19.0",
+    "canopyjs": "../../canopyjs/",
+    "history": "^4.10.1",
+    "js-sha256": "^0.9.0"
+  },
+  "scripts": {
+    "preinstall": "(cd ../../canopyjs && npm install && npm run build)",
+    "test": "jest",
+    "build": "webpack",
+    "add-to-canopy": "cp ./dist/register-login.js ../../app/saplings/register-login.js",
+    "deploy": "npm run build && npm run add-to-canopy",
+    "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
+    "lint": "eslint src/*"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.19",
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
+    "eslint": "^6.5.1",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-react": "^7.16.0",
+    "jest": "^24.9.0",
+    "prettier": "^1.18.2",
+    "ts-jest": "^24.1.0",
+    "ts-loader": "^6.2.1",
+    "typescript": "^3.7.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10"
+  }
+}

--- a/canopy/saplings/register-login/src/html.ts
+++ b/canopy/saplings/register-login/src/html.ts
@@ -1,0 +1,58 @@
+export const html = `<div style="padding: 3rem"><div class="tab-box">
+<div class="tab-box-options" role="tablist" aria-label="login-or-register">
+  <button
+    class="tab-box-option active"
+    role="tab"
+    aria-selected="true"
+    aria-controls="login-panel"
+    id="login-panel-tab"
+    tabindex="0"
+  >
+    Login
+  </button>
+  <button
+    class="tab-box-option"
+    role="tab"
+    aria-selected="false"
+    aria-controls="register-panel"
+    id="register-panel-tab"
+    tabindex="-1"
+  >
+    Register
+  </button>
+</div>
+<div
+  class="tab-box-content"
+  id="login-panel"
+  role="tabpanel"
+  tabindex="0"
+  aria-labelledby="login-panel-tab"
+>
+  <form id="login-form">
+    <h1>Login</h1>
+    <input type="text" name="username" /><input
+      type="password"
+      name="password"
+    /><button type="submit">Login</button>
+  </form>
+</div>
+<div
+  class="tab-box-content"
+  id="register-panel"
+  role="tabpanel"
+  tabindex="0"
+  aria-labelledby="register-panel-tab"
+  hidden
+>
+  <form id="register-form">
+    <h1>Register</h1>
+    <input type="text" name="username" /><input
+      type="password"
+      name="password"
+    /><button type="submit">Register</button>
+  </form>
+</div>
+</div>
+<span id='login-register-error-message' class='color-danger'></span>
+</div>
+`;

--- a/canopy/saplings/register-login/src/index.ts
+++ b/canopy/saplings/register-login/src/index.ts
@@ -1,0 +1,195 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  registerConfigSapling,
+  getUser,
+  registerApp,
+  setUser,
+  getSharedConfig
+} from 'canopyjs';
+import { createBrowserHistory } from 'history';
+import axios from 'axios';
+import { sha256 } from 'js-sha256';
+import { html } from './html';
+
+const history = createBrowserHistory();
+
+interface FormEventHandler {
+  (this: HTMLFormElement, event: Event): void;
+}
+
+registerConfigSapling('login', () => {
+  const canopyUser = window.sessionStorage.getItem('canopy_user');
+
+  if (!getUser() && canopyUser) {
+    setUser(JSON.parse(canopyUser));
+    return;
+  }
+
+  if (!getUser()) {
+    const canopyUrl = new URL(window.location.href);
+    canopyUrl.pathname =
+      canopyUrl.pathname === '/login' ? '/' : canopyUrl.pathname;
+
+    history.push('/login');
+    registerApp(domNode => {
+      const div = domNode as HTMLDivElement;
+      div.innerHTML = html;
+
+      const tabs = Array.from(div.querySelectorAll('.tab-box-option'));
+      const forms = Array.from(div.querySelectorAll('form'));
+
+      const errorMessageNode = div.querySelector(
+        '#login-register-error-message'
+      );
+
+      const [loginForm, registerForm] = forms;
+      const panels = Array.from(div.querySelectorAll('.tab-box-content'));
+
+      function formSumbitEventToFormData(event: Event): FormData {
+        event.preventDefault();
+        return new FormData(event.target as HTMLFormElement);
+      }
+
+      function showErrorResponse(message): void {
+        errorMessageNode.innerHTML = message;
+      }
+
+      function createFormActionCapture(
+        action: 'register' | 'login'
+      ): FormEventHandler {
+        return async function captureForm(
+          this: HTMLFormElement,
+          event: Event
+        ): Promise<void> {
+          const formData = formSumbitEventToFormData(event);
+
+          const user = {
+            displayName: formData.get('username') as string
+          };
+
+          const hash = sha256.hmac.create(formData.get('username') as string);
+          hash.update(formData.get('password') as string);
+          const hashedPassword = hash.hex();
+
+          const http = axios.create({
+            baseURL: getSharedConfig().canopyConfig.splinterEndpoint
+          });
+
+          const target = event.target as HTMLFormElement;
+          const formParent = target.parentNode as HTMLDivElement;
+
+          const progressNode = document.createElement('div');
+          progressNode.setAttribute(
+            'style',
+            'width: 100%; height: 100%; display: flex; justify-content: center; align-items: center;'
+          );
+
+          formParent.replaceChild(progressNode, target);
+
+          let animationRequest = null;
+
+          function doProgress(ts = 0): void {
+            const step = (Math.sin(ts / 500) + 1) / 2;
+            progressNode.innerHTML = `<progress class='progress' max="${1000}" value="${step *
+              1000}"/>`;
+            animationRequest = window.requestAnimationFrame(doProgress);
+          }
+          doProgress();
+
+          tabs.forEach(tab => {
+            tab.setAttribute('disabled', 'true');
+          });
+
+          try {
+            const jsonPayload = {
+              username: formData.get('username') as string,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              hashed_password: hashedPassword
+            };
+
+            if (action === 'register') {
+              await http.post(`/biome/register`, jsonPayload);
+            }
+
+            const response = await http.post(`/biome/login`, jsonPayload);
+            delete response.data.message;
+            window.sessionStorage.setItem(
+              'canopy_user',
+              JSON.stringify({ ...user, ...response.data })
+            );
+            window.location.href = canopyUrl.href;
+          } catch (err) {
+            switch (err.response.status) {
+              case 404:
+                showErrorResponse('Splinter Node could not be found');
+                break;
+              default:
+                showErrorResponse(
+                  'Unknown error communicating with Splinter Node'
+                );
+            }
+            tabs.forEach(tab => {
+              tab.removeAttribute('disabled');
+            });
+            window.cancelAnimationFrame(animationRequest);
+            formParent.replaceChild(target, progressNode);
+          }
+        };
+      }
+
+      const handleRegisterEvent = createFormActionCapture('register');
+      const handleLoginEvent = createFormActionCapture('login');
+
+      registerForm.addEventListener('submit', handleRegisterEvent);
+
+      loginForm.addEventListener('submit', handleLoginEvent);
+
+      forms.forEach(form => {
+        form.addEventListener('submit', e => {
+          e.preventDefault();
+        });
+      });
+
+      function setSelectedTab(tabIndex): void {
+        tabs.forEach((tab, i) => {
+          const selected = i === tabIndex;
+          tab.setAttribute('tabindex', selected ? '0' : '-1');
+          tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+          tab.setAttribute(
+            'class',
+            selected ? 'tab-box-option active' : 'tab-box-option'
+          );
+        });
+
+        panels.forEach((panel, i) => {
+          if (i === tabIndex) {
+            panel.removeAttribute('hidden');
+          } else {
+            panel.setAttribute('hidden', 'true');
+          }
+        });
+      }
+
+      tabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => {
+          setSelectedTab(index);
+        });
+      });
+    });
+  }
+});

--- a/canopy/saplings/register-login/tsconfig.json
+++ b/canopy/saplings/register-login/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015", "dom"],
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "**/*.spec.ts"],
+  "include": ["src/**/*"]
+}

--- a/canopy/saplings/register-login/webpack.config.js
+++ b/canopy/saplings/register-login/webpack.config.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  mode: "production",
+  entry: "./src/index.ts",
+  output: {
+    library: "register-login",
+    libraryTarget: "umd",
+    filename: "register-login.js",
+    globalObject: "this"
+  },
+  resolve: {
+    extensions: [".ts", ".js"]
+  },
+  module: {
+    rules: [{ test: /\.ts$/, loader: "ts-loader" }]
+  }
+};


### PR DESCRIPTION
Looking for comments. Until I can test this locally end-to-end, I want to make sure this stays a draft.

From the `canopy/saplings/register-login` directory, after installing dependencies one can run
`npm run deploy` to build the register/login sapling and it will automatically be added to the appropriate directory in `canopy/app`.

Specifically looking for feedback during this draft around:
1. The aforementioned `deploy` strategy
2. If the example is simple enough from an instructional perspective. My thinking is that our example saplings are meant to be demonstrative as to how to use CanopyJS.