### PR TITLE
Simplify package.metadata.docs.rs feature list

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -128,18 +128,6 @@ ursa-compat = ["ursa"]
 
 [package.metadata.docs.rs]
 features = [
-    "biome",
-    "biome-credentials",
-    "biome-key-management",
-    "biome-notifications",
-    "connection-manager",
-    "connection-manager-notification-iter-try-next",
-    "database",
-    "database",
-    "events",
-    "node-registry-unified",
-    "rest-api",
-    "sawtooth-signing-compat",
-    "ursa-compat",
-    "zmq-transport",
+    "stable",
+    "experimental"
   ]


### PR DESCRIPTION
This changes the features to only list stable and
experimental to reduce the number of lists that need
to be maintained.

This also leaves out urse-compat which is currenlty
broken and breaks the doc builds.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>