### PR TITLE
Splinter State Interface

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -20,7 +20,7 @@ mod open_proposals;
 mod shared;
 
 use std::any::Any;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use openssl::hash::{hash, MessageDigest};
@@ -124,7 +124,7 @@ impl AdminService {
         orchestrator: ServiceOrchestrator,
         peer_connector: PeerConnector,
         authorization_inquistor: Box<dyn AuthorizationInquisitor>,
-        splinter_state: Arc<RwLock<SplinterState>>,
+        splinter_state: SplinterState,
         signature_verifier: Box<dyn SignatureVerifier + Send>,
         key_registry: Box<dyn KeyRegistry>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
@@ -500,10 +500,7 @@ mod tests {
         key_registry.save_key(key_info).unwrap();
 
         let circuit_directory = storage.write().clone();
-        let state = Arc::new(RwLock::new(SplinterState::new(
-            "memory".to_string(),
-            circuit_directory,
-        )));
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
 
         let orchestrator_connection = transport
             .connect("inproc://admin-service")

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -476,6 +476,48 @@ pub enum WriteError {
     GetStorageError(String),
 }
 
+#[derive(Debug)]
+pub struct SplinterStateError {
+    context: String,
+    source: Option<Box<dyn Error + Send + 'static>>,
+}
+
+impl SplinterStateError {
+    pub fn new(context: String) -> Self {
+        Self {
+            context,
+            source: None,
+        }
+    }
+
+    pub fn from_source<T: Error + Send + 'static>(context: String, source: T) -> Self {
+        Self {
+            context,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub fn context(&self) -> String {
+        self.context.clone()
+    }
+}
+
+impl Error for SplinterStateError {}
+
+impl fmt::Display for SplinterStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(ref source) = self.source {
+            write!(
+                f,
+                "SplinterStateError: Source: {} Context: {}",
+                source, self.context
+            )
+        } else {
+            write!(f, "SplinterStateError: Context {}", self.context)
+        }
+    }
+}
+
 impl Error for WriteError {}
 
 impl std::fmt::Display for WriteError {

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -17,6 +17,7 @@ pub mod handlers;
 #[cfg(feature = "rest-api")]
 pub mod rest_api;
 pub mod service;
+pub mod store;
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -28,6 +29,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::circuit::directory::CircuitDirectory;
 use crate::circuit::service::{Service, ServiceId, SplinterNode};
+use crate::circuit::store::{CircuitStore, CircuitStoreError};
 use crate::storage::get_storage;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -565,6 +567,18 @@ impl SplinterState {
             .read()
             .map_err(|_| SplinterStateError::new("Failed to read circuit directory".into()))?;
         Ok(circuit_directory.has_circuit(circuit_name))
+    }
+}
+
+impl CircuitStore for SplinterState {
+    fn circuits(&self) -> Result<BTreeMap<String, Circuit>, CircuitStoreError> {
+        self.circuits()
+            .map_err(|err| CircuitStoreError::new(err.context()))
+    }
+
+    fn circuit(&self, circuit_name: &str) -> Result<Option<Circuit>, CircuitStoreError> {
+        self.circuit(circuit_name)
+            .map_err(|err| CircuitStoreError::new(err.context()))
     }
 }
 

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -422,13 +422,13 @@ impl SplinterState {
 
     // ---------- methods to access service directory ----------
 
-    pub fn service_directory(&self) -> Result<HashMap<ServiceId, Service>, SplinterStateError> {
+    pub fn get_service(&self, id: &ServiceId) -> Result<Option<Service>, SplinterStateError> {
         let service_directory = self
             .service_directory
             .read()
             .map_err(|_| SplinterStateError::new("Failed to read service directory".into()))?;
 
-        Ok(service_directory.clone())
+        Ok(service_directory.get(id).map(Service::clone))
     }
 
     pub fn add_service(

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -431,6 +431,15 @@ impl SplinterState {
         Ok(service_directory.get(id).map(Service::clone))
     }
 
+    pub fn has_service(&self, id: &ServiceId) -> Result<bool, SplinterStateError> {
+        let service_directory = self
+            .service_directory
+            .read()
+            .map_err(|_| SplinterStateError::new("Failed to read service directory".into()))?;
+
+        Ok(service_directory.contains_key(id))
+    }
+
     pub fn add_service(
         &self,
         service_id: ServiceId,

--- a/libsplinter/src/circuit/store.rs
+++ b/libsplinter/src/circuit/store.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use crate::circuit::Circuit;
+
+pub trait CircuitStore: Send + Sync + Clone {
+    fn circuits(&self) -> Result<BTreeMap<String, Circuit>, CircuitStoreError>;
+
+    fn circuit(&self, circuit_name: &str) -> Result<Option<Circuit>, CircuitStoreError>;
+}

--- a/libsplinter/src/circuit/store.rs
+++ b/libsplinter/src/circuit/store.rs
@@ -21,3 +21,45 @@ pub trait CircuitStore: Send + Sync + Clone {
 
     fn circuit(&self, circuit_name: &str) -> Result<Option<Circuit>, CircuitStoreError>;
 }
+
+#[derive(Debug)]
+pub struct CircuitStoreError {
+    context: String,
+    source: Option<Box<dyn std::error::Error + Send + 'static>>,
+}
+
+impl std::error::Error for CircuitStoreError {}
+
+impl CircuitStoreError {
+    pub fn new(context: String) -> Self {
+        Self {
+            context,
+            source: None,
+        }
+    }
+
+    pub fn from_source<T: std::error::Error + Send + 'static>(context: String, source: T) -> Self {
+        Self {
+            context,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub fn context(&self) -> String {
+        self.context.clone()
+    }
+}
+
+impl std::fmt::Display for CircuitStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(ref source) = self.source {
+            write!(
+                f,
+                "CircuitStoreError: Source: {} Context: {}",
+                source, self.context
+            )
+        } else {
+            write!(f, "CircuitStoreError: Context {}", self.context)
+        }
+    }
+}


### PR DESCRIPTION
This PR removes the use of lock wrapped splinter states (`Arc<RwLock<SplinterState>>`). The circuit and service directories are now wrapped in arc locks and the interface for splinter state has been updated so the internal locks are hidden.