### PR TITLE
Remove unwrap from parsing bad protobuf msg

### DIFF
--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -285,7 +285,14 @@ impl SplinterDaemon {
                         // This is where the message should be dispatched
                         Ok(message) => {
                             let mut msg: NetworkMessage =
-                                protobuf::parse_from_bytes(message.payload()).unwrap();
+                                match protobuf::parse_from_bytes(message.payload()) {
+                                    Ok(msg) => msg,
+                                    Err(err) => {
+                                        warn!("Received invalid network message: {}", err);
+                                        continue;
+                                    }
+                                };
+
                             let dispatch_msg = DispatchMessage::new(
                                 msg.get_message_type(),
                                 msg.take_payload(),


### PR DESCRIPTION
Remove an unwrap when parsing a bad protobuf network message.  This may
occur when network returns a message that did not completely fill the
buffer based on the frame size.

This prevents a panic in the main loop.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>