### PR TITLE
Final Config and ConfigBuilder

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -42,7 +42,7 @@ serde = "1.0.80"
 serde_derive = "1.0.80"
 splinter = { path = "../libsplinter", features = ["rest-api", "rest-api-actix", "sawtooth-signing-compat"] }
 tempdir = "0.3"
-toml = "0.4.8"
+toml = "0.5"
 
 [features]
 default = [

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -24,6 +24,8 @@ pub trait PartialConfigBuilder {
 mod tests {
     use super::*;
 
+    use crate::config::ConfigSource;
+
     /// Values present in the existing example config TEST_TOML file.
     static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_TRANSPORT: &str = "tls";
@@ -76,7 +78,7 @@ mod tests {
     /// contains the correct values by asserting each expected value.
     fn test_builder_chain() {
         // Create an empty PartialConfig object.
-        let mut partial_config = PartialConfig::default();
+        let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the PartialConfig fields by chaining the builder methods.
         partial_config = partial_config
             .with_storage(Some(EXAMPLE_STORAGE.to_string()))
@@ -112,7 +114,7 @@ mod tests {
     /// methods contains the correct values by asserting each expected value.
     fn test_builder_separate() {
         // Create a new PartialConfig object.
-        let mut partial_config = PartialConfig::default();
+        let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the PartialConfig fields by separately applying the builder methods.
         partial_config = partial_config.with_storage(Some(EXAMPLE_STORAGE.to_string()));
         partial_config = partial_config.with_transport(Some(EXAMPLE_TRANSPORT.to_string()));

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -262,7 +262,7 @@ impl ConfigBuilder {
 mod tests {
     use super::*;
 
-    /// Values present in the existing example config TEST_TOML file.
+    /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_TRANSPORT: &str = "tls";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
@@ -274,7 +274,7 @@ mod tests {
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
-    /// Asserts config values based on the TEST_TOML file values.
+    /// Asserts the example configuration values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
         assert_eq!(config.transport(), Some(EXAMPLE_TRANSPORT.to_string()));
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     /// This test verifies that a PartialConfig object is accurately constructed by chaining the
-    /// PartialConfigBuilder methods from a new TomlConfig object. The following steps are performed:
+    /// PartialConfigBuilder methods. The following steps are performed:
     ///
     /// 1. An empty PartialConfig object is constructed.
     /// 2. The fields of the PartialConfig object are populated by chaining the builder methods.

--- a/splinterd/src/config/command_line.rs
+++ b/splinterd/src/config/command_line.rs
@@ -210,10 +210,10 @@ mod tests {
         ];
         // Create an example ArgMatches object to initialize the CommandLineConfig.
         let matches = create_arg_matches(args);
-        // Create a new CommandLiine object from the arg matches.
+        // Create a new CommandLine object from the arg matches.
         let command_config = CommandLineConfig::new(matches)
             .expect("Unable to create new CommandLineConfig object.");
-        // Build a PartialConfig from the TomlConfig object created.
+        // Build a PartialConfig from the CommandLineConfig object created.
         let built_config = command_config.build();
         // Assert the source is correctly identified for this PartialConfig object.
         assert_eq!(built_config.source(), ConfigSource::CommandLine);

--- a/splinterd/src/config/command_line.rs
+++ b/splinterd/src/config/command_line.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::config::{ConfigError, PartialConfig, PartialConfigBuilder};
+use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 use clap::{ArgMatches, ErrorKind};
 
 /// Holds configuration values from command line arguments, represented by clap ArgMatches.
@@ -77,7 +77,7 @@ impl CommandLineConfig {
 
 impl PartialConfigBuilder for CommandLineConfig {
     fn build(self) -> PartialConfig {
-        let partial_config = PartialConfig::default()
+        let partial_config = PartialConfig::new(ConfigSource::CommandLine)
             .with_storage(self.storage)
             .with_transport(self.transport)
             .with_cert_dir(self.cert_dir)
@@ -215,6 +215,8 @@ mod tests {
             .expect("Unable to create new CommandLineConfig object.");
         // Build a PartialConfig from the TomlConfig object created.
         let built_config = command_config.build();
+        // Assert the source is correctly identified for this PartialConfig object.
+        assert_eq!(built_config.source(), ConfigSource::CommandLine);
         // Compare the generated PartialConfig object against the expected values.
         assert_config_values(built_config);
     }

--- a/splinterd/src/config/command_line.rs
+++ b/splinterd/src/config/command_line.rs
@@ -48,7 +48,6 @@ fn parse_value(matches: &ArgMatches) -> Result<Option<u64>, ConfigError> {
 }
 
 impl CommandLineConfig {
-    #[allow(dead_code)]
     pub fn new(matches: ArgMatches) -> Result<Self, ConfigError> {
         Ok(CommandLineConfig {
             storage: matches.value_of("storage").map(String::from),

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-use crate::config::{PartialConfig, PartialConfigBuilder};
+use crate::config::{ConfigSource, PartialConfig, PartialConfigBuilder};
 
 const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs/";
 const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
@@ -92,7 +92,7 @@ impl DefaultConfig {
 
 impl PartialConfigBuilder for DefaultConfig {
     fn build(self) -> PartialConfig {
-        let partial_config = PartialConfig::default()
+        let partial_config = PartialConfig::new(ConfigSource::Default)
             .with_storage(self.storage)
             .with_transport(self.transport)
             .with_cert_dir(self.cert_dir)
@@ -174,6 +174,8 @@ mod tests {
             ))
         );
         assert_eq!(config.state_dir(), Some(String::from(DEFAULT_STATE_DIR)));
+        // Assert the source is correctly identified for this PartialConfig object.
+        assert_eq!(config.source(), ConfigSource::Default);
     }
 
     #[test]

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -68,8 +68,8 @@ impl DefaultConfig {
             bind: Some(String::from("127.0.0.1:8080")),
             #[cfg(feature = "database")]
             database: Some(String::from("127.0.0.1:5432")),
-            registry_backend: None,
-            registry_file: None,
+            registry_backend: Some(String::from("FILE")),
+            registry_file: Some(String::from("/etc/splinter/nodes.yaml")),
             heartbeat_interval: Some(HEARTBEAT_DEFAULT),
             admin_service_coordinator_timeout: Some(
                 DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS,
@@ -138,8 +138,11 @@ mod tests {
         assert_eq!(config.bind(), Some(String::from("127.0.0.1:8080")));
         #[cfg(feature = "database")]
         assert_eq!(config.database(), Some(String::from("127.0.0.1:5432")));
-        assert_eq!(config.registry_backend(), None);
-        assert_eq!(config.registry_file(), None);
+        assert_eq!(config.registry_backend(), Some(String::from("FILE")));
+        assert_eq!(
+            config.registry_file(),
+            Some(String::from("/etc/splinter/nodes.yaml"))
+        );
         assert_eq!(config.heartbeat_interval(), Some(HEARTBEAT_DEFAULT));
         assert_eq!(
             config.admin_service_coordinator_timeout(),

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
-
 use crate::config::{ConfigSource, PartialConfig, PartialConfigBuilder};
 
 const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs/";
@@ -51,15 +49,6 @@ pub struct DefaultConfig {
     state_dir: Option<String>,
 }
 
-fn get_cert_file_path(cert_dir: &str, file: &str) -> Option<String> {
-    let cert_dir_path = Path::new(cert_dir);
-    let cert_file_path = cert_dir_path.join(file);
-    if !cert_file_path.is_file() {
-        debug!("Configuration file not found: {}{}", cert_dir, file);
-    }
-    cert_file_path.to_str().map(ToOwned::to_owned)
-}
-
 impl DefaultConfig {
     #[allow(dead_code)]
     pub fn new() -> Self {
@@ -67,11 +56,11 @@ impl DefaultConfig {
             storage: Some(String::from("yaml")),
             transport: Some(String::from("raw")),
             cert_dir: Some(String::from(DEFAULT_CERT_DIR)),
-            ca_certs: get_cert_file_path(DEFAULT_CERT_DIR, CA_PEM),
-            client_cert: get_cert_file_path(DEFAULT_CERT_DIR, CLIENT_CERT),
-            client_key: get_cert_file_path(DEFAULT_CERT_DIR, CLIENT_KEY),
-            server_cert: get_cert_file_path(DEFAULT_CERT_DIR, SERVER_CERT),
-            server_key: get_cert_file_path(DEFAULT_CERT_DIR, SERVER_KEY),
+            ca_certs: Some(String::from(CA_PEM)),
+            client_cert: Some(String::from(CLIENT_CERT)),
+            client_key: Some(String::from(CLIENT_KEY)),
+            server_cert: Some(String::from(SERVER_CERT)),
+            server_key: Some(String::from(SERVER_KEY)),
             service_endpoint: Some(String::from("127.0.0.1:8043")),
             network_endpoint: Some(String::from("127.0.0.1:8044")),
             peers: Some(vec![]),
@@ -131,26 +120,11 @@ mod tests {
         assert_eq!(config.storage(), Some(String::from("yaml")));
         assert_eq!(config.transport(), Some(String::from("raw")));
         assert_eq!(config.cert_dir(), Some(String::from(DEFAULT_CERT_DIR)));
-        assert_eq!(
-            config.ca_certs(),
-            Some(format!("{}{}", DEFAULT_CERT_DIR, CA_PEM))
-        );
-        assert_eq!(
-            config.client_cert(),
-            Some(format!("{}{}", DEFAULT_CERT_DIR, CLIENT_CERT))
-        );
-        assert_eq!(
-            config.client_key(),
-            Some(format!("{}{}", DEFAULT_CERT_DIR, CLIENT_KEY))
-        );
-        assert_eq!(
-            config.server_cert(),
-            Some(format!("{}{}", DEFAULT_CERT_DIR, SERVER_CERT))
-        );
-        assert_eq!(
-            config.server_key(),
-            Some(format!("{}{}", DEFAULT_CERT_DIR, SERVER_KEY))
-        );
+        assert_eq!(config.ca_certs(), Some(String::from(CA_PEM)));
+        assert_eq!(config.client_cert(), Some(String::from(CLIENT_CERT)));
+        assert_eq!(config.client_key(), Some(String::from(CLIENT_KEY)));
+        assert_eq!(config.server_cert(), Some(String::from(SERVER_CERT)));
+        assert_eq!(config.server_key(), Some(String::from(SERVER_KEY)));
         assert_eq!(
             config.service_endpoint(),
             Some(String::from("127.0.0.1:8043"))

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -50,7 +50,6 @@ pub struct DefaultConfig {
 }
 
 impl DefaultConfig {
-    #[allow(dead_code)]
     pub fn new() -> Self {
         DefaultConfig {
             storage: Some(String::from("yaml")),

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -14,7 +14,7 @@
 
 use std::env;
 
-use crate::config::{PartialConfig, PartialConfigBuilder};
+use crate::config::{ConfigSource, PartialConfig, PartialConfigBuilder};
 
 const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
@@ -37,7 +37,7 @@ impl EnvVarConfig {
 
 impl PartialConfigBuilder for EnvVarConfig {
     fn build(self) -> PartialConfig {
-        PartialConfig::default()
+        PartialConfig::new(ConfigSource::Environment)
             .with_cert_dir(self.cert_dir)
             .with_state_dir(self.state_dir)
     }
@@ -71,6 +71,7 @@ mod tests {
         let env_var_config = EnvVarConfig::new();
         // Build a PartialConfig from the EnvVarConfig object created.
         let unset_config = env_var_config.build();
+        assert_eq!(unset_config.source(), ConfigSource::Environment);
         // Compare the generated PartialConfig object against the expected values.
         assert_eq!(unset_config.state_dir(), None);
         assert_eq!(unset_config.cert_dir(), None);
@@ -82,6 +83,7 @@ mod tests {
         let env_var_config = EnvVarConfig::new();
         // Build a PartialConfig from the EnvVarConfig object created.
         let set_config = env_var_config.build();
+        assert_eq!(set_config.source(), ConfigSource::Environment);
         // Compare the generated PartialConfig object against the expected values.
         assert_eq!(
             set_config.state_dir(),

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -26,7 +26,6 @@ pub struct EnvVarConfig {
 }
 
 impl EnvVarConfig {
-    #[allow(dead_code)]
     pub fn new() -> Self {
         EnvVarConfig {
             state_dir: env::var(STATE_DIR_ENV).ok(),

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -24,6 +24,7 @@ pub enum ConfigError {
     ReadError(io::Error),
     TomlParseError(TomlError),
     InvalidArgument(clap::Error),
+    MissingValue(String),
 }
 
 impl From<io::Error> for ConfigError {
@@ -50,6 +51,7 @@ impl Error for ConfigError {
             ConfigError::ReadError(source) => Some(source),
             ConfigError::TomlParseError(source) => Some(source),
             ConfigError::InvalidArgument(source) => Some(source),
+            ConfigError::MissingValue(_) => None,
         }
     }
 }
@@ -62,6 +64,7 @@ impl fmt::Display for ConfigError {
             ConfigError::InvalidArgument(source) => {
                 write!(f, "Unable to parse command line argument: {}", source)
             }
+            ConfigError::MissingValue(msg) => write!(f, "Configuration value must be set: {}", msg),
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -23,6 +23,8 @@ mod error;
 mod partial;
 mod toml;
 
+use std::time::Duration;
+
 #[cfg(feature = "config-command-line")]
 pub use crate::config::command_line::CommandLineConfig;
 #[cfg(feature = "config-default")]
@@ -36,3 +38,285 @@ pub use crate::config::toml::TomlConfig;
 pub use builder::PartialConfigBuilder;
 pub use error::ConfigError;
 pub use partial::{ConfigSource, PartialConfig};
+
+/// Config is the final representation of configuration values. This final config object assembles
+/// values from PartialConfig objects generated from various sources.
+#[derive(Debug)]
+pub struct Config {
+    storage: (String, ConfigSource),
+    transport: (String, ConfigSource),
+    cert_dir: (String, ConfigSource),
+    ca_certs: (String, ConfigSource),
+    client_cert: (String, ConfigSource),
+    client_key: (String, ConfigSource),
+    server_cert: (String, ConfigSource),
+    server_key: (String, ConfigSource),
+    service_endpoint: (String, ConfigSource),
+    network_endpoint: (String, ConfigSource),
+    peers: (Vec<String>, ConfigSource),
+    node_id: (String, ConfigSource),
+    bind: (String, ConfigSource),
+    #[cfg(feature = "database")]
+    database: (String, ConfigSource),
+    registry_backend: (String, ConfigSource),
+    registry_file: (String, ConfigSource),
+    heartbeat_interval: (u64, ConfigSource),
+    admin_service_coordinator_timeout: (Duration, ConfigSource),
+    state_dir: (String, ConfigSource),
+}
+
+impl Config {
+    pub fn storage(&self) -> &str {
+        &self.storage.0
+    }
+
+    pub fn transport(&self) -> &str {
+        &self.transport.0
+    }
+
+    pub fn cert_dir(&self) -> &str {
+        &self.cert_dir.0
+    }
+
+    pub fn ca_certs(&self) -> &str {
+        &self.ca_certs.0
+    }
+
+    pub fn client_cert(&self) -> &str {
+        &self.client_cert.0
+    }
+
+    pub fn client_key(&self) -> &str {
+        &self.client_key.0
+    }
+
+    pub fn server_cert(&self) -> &str {
+        &self.server_cert.0
+    }
+
+    pub fn server_key(&self) -> &str {
+        &self.server_key.0
+    }
+
+    pub fn service_endpoint(&self) -> &str {
+        &self.service_endpoint.0
+    }
+
+    pub fn network_endpoint(&self) -> &str {
+        &self.network_endpoint.0
+    }
+
+    pub fn peers(&self) -> &[String] {
+        &self.peers.0
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.node_id.0
+    }
+
+    pub fn bind(&self) -> &str {
+        &self.bind.0
+    }
+
+    #[cfg(feature = "database")]
+    pub fn database(&self) -> &str {
+        &self.database.0
+    }
+
+    pub fn registry_backend(&self) -> &str {
+        &self.registry_backend.0
+    }
+
+    pub fn registry_file(&self) -> &str {
+        &self.registry_file.0
+    }
+
+    pub fn heartbeat_interval(&self) -> u64 {
+        self.heartbeat_interval.0
+    }
+
+    pub fn admin_service_coordinator_timeout(&self) -> Duration {
+        self.admin_service_coordinator_timeout.0
+    }
+
+    pub fn state_dir(&self) -> &str {
+        &self.state_dir.0
+    }
+
+    fn storage_source(&self) -> &ConfigSource {
+        &self.storage.1
+    }
+
+    fn transport_source(&self) -> &ConfigSource {
+        &self.transport.1
+    }
+
+    fn cert_dir_source(&self) -> &ConfigSource {
+        &self.cert_dir.1
+    }
+
+    fn ca_certs_source(&self) -> &ConfigSource {
+        &self.ca_certs.1
+    }
+
+    fn client_cert_source(&self) -> &ConfigSource {
+        &self.client_cert.1
+    }
+
+    fn client_key_source(&self) -> &ConfigSource {
+        &self.client_key.1
+    }
+
+    fn server_cert_source(&self) -> &ConfigSource {
+        &self.server_cert.1
+    }
+
+    fn server_key_source(&self) -> &ConfigSource {
+        &self.server_key.1
+    }
+
+    fn service_endpoint_source(&self) -> &ConfigSource {
+        &self.service_endpoint.1
+    }
+
+    fn network_endpoint_source(&self) -> &ConfigSource {
+        &self.network_endpoint.1
+    }
+
+    fn peers_source(&self) -> &ConfigSource {
+        &self.peers.1
+    }
+
+    fn node_id_source(&self) -> &ConfigSource {
+        &self.node_id.1
+    }
+
+    fn bind_source(&self) -> &ConfigSource {
+        &self.bind.1
+    }
+
+    #[cfg(feature = "database")]
+    fn database_source(&self) -> &ConfigSource {
+        &self.database.1
+    }
+
+    fn registry_backend_source(&self) -> &ConfigSource {
+        &self.registry_backend.1
+    }
+
+    fn registry_file_source(&self) -> &ConfigSource {
+        &self.registry_file.1
+    }
+
+    fn heartbeat_interval_source(&self) -> &ConfigSource {
+        &self.heartbeat_interval.1
+    }
+
+    fn admin_service_coordinator_timeout_source(&self) -> &ConfigSource {
+        &self.admin_service_coordinator_timeout.1
+    }
+
+    fn state_dir_source(&self) -> &ConfigSource {
+        &self.state_dir.1
+    }
+
+    /// Displays the configuration value along with where the value was sourced from.
+    pub fn log_as_debug(&self) {
+        debug!(
+            "Config: storage: {} (source: {:?})",
+            self.storage(),
+            self.storage_source()
+        );
+        debug!(
+            "Config: transport: {} (source: {:?})",
+            self.transport(),
+            self.transport_source()
+        );
+        debug!(
+            "Config: cert_dir: {} (source: {:?})",
+            self.cert_dir(),
+            self.cert_dir_source()
+        );
+        debug!(
+            "Config: ca_certs: {} (source: {:?})",
+            self.ca_certs(),
+            self.ca_certs_source()
+        );
+        debug!(
+            "Config: client_cert: {} (source: {:?})",
+            self.client_cert(),
+            self.client_cert_source()
+        );
+        debug!(
+            "Config: client_key: {} (source: {:?})",
+            self.client_key(),
+            self.client_key_source()
+        );
+        debug!(
+            "Config: server_cert: {} (source: {:?})",
+            self.server_cert(),
+            self.server_cert_source()
+        );
+        debug!(
+            "Config: server_key: {} (source: {:?})",
+            self.server_key(),
+            self.server_key_source()
+        );
+        debug!(
+            "Config: service_endpoint: {} (source: {:?})",
+            self.service_endpoint(),
+            self.service_endpoint_source()
+        );
+        debug!(
+            "Config: network_endpoint: {} (source: {:?})",
+            self.network_endpoint(),
+            self.network_endpoint_source()
+        );
+        debug!(
+            "Config: peers: {:?} (source: {:?})",
+            self.peers(),
+            self.peers_source()
+        );
+        debug!(
+            "Config: node_id: {} (source: {:?})",
+            self.node_id(),
+            self.node_id_source()
+        );
+        debug!(
+            "Config: bind: {} (source: {:?})",
+            self.bind(),
+            self.bind_source()
+        );
+        debug!(
+            "Config: registry_backend: {} (source: {:?})",
+            self.registry_backend(),
+            self.registry_backend_source()
+        );
+        debug!(
+            "Config: registry_file: {} (source: {:?})",
+            self.registry_file(),
+            self.registry_file_source()
+        );
+        debug!(
+            "Config: state_dir: {} (source: {:?})",
+            self.state_dir(),
+            self.state_dir_source()
+        );
+        debug!(
+            "Config: heartbeat_interval: {} (source: {:?})",
+            self.heartbeat_interval(),
+            self.heartbeat_interval_source()
+        );
+        debug!(
+            "Config: admin_service_coordinator_timeout: {:?} (source: {:?})",
+            self.admin_service_coordinator_timeout(),
+            self.admin_service_coordinator_timeout_source()
+        );
+        #[cfg(feature = "database")]
+        debug!(
+            "database: {} (source: {:?})",
+            self.database(),
+            self.database_source(),
+        );
+    }
+}

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -35,7 +35,7 @@ pub use crate::config::env::EnvVarConfig;
 pub use crate::config::toml::from_file;
 #[cfg(feature = "config-toml")]
 pub use crate::config::toml::TomlConfig;
-pub use builder::PartialConfigBuilder;
+pub use builder::{ConfigBuilder, PartialConfigBuilder};
 pub use error::ConfigError;
 pub use partial::{ConfigSource, PartialConfig};
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -35,4 +35,4 @@ pub use crate::config::toml::from_file;
 pub use crate::config::toml::TomlConfig;
 pub use builder::PartialConfigBuilder;
 pub use error::ConfigError;
-pub use partial::PartialConfig;
+pub use partial::{ConfigSource, PartialConfig};

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -221,7 +221,7 @@ impl Config {
     }
 
     /// Displays the configuration value along with where the value was sourced from.
-    pub fn log_as_debug(&self) {
+    pub fn log_as_debug(&self, insecure: bool) {
         debug!(
             "Config: storage: {} (source: {:?})",
             self.storage(),
@@ -232,36 +232,42 @@ impl Config {
             self.transport(),
             self.transport_source()
         );
-        debug!(
-            "Config: cert_dir: {} (source: {:?})",
-            self.cert_dir(),
-            self.cert_dir_source()
-        );
-        debug!(
-            "Config: ca_certs: {} (source: {:?})",
-            self.ca_certs(),
-            self.ca_certs_source()
-        );
-        debug!(
-            "Config: client_cert: {} (source: {:?})",
-            self.client_cert(),
-            self.client_cert_source()
-        );
-        debug!(
-            "Config: client_key: {} (source: {:?})",
-            self.client_key(),
-            self.client_key_source()
-        );
-        debug!(
-            "Config: server_cert: {} (source: {:?})",
-            self.server_cert(),
-            self.server_cert_source()
-        );
-        debug!(
-            "Config: server_key: {} (source: {:?})",
-            self.server_key(),
-            self.server_key_source()
-        );
+        if self.transport() == "tls" {
+            if insecure {
+                warn!("Starting TlsTransport in insecure mode");
+            } else {
+                debug!(
+                    "Config: ca_certs: {} (source: {:?})",
+                    self.ca_certs(),
+                    self.ca_certs_source()
+                );
+            }
+            debug!(
+                "Config: cert_dir: {} (source: {:?})",
+                self.cert_dir(),
+                self.cert_dir_source()
+            );
+            debug!(
+                "Config: client_cert: {} (source: {:?})",
+                self.client_cert(),
+                self.client_cert_source()
+            );
+            debug!(
+                "Config: client_key: {} (source: {:?})",
+                self.client_key(),
+                self.client_key_source()
+            );
+            debug!(
+                "Config: server_cert: {} (source: {:?})",
+                self.server_cert(),
+                self.server_cert_source()
+            );
+            debug!(
+                "Config: server_key: {} (source: {:?})",
+                self.server_key(),
+                self.server_key_source()
+            );
+        }
         debug!(
             "Config: service_endpoint: {} (source: {:?})",
             self.service_endpoint(),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -320,3 +320,539 @@ impl Config {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env;
+    use std::time::Duration;
+
+    use ::toml::{map::Map, to_string, Value};
+    use clap::ArgMatches;
+
+    use crate::config::{DefaultConfig, EnvVarConfig, TomlConfig};
+
+    /// Path to example config toml file.
+    static TEST_TOML: &str = "config_test.toml";
+
+    /// Values present in the example config TEST_TOML file.
+    static EXAMPLE_STORAGE: &str = "yaml";
+    static EXAMPLE_TRANSPORT: &str = "tls";
+    static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
+    static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
+    static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
+    static EXAMPLE_SERVER_CERT: &str = "certs/server.crt";
+    static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
+    static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
+    static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static EXAMPLE_NODE_ID: &str = "012";
+
+    static DEFAULT_CLIENT_CERT: &str = "client.crt";
+    static DEFAULT_CLIENT_KEY: &str = "private/client.key";
+    static DEFAULT_SERVER_CERT: &str = "server.crt";
+    static DEFAULT_SERVER_KEY: &str = "private/server.key";
+    static DEFAULT_CA_CERT: &str = "ca.pem";
+
+    /// Converts a list of tuples to a toml Table Value used to write a toml file.
+    pub fn get_toml_value() -> Value {
+        let values = vec![
+            ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
+            ("transport".to_string(), EXAMPLE_TRANSPORT.to_string()),
+            ("ca_certs".to_string(), EXAMPLE_CA_CERTS.to_string()),
+            ("client_cert".to_string(), EXAMPLE_CLIENT_CERT.to_string()),
+            ("client_key".to_string(), EXAMPLE_CLIENT_KEY.to_string()),
+            ("server_cert".to_string(), EXAMPLE_SERVER_CERT.to_string()),
+            ("server_key".to_string(), EXAMPLE_SERVER_KEY.to_string()),
+            (
+                "service_endpoint".to_string(),
+                EXAMPLE_SERVICE_ENDPOINT.to_string(),
+            ),
+            (
+                "network_endpoint".to_string(),
+                EXAMPLE_NETWORK_ENDPOINT.to_string(),
+            ),
+            ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
+        ];
+
+        let mut config_values = Map::new();
+        values.iter().for_each(|v| {
+            config_values.insert(v.0.clone(), Value::String(v.1.clone()));
+        });
+        Value::Table(config_values)
+    }
+
+    /// Creates an ArgMatches object to be used to construct a CommandLineConfig object.
+    fn create_arg_matches(args: Vec<&str>) -> ArgMatches<'static> {
+        clap_app!(configtest =>
+        (version: crate_version!())
+        (about: "Config-Test")
+        (@arg config: -c --config +takes_value)
+        (@arg node_id: --("node-id") +takes_value)
+        (@arg storage: --("storage") +takes_value)
+        (@arg transport: --("transport") +takes_value)
+        (@arg network_endpoint: -n --("network-endpoint") +takes_value)
+        (@arg service_endpoint: --("service-endpoint") +takes_value)
+        (@arg peers: --peer +takes_value +multiple)
+        (@arg ca_file: --("ca-file") +takes_value)
+        (@arg cert_dir: --("cert-dir") +takes_value)
+        (@arg client_cert: --("client-cert") +takes_value)
+        (@arg server_cert: --("server-cert") +takes_value)
+        (@arg server_key:  --("server-key") +takes_value)
+        (@arg client_key:  --("client-key") +takes_value)
+        (@arg bind: --("bind") +takes_value)
+        (@arg registry_backend: --("registry-backend") +takes_value)
+        (@arg registry_file: --("registry-file") +takes_value))
+        .get_matches_from(args)
+    }
+
+    #[test]
+    /// This test verifies that a finalized Config object constructed from just a DefaultConfig
+    /// object will be unsuccessful because of the missing values, in the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is created.
+    /// 2. A PartialConfig built from a DefaultConfig is added to the ConfigBuilder.
+    ///
+    /// This test then verifies the final Config object built from the ConfigBuilder object has
+    /// resulted in an error because of the missing values.
+    fn test_default_final_config_err() {
+        // Create a new ConfigBuilder object.
+        let mut builder = ConfigBuilder::new();
+        // Add a PartialConfig built from a DefaultConfig object to the ConfigBuilder.
+        builder = builder.with_partial_config(DefaultConfig::new().build());
+        // Build the final Config object.
+        let final_config = builder.build();
+        // Asserts the final Config was not successfully built.
+        assert!(final_config.is_err());
+    }
+
+    #[test]
+    /// This test verifies that a finalized Config object constructed from just a TomlConfig
+    /// object will be unsuccessful because of the missing values, in the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is created.
+    /// 2. The example config toml, TEST_TOML, is created, read and converted to a string.
+    /// 3. A TomlConfig object is constructed by passing in the toml string created in the previous
+    ///    step.
+    /// 4. The TomlConfig object is added to the ConfigBuilder.
+    ///
+    /// This test then verifies the final Config object built from the ConfigBuilder object has
+    /// resulted in an error because of the missing values.
+    fn test_final_config_toml_err() {
+        // Create a new ConfigBuilder object.
+        let mut builder = ConfigBuilder::new();
+        // Create an example toml string.
+        let toml_string = to_string(&get_toml_value()).expect("Could not encode TOML value");
+        // Create a TomlConfig object from the toml string.
+        let toml_builder = TomlConfig::new(toml_string, TEST_TOML.to_string())
+            .expect(&format!("Unable to create TomlConfig from: {}", TEST_TOML));
+        // Add a PartialConfig built from a DefaultConfig object to the ConfigBuilder.
+        builder = builder.with_partial_config(toml_builder.build());
+        // Build the final Config object.
+        let final_config = builder.build();
+        // Asserts the final Config was not successfully built.
+        assert!(final_config.is_err());
+    }
+
+    #[test]
+    /// This test verifies that a Config object, constructed from just a CommandLineConfig object,
+    /// is unsuccessful because of the missing values, in the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is created.
+    /// 2. An example ArgMatches object is created using `create_arg_matches`.
+    /// 3. A CommandLineConfig object is constructed by passing in the example ArgMatches created
+    ///    in the previous step.
+    /// 4. A PartialConfig built from the CommandLineConfig is added to the ConfigBuilder.
+    ///
+    /// This test then verifies the Config object built from the CommandLineConfig has resulted
+    /// in an error because of the missing values.
+    fn test_command_line_final_config_err() {
+        // Create a new ConfigBuilder object.
+        let mut builder = ConfigBuilder::new();
+        let args = vec![
+            "configtest",
+            "--node-id",
+            EXAMPLE_NODE_ID,
+            "--storage",
+            EXAMPLE_STORAGE,
+            "--transport",
+            EXAMPLE_TRANSPORT,
+            "--network-endpoint",
+            EXAMPLE_NETWORK_ENDPOINT,
+            "--service-endpoint",
+            EXAMPLE_SERVICE_ENDPOINT,
+            "--ca-file",
+            EXAMPLE_CA_CERTS,
+            "--client-cert",
+            EXAMPLE_CLIENT_CERT,
+            "--client-key",
+            EXAMPLE_CLIENT_KEY,
+            "--server-cert",
+            EXAMPLE_SERVER_CERT,
+            "--server-key",
+            EXAMPLE_SERVER_KEY,
+            "--registry-backend",
+            "FILE",
+            "--registry-file",
+            "/etc/splinter/test.yaml",
+        ];
+        // Create an example ArgMatches object to initialize the CommandLineConfig.
+        let matches = create_arg_matches(args);
+        // Create a new CommandLiine object from the arg matches.
+        let command_config = CommandLineConfig::new(matches)
+            .expect("Unable to create new CommandLineConfig object.");
+        // Add a PartialConfig built from a DefaultConfig object to the ConfigBuilder.
+        builder = builder.with_partial_config(command_config.build());
+        let final_config = builder.build();
+        // Assert the Config object was not successfully built.
+        assert!(final_config.is_err());
+    }
+
+    #[test]
+    /// This test verifies that a Config object, constructed from multiple config modules,
+    /// contains the correct values, giving CommandLineConfig values ultimate precedence,
+    /// using the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is created.
+    /// 2. A PartialConfig is created from the EnvVarConfig module.
+    /// 3. A PartialConfig is created from the DefaultConfig module.
+    /// 4. A PartialConfig is created from the TomlConfig module, using the TEST_TOML string.
+    /// 5. An example ArgMatches object is created using `create_arg_matches`.
+    /// 6. A CommandLineConfig object is constructed by passing in the example ArgMatches created
+    ///    in the previous step.
+    /// 7. All PartialConfig objects are added to the ConfigBuilder and the final Config object is
+    ///    built.
+    ///
+    /// This test then verifies the Config object built from the ConfigBuilder object by
+    /// asserting each expected value.
+    fn test_final_config_precedence() {
+        // Set the environment variables to populate the EnvVarConfig object.
+        env::set_var("SPLINTER_STATE_DIR", "/state/test/config/");
+        env::set_var("SPLINTER_CERT_DIR", "/cert/test/config/");
+        // Create a new ConfigBuilder object.
+        let builder = ConfigBuilder::new();
+        // Arguments to be used to create a CommandLineConfig object.
+        let args = vec![
+            "configtest",
+            "--node-id",
+            "123",
+            "--registry-file",
+            "/etc/splinter/test.yaml",
+        ];
+        // Create an example ArgMatches object to initialize the CommandLineConfig.
+        let matches = create_arg_matches(args);
+        // Create a new CommandLine object from the arg matches.
+        let command_config = CommandLineConfig::new(matches)
+            .expect("Unable to create new CommandLineConfig object.")
+            .build();
+
+        // Create an example toml string.
+        let toml_string = to_string(&get_toml_value()).expect("Could not encode TOML value");
+        // Create a TomlConfig object from the toml string.
+        let toml_config = TomlConfig::new(toml_string, TEST_TOML.to_string())
+            .expect(&format!("Unable to create TomlConfig from: {}", TEST_TOML))
+            .build();
+
+        // Create a PartialConfig from the EnvVarConfig module.
+        let env_config = EnvVarConfig::new().build();
+
+        // Create a PartialConfig from the DefaultConfig module.
+        let default_config = DefaultConfig::new().build();
+
+        // Add the PartialConfigs to the final ConfigBuilder in the order of precedence.
+        let final_config = builder
+            .with_partial_config(command_config)
+            .with_partial_config(toml_config)
+            .with_partial_config(env_config)
+            .with_partial_config(default_config)
+            .build()
+            .expect("Unable to build final Config.");
+
+        // Assert the final configuration values.
+        // Both the DefaultConfig and TomlConfig had values for `storage`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (final_config.storage(), final_config.storage_source()),
+            (
+                EXAMPLE_STORAGE,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `transport`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (final_config.transport(), final_config.transport_source()),
+            (
+                EXAMPLE_TRANSPORT,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // The DefaultConfig and EnvVarConfig had values for `cert_dir`, but the EnvVarConfig value
+        // should have precedence (source should be Environment).
+        assert_eq!(
+            (final_config.cert_dir(), final_config.cert_dir_source()),
+            ("/cert/test/config/", &ConfigSource::Environment)
+        );
+        // Both the DefaultConfig and TomlConfig had values for `ca_certs`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (final_config.ca_certs(), final_config.ca_certs_source()),
+            (
+                EXAMPLE_CA_CERTS,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                },
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `client_cert`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (
+                final_config.client_cert(),
+                final_config.client_cert_source()
+            ),
+            (
+                EXAMPLE_CLIENT_CERT,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `client_key`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (final_config.client_key(), final_config.client_key_source()),
+            (
+                EXAMPLE_CLIENT_KEY,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                },
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `server_cert`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (
+                final_config.server_cert(),
+                final_config.server_cert_source()
+            ),
+            (
+                EXAMPLE_SERVER_CERT,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `server_key`, but the TomlConfig
+        // value should have precedence (source should be Toml).
+        assert_eq!(
+            (final_config.server_key(), final_config.server_key_source()),
+            (
+                EXAMPLE_SERVER_KEY,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `service_endpoint`, but the
+        // TomlConfig value should have precedence (source should be Toml).
+        assert_eq!(
+            (
+                final_config.service_endpoint(),
+                final_config.service_endpoint_source()
+            ),
+            (
+                EXAMPLE_SERVICE_ENDPOINT,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // Both the DefaultConfig and TomlConfig had values for `network_endpoint`, but the
+        // TomlConfig value should have precedence (source should be Toml).
+        assert_eq!(
+            (
+                final_config.network_endpoint(),
+                final_config.network_endpoint_source()
+            ),
+            (
+                EXAMPLE_NETWORK_ENDPOINT,
+                &ConfigSource::Toml {
+                    file: TEST_TOML.to_string()
+                }
+            )
+        );
+        // The DefaultConfig is the only config with a value for `database` (source should be Default).
+        assert_eq!(
+            (final_config.peers(), final_config.peers_source()),
+            (&[] as &[String], &ConfigSource::Default,)
+        );
+        // Both the TomlConfig and CommandLineConfig had values for `node_id`, but the
+        // CommandLineConfig value should have precedence (source should be CommandLine).
+        assert_eq!(
+            (final_config.node_id(), final_config.node_id_source()),
+            ("123", &ConfigSource::CommandLine)
+        );
+        // The DefaultConfig is the only config with a value for `bind` (source should be Default).
+        assert_eq!(
+            (final_config.bind(), final_config.bind_source()),
+            ("127.0.0.1:8080", &ConfigSource::Default)
+        );
+        #[cfg(feature = "database")]
+        // The DefaultConfig is the only config with a value for `database` (source should be Default).
+        assert_eq!(
+            (final_config.database(), final_config.database_source()),
+            ("127.0.0.1:5432", &ConfigSource::Default)
+        );
+        // The DefaultConfig is the only config with a value for `registry_backend` (source should
+        // be Default).
+        assert_eq!(
+            (
+                final_config.registry_backend(),
+                final_config.registry_backend_source()
+            ),
+            ("FILE", &ConfigSource::Default)
+        );
+        // Both the DefaultConfig and CommandLineConfig had values for `registry_file`, but the
+        // CommandLineConfig value should have precedence (source should be CommandLine).
+        assert_eq!(
+            (
+                final_config.registry_file(),
+                final_config.registry_file_source()
+            ),
+            ("/etc/splinter/test.yaml", &ConfigSource::CommandLine,)
+        );
+        // The DefaultConfig is the only config with a value for `registry_backend` (source should
+        // be Default).
+        assert_eq!(
+            (
+                final_config.heartbeat_interval(),
+                final_config.heartbeat_interval_source()
+            ),
+            (30, &ConfigSource::Default)
+        );
+        // The DefaultConfig is the only config with a value for `registry_backend` (source should
+        // be Default).
+        assert_eq!(
+            (
+                final_config.admin_service_coordinator_timeout(),
+                final_config.admin_service_coordinator_timeout_source()
+            ),
+            (Duration::from_millis(30000), &ConfigSource::Default)
+        );
+        // Both the DefaultConfig and EnvVarConfig had values for `state_dir`, but the
+        // EnvVarConfig value should have precedence (source should be EnvVarConfig).
+        assert_eq!(
+            (final_config.state_dir(), final_config.state_dir_source()),
+            ("/state/test/config/", &ConfigSource::Environment)
+        );
+    }
+
+    #[test]
+    /// This test verifies that a Config object, created from a DefaultConfig and CommandLineConfig
+    /// object holds the correct file paths, using the following steps:
+    ///
+    /// 1. An empty ConfigBuilder object is created.
+    /// 2. A PartialConfig is created from the DefaultConfig module.
+    /// 3. An example ArgMatches object is created using `create_arg_matches`.
+    /// 4. A CommandLineConfig object is constructed by passing in the example ArgMatches created
+    ///    in the previous step.
+    /// 5. All PartialConfig objects are added to the ConfigBuilder and the final Config object is
+    ///    built.
+    ///
+    /// This test then verifies the Config object built holds the correct file paths. The cert_dir
+    /// value passed into the CommandLineConfig object should be appended to the default file names
+    /// for the certificate files.
+    fn test_final_config_file_paths() {
+        // Create a new ConfigBuilder object.
+        let builder = ConfigBuilder::new();
+        // Arguments to be used to create a CommandLineConfig object, passing in a cert_dir.
+        let args = vec![
+            "configtest",
+            "--node-id",
+            "123",
+            "--cert-dir",
+            "/my_files/",
+            "--registry-file",
+            "/etc/splinter/test.yaml",
+        ];
+        // Create an example ArgMatches object to initialize the CommandLineConfig.
+        let matches = create_arg_matches(args);
+        // Create a new CommandLine object from the arg matches.
+        let command_config = CommandLineConfig::new(matches)
+            .expect("Unable to create new CommandLineConfig object.")
+            .build();
+
+        // Create a PartialConfig from the DefaultConfig module.
+        let default_config = DefaultConfig::new().build();
+
+        // Add the PartialConfigs to the final ConfigBuilder in the order of precedence.
+        let final_config = builder
+            .with_partial_config(command_config)
+            .with_partial_config(default_config)
+            .build()
+            .expect("Unable to build final Config.");
+
+        // The DefaultConfig and EnvVarConfig had values for `cert_dir`, but the EnvVarConfig value
+        // should have precedence (source should be Environment).
+        assert_eq!(
+            (final_config.cert_dir(), final_config.cert_dir_source()),
+            ("/my_files/", &ConfigSource::CommandLine)
+        );
+        // The DefaultConfig had a value for the ca_certs, and since the cert_dir value was provided
+        // to the CommandLineConfig, the cert_dir value should be appended to the default file name.
+        assert_eq!(
+            (final_config.ca_certs(), final_config.ca_certs_source()),
+            (
+                format!("{}{}", "/my_files/", DEFAULT_CA_CERT).as_str(),
+                &ConfigSource::Default,
+            )
+        );
+        // The DefaultConfig had a value for the client_cert, and since the cert_dir value was provided
+        // to the CommandLineConfig, the cert_dir value should be appended to the default file name.
+        assert_eq!(
+            (
+                final_config.client_cert(),
+                final_config.client_cert_source()
+            ),
+            (
+                format!("{}{}", "/my_files/", DEFAULT_CLIENT_CERT).as_str(),
+                &ConfigSource::Default,
+            )
+        );
+        // The DefaultConfig had a value for the client_key, and since the cert_dir value was provided
+        // to the CommandLineConfig, the cert_dir value should be appended to the default file name.
+        assert_eq!(
+            (final_config.client_key(), final_config.client_key_source()),
+            (
+                format!("{}{}", "/my_files/", DEFAULT_CLIENT_KEY).as_str(),
+                &ConfigSource::Default,
+            )
+        );
+        // The DefaultConfig had a value for the server_cert, and since the cert_dir value was provided
+        // to the CommandLineConfig, the cert_dir value should be appended to the default file name.
+        assert_eq!(
+            (
+                final_config.server_cert(),
+                final_config.server_cert_source()
+            ),
+            (
+                format!("{}{}", "/my_files/", DEFAULT_SERVER_CERT).as_str(),
+                &ConfigSource::Default,
+            )
+        );
+        // The DefaultConfig had a value for the server_key, and since the cert_dir value was provided
+        // to the CommandLineConfig, the cert_dir value should be appended to the default file name.
+        assert_eq!(
+            (final_config.server_key(), final_config.server_key_source()),
+            (
+                format!("{}{}", "/my_files/", DEFAULT_SERVER_KEY).as_str(),
+                &ConfigSource::Default,
+            )
+        );
+    }
+}

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -115,12 +115,15 @@ pub fn from_file(mut f: File) -> Result<PartialConfig, ConfigError> {
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "config-toml"))]
     use std::fs;
 
-    /// Path to existing example config toml files from the top-level Splinterd directory.
-    static TEST_TOML: &str = "sample_configs/splinterd.toml.example";
+    use toml::{map::Map, Value};
 
-    /// Values present in the existing example config TEST_TOML file.
+    /// Path to an example config toml file.
+    static TEST_TOML: &str = "config_test.toml";
+
+    /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_TRANSPORT: &str = "tls";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
@@ -132,7 +135,42 @@ mod tests {
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
-    /// Asserts config values based on the TEST_TOML file values.
+    /// Converts a list of tuples to a toml Table Value used to write a toml file.
+    fn get_toml_value() -> Value {
+        let values = vec![
+            ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
+            ("transport".to_string(), EXAMPLE_TRANSPORT.to_string()),
+            ("ca_certs".to_string(), EXAMPLE_CA_CERTS.to_string()),
+            ("client_cert".to_string(), EXAMPLE_CLIENT_CERT.to_string()),
+            ("client_key".to_string(), EXAMPLE_CLIENT_KEY.to_string()),
+            ("server_cert".to_string(), EXAMPLE_SERVER_CERT.to_string()),
+            ("server_key".to_string(), EXAMPLE_SERVER_KEY.to_string()),
+            (
+                "service_endpoint".to_string(),
+                EXAMPLE_SERVICE_ENDPOINT.to_string(),
+            ),
+            (
+                "network_endpoint".to_string(),
+                EXAMPLE_NETWORK_ENDPOINT.to_string(),
+            ),
+            ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
+        ];
+
+        let mut config_values = Map::new();
+        values.iter().for_each(|v| {
+            config_values.insert(v.0.clone(), Value::String(v.1.clone()));
+        });
+        Value::Table(config_values)
+    }
+
+    #[cfg(not(feature = "config-toml"))]
+    /// Creates the example toml file used to populate a PartialConfig object.
+    fn create_toml_file() {
+        let toml_string = toml::to_string(&get_toml_value()).expect("Could not encode TOML value");
+        fs::write("config_test.toml", toml_string).expect("Could not write test toml file");
+    }
+
+    /// Asserts config values based on the example configuration values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
         assert_eq!(config.transport(), Some(EXAMPLE_TRANSPORT.to_string()));
@@ -150,7 +188,7 @@ mod tests {
             config.network_endpoint(),
             Some(EXAMPLE_NETWORK_ENDPOINT.to_string())
         );
-        assert_eq!(config.peers(), Some(vec![]));
+        assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
         assert_eq!(config.bind(), None);
         #[cfg(feature = "database")]
@@ -167,13 +205,15 @@ mod tests {
     /// PartialConfig module's `from_file` method, contains the correct values using the following
     /// steps:
     ///
-    /// 1. The example config toml file, TEST_TOML, is opened.
+    /// 1. An example config toml file, TEST_TOML, is created, and then opened.
     /// 2. A PartialConfig object is created by passing the opened file into the `from_file`
     ///    function defined in the PartialConfig module.
     ///
     /// This test then verifies the PartialConfig object built in step 2 contains the correct
-    /// values by asserting each expected value.
+    /// values by asserting each expected value. The TEST_TOML file is then removed.
     fn test_partial_config_from_file() {
+        // Create example toml file.
+        create_toml_file();
         // Opening the toml file using the TEST_TOML path
         let config_file =
             fs::File::open(TEST_TOML).expect(&format!("Unable to load {}", TEST_TOML));
@@ -182,14 +222,15 @@ mod tests {
         let generated_config = from_file(config_file).unwrap();
         // Compare the generated PartialConfig object against the expected values.
         assert_config_values(generated_config);
+        // Remove example file.
+        fs::remove_file(TEST_TOML).expect("Unable to remove test toml file");
     }
 
-    #[cfg(feature = "config-toml")]
     #[test]
     /// This test verifies that a PartialConfig object, constructed from the TomlConfig module,
     /// contains the correct values using the following steps:
     ///
-    /// 1. The example config toml file, TEST_TOML, is read and converted to a string.
+    /// 1. An example config toml is string is created.
     /// 2. A TomlConfig object is constructed by passing in the toml string created in the previous
     ///    step.
     /// 3. The TomlConfig object is transformed to a PartialConfig object using the `build` method.
@@ -197,9 +238,8 @@ mod tests {
     /// This test then verifies the PartialConfig object built from the TomlConfig object by
     /// asserting each expected value.
     fn test_toml_build() {
-        // Read the TEST_TOML example file to a string.
-        let toml_string =
-            fs::read_to_string(TEST_TOML).expect(&format!("Unable to load {}", TEST_TOML));
+        // Create an example toml string.
+        let toml_string = toml::to_string(&get_toml_value()).expect("Could not encode TOML value");
         // Create a TomlConfig object from the toml string.
         let toml_builder = TomlConfig::new(toml_string, TEST_TOML.to_string())
             .expect(&format!("Unable to create TomlConfig from: {}", TEST_TOML));

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -683,7 +683,7 @@ pub enum UserError {
     TransportError(GetTransportError),
     MissingArgument(String),
     InvalidArgument(String),
-
+    ConfigError(ConfigError),
     DaemonError {
         context: String,
         source: Option<Box<dyn Error>>,
@@ -712,6 +712,7 @@ impl Error for UserError {
             UserError::TransportError(err) => Some(err),
             UserError::MissingArgument(_) => None,
             UserError::InvalidArgument(_) => None,
+            UserError::ConfigError(err) => Some(err),
             UserError::DaemonError { source, .. } => {
                 if let Some(ref err) = source {
                     Some(&**err)
@@ -729,6 +730,9 @@ impl fmt::Display for UserError {
             UserError::TransportError(err) => write!(f, "unable to get transport: {}", err),
             UserError::MissingArgument(msg) => write!(f, "missing required argument: {}", msg),
             UserError::InvalidArgument(msg) => write!(f, "required argument is invalid: {}", msg),
+            UserError::ConfigError(msg) => {
+                write!(f, "error occurred building config object: {}", msg)
+            }
             UserError::DaemonError { context, source } => {
                 if let Some(ref err) = source {
                     write!(f, "{}: {}", context, err)
@@ -749,6 +753,12 @@ impl From<StartError> for UserError {
 impl From<GetTransportError> for UserError {
     fn from(error: GetTransportError) -> Self {
         UserError::TransportError(error)
+    }
+}
+
+impl From<ConfigError> for UserError {
+    fn from(error: ConfigError) -> Self {
+        UserError::ConfigError(error)
     }
 }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -31,9 +31,11 @@ use log::Record;
 
 #[cfg(feature = "generate-certs")]
 use crate::certs::{make_ca_cert, make_ca_signed_cert, write_file, CertError};
-use crate::config::{ConfigError, ConfigSource, PartialConfig};
-#[cfg(feature = "config-toml")]
-use crate::config::{PartialConfigBuilder, TomlConfig};
+use crate::config::ConfigError;
+use crate::config::{
+    CommandLineConfig, Config, ConfigBuilder, DefaultConfig, EnvVarConfig, PartialConfigBuilder,
+    TomlConfig,
+};
 use crate::daemon::{SplinterDaemonBuilder, StartError};
 use clap::{clap_app, crate_version};
 use clap::{Arg, ArgMatches};
@@ -49,77 +51,33 @@ use std::env;
 use std::error::Error;
 use std::fmt;
 use std::fs;
-#[cfg(not(feature = "config-toml"))]
-use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::thread;
-use std::time::Duration;
 
-const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
-const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
+fn create_config(toml_path: Option<&str>, matches: ArgMatches) -> Result<Config, UserError> {
+    let mut builder = ConfigBuilder::new();
 
-const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs/";
-const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
+    let command_line_config = CommandLineConfig::new(matches)
+        .map_err(UserError::ConfigError)?
+        .build();
+    builder = builder.with_partial_config(command_line_config);
 
-const CLIENT_CERT: &str = "client.crt";
-const CLIENT_KEY: &str = "private/client.key";
-const SERVER_CERT: &str = "server.crt";
-const SERVER_KEY: &str = "private/server.key";
-const CA_PEM: &str = "ca.pem";
-
-const HEARTBEAT_DEFAULT: u64 = 30;
-
-const DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS: u64 = 30000;
-
-#[cfg(not(feature = "config-toml"))]
-fn load_toml_config(config_file_path: &str) -> PartialConfig {
-    match File::open(config_file_path) {
-        Ok(f) => config::from_file(f),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            debug!("Configuration file not found: {}", config_file_path);
-            Ok(PartialConfig::new(ConfigSource::Toml {
-                file: config_file_path.to_string(),
-            }))
-        }
-        Err(err) => Err(ConfigError::from(err)),
+    if let Some(file) = toml_path {
+        let toml_string = fs::read_to_string(file).map_err(ConfigError::ReadError)?;
+        let toml_config = TomlConfig::new(toml_string, String::from(file))
+            .map_err(UserError::ConfigError)?
+            .build();
+        builder = builder.with_partial_config(toml_config);
     }
-    .unwrap_or_else(|err| {
-        warn!(
-            "Unable to load configuration file {}: {}",
-            config_file_path, err
-        );
-        Ok(PartialConfig::new(ConfigSource::Toml {
-            file: config_file_path.to_string(),
-        }))
-    })
-}
 
-#[cfg(feature = "config-toml")]
-fn load_toml_config(config_file_path: &str) -> PartialConfig {
-    match fs::read_to_string(config_file_path) {
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            debug!("Configuration file not found: {}", config_file_path);
-            PartialConfig::new(ConfigSource::Toml {
-                file: config_file_path.to_string(),
-            })
-        }
-        result => match result
-            .map_err(ConfigError::from)
-            .and_then(|res| TomlConfig::new(res, String::from(config_file_path)))
-        {
-            Ok(toml_config) => toml_config.build(),
-            Err(err) => {
-                warn!(
-                    "Unable to load configuration file {}: {}",
-                    config_file_path, err
-                );
-                PartialConfig::new(ConfigSource::Toml {
-                    file: config_file_path.to_string(),
-                })
-            }
-        },
-    }
+    let env_config = EnvVarConfig::new().build();
+    let default_config = DefaultConfig::new().build();
+    builder
+        .with_partial_config(env_config)
+        .with_partial_config(default_config)
+        .build()
+        .map_err(|e| UserError::MissingArgument(e.to_string()))
 }
 
 // format for logs
@@ -257,62 +215,35 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     debug!("Loading configuration file");
 
     // get provided config file or search default location
-    let config_file_path = matches
+    let config_file = matches
         .value_of("config")
         .unwrap_or("/etc/splinter/splinterd.toml");
 
-    let config = load_toml_config(config_file_path);
-
-    let node_id = matches
-        .value_of("node_id")
-        .map(String::from)
-        .or_else(|| config.node_id())
-        .ok_or_else(|| UserError::MissingArgument("node_id".into()))?;
-
-    let storage_type = matches
-        .value_of("storage")
-        .map(String::from)
-        .or_else(|| config.storage())
-        .unwrap_or_else(|| String::from("yaml"));
-
-    let transport_type = matches
-        .value_of("transport")
-        .map(String::from)
-        .or_else(|| config.transport())
-        .unwrap_or_else(|| String::from("raw"));
-
-    let service_endpoint = matches
-        .value_of("service_endpoint")
-        .map(String::from)
-        .or_else(|| config.service_endpoint())
-        .unwrap_or_else(|| "127.0.0.1:8043".to_string());
-
-    let network_endpoint = matches
-        .value_of("network_endpoint")
-        .map(String::from)
-        .or_else(|| config.network_endpoint())
-        .unwrap_or_else(|| "127.0.0.1:8044".to_string());
-
-    let initial_peers = matches
-        .values_of("peers")
-        .map(|values| values.map(String::from).collect::<Vec<String>>())
-        .or_else(|| config.peers())
-        .unwrap_or_default();
-
-    let heartbeat_interval = value_t!(matches.value_of("heartbeat_interval"), u64)
-        .unwrap_or_else(|_| config.heartbeat_interval().unwrap_or(HEARTBEAT_DEFAULT));
-
-    let (transport, transport_log) = get_transport(&transport_type, &matches, &config)?;
-
-    let location = {
-        if let Ok(s) = env::var(STATE_DIR_ENV) {
-            s
-        } else if let Some(s) = config.state_dir() {
-            s
-        } else {
-            DEFAULT_STATE_DIR.to_string()
-        }
+    let config_file_path = if Path::new(&config_file).is_file() {
+        Some(config_file)
+    } else {
+        None
     };
+
+    let final_config = create_config(config_file_path, matches.clone())?;
+
+    let node_id = final_config.node_id();
+
+    let storage_type = final_config.storage();
+
+    let transport_type = final_config.transport();
+
+    let service_endpoint = final_config.service_endpoint();
+
+    let network_endpoint = final_config.network_endpoint();
+
+    let initial_peers = final_config.peers();
+
+    let heartbeat_interval = final_config.heartbeat_interval();
+
+    let (transport, insecure) = get_transport(&transport_type, &matches, &final_config)?;
+
+    let location = final_config.state_dir();
 
     let storage_location = match &storage_type as &str {
         "yaml" => format!("{}{}", location, "circuits.yaml"),
@@ -336,95 +267,45 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         }
     };
 
-    let rest_api_endpoint = matches
-        .value_of("bind")
-        .map(String::from)
-        .or_else(|| config.bind())
-        .unwrap_or_else(|| "127.0.0.1:8080".to_string());
+    let rest_api_endpoint = final_config.bind();
 
     #[cfg(feature = "database")]
-    let db_url = matches
-        .value_of("database")
-        .map(String::from)
-        .or_else(|| config.database());
+    let db_url = final_config.database();
 
     #[cfg(feature = "biome")]
     let biome_enabled: bool = matches.is_present("biome_enabled");
 
-    let registry_backend = matches
-        .value_of("registry_backend")
-        .map(String::from)
-        .or_else(|| config.registry_backend());
+    let registry_backend = final_config.registry_backend();
 
-    let registry_file = matches
-        .value_of("registry_file")
-        .map(String::from)
-        .or_else(|| config.registry_file());
-
+    #[cfg(feature = "experimental")]
     // Allow unused mut for experimental features
     #[allow(unused_mut)]
     let mut feature_fields = "".to_string();
 
-    #[cfg(feature = "database")]
-    {
-        feature_fields = format!("{}, db_url: {:?}", feature_fields, db_url);
-    }
+    let admin_service_coordinator_timeout = final_config.admin_service_coordinator_timeout();
 
     #[cfg(feature = "biome")]
     {
-        feature_fields = format!("{}, biome_enabled: {}", feature_fields, biome_enabled);
+        debug!("{}, biome_enabled: {}", feature_fields, biome_enabled);
     }
 
-    let admin_service_coordinator_timeout = matches
-        .value_of("admin_service_coordinator_timeout")
-        .map(&str::parse::<u64>)
-        .transpose()
-        .map_err(|err| {
-            UserError::InvalidArgument(format!(
-                "admin service coordinator timeout is not a valid integer: {}",
-                err
-            ))
-        })?
-        .map(Duration::from_millis)
-        .or_else(|| config.admin_service_coordinator_timeout())
-        .unwrap_or_else(|| Duration::from_millis(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS));
-
-    debug!(
-        "Configuration: {{ storage_type: {}, storage_location: {}, key_registry_location: {}, {}, \
-         service_endpoint: {}, network_endpoint: {}, initial_peers: {:?}, node_id: {}, \
-         rest_api_endpoint: {}, registry_backend: {:?}, registry_file: {:?}, \
-         heartbeat_interval: {}{} }}",
-        storage_type,
-        storage_location,
-        key_registry_location,
-        transport_log,
-        service_endpoint,
-        network_endpoint,
-        initial_peers,
-        node_id,
-        rest_api_endpoint,
-        registry_backend,
-        registry_file,
-        heartbeat_interval,
-        feature_fields,
-    );
+    final_config.log_as_debug(insecure);
 
     let mut daemon_builder = SplinterDaemonBuilder::new()
         .with_storage_location(storage_location)
         .with_key_registry_location(key_registry_location)
-        .with_network_endpoint(network_endpoint)
-        .with_service_endpoint(service_endpoint)
-        .with_initial_peers(initial_peers)
-        .with_node_id(node_id)
-        .with_rest_api_endpoint(rest_api_endpoint)
-        .with_registry_backend(registry_backend)
-        .with_storage_type(storage_type)
+        .with_network_endpoint(String::from(network_endpoint))
+        .with_service_endpoint(String::from(service_endpoint))
+        .with_initial_peers(initial_peers.to_vec())
+        .with_node_id(String::from(node_id))
+        .with_rest_api_endpoint(String::from(rest_api_endpoint))
+        .with_storage_type(String::from(storage_type))
         .with_heartbeat_interval(heartbeat_interval)
         .with_admin_service_coordinator_timeout(admin_service_coordinator_timeout);
 
     #[cfg(feature = "database")]
     {
-        daemon_builder = daemon_builder.with_db_url(db_url);
+        daemon_builder = daemon_builder.with_db_url(Some(String::from(db_url)));
     }
 
     #[cfg(feature = "biome")]
@@ -432,8 +313,12 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         daemon_builder = daemon_builder.enable_biome(biome_enabled);
     }
 
-    if let Some(registry_file) = registry_file {
-        daemon_builder = daemon_builder.with_registry_file(registry_file);
+    if Path::new(&final_config.registry_file()).is_file() && registry_backend == "FILE" {
+        daemon_builder = daemon_builder
+            .with_registry_backend(Some(String::from(registry_backend)))
+            .with_registry_file(String::from(final_config.registry_file()));
+    } else {
+        daemon_builder = daemon_builder.with_registry_backend(None);
     }
 
     let mut node = daemon_builder.build().map_err(|err| {
@@ -446,8 +331,8 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 fn get_transport(
     transport_type: &str,
     matches: &clap::ArgMatches,
-    config: &PartialConfig,
-) -> Result<(Box<dyn Transport + Send>, String), GetTransportError> {
+    config: &Config,
+) -> Result<(Box<dyn Transport + Send>, bool), GetTransportError> {
     match transport_type {
         "tls" => {
             #[cfg(feature = "generate-certs")]
@@ -497,12 +382,6 @@ fn get_transport(
                         &server_key.private_key_to_pem_pkcs8()?,
                     )?;
 
-                    warn!("Starting TlsTransport in insecure mode");
-
-                    let log_value = "ca_certs: generated, client_cert: generated, client_key: \
-                                     generated, server_cert: generated, server_key: generated"
-                        .to_string();
-
                     // Start transport in insecure mode, do not verify the certs if auto generated,
                     // as the ca will not match
                     let transport = TlsTransport::new(
@@ -513,164 +392,75 @@ fn get_transport(
                         server_cert,
                     )?;
 
-                    return Ok((Box::new(transport), log_value));
+                    return Ok((Box::new(transport), true));
                 }
             }
 
-            let cert_location = {
-                if let Ok(s) = env::var(CERT_DIR_ENV) {
-                    s
-                } else {
-                    DEFAULT_CERT_DIR.to_string()
-                }
-            };
-
-            let cert_dir = matches
-                .value_of("cert_dir")
-                .map(String::from)
-                .or_else(|| config.cert_dir())
-                .unwrap_or(cert_location);
-
-            let client_cert = matches
-                .value_of("client_cert")
-                .map(String::from)
-                .or_else(|| config.client_cert())
-                .or_else(|| {
-                    let cert_dir_path = Path::new(&cert_dir);
-                    let client_cert = cert_dir_path.join(CLIENT_CERT);
-                    if !client_cert.is_file() {
-                        error!("Client cert file not found: {:?}", client_cert);
-                        return None;
-                    }
-                    let client_cert: Option<String> = client_cert.to_str().map(ToOwned::to_owned);
+            let client_cert = config.client_cert();
+            if !Path::new(&client_cert).is_file() {
+                return Err(GetTransportError::CertError(format!(
+                    "Must provide a valid client certificate: {}",
                     client_cert
-                })
-                .ok_or_else(|| {
-                    GetTransportError::CertError("must provide a valid client certificate".into())
-                })?;
+                )));
+            }
 
-            let server_cert = matches
-                .value_of("server_cert")
-                .map(String::from)
-                .or_else(|| config.server_cert())
-                .or_else(|| {
-                    let cert_dir_path = Path::new(&cert_dir);
-                    let server_cert = cert_dir_path.join(SERVER_CERT);
-                    if !server_cert.is_file() {
-                        error!("Server cert file not found: {:?}", server_cert);
-                        return None;
-                    }
-                    let server_cert: Option<String> = server_cert.to_str().map(ToOwned::to_owned);
+            let server_cert = config.server_cert();
+            if !Path::new(&server_cert).is_file() {
+                return Err(GetTransportError::CertError(format!(
+                    "Must provide a valid server certificate: {}",
                     server_cert
-                })
-                .ok_or_else(|| {
-                    GetTransportError::CertError("must provide a valid server certificate".into())
-                })?;
+                )));
+            }
 
-            let server_key_file = matches
-                .value_of("server_key")
-                .map(String::from)
-                .or_else(|| config.server_key())
-                .or_else(|| {
-                    let cert_dir_path = Path::new(&cert_dir);
-                    let server_key = cert_dir_path.join(SERVER_KEY);
-                    if !server_key.is_file() {
-                        error!("Server key file not found: {:?}", server_key);
-                        return None;
-                    }
-                    let server_key: Option<String> = server_key.to_str().map(ToOwned::to_owned);
-                    server_key
-                })
-                .ok_or_else(|| {
-                    GetTransportError::CertError("must provide a valid server key path".into())
-                })?;
+            let server_key_file = config.server_key();
+            if !Path::new(&server_key_file).is_file() {
+                return Err(GetTransportError::CertError(format!(
+                    "Must provide a valid server key path: {}",
+                    server_key_file
+                )));
+            }
 
-            let client_key_file = matches
-                .value_of("client_key")
-                .map(String::from)
-                .or_else(|| config.client_key())
-                .or_else(|| {
-                    let cert_dir_path = Path::new(&cert_dir);
-                    let client_key = cert_dir_path.join(CLIENT_KEY);
-                    if !client_key.is_file() {
-                        error!("Client key file not found: {:?}", client_key);
-                        return None;
-                    }
-                    let client_key: Option<String> = client_key.to_str().map(ToOwned::to_owned);
-                    client_key
-                })
-                .ok_or_else(|| {
-                    GetTransportError::CertError("must provide a valid client key path".into())
-                })?;
+            let client_key_file = config.client_key();
+            if !Path::new(&client_key_file).is_file() {
+                return Err(GetTransportError::CertError(format!(
+                    "Must provide a valid client key path: {}",
+                    client_key_file
+                )));
+            }
 
             let ca_file = {
                 if matches.is_present("insecure") {
-                    warn!("Starting TlsTransport in insecure mode");
                     None
                 } else {
-                    let ca_file = matches
-                        .value_of("ca_file")
-                        .map(String::from)
-                        .or_else(|| config.ca_certs())
-                        .or_else(|| {
-                            let cert_dir_path = Path::new(&cert_dir);
-                            let ca_path = cert_dir_path.join(CA_PEM);
-                            if !ca_path.is_file() {
-                                error!("CA file not found: {:?}", ca_path);
-                                return None;
-                            }
-                            let ca_file: Option<String> =
-                                cert_dir_path.join(CA_PEM).to_str().map(ToOwned::to_owned);
+                    let ca_file = config.ca_certs();
+                    if !Path::new(&ca_file).is_file() {
+                        return Err(GetTransportError::CertError(format!(
+                            "Must provide a valid file containing ca certs: {}",
                             ca_file
-                        })
-                        .ok_or_else(|| {
-                            GetTransportError::CertError(
-                                "must provide a valid file containing ca certs".into(),
-                            )
-                        })?;
-                    Some(ca_file)
-                }
-            };
-
-            let ca_file_log = {
-                if let Some(ca_file) = &ca_file {
+                        )));
+                    }
                     match fs::canonicalize(&ca_file)?.to_str() {
-                        Some(ca_path) => ca_path.to_string(),
+                        Some(ca_path) => Some(ca_path.to_string()),
                         None => {
                             return Err(GetTransportError::CertError(
                                 "CA path is not a valid path".to_string(),
                             ))
                         }
                     }
-                } else {
-                    "insecure".to_string()
                 }
             };
 
-            let log_value = format!(
-                "transport_type: tls, ca_certs: {:?}, client_cert: {:?}, \
-                 client_key: {:?}, server_cert: {:?}, server_key: {:?}",
-                ca_file_log,
-                fs::canonicalize(client_cert.clone())?,
-                fs::canonicalize(client_key_file.clone())?,
-                fs::canonicalize(server_cert.clone())?,
-                fs::canonicalize(server_key_file.clone())?,
-            );
-
             let transport = TlsTransport::new(
-                ca_file,
-                client_key_file,
-                client_cert,
-                server_key_file,
-                server_cert,
+                ca_file.map(String::from),
+                String::from(client_key_file),
+                String::from(client_cert),
+                String::from(server_key_file),
+                String::from(server_cert),
             )?;
 
-            Ok((Box::new(transport), log_value))
+            Ok((Box::new(transport), false))
         }
-        "raw" => Ok((
-            Box::new(RawTransport::default()),
-            "transport_type: raw".to_string(),
-        )),
+        "raw" => Ok((Box::new(RawTransport::default()), true)),
         _ => Err(GetTransportError::NotSupportedError(format!(
             "Transport type {} is not supported",
             transport_type

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -64,7 +64,10 @@ fn create_config(toml_path: Option<&str>, matches: ArgMatches) -> Result<Config,
     builder = builder.with_partial_config(command_line_config);
 
     if let Some(file) = toml_path {
-        let toml_string = fs::read_to_string(file).map_err(ConfigError::ReadError)?;
+        let toml_string = fs::read_to_string(file).map_err(|err| ConfigError::ReadError {
+            file: String::from(file),
+            err,
+        })?;
         let toml_config = TomlConfig::new(toml_string, String::from(file))
             .map_err(UserError::ConfigError)?
             .build();


### PR DESCRIPTION
Adds the final Config and ConfigBuilder, as well as tests and supporting changes for these. Also incorporates the Config object into the main of splinterd. The previous config object being used here had optional values, whereas this Config object does not. 

Also adds a `ConfigSource` to support displaying the location a configuration variable was sourced. 