### PR TITLE
Initialize scabbard crate

### DIFF
--- a/services/scabbard/Cargo.toml
+++ b/services/scabbard/Cargo.toml
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[workspace]
+[package]
+name = "scabbard"
+version = "0.3.11"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+license = "Apache-2.0"
+description = """\
+    Splinter is a privacy-focused platform for distributed applications that \
+    provides a blockchain-inspired networking environment for communication \
+    and transactions between organizations.
+"""
 
-members = [
-    "cli",
-    "client",
-    "libsplinter",
-    "splinterd",
-    "examples/private_counter/cli",
-    "examples/private_counter/service",
-    "examples/private_xo",
-    "examples/gameroom/cli",
-    "examples/gameroom/database",
-    "examples/gameroom/daemon",
-    "services/health",
-    "services/scabbard",
-]
+[dependencies]
+
+[features]
+default = []
+
+stable = ["default"]
+
+experimental = []

--- a/services/scabbard/src/lib.rs
+++ b/services/scabbard/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
Initialize the `services/scabbard` crate that will contain all code
related to the scabbard service.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

The single commit in this PR is broken out from #454 to work around an issue with the workspace Cargo.toml.