### PR TITLE
Scabbard get state

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -98,6 +98,7 @@ experimental = [
     "postgres",
     "proposal-read",
     "scabbard-client",
+    "scabbard-get-state",
     "zmq-transport",
 ]
 
@@ -118,6 +119,7 @@ postgres = ["diesel/postgres"]
 rest-api = ["actix", "actix-http", "actix-web", "actix-web-actors", "futures", "percent-encoding"]
 sawtooth-signing-compat = ["sawtooth-sdk"]
 scabbard-client = ["bzip2", "futures", "reqwest", "sawtooth-sdk", "tar"]
+scabbard-get-state = []
 zmq-transport = ["zmq"]
 
 # The following features are broken and should not be used.

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -116,11 +116,18 @@ impl ServiceFactory for ScabbardFactory {
 
     #[cfg(feature = "rest-api")]
     fn get_rest_endpoints(&self) -> Vec<crate::service::rest_api::ServiceEndpoint> {
-        vec![
-            super::rest_api::make_add_batches_to_queue_endpoint(),
-            super::rest_api::make_subscribe_endpoint(),
-            super::rest_api::make_get_batch_status_endpoint(),
-        ]
+        let mut endpoints = vec![];
+
+        endpoints.push(super::rest_api::make_add_batches_to_queue_endpoint());
+        endpoints.push(super::rest_api::make_subscribe_endpoint());
+        endpoints.push(super::rest_api::make_get_batch_status_endpoint());
+        #[cfg(feature = "scabbard-get-state")]
+        {
+            endpoints.push(super::rest_api::make_get_state_at_address_endpoint());
+            endpoints.push(super::rest_api::make_get_state_with_prefix_endpoint());
+        }
+
+        endpoints
     }
 }
 

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -50,6 +50,8 @@ use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
+#[cfg(feature = "scabbard-get-state")]
+use state::StateIter;
 pub use state::{BatchInfo, BatchStatus, Events, StateChange, StateChangeEvent};
 use state::{ScabbardState, StateSubscriber};
 
@@ -111,6 +113,27 @@ impl Scabbard {
             state: Arc::new(Mutex::new(state)),
             consensus: Arc::new(Mutex::new(None)),
         })
+    }
+
+    #[cfg(feature = "scabbard-get-state")]
+    pub fn get_state_at_address(&self, address: &str) -> Result<Option<Vec<u8>>, ScabbardError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| ScabbardError::LockPoisoned)?
+            .get_state_at_address(address)?)
+    }
+
+    #[cfg(feature = "scabbard-get-state")]
+    pub fn get_state_with_prefix(
+        &self,
+        prefix: Option<&str>,
+    ) -> Result<Box<StateIter>, ScabbardError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| ScabbardError::LockPoisoned)?
+            .get_state_with_prefix(prefix)?)
     }
 
     pub fn add_batches(

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -57,7 +57,8 @@ experimental = [
     "config-builder",
     "config-toml",
     "health",
-    "proposal-read"
+    "proposal-read",
+    "scabbard-get-state",
 ]
 
 biome = ["splinter/biome", "database"]
@@ -69,6 +70,7 @@ config-builder = []
 config-toml = ["config-builder"]
 database = ["splinter/database"]
 generate-certs = ["openssl"]
+scabbard-get-state = ["splinter/scabbard-get-state"]
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -599,6 +599,106 @@ paths:
         500:
           description: Internal service error
 
+  /scabbard/{circuit}/{service_id}/state:
+    get:
+      description: Experimental - Get a list of entries in state from the specified Scabbard service
+      parameters:
+        - name: circuit
+          in: path
+          description: circuit the targeted service belongs to
+          required: true
+          schema:
+            type: string
+        - name: service_id
+          in: path
+          description: ID of the targeted service
+          required: true
+          schema:
+            type: string
+        - name: prefix
+          in: query
+          description: The address prefix for filtering state entries
+          required: false
+          schema:
+            type: string
+            example: 00ec01
+      responses:
+        200:
+          description: List of entries in state (under given address prefix, if specified)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+                    value:
+                      type: array
+                      items:
+                        type: integer
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /scabbard/{circuit}/{service_id}/state/{address}:
+    get:
+      description: Experimental - Get the value at a given address in state from the specified Scabbard service
+      parameters:
+        - name: circuit
+          in: path
+          description: circuit the targeted service belongs to
+          required: true
+          schema:
+            type: string
+        - name: service_id
+          in: path
+          description: ID of the targeted service
+          required: true
+          schema:
+            type: string
+        - name: address
+          in: path
+          description: The address of the value to retrieve from state
+          required: true
+          schema:
+            type: string
+            example: 000000a87cb5eafdcca6a814e4add97c4b517d3c530c2f44b31d18e3b0c44298fc1c14
+      responses:
+        200:
+          description: The value at the requested address
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: There is no value at the given address
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
 components:
   schemas:
     Error:


### PR DESCRIPTION
Add the `get_state_at_address` and `get_state_with_prefix` methods to
scabbard to enable getting the value at a specific address in state, and
all values under a given address prefix in state (respectively).

Add REST API endpoints for getting state from a scabbard service.