### PR TITLE
Add remaining config objects

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -56,6 +56,7 @@ experimental = [
     "circuit-read",
     "config-builder",
     "config-default",
+    "config-command-line",
     "config-toml",
     "health",
     "proposal-read",
@@ -69,6 +70,7 @@ circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-builder = []
 config-default = ["config-builder"]
+config-command-line = ["config-builder"]
 config-toml = ["config-builder"]
 database = ["splinter/database"]
 generate-certs = ["openssl"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -57,6 +57,7 @@ experimental = [
     "config-builder",
     "config-default",
     "config-command-line",
+    "config-env-var",
     "config-toml",
     "health",
     "proposal-read",
@@ -71,6 +72,7 @@ proposal-read = ["splinter/proposal-read"]
 config-builder = []
 config-default = ["config-builder"]
 config-command-line = ["config-builder"]
+config-env-var = ["config-builder"]
 config-toml = ["config-builder"]
 database = ["splinter/database"]
 generate-certs = ["openssl"]

--- a/splinterd/src/config/command_line.rs
+++ b/splinterd/src/config/command_line.rs
@@ -1,0 +1,103 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::config::{ConfigError, PartialConfig, PartialConfigBuilder};
+use clap::{ArgMatches, ErrorKind};
+
+pub struct CommandLineConfig {
+    storage: Option<String>,
+    transport: Option<String>,
+    cert_dir: Option<String>,
+    ca_certs: Option<String>,
+    client_cert: Option<String>,
+    client_key: Option<String>,
+    server_cert: Option<String>,
+    server_key: Option<String>,
+    service_endpoint: Option<String>,
+    network_endpoint: Option<String>,
+    peers: Option<Vec<String>>,
+    node_id: Option<String>,
+    bind: Option<String>,
+    #[cfg(feature = "database")]
+    database: Option<String>,
+    registry_backend: Option<String>,
+    registry_file: Option<String>,
+    heartbeat_interval: Option<u64>,
+}
+
+fn parse_value(matches: &ArgMatches) -> Result<Option<u64>, ConfigError> {
+    match value_t!(matches.value_of("heartbeat_interval"), u64) {
+        Ok(v) => Ok(Some(v)),
+        Err(e) => match e.kind {
+            ErrorKind::ValueValidation => Err(ConfigError::InvalidArgument(e)),
+            _ => Ok(None),
+        },
+    }
+}
+
+impl CommandLineConfig {
+    #[allow(dead_code)]
+    pub fn new(matches: ArgMatches) -> Result<Self, ConfigError> {
+        Ok(CommandLineConfig {
+            storage: matches.value_of("storage").map(String::from),
+            transport: matches.value_of("transport").map(String::from),
+            cert_dir: matches.value_of("cert_dir").map(String::from),
+            ca_certs: matches.value_of("ca_file").map(String::from),
+            client_cert: matches.value_of("client_cert").map(String::from),
+            client_key: matches.value_of("client_key").map(String::from),
+            server_cert: matches.value_of("server_cert").map(String::from),
+            server_key: matches.value_of("server_key").map(String::from),
+            service_endpoint: matches.value_of("service_endpoint").map(String::from),
+            network_endpoint: matches.value_of("network_endpoint").map(String::from),
+            peers: matches
+                .values_of("peers")
+                .map(|values| values.map(String::from).collect::<Vec<String>>()),
+            node_id: matches.value_of("node_id").map(String::from),
+            bind: matches.value_of("bind").map(String::from),
+            #[cfg(feature = "database")]
+            database: matches.value_of("database").map(String::from),
+            registry_backend: matches.value_of("registry_backend").map(String::from),
+            registry_file: matches.value_of("registry_file").map(String::from),
+            heartbeat_interval: parse_value(&matches)?,
+        })
+    }
+}
+
+impl PartialConfigBuilder for CommandLineConfig {
+    fn build(self) -> PartialConfig {
+        let partial_config = PartialConfig::default()
+            .with_storage(self.storage)
+            .with_transport(self.transport)
+            .with_cert_dir(self.cert_dir)
+            .with_ca_certs(self.ca_certs)
+            .with_client_cert(self.client_cert)
+            .with_client_key(self.client_key)
+            .with_server_cert(self.server_cert)
+            .with_server_key(self.server_key)
+            .with_service_endpoint(self.service_endpoint)
+            .with_network_endpoint(self.network_endpoint)
+            .with_peers(self.peers)
+            .with_node_id(self.node_id)
+            .with_bind(self.bind)
+            .with_registry_backend(self.registry_backend)
+            .with_registry_file(self.registry_file)
+            .with_heartbeat_interval(self.heartbeat_interval);
+
+        #[cfg(not(feature = "database"))]
+        return partial_config;
+
+        #[cfg(feature = "database")]
+        return partial_config.with_database(self.database);
+    }
+}

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -41,3 +41,63 @@ impl PartialConfigBuilder for EnvVarConfig {
             .with_state_dir(self.state_dir)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// This test verifies that a PartialConfig object, constructed from the EnvVarConfig module,
+    /// contains the correct values when the environment variables are not set using the following
+    /// steps:
+    ///
+    /// 1. Remove any existing environment variables which may be set.
+    /// 2. A new EnvVarConfig object is created.
+    /// 3. The EnvVarConfig object is transformed to a PartialConfig object using the `build`.
+    ///
+    /// This test then verifies the PartialConfig object built from the EnvVarConfig object by
+    /// asserting each expected value. As the environment variables were unset, the configuration
+    /// values should be set to None.
+    fn test_environment_var_unset_config() {
+        // Remove any existing environment variables.
+        env::remove_var(STATE_DIR_ENV);
+        env::remove_var(CERT_DIR_ENV);
+        // Create a new EnvVarConfig object from the arg matches.
+        let env_var_config = EnvVarConfig::new();
+        // Build a PartialConfig from the EnvVarConfig object created.
+        let built_config = env_var_config.build();
+        // Compare the generated PartialConfig object against the expected values.
+        assert_eq!(built_config.state_dir(), None);
+        assert_eq!(built_config.cert_dir(), None);
+    }
+
+    #[test]
+    /// This test verifies that a PartialConfig object, constructed from the EnvVarConfig module,
+    /// contains the correct values using the following steps:
+    ///
+    /// 1. Set the environment variables for both the state and cert directories.
+    /// 2. A new EnvVarConfig object is created.
+    /// 3. The EnvVarConfig object is transformed to a PartialConfig object using the `build`.
+    ///
+    /// This test then verifies the PartialConfig object built from the EnvVarConfig object by
+    /// asserting each expected value. As the environment variables were set, the configuration
+    /// values should reflect those values.
+    fn test_environment_var_set_config() {
+        // Set the environment variables.
+        env::set_var(STATE_DIR_ENV, "state/test/config");
+        env::set_var(CERT_DIR_ENV, "cert/test/config");
+        // Create a new EnvVarConfig object from the arg matches.
+        let env_var_config = EnvVarConfig::new();
+        // Build a PartialConfig from the EnvVarConfig object created.
+        let built_config = env_var_config.build();
+        // Compare the generated PartialConfig object against the expected values.
+        assert_eq!(
+            built_config.state_dir(),
+            Some(String::from("state/test/config"))
+        );
+        assert_eq!(
+            built_config.cert_dir(),
+            Some(String::from("cert/test/config"))
+        );
+    }
+}

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -1,0 +1,43 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+
+use crate::config::{PartialConfig, PartialConfigBuilder};
+
+const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
+const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
+
+pub struct EnvVarConfig {
+    state_dir: Option<String>,
+    cert_dir: Option<String>,
+}
+
+impl EnvVarConfig {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        EnvVarConfig {
+            state_dir: env::var(STATE_DIR_ENV).ok(),
+            cert_dir: env::var(CERT_DIR_ENV).ok(),
+        }
+    }
+}
+
+impl PartialConfigBuilder for EnvVarConfig {
+    fn build(self) -> PartialConfig {
+        PartialConfig::default()
+            .with_cert_dir(self.cert_dir)
+            .with_state_dir(self.state_dir)
+    }
+}

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -16,12 +16,14 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
+use clap;
 use toml::de::Error as TomlError;
 
 #[derive(Debug)]
 pub enum ConfigError {
     ReadError(io::Error),
     TomlParseError(TomlError),
+    InvalidArgument(clap::Error),
 }
 
 impl From<io::Error> for ConfigError {
@@ -36,11 +38,18 @@ impl From<TomlError> for ConfigError {
     }
 }
 
+impl From<clap::Error> for ConfigError {
+    fn from(e: clap::Error) -> Self {
+        ConfigError::InvalidArgument(e)
+    }
+}
+
 impl Error for ConfigError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             ConfigError::ReadError(source) => Some(source),
             ConfigError::TomlParseError(source) => Some(source),
+            ConfigError::InvalidArgument(source) => Some(source),
         }
     }
 }
@@ -50,6 +59,9 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::ReadError(source) => source.fmt(f),
             ConfigError::TomlParseError(source) => write!(f, "Invalid File Format: {}", source),
+            ConfigError::InvalidArgument(source) => {
+                write!(f, "Unable to parse command line argument: {}", source)
+            }
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -14,12 +14,16 @@
 
 #[cfg(feature = "config-builder")]
 mod builder;
+#[cfg(feature = "config-command-line")]
+mod command_line;
 #[cfg(feature = "config-default")]
 mod default;
 mod error;
 mod partial;
 mod toml;
 
+#[cfg(feature = "config-command-line")]
+pub use crate::config::command_line::CommandLineConfig;
 #[cfg(feature = "config-default")]
 pub use crate::config::default::DefaultConfig;
 #[cfg(not(feature = "config-toml"))]

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -18,6 +18,8 @@ mod builder;
 mod command_line;
 #[cfg(feature = "config-default")]
 mod default;
+#[cfg(feature = "config-env-var")]
+mod env;
 mod error;
 mod partial;
 mod toml;
@@ -26,6 +28,8 @@ mod toml;
 pub use crate::config::command_line::CommandLineConfig;
 #[cfg(feature = "config-default")]
 pub use crate::config::default::DefaultConfig;
+#[cfg(feature = "config-env-var")]
+pub use crate::config::env::EnvVarConfig;
 #[cfg(not(feature = "config-toml"))]
 pub use crate::config::toml::from_file;
 #[cfg(feature = "config-toml")]


### PR DESCRIPTION
Adds the remaining config objects, for command line args and environment variables. Also adds tests for these objects.