### PR TITLE
Add command to set default value for service type and management type

### DIFF
--- a/cli/src/action/circuit/defaults.rs
+++ b/cli/src/action/circuit/defaults.rs
@@ -1,0 +1,80 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+
+use crate::error::CliError;
+use crate::store::default_value::{
+    DefaultStoreError, DefaultValue, DefaultValueStore, FileBackedDefaultStore,
+};
+
+const MANAGEMENT_TYPE_KEY: &str = "management_type";
+const SERVICE_TYPE_KEY: &str = "service_type";
+
+use super::Action;
+
+pub struct SetDefaultValueAction;
+
+impl Action for SetDefaultValueAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let name = match args.value_of("name") {
+            Some(key) => key,
+            None => return Err(CliError::ActionError("name is required".into())),
+        };
+
+        let key = get_key(name)?;
+
+        let value = match args.value_of("value") {
+            Some(value) => value,
+            None => return Err(CliError::ActionError("value is required".into())),
+        };
+
+        let store = get_default_value_store();
+
+        if !args.is_present("force") && store.get_default_value(key)?.is_some() {
+            return Err(CliError::ActionError(format!(
+                "Default value for {} is already in use",
+                key
+            )));
+        }
+
+        let default_value = DefaultValue::new(key, value);
+        store.set_default_value(&default_value)?;
+
+        Ok(())
+    }
+}
+
+fn get_key(name: &str) -> Result<&str, CliError> {
+    match name {
+        "service-type" => Ok(SERVICE_TYPE_KEY),
+        "management-type" => Ok(MANAGEMENT_TYPE_KEY),
+        _ => Err(CliError::ActionError(format!(
+            "{} is not a valid default name",
+            name
+        ))),
+    }
+}
+
+fn get_default_value_store() -> FileBackedDefaultStore {
+    FileBackedDefaultStore::default()
+}
+
+impl From<DefaultStoreError> for CliError {
+    fn from(err: DefaultStoreError) -> Self {
+        CliError::ActionError(format!("Failed to perform defaults operation: {}", err))
+    }
+}

--- a/cli/src/action/circuit/defaults.rs
+++ b/cli/src/action/circuit/defaults.rs
@@ -58,6 +58,25 @@ impl Action for SetDefaultValueAction {
     }
 }
 
