### PR TITLE
Support configuration of 2PC commit timeout

### DIFF
--- a/examples/private_counter/service/src/main.rs
+++ b/examples/private_counter/service/src/main.rs
@@ -66,6 +66,7 @@ use crate::protos::private_counter::{PrivateCounterMessage, PrivateCounterMessag
 // Recv timeout in secs
 const TIMEOUT_SEC: u64 = 2;
 const HEARTBEAT: u64 = 60;
+const TWO_PHASE_COORDINATOR_TIMEOUT_MILLIS: u64 = 30000; // 30 seconds
 
 #[derive(Debug)]
 pub struct ServiceState {
@@ -167,7 +168,8 @@ fn main() -> Result<(), ServiceError> {
     let consensus_thread = Builder::new()
         .name("TwoPhaseConsensus".into())
         .spawn(move || {
-            let mut two_phase_engine = TwoPhaseEngine::default();
+            let mut two_phase_engine =
+                TwoPhaseEngine::new(Duration::from_millis(TWO_PHASE_COORDINATOR_TIMEOUT_MILLIS));
             two_phase_engine
                 .run(
                     consensus_msg_rx,

--- a/libsplinter/src/consensus/two_phase/mod.rs
+++ b/libsplinter/src/consensus/two_phase/mod.rs
@@ -59,7 +59,6 @@ use crate::protos::two_phase::{
 
 use self::timing::Timeout;
 
-const DEFAULT_COORDINATOR_TIMEOUT_MILLIS: u64 = 5000; // 5 seconds
 const MESSAGE_RECV_TIMEOUT_MILLIS: u64 = 100;
 const PROPOSAL_RECV_TIMEOUT_MILLIS: u64 = 100;
 
@@ -121,12 +120,6 @@ pub struct TwoPhaseEngine {
     coordinator_timeout: Timeout,
     proposal_backlog: VecDeque<TwoPhaseProposal>,
     verification_request_backlog: VecDeque<ProposalId>,
-}
-
-impl Default for TwoPhaseEngine {
-    fn default() -> Self {
-        Self::new(Duration::from_millis(DEFAULT_COORDINATOR_TIMEOUT_MILLIS))
-    }
 }
 
 impl TwoPhaseEngine {
@@ -726,6 +719,8 @@ pub mod tests {
     use crate::consensus::tests::{MockConsensusNetworkSender, MockProposalManager};
     use crate::consensus::Proposal;
 
+    const COORDINATOR_TIMEOUT_MILLIS: u64 = 5000;
+
     /// Verify that the engine properly shuts down when it receives the Shutdown update.
     #[test]
     fn test_shutdown() {
@@ -740,7 +735,7 @@ pub mod tests {
             last_proposal: None,
         };
 
-        let mut engine = TwoPhaseEngine::default();
+        let mut engine = TwoPhaseEngine::new(Duration::from_millis(COORDINATOR_TIMEOUT_MILLIS));
         let thread = std::thread::spawn(move || {
             engine
                 .run(
@@ -776,7 +771,7 @@ pub mod tests {
             last_proposal: None,
         };
 
-        let mut engine = TwoPhaseEngine::default();
+        let mut engine = TwoPhaseEngine::new(Duration::from_millis(COORDINATOR_TIMEOUT_MILLIS));
         let network_clone = network.clone();
         let manager_clone = manager.clone();
         let thread = std::thread::spawn(move || {
@@ -951,7 +946,7 @@ pub mod tests {
             last_proposal: None,
         };
 
-        let mut engine = TwoPhaseEngine::default();
+        let mut engine = TwoPhaseEngine::new(Duration::from_millis(COORDINATOR_TIMEOUT_MILLIS));
         let network_clone = network.clone();
         let manager_clone = manager.clone();
         let thread = std::thread::spawn(move || {
@@ -1114,7 +1109,7 @@ pub mod tests {
             last_proposal: None,
         };
 
-        let mut engine = TwoPhaseEngine::default();
+        let mut engine = TwoPhaseEngine::new(Duration::from_millis(COORDINATOR_TIMEOUT_MILLIS));
         let network_clone = network.clone();
         let manager_clone = manager.clone();
         let thread = std::thread::spawn(move || {

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -61,7 +61,7 @@ impl ServiceFactory for ScabbardFactory {
         self.service_types.as_slice()
     }
 
-    /// `args` should include the following:
+    /// `args` must include the following:
     /// - `admin_keys`: list of public keys that are allowed to create and modify sabre contracts,
     ///   formatted as a serialized JSON array of strings
     /// - `peer_services`: list of other scabbard services on the same circuit that this service

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::path::Path;
+use std::time::Duration;
 
 use serde_json;
 
@@ -66,6 +67,10 @@ impl ServiceFactory for ScabbardFactory {
     ///   formatted as a serialized JSON array of strings
     /// - `peer_services`: list of other scabbard services on the same circuit that this service
     ///   will share state with
+    /// `args` may include the following optional entries:
+    /// - `coordinator_timeout`: the length of time (in milliseconds) that the network has to
+    ///   commit a proposal before the coordinator rejects it (if not provided, default is 30
+    ///   seconds)
     fn create(
         &self,
         service_id: String,
@@ -98,6 +103,17 @@ impl ServiceFactory for ScabbardFactory {
             ))
         })?;
 
+        let coordinator_timeout = args
+            .get("coordinator_timeout")
+            .map(|timeout| match timeout.parse::<u64>() {
+                Ok(timeout) => Ok(Duration::from_millis(timeout)),
+                Err(err) => Err(FactoryCreateError::InvalidArguments(format!(
+                    "invalid coordinator_timeout: {}",
+                    err
+                ))),
+            })
+            .transpose()?;
+
         let service = Scabbard::new(
             service_id,
             circuit_id,
@@ -108,7 +124,7 @@ impl ServiceFactory for ScabbardFactory {
             self.receipt_db_size,
             self.signature_verifier_factory.create_verifier(),
             admin_keys,
-            None,
+            coordinator_timeout,
         )
         .map_err(|err| FactoryCreateError::CreationFailed(Box::new(err)))?;
 
@@ -147,6 +163,25 @@ mod tests {
             .expect("failed to downcast Service to Scabbard");
         assert_eq!(&scabbard.service_id, "0");
         assert_eq!(&scabbard.circuit_id, "1");
+    }
+
+    /// Verify that the `coordinator_timeout` service argument is properly set for a new `Scabbard`
+    /// instance.
+    #[test]
+    fn create_with_coordinator_timeout() {
+        let factory = get_factory();
+        let mut args = get_mock_args();
+        args.insert("coordinator_timeout".into(), "123".into());
+
+        let service = factory
+            .create("".into(), "", "", args)
+            .expect("failed to create service");
+        let scabbard = (&*service)
+            .as_any()
+            .downcast_ref::<Scabbard>()
+            .expect("failed to downcast Service to Scabbard");
+
+        assert_eq!(scabbard.coordinator_timeout, Duration::from_millis(123));
     }
 
     /// Verify that `Scabbard` creation fails when the `peer_services` argument isn't specified.

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -108,6 +108,7 @@ impl ServiceFactory for ScabbardFactory {
             self.receipt_db_size,
             self.signature_verifier_factory.create_verifier(),
             admin_keys,
+            None,
         )
         .map_err(|err| FactoryCreateError::CreationFailed(Box::new(err)))?;
 

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use crate::config::Config;
 
 pub struct ConfigBuilder {
@@ -33,6 +35,7 @@ pub struct ConfigBuilder {
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
+    admin_service_coordinator_timeout: Option<Duration>,
 }
 
 impl ConfigBuilder {
@@ -56,6 +59,7 @@ impl ConfigBuilder {
             registry_backend: None,
             registry_file: None,
             heartbeat_interval: None,
+            admin_service_coordinator_timeout: None,
         }
     }
 
@@ -145,6 +149,11 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_admin_service_coordinator_timeout(mut self, timeout: Duration) -> Self {
+        self.admin_service_coordinator_timeout = Some(timeout);
+        self
+    }
+
     pub fn build(self) -> Config {
         Config {
             storage: self.storage,
@@ -165,6 +174,7 @@ impl ConfigBuilder {
             registry_backend: self.registry_backend,
             registry_file: self.registry_file,
             heartbeat_interval: self.heartbeat_interval,
+            admin_service_coordinator_timeout: self.admin_service_coordinator_timeout,
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -28,6 +28,7 @@ pub use error::ConfigError;
 use std::fs::File;
 #[cfg(not(feature = "config-toml"))]
 use std::io::Read;
+use std::time::Duration;
 
 #[cfg(not(feature = "config-toml"))]
 use serde_derive::Deserialize;
@@ -54,6 +55,7 @@ pub struct Config {
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
+    admin_service_coordinator_timeout: Option<Duration>,
 }
 
 impl Config {
@@ -132,5 +134,9 @@ impl Config {
 
     pub fn heartbeat_interval(&self) -> Option<u64> {
         self.heartbeat_interval
+    }
+
+    pub fn admin_service_coordinator_timeout(&self) -> Option<Duration> {
+        self.admin_service_coordinator_timeout
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use crate::config::ConfigBuilder;
 use crate::config::ConfigError;
 
@@ -39,6 +41,7 @@ pub struct TomlConfig {
     registry_backend: Option<String>,
     registry_file: Option<String>,
     heartbeat_interval: Option<u64>,
+    admin_service_coordinator_timeout: Option<u64>,
 }
 
 impl TomlConfig {
@@ -115,6 +118,10 @@ impl TomlConfig {
         self.heartbeat_interval.take()
     }
 
+    pub fn take_admin_service_coordinator_timeout(&mut self) -> Option<u64> {
+        self.admin_service_coordinator_timeout.take()
+    }
+
     pub fn apply_to_builder(mut self, mut builder: ConfigBuilder) -> ConfigBuilder {
         if let Some(x) = self.take_storage() {
             builder = builder.with_storage(x);
@@ -169,6 +176,9 @@ impl TomlConfig {
         }
         if let Some(x) = self.take_heartbeat_interval() {
             builder = builder.with_heartbeat_interval(x);
+        }
+        if let Some(x) = self.take_admin_service_coordinator_timeout() {
+            builder = builder.with_admin_service_coordinator_timeout(Duration::from_millis(x));
         }
 
         builder

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -110,6 +110,7 @@ pub struct SplinterDaemon {
     biome_enabled: bool,
     registry_config: RegistryConfig,
     storage_type: String,
+    admin_service_coordinator_timeout: Duration,
 }
 
 impl SplinterDaemon {
@@ -356,7 +357,7 @@ impl SplinterDaemon {
             key_registry.clone(),
             Box::new(AllowAllKeyPermissionManager),
             &self.storage_type,
-            None,
+            Some(self.admin_service_coordinator_timeout),
         )
         .map_err(|err| {
             StartError::AdminServiceError(format!("unable to create admin service: {}", err))
@@ -661,6 +662,7 @@ pub struct SplinterDaemonBuilder {
     registry_file: Option<String>,
     storage_type: Option<String>,
     heartbeat_interval: Option<u64>,
+    admin_service_coordinator_timeout: Duration,
 }
 
 impl SplinterDaemonBuilder {
@@ -732,6 +734,11 @@ impl SplinterDaemonBuilder {
 
     pub fn with_heartbeat_interval(mut self, value: u64) -> Self {
         self.heartbeat_interval = Some(value);
+        self
+    }
+
+    pub fn with_admin_service_coordinator_timeout(mut self, value: Duration) -> Self {
+        self.admin_service_coordinator_timeout = value;
         self
     }
 
@@ -813,6 +820,7 @@ impl SplinterDaemonBuilder {
             registry_config,
             key_registry_location,
             storage_type,
+            admin_service_coordinator_timeout: self.admin_service_coordinator_timeout,
         })
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -356,6 +356,7 @@ impl SplinterDaemon {
             key_registry.clone(),
             Box::new(AllowAllKeyPermissionManager),
             &self.storage_type,
+            None,
         )
         .map_err(|err| {
             StartError::AdminServiceError(format!("unable to create admin service: {}", err))


### PR DESCRIPTION
Moves the default coordinator timeout (aka commit/proposal timeout) for two-phase commit consensus up to the services, since the consensus engine itself is too low-level to make decisions about what a reasonable default should be.

Sets the default timeout for both admin and scabbard to 30 seconds.

Allows configuring the scabbard timeout by providing a service argument in the circuit definition.

Allows configuring the admin timeout by providing a CLI arg or config variable for splinterd.