### PR TITLE
Install curl in scabbard-cli docker image

### DIFF
--- a/services/scabbard/Dockerfile-installed-bionic
+++ b/services/scabbard/Dockerfile-installed-bionic
@@ -42,5 +42,6 @@ COPY --from=builder /build/target/debian/scabbard_*.deb /tmp
 COPY --from=builder /commit-hash /commit-hash
 
 RUN apt-get update \
+ && apt-get install -y curl \
  && dpkg --unpack /tmp/scabbard_*.deb \
  && apt-get -f -y install


### PR DESCRIPTION
Add `curl` to the scabbard-cli docker image to enable fetching remote
`.scar` files.

Signed-off-by: Logan Seeley <seeley@bitwise.io>