+pub struct UnsetDefaultValueAction;
+
+impl Action for UnsetDefaultValueAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let name = match args.value_of("name") {
+            Some(key) => key,
+            None => return Err(CliError::ActionError("name is required".into())),
+        };
+
+        let key = get_key(name)?;
+
+        let store = get_default_value_store();
+        store.unset_default_value(key)?;
+        Ok(())
+    }
+}
+
 fn get_key(name: &str) -> Result<&str, CliError> {
     match name {
         "service-type" => Ok(SERVICE_TYPE_KEY),

--- a/cli/src/action/circuit/defaults.rs
+++ b/cli/src/action/circuit/defaults.rs
@@ -95,6 +95,35 @@ impl Action for ListDefaultsAction {
     }
 }
 
+pub struct ShowDefaultValueAction;
+
+impl Action for ShowDefaultValueAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+
+        let name = match args.value_of("name") {
+            Some(key) => key,
+            None => return Err(CliError::ActionError("name is required".into())),
+        };
+
+        let key = get_key(name)?;
+
+        let store = get_default_value_store();
+
+        match store.get_default_value(key)? {
+            Some(default_value) => println!("{} {}", default_value.key(), default_value.value()),
+            None => {
+                return Err(CliError::ActionError(format!(
+                    "Default value for {} is not set",
+                    key
+                )))
+            }
+        }
+
+        Ok(())
+    }
+}
+
 fn get_key(name: &str) -> Result<&str, CliError> {
     match name {
         "service-type" => Ok(SERVICE_TYPE_KEY),

--- a/cli/src/action/circuit/defaults.rs
+++ b/cli/src/action/circuit/defaults.rs
@@ -77,6 +77,24 @@ impl Action for UnsetDefaultValueAction {
     }
 }
 
+pub struct ListDefaultsAction;
+
+impl Action for ListDefaultsAction {
+    fn run<'a>(&mut self, _: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let store = get_default_value_store();
+
+        let defaults = store.list_default_values()?;
+        if defaults.is_empty() {
+            println!("No defaults have been set yet");
+        } else {
+            defaults.iter().for_each(|default_val| {
+                println!("{} {}", default_val.key(), default_val.value());
+            })
+        }
+        Ok(())
+    }
+}
+
 fn get_key(name: &str) -> Result<&str, CliError> {
     match name {
         "service-type" => Ok(SERVICE_TYPE_KEY),

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod api;
+pub mod defaults;
 mod payload;
 
 use std::fs::File;

--- a/cli/src/action/node.rs
+++ b/cli/src/action/node.rs
@@ -51,9 +51,9 @@ impl Action for AddNodeAliasAction {
     }
 }
 
-pub struct GetNodeAliasAction;
+pub struct ShowNodeAliasAction;
 
-impl Action for GetNodeAliasAction {
+impl Action for ShowNodeAliasAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
         let alias = match args.value_of("alias") {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -402,8 +402,8 @@ fn run() -> Result<(), CliError> {
                         )
                         .subcommand(SubCommand::with_name("list").about("List all node alias"))
                         .subcommand(
-                            SubCommand::with_name("get")
-                                .about("Get endpoint for a alias")
+                            SubCommand::with_name("show")
+                                .about("Show endpoint for a node")
                                 .arg(
                                     Arg::with_name("alias")
                                         .takes_value(true)
@@ -500,7 +500,7 @@ fn run() -> Result<(), CliError> {
                 "alias",
                 SubcommandActions::new()
                     .with_command("add", node::AddNodeAliasAction)
-                    .with_command("get", node::GetNodeAliasAction)
+                    .with_command("show", node::ShowNodeAliasAction)
                     .with_command("list", node::ListNodeAliasAction)
                     .with_command("delete", node::DeleteNodeAliasAction),
             ),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -319,6 +319,33 @@ fn run() -> Result<(), CliError> {
                                 .default_value("human")
                                 .takes_value(true),
                         ),
+                )
+                .subcommand(
+                    SubCommand::with_name("default")
+                        .about("Manage default values for circuit creation")
+                        .subcommand(
+                            SubCommand::with_name("set")
+                                .about("Set a default value")
+                                .arg(
+                                    Arg::with_name("name")
+                                        .takes_value(true)
+                                        .value_name("name")
+                                        .possible_values(&["service-type", "management-type"])
+                                        .help("The name of the default setting"),
+                                )
+                                .arg(
+                                    Arg::with_name("value")
+                                        .takes_value(true)
+                                        .value_name("value")
+                                        .help("The value for the default setting"),
+                                )
+                                .arg(
+                                    Arg::with_name("force")
+                                        .short("f")
+                                        .long("force")
+                                        .help("Overwrite default if it is already set"),
+                                ),
+                        ),
                 ),
         );
 
@@ -434,7 +461,12 @@ fn run() -> Result<(), CliError> {
                 .with_command("vote", circuit::CircuitVoteAction)
                 .with_command("list", circuit::CircuitListAction)
                 .with_command("show", circuit::CircuitShowAction)
-                .with_command("proposals", circuit::CircuitProposalsAction),
+                .with_command("proposals", circuit::CircuitProposalsAction)
+                .with_command(
+                    "default",
+                    SubcommandActions::new()
+                        .with_command("set", circuit::defaults::SetDefaultValueAction),
+                ),
         );
         subcommands = subcommands.with_command(
             "node",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -357,7 +357,18 @@ fn run() -> Result<(), CliError> {
                                         .help("The name of the default setting"),
                                 ),
                         )
-                        .subcommand(SubCommand::with_name("list").about("List set default values")),
+                        .subcommand(SubCommand::with_name("list").about("List set default values"))
+                        .subcommand(
+                            SubCommand::with_name("show")
+                                .about("Show a default value")
+                                .arg(
+                                    Arg::with_name("name")
+                                        .takes_value(true)
+                                        .value_name("name")
+                                        .possible_values(&["service-type", "management-type"])
+                                        .help("The name of the default setting"),
+                                ),
+                        ),
                 ),
         );
 
@@ -479,7 +490,8 @@ fn run() -> Result<(), CliError> {
                     SubcommandActions::new()
                         .with_command("set", circuit::defaults::SetDefaultValueAction)
                         .with_command("unset", circuit::defaults::UnsetDefaultValueAction)
-                        .with_command("list", circuit::defaults::ListDefaultsAction),
+                        .with_command("list", circuit::defaults::ListDefaultsAction)
+                        .with_command("show", circuit::defaults::ShowDefaultValueAction),
                 ),
         );
         subcommands = subcommands.with_command(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -345,6 +345,17 @@ fn run() -> Result<(), CliError> {
                                         .long("force")
                                         .help("Overwrite default if it is already set"),
                                 ),
+                        )
+                        .subcommand(
+                            SubCommand::with_name("unset")
+                                .about("Unset a default value")
+                                .arg(
+                                    Arg::with_name("name")
+                                        .takes_value(true)
+                                        .value_name("name")
+                                        .possible_values(&["service-type", "management-type"])
+                                        .help("The name of the default setting"),
+                                ),
                         ),
                 ),
         );
