### PR TITLE
Initial Optional Protocol Header

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -75,6 +75,8 @@ pub mod mesh;
 pub mod network;
 pub mod node_registry;
 pub mod orchestrator;
+#[cfg(feature = "rest-api")]
+mod protocol;
 pub mod protos;
 #[cfg(feature = "rest-api")]
 pub mod rest_api;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Protocol versions for various endpoints provided by splinter.

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -13,3 +13,15 @@
 // limitations under the License.
 
 //! Protocol versions for various endpoints provided by splinter.
+
+pub const ADMIN_PROTOCOL_VERSION: u32 = 1;
+
+pub const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
+
+pub const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
+
+#[cfg(feature = "proposal-read")]
+pub const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
+
+#[cfg(feature = "proposal-read")]
+pub const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -330,6 +330,94 @@ impl RequestGuard for Box<dyn RequestGuard> {
     }
 }
 
+/// Guards requests based on a minimum protocol version.
+///
+/// A protocol version is specified via the HTTP header `"SplinterProtocolVersion"`.  This header
+/// is a positive integer value.
+#[derive(Clone)]
+pub struct ProtocolVersionRangeGuard {
+    min: u32,
+    max: u32,
+}
+
+impl ProtocolVersionRangeGuard {
+    /// Constructs a new protocol version guard with the given minimum.
+    pub fn new(min: u32, max: u32) -> Self {
+        Self { min, max }
+    }
+}
+
+impl RequestGuard for ProtocolVersionRangeGuard {
+    fn evaluate(&self, req: &HttpRequest) -> Continuation {
+        if let Some(header_value) = req.headers().get("SplinterProtocolVersion") {
+            let parsed_header = header_value
+                .to_str()
+                .map_err(|err| {
+                    format!(
+                        "Invalid characters in SplinterProtocolVersion header: {}",
+                        err
+                    )
+                })
+                .and_then(|val_str| {
+                    val_str.parse::<u32>().map_err(|_| {
+                        "SplinterProtocolVersion must be a valid positive integer".to_string()
+                    })
+                });
+            match parsed_header {
+                Err(msg) => Continuation::terminate(
+                    HttpResponse::BadRequest()
+                        .json(json!({
+                            "message": msg,
+                        }))
+                        .into_future(),
+                ),
+                Ok(version) if version < self.min => Continuation::terminate(
+                    HttpResponse::BadRequest()
+                        .json(json!({
+                            "message": format!(
+                                "Client must support protocol version {} or greater.",
+                                self.min,
+                            ),
+                            "requested_protocol": version,
+                            "splinter_protocol": self.max,
+                            "libsplinter_version": format!(
+                                "{}.{}.{}",
+                                env!("CARGO_PKG_VERSION_MAJOR"),
+                                env!("CARGO_PKG_VERSION_MINOR"),
+                                env!("CARGO_PKG_VERSION_PATCH")
+                            )
+                        }))
+                        .into_future(),
+                ),
+                Ok(version) if version > self.max => Continuation::terminate(
+                    HttpResponse::BadRequest()
+                        .json(json!({
+                            "message": format!(
+                                "Client requires a newer protocol than can be provided: {} > {}",
+                                version,
+                                self.max,
+                            ),
+                            "requested_protocol": version,
+                            "splinter_protocol": self.max,
+                            "libsplinter_version": format!(
+                                "{}.{}.{}",
+                                env!("CARGO_PKG_VERSION_MAJOR"),
+                                env!("CARGO_PKG_VERSION_MINOR"),
+                                env!("CARGO_PKG_VERSION_PATCH")
+                            )
+                        }))
+                        .into_future(),
+                ),
+                Ok(_) => Continuation::Continue,
+            }
+        } else {
+            // Ignore the missing header, and assume the client will handle version mismatches by
+            // inspecting the output
+            Continuation::Continue
+        }
+    }
+}
+
 /// `RestApi` is used to create an instance of a restful web server.
 #[derive(Clone)]
 pub struct RestApi {

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -180,6 +180,7 @@ pub enum Method {
 #[derive(Clone)]
 pub struct Resource {
     route: String,
+    request_guards: Vec<Arc<dyn RequestGuard>>,
     methods: Vec<(Method, Arc<HandlerFunction>)>,
 }
 
@@ -202,6 +203,7 @@ impl Resource {
         Self {
             route: route.to_string(),
             methods: vec![],
+            request_guards: vec![],
         }
     }
 
@@ -219,11 +221,63 @@ impl Resource {
         self
     }
 
+    /// Adds a RequestGuard to the given Resource.
+    ///
+    /// This guard applies to all methods defined for this resource.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use splinter::rest_api::{Resource, Method, Continuation};
+    /// use actix_web::{HttpRequest, HttpResponse};
+    /// use futures::IntoFuture;
+    ///
+    /// Resource::build("/index")
+    ///     .add_request_guard(|r: &HttpRequest| {
+    ///         if !r.headers().contains_key("GuardFlag") {
+    ///             Continuation::terminate(
+    ///                 HttpResponse::BadRequest().finish().into_future(),
+    ///             )
+    ///         } else {
+    ///             Continuation::Continue
+    ///         }
+    ///     })
+    ///     .add_method(Method::Get, |r, p| {
+    ///         Box::new(
+    ///             HttpResponse::Ok()
+    ///                 .body("Hello, World")
+    ///                 .into_future()
+    ///         )
+    ///     });
+    /// ```
+    pub fn add_request_guard<RG>(mut self, guard: RG) -> Self
+    where
+        RG: RequestGuard + Clone + 'static,
+    {
+        self.request_guards.push(Arc::new(guard));
+        self
+    }
+
     fn into_route(self) -> actix_web::Resource {
+        let resource = web::resource(&self.route);
+
+        let request_guards = self.request_guards;
         self.methods
             .into_iter()
-            .fold(web::resource(&self.route), |resource, (method, handler)| {
-                let func = move |r: HttpRequest, p: web::Payload| (handler)(r, p);
+            .fold(resource, |resource, (method, handler)| {
+                let guards = request_guards.clone();
+                let func = move |r: HttpRequest, p: web::Payload| {
+                    // This clone satisfies a requirement that this be FnOnce
+                    if !guards.is_empty() {
+                        for guard in guards.clone() {
+                            match guard.evaluate(&r) {
+                                Continuation::Terminate(result) => return result,
+                                Continuation::Continue => (),
+                            }
+                        }
+                    }
+                    (handler)(r, p)
+                };
                 resource.route(match method {
                     Method::Get => web::get().to_async(func),
                     Method::Post => web::post().to_async(func),
@@ -233,6 +287,46 @@ impl Resource {
                     Method::Head => web::head().to_async(func),
                 })
             })
+    }
+}
+
+/// A continuation indicates whether or not a guard should allow a given request to continue, or to
+/// return a result.
+pub enum Continuation {
+    Continue,
+    Terminate(Box<dyn Future<Item = HttpResponse, Error = ActixError>>),
+}
+
+impl Continuation {
+    /// Wraps the given future in the Continuation::Terminate variant.
+    pub fn terminate<F>(fut: F) -> Continuation
+    where
+        F: Future<Item = HttpResponse, Error = ActixError> + 'static,
+    {
+        Continuation::Terminate(Box::new(fut))
+    }
+}
+
+/// A guard checks the request content in advance, and either continues the request, or
+/// returns a terminating result.
+pub trait RequestGuard: Send + Sync {
+    /// Evaluates the request and determines whether or not the request should be continued or
+    /// short-circuited with a terminating future.
+    fn evaluate(&self, req: &HttpRequest) -> Continuation;
+}
+
+impl<F> RequestGuard for F
+where
+    F: Fn(&HttpRequest) -> Continuation + Sync + Send,
+{
+    fn evaluate(&self, req: &HttpRequest) -> Continuation {
+        (*self)(req)
+    }
+}
+
+impl RequestGuard for Box<dyn RequestGuard> {
+    fn evaluate(&self, req: &HttpRequest) -> Continuation {
+        (**self).evaluate(req)
     }
 }
 
@@ -412,6 +506,18 @@ mod test {
     #[test]
     fn test_resource() {
         Resource::build("/test")
+            .add_method(Method::Get, |_: HttpRequest, _: web::Payload| {
+                Box::new(Response::Ok().finish().into_future())
+            })
+            .into_route();
+    }
+
+    #[test]
+    fn test_resource_with_guard() {
+        Resource::build("/test-guarded")
+            .add_request_guard(|_: &HttpRequest| {
+                Continuation::terminate(Response::BadRequest().finish().into_future())
+            })
             .add_method(Method::Get, |_: HttpRequest, _: web::Payload| {
                 Box::new(Response::Ok().finish().into_future())
             })

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -28,6 +28,8 @@ paths:
       tags:
         - diagnostics
       description: Used to check if server is successfully running
+      parameters:
+        - $ref: "#/parameters/protocol_version"
       responses:
         200:
           description: Server is running correctly and accepting connections
@@ -48,6 +50,7 @@ paths:
           - Proposals
       description: Experimental - List of proposals in Admin Service state
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: offset
           in: query
           description: paging offset
@@ -96,6 +99,7 @@ paths:
         - Proposals
       description: Experimental - Fetch a proposal in Admin Service state by its circuit id
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit_id
           in: path
           description: circuit id of the proposal to fetch
@@ -124,6 +128,8 @@ paths:
       tags:
         - Admin Service
       description: Send circuit management payload in bytes to admin service
+      parameters:
+        - $ref: "#/parameters/protocol_version"
       requestBody:
         required: true
         content:
@@ -154,6 +160,7 @@ paths:
         - Admin Service
       description: Register the handler for a circuit management type
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: type
           description: The circuit management type is the type of circuit the handler will manage
           in: path
@@ -195,6 +202,7 @@ paths:
           - Circuits
       description: Experimental - List of circuits in Splinter state
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: offset
           in: query
           description: paging offset
@@ -243,6 +251,7 @@ paths:
         - Circuits
       description: Experimental - Fetch a circuit in Splinter State by its circuit id
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit_id
           in: path
           description: cirucit id of circuit to fetch
@@ -272,6 +281,7 @@ paths:
         - Key Registry
       description: List public key information in the Key Registry
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: offset
           in: query
           description: paging offset
@@ -313,6 +323,7 @@ paths:
         - Key Registry
       description: Fetch public key information in the Key Registry by public key
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: public_key
           in: path
           description: public key to query, in hex
@@ -347,6 +358,8 @@ paths:
       tags:
         - Node Registry
       description: Add node to the Node Registry
+      parameters:
+        - $ref: "#/parameters/protocol_version"
       requestBody:
         required: true
         content:
@@ -380,6 +393,7 @@ paths:
         - Node Registry
       description: List nodes in the Node Registry
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: offset
           in: query
           description: paging offset
@@ -437,6 +451,7 @@ paths:
         - Node Registry
       description: Fetch a nodes in the Node Registry by their identity
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: identity
           in: path
           description: identity of node to fetch
@@ -465,6 +480,7 @@ paths:
         - Node Registry
       description: Add a node to or replace a node in the Node Registry. This action is idempotent.
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: identity
           in: path
           description: identity of node to add/replace
@@ -504,6 +520,7 @@ paths:
         - Node Registry
       description: Delete a node from the Node Registry
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: identity
           in: path
           description: identity of node to delete
@@ -530,6 +547,7 @@ paths:
     post:
       description: Send a list of Sabre batches to the specified Scabbard service
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit
           in: path
           description: circuit the targeted service belongs to
@@ -558,6 +576,7 @@ paths:
     post:
       description: Send a list of Sabre batches to the specified Scabbard service
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit
           in: path
           description: circuit the targeted service belongs to
@@ -603,6 +622,7 @@ paths:
     get:
       description: Experimental - Get a list of entries in state from the specified Scabbard service
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit
           in: path
           description: circuit the targeted service belongs to
@@ -655,6 +675,7 @@ paths:
     get:
       description: Experimental - Get the value at a given address in state from the specified Scabbard service
       parameters:
+        - $ref: "#/parameters/protocol_version"
         - name: circuit
           in: path
           description: circuit the targeted service belongs to
@@ -698,6 +719,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+parameters:
+  protocol_version:
+    type: integer
+    description: The protocol version which the client can understand
+    in: header
+    name: SplinterProtocolVersion
+    example: 1
 
 components:
   schemas:


### PR DESCRIPTION
This introduces the trait RequestGuard for the REST API Resource classes. It also adds a ProtocolVersionRangeGuard implementation of this trait.

The protocol guard looks for an optional header, `SplinterProtocolVersion`.  If this is provided, it will return a BadRequest if the version provide is out of range.

It adds this guard to the admin routes, with the remaining routes to be guarded in a future PR.

To test (use  with experimental):

`curl --verbose -s -H "SplinterProtocolVersion: 1" localhost:8088/admin/proposals`

The above should result in a 200 and empty list

Modify the value of the header, either `0`, or greater than `1` and the 400 error with a json error response will be returned.