### PR TITLE
Update output for circuit list and proposals

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -252,6 +252,15 @@ fn run() -> Result<(), CliError> {
                                 .long("member")
                                 .help("Filter the circuits by a node ID in the member list")
                                 .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("format")
+                                .short("f")
+                                .long("format")
+                                .help("Output format")
+                                .possible_values(&["human", "csv"])
+                                .default_value("human")
+                                .takes_value(true),
                         ),
                 )
                 .subcommand(
@@ -273,7 +282,7 @@ fn run() -> Result<(), CliError> {
                             Arg::with_name("format")
                                 .short("f")
                                 .long("format")
-                                .help("Format of the circuit")
+                                .help("Output format")
                                 .possible_values(&["yaml", "json"])
                                 .default_value("yaml")
                                 .takes_value(true),
@@ -297,6 +306,15 @@ fn run() -> Result<(), CliError> {
                                     "Filter the circuit proposals by the circuit \
                                      management type of the circuits",
                                 )
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("format")
+                                .short("f")
+                                .long("format")
+                                .help("Output format")
+                                .possible_values(&["human", "csv"])
+                                .default_value("human")
                                 .takes_value(true),
                         ),
                 ),


### PR DESCRIPTION
This commit updates the headers to be ID and MANAGEMENT.
It also add a new column to list members. The column
width is now calculated based on the max length of an
item in that column.

It also adds a csv format option.

```
splinter circuit list  --format csv
ID,MANAGEMENT,MEMBERS
gameroom::bubba-node-000::acme-node-000::551719c5-ea3a-4954-8db4-f387400d13c1,gameroom,bubba-node-000;acme-node-000
gameroom::bubba-node-000::acme-node-000::9b940875-ea23-4ce7-8776-4f521b1be346,gameroom,bubba-node-000;acme-node-000
```

```
splinter circuit list 
ID                                                                            MANAGEMENT MEMBERS                      
gameroom::bubba-node-000::acme-node-000::551719c5-ea3a-4954-8db4-f387400d13c1 gameroom   bubba-node-000;acme-node-000 
gameroom::bubba-node-000::acme-node-000::9b940875-ea23-4ce7-8776-4f521b1be346 gameroom   bubba-node-000;acme-node-000 
```


```
splinter circuit proposals  --format csv
ID,MANAGEMENT,MEMBERS
gameroom::bubba-node-000::acme-node-000::f213703d-b955-475e-8d3a-a087d6260fbb,gameroom,bubba-node-000;acme-node-000
```

```
splinter circuit proposals
ID                                                                            MANAGEMENT MEMBERS                      
gameroom::bubba-node-000::acme-node-000::f213703d-b955-475e-8d3a-a087d6260fbb gameroom   bubba-node-000;acme-node-000 
```