@@ -465,7 +476,8 @@ fn run() -> Result<(), CliError> {
                 .with_command(
                     "default",
                     SubcommandActions::new()
-                        .with_command("set", circuit::defaults::SetDefaultValueAction),
+                        .with_command("set", circuit::defaults::SetDefaultValueAction)
+                        .with_command("unset", circuit::defaults::UnsetDefaultValueAction),
                 ),
         );
         subcommands = subcommands.with_command(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -356,7 +356,8 @@ fn run() -> Result<(), CliError> {
                                         .possible_values(&["service-type", "management-type"])
                                         .help("The name of the default setting"),
                                 ),
-                        ),
+                        )
+                        .subcommand(SubCommand::with_name("list").about("List set default values")),
                 ),
         );
 
@@ -477,7 +478,8 @@ fn run() -> Result<(), CliError> {
                     "default",
                     SubcommandActions::new()
                         .with_command("set", circuit::defaults::SetDefaultValueAction)
-                        .with_command("unset", circuit::defaults::UnsetDefaultValueAction),
+                        .with_command("unset", circuit::defaults::UnsetDefaultValueAction)
+                        .with_command("list", circuit::defaults::ListDefaultsAction),
                 ),
         );
         subcommands = subcommands.with_command(

--- a/cli/src/store/default_value/error.rs
+++ b/cli/src/store/default_value/error.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+use std::io::Error as IoError;
+
+use serde_yaml::Error as SerdeError;
+
+#[derive(Debug)]
+pub enum DefaultStoreError {
+    NotSet(String),
+    IoError(IoError),
+    SerdeError(SerdeError),
+}
+
+impl Error for DefaultStoreError {}
+
+impl fmt::Display for DefaultStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DefaultStoreError::NotSet(msg) => write!(f, "Default not set: {}", msg),
+            DefaultStoreError::IoError(err) => {
+                write!(f, "Default value store encountered an IO error: {}", err)
+            }
+            DefaultStoreError::SerdeError(err) => write!(
+                f,
+                "Default value store encountered and serialization/deserialization error  {}",
+                err
+            ),
+        }
+    }
+}
+
+impl From<IoError> for DefaultStoreError {
+    fn from(err: IoError) -> DefaultStoreError {
+        DefaultStoreError::IoError(err)
+    }
+}
+
+impl From<SerdeError> for DefaultStoreError {
+    fn from(err: SerdeError) -> DefaultStoreError {
+        DefaultStoreError::SerdeError(err)
+    }
+}

--- a/cli/src/store/default_value/mod.rs
+++ b/cli/src/store/default_value/mod.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 mod error;
+mod yaml_store;
 
 pub use error::DefaultStoreError;
+
+pub use yaml_store::FileBackedDefaultStore;
 
 pub struct DefaultValue {
     key: String,

--- a/cli/src/store/default_value/mod.rs
+++ b/cli/src/store/default_value/mod.rs
@@ -1,0 +1,53 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+pub use error::DefaultStoreError;
+
+pub struct DefaultValue {
+    key: String,
+    value: String,
+}
+
+impl DefaultValue {
+    pub fn new(key: &str, value: &str) -> DefaultValue {
+        DefaultValue {
+            key: key.to_owned(),
+            value: value.to_owned(),
+        }
+    }
+
+    pub fn key(&self) -> String {
+        self.key.to_owned()
+    }
+
+    pub fn value(&self) -> String {
+        self.value.to_owned()
+    }
+}
+
+pub trait DefaultValueStore {
+    /// Set new default value
+    fn set_default_value(&self, default_value: &DefaultValue) -> Result<(), DefaultStoreError>;
+
+    /// Unset a default value
+    fn unset_default_value(&self, default_key: &str) -> Result<(), DefaultStoreError>;
+
+    /// List default values
+    fn list_default_values(&self) -> Result<Vec<DefaultValue>, DefaultStoreError>;
+
+    /// Get a default value
+    fn get_default_value(&self, key: &str) -> Result<Option<DefaultValue>, DefaultStoreError>;
+}

--- a/cli/src/store/default_value/yaml_store.rs
+++ b/cli/src/store/default_value/yaml_store.rs
@@ -1,0 +1,182 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Error as IoError, ErrorKind};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::{DefaultStoreError, DefaultValue, DefaultValueStore};
+
+const DEFAULT_FILE_NAME: &str = "circuit_default_values.yaml";
+const DEFAULTS_PATH: &str = ".splinter";
+
+#[derive(Serialize, Deserialize)]
+pub struct SerdeDefaultValue {
+    key: String,
+    value: String,
+}
+
+impl Into<DefaultValue> for SerdeDefaultValue {
+    fn into(self) -> DefaultValue {
+        DefaultValue {
+            key: self.key,
+            value: self.value,
+        }
+    }
+}
+
+impl From<&DefaultValue> for SerdeDefaultValue {
+    fn from(default_value: &DefaultValue) -> SerdeDefaultValue {
+        SerdeDefaultValue {
+            key: default_value.key.clone(),
+            value: default_value.value.clone(),
+        }
+    }
+}
+
+pub struct FileBackedDefaultStore {
+    file_name: String,
+}
+
+impl Default for FileBackedDefaultStore {
+    fn default() -> Self {
+        FileBackedDefaultStore {
+            file_name: DEFAULT_FILE_NAME.to_owned(),
+        }
+    }
+}
+
+impl DefaultValueStore for FileBackedDefaultStore {
+    fn set_default_value(&self, new_default_value: &DefaultValue) -> Result<(), DefaultStoreError> {
+        let mut defaults = self.load()?;
+        let existing_default_index = defaults.iter().enumerate().find_map(|(index, default)| {
+            if default.key == new_default_value.key() {
+                Some(index)
+            } else {
+                None
+            }
+        });
+        if let Some(index) = existing_default_index {
+            defaults.remove(index);
+        }
+
+        defaults.push(SerdeDefaultValue::from(new_default_value));
+
+        self.save(&defaults)?;
+
+        Ok(())
+    }
+
+    fn unset_default_value(&self, default_key: &str) -> Result<(), DefaultStoreError> {
+        let mut all_defaults = self.load()?;
+
+        let key_index = all_defaults
+            .iter()
+            .enumerate()
+            .find_map(|(index, default)| {
+                if default.key == default_key {
+                    Some(index)
+                } else {
+                    None
+                }
+            });
+
+        if let Some(index) = key_index {
+            all_defaults.remove(index);
+            self.save(&all_defaults)?;
+        } else {
+            return Err(DefaultStoreError::NotSet(format!(
+                "Default value for {} not found",
+                default_key
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn list_default_values(&self) -> Result<Vec<DefaultValue>, DefaultStoreError> {
+        let serde_defaults = self.load()?;
+        let defaults = serde_defaults
+            .into_iter()
+            .map(|default_value| default_value.into())
+            .collect::<Vec<DefaultValue>>();
+        Ok(defaults)
+    }
+
+    fn get_default_value(&self, key: &str) -> Result<Option<DefaultValue>, DefaultStoreError> {
+        let defaults = self.load()?;
+
+        let default_value = defaults.into_iter().find_map(|default_value| {
+            if default_value.key == key {
+                return Some(default_value.into());
+            }
+            None
+        });
+
+        Ok(default_value)
+    }
+}
+
+impl FileBackedDefaultStore {
+    fn load(&self) -> Result<Vec<SerdeDefaultValue>, DefaultStoreError> {
+        let file = open_file(false, &self.file_name)?;
+
+        if file.metadata()?.len() == 0 {
+            return Ok(vec![]);
+        }
+
+        let default_values = serde_yaml::from_reader(file)?;
+        Ok(default_values)
+    }
+
+    fn save(&self, default_values: &[SerdeDefaultValue]) -> Result<(), DefaultStoreError> {
+        let temp_file_name = format!("{}.tmp", self.file_name);
+        let file = open_file(true, &temp_file_name)?;
+
+        serde_yaml::to_writer(file, &default_values)?;
+
+        let temp_file_path = build_file_path(&temp_file_name)?;
+        let perm_file_path = build_file_path(&self.file_name)?;
+        fs::rename(temp_file_path, perm_file_path)?;
+        Ok(())
+    }
+}
+
+fn build_file_path(file_name: &str) -> Result<PathBuf, DefaultStoreError> {
+    let mut path = get_file_path()?;
+    path.push(file_name);
+    Ok(path)
+}
+
+fn open_file(truncate: bool, file_name: &str) -> Result<File, DefaultStoreError> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(truncate)
+        .open(&build_file_path(file_name)?)?;
+    Ok(file)
+}
+
+fn get_file_path() -> Result<PathBuf, DefaultStoreError> {
+    let mut path = dirs::home_dir().ok_or_else(|| {
+        let err = IoError::new(ErrorKind::NotFound, "Home directory not found");
+        DefaultStoreError::IoError(err)
+    })?;
+    path.push(DEFAULTS_PATH);
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}

--- a/cli/src/store/mod.rs
+++ b/cli/src/store/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod default_value;
 pub mod node;


### PR DESCRIPTION
PR adds the commands bellow that will support creating circuits via cli
- `splinter circuit default`:
  - `set service-type <service-type>`: set a default service-type, the default value will be used during circuit creation if no service type is passed.
  - `set management-type <management-type>`: set a default management-type, the default value will be used during circuit creation if no management type is passed.
  - ` get service-type`: get the default value for service-type
  - `get management-type`: get the default value for management-type
  - `list`: list all defaults
  - `unset service-type` unset the default value for service-type
  - `unset management-type`: unset the default value for management-type

For more context on how these command can be used refer to [Shawn's comment](https://zenhub.cglcloud.com/app/workspaces/product-core-5d37298b0add7306b30efde2/issues/digitalsupplychain/product-core/1743#issuecomment-110397).