### PR TITLE
Rename keygen admin flag to system

### DIFF
--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -30,7 +30,7 @@ use crate::error::CliError;
 
 use super::{chown, Action};
 
-const ADMIN_KEY_PATH: &str = "/etc/splinter/keys";
+const SYSTEM_KEY_PATH: &str = "/etc/splinter/keys";
 
 pub struct KeyGenAction;
 
@@ -42,8 +42,8 @@ impl Action for KeyGenAction {
             .value_of("key-name")
             .map(String::from)
             .unwrap_or_else(whoami::username);
-        let key_dir = if args.is_present("admin") {
-            PathBuf::from(ADMIN_KEY_PATH)
+        let key_dir = if args.is_present("system") {
+            PathBuf::from(SYSTEM_KEY_PATH)
         } else {
             dirs::home_dir()
                 .map(|mut p| {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -99,7 +99,7 @@ fn run() -> Result<(), CliError> {
             SubCommand::with_name("keygen")
                 .about(
                     "Generates secp256k1 keys. By default, keys are stored in\n\
-                     the user's home directory, $HOME/splinter/keys. The --admin\n\
+                     the user's home directory, $HOME/splinter/keys. The --system\n\
                      option generates keys for the Splinter daemon (splinterd) that\n\
                      are stored in /etc/splinter/keys.",
                 )
@@ -115,9 +115,9 @@ fn run() -> Result<(), CliError> {
                         .help("Overwrite files if they exist"),
                 )
                 .arg(
-                    Arg::with_name("admin")
-                        .long("admin")
-                        .help("Generate admin keys in /etc/splinter/keys"),
+                    Arg::with_name("system")
+                        .long("system")
+                        .help("Generate system keys in /etc/splinter/keys"),
                 ),
         )
     }


### PR DESCRIPTION
Rename `--admin` to`--system` to better reflect the functionality of the
flag, which is to generate keys for use by a splinter node.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>