### PR TITLE
Update output for splinter cli circuit show command

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -259,7 +259,7 @@ impl fmt::Display for CircuitSlice {
                     );
 
                     for (key, value) in service.arguments() {
-                        display_string += &format!("          {} :\n", key);
+                        display_string += &format!("          {}:\n", key);
                         // break apart value if its a list
                         if value.starts_with('[') && value.ends_with(']') {
                             let values: JsonResult<Vec<String>> = serde_json::from_str(value);

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -205,7 +205,7 @@ impl Action for CircuitShowAction {
             .ok_or_else(|| CliError::ActionError("Circuit name must be provided".to_string()))?;
 
         // A value should always be passed because a default is defined
-        let format = args.value_of("format").expect("format was not provided");
+        let format = args.value_of("format").unwrap_or("human");
 
         show_circuit(url, circuit_id, format)
     }
@@ -226,14 +226,14 @@ fn show_circuit(url: &str, circuit_id: &str, format: &str) -> Result<(), CliErro
                     err
                 )))?
             ),
-            // default is yaml
-            _ => println!(
+            "yaml" => println!(
                 "{}",
                 serde_yaml::to_string(&circuit).map_err(|err| CliError::ActionError(format!(
                     "Cannot format circuit into yaml: {}",
                     err
                 )))?
             ),
+            _ => println!("{}", circuit),
         }
     }
 
@@ -249,14 +249,14 @@ fn show_circuit(url: &str, circuit_id: &str, format: &str) -> Result<(), CliErro
                     err
                 )))?
             ),
-            // default is yaml
-            _ => println!(
+            "yaml" => println!(
                 "{}",
                 serde_yaml::to_string(&proposal).map_err(|err| CliError::ActionError(format!(
                     "Cannot format proposal into yaml: {}",
                     err
                 )))?
             ),
+            _ => println!("{}", proposal),
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -285,8 +285,8 @@ fn run() -> Result<(), CliError> {
                                 .short("f")
                                 .long("format")
                                 .help("Output format")
-                                .possible_values(&["yaml", "json"])
-                                .default_value("yaml")
+                                .possible_values(&["human", "yaml", "json"])
+                                .default_value("human")
                                 .takes_value(true),
                         ),
                 )


### PR DESCRIPTION
The output for a circuit would now be (if using default):

```
Circuit: gameroom::bubba-node-000::acme-node-000::551719c5-ea3a-4954-8db4-f387400d13c1
    Management Type: gameroom

    bubba-node-000
        Service (scabbard): gameroom_bubba-node-000
           admin_keys:
              02a50862fd5cf93e0a18852ce64ec4c5a0a1fc80c85115d48625dd6746311df8e5
          peer_services:
              gameroom_acme-node-000

    acme-node-000
        Service (scabbard): gameroom_acme-node-000
           admin_keys:
              02a50862fd5cf93e0a18852ce64ec4c5a0a1fc80c85115d48625dd6746311df8e5
          peer_services:
              gameroom_bubba-node-000
```

and a proposal:

```
Proposal to create:: gameroom::bubba-node-000::acme-node-000::f213703d-b955-475e-8d3a-a087d6260fbb
    Management Type: gameroom

    bubba-node-000 (tls://splinterd-node-bubba:8044)
        Vote: PENDING
        Service (scabbard): gameroom_bubba-node-000
            admin_keys:
                02276de8d39f9281f7c10c27e36e72d5ad63846bfbaf9fdab2d474f74cd261518e
            peer_services:
                gameroom_acme-node-000

    acme-node-000 (tls://splinterd-node-acme:8044)
        Vote: ACCEPT (implied as requester):
            02e2dcd0d7afe0de2118ef7e9584546b6d2215a9850a1917706206748b047161c3
        Service (scabbard): gameroom_acme-node-000
            admin_keys:
                02276de8d39f9281f7c10c27e36e72d5ad63846bfbaf9fdab2d474f74cd261518e
            peer_services:
                gameroom_bubba-node-000
```