### PR TITLE
Wait full time in scabbard batch status check

### DIFF
--- a/libsplinter/src/service/scabbard/client/submit.rs
+++ b/libsplinter/src/service/scabbard/client/submit.rs
@@ -14,7 +14,10 @@
 
 //! Contains functions which assist with batch submission to a REST API
 
-use std::{fmt, str};
+use std::{
+    fmt, str,
+    time::{Duration, Instant},
+};
 
 use protobuf::Message;
 use reqwest::{
@@ -54,34 +57,72 @@ pub fn submit_batches(
 
 pub fn wait_for_batches(base_url: &str, batch_link: &str, wait: u64) -> Result<(), Error> {
     let url = if batch_link.starts_with("http") || batch_link.starts_with("https") {
-        parse_http_url(&format!("{}&wait={}", batch_link, wait))?
+        parse_http_url(batch_link)
     } else {
-        parse_http_url(&format!("{}{}&wait={}", base_url, batch_link, wait))?
+        parse_http_url(&format!("{}{}", base_url, batch_link))
+    }?;
+
+    let time_left = Duration::from_secs(wait);
+
+    wait_for_batches_until_timeout(url, time_left)
+}
+
+/// Recursive function that will repeatedly get the batch statuses with `url` until no batches are
+/// pending or the `time_left` reaches zero.
+fn wait_for_batches_until_timeout(url: Url, time_left: Duration) -> Result<(), Error> {
+    let start_time = Instant::now();
+
+    let wait_query = format!("wait={}", time_left.as_secs());
+    let query_string = if let Some(existing_query) = url.query() {
+        format!("{}&{}", existing_query, wait_query)
+    } else {
+        wait_query
     };
 
+    let mut url_with_query = url.clone();
+    url_with_query.set_query(Some(&query_string));
+
     debug!("Checking batches via {}", url);
-    let request = Client::new().get(url);
+    let request = Client::new().get(url.clone());
     let response = perform_request(request)?;
 
     let batch_infos: Vec<BatchInfo> = response.json().map_err(|err| {
         Error::new_with_source("failed to parse response as batch statuses", err.into())
     })?;
 
-    let any_invalid_batches = batch_infos.iter().any(|info| {
-        if let BatchStatus::Invalid(_) = info.status {
-            true
-        } else {
-            false
+    let any_pending_batches = batch_infos.iter().any(|info| {
+        match info.status {
+            // `Valid` is still technically pending until it's `Committed`
+            BatchStatus::Pending | BatchStatus::Valid(_) => true,
+            _ => false,
         }
     });
 
-    if any_invalid_batches {
-        Err(Error::new(&format!(
-            "one or more batches were invalid: {:?}",
-            batch_infos
-        )))
+    if any_pending_batches {
+        match time_left.checked_sub(start_time.elapsed()) {
+            Some(time_still_left) => wait_for_batches_until_timeout(url, time_still_left),
+            None => Err(Error::new(&format!(
+                "one or more batches are still pending: {:?}",
+                batch_infos
+            ))),
+        }
     } else {
-        Ok(())
+        let any_invalid_batches = batch_infos.iter().any(|info| {
+            if let BatchStatus::Invalid(_) = info.status {
+                true
+            } else {
+                false
+            }
+        });
+
+        if any_invalid_batches {
+            Err(Error::new(&format!(
+                "one or more batches were invalid: {:?}",
+                batch_infos
+            )))
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
When checking the status of submitted batches, the scabbard client
should wait up to the full time the user specified. The `wait` parameter
provided in the `/batch_statuses` query string is not guaranteed to be
honored by the server, and it may have a limit. This commit updates the
scabbard client to ensure that it waits the full time for batches to
move out of "pending" status by repeatedly checking batch statuses (if
need be).

Signed-off-by: Logan Seeley <seeley@bitwise.io>