### PR TITLE
Fix unused biome protocol min consts

### DIFF
--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -44,14 +44,14 @@ pub(crate) const SCABBARD_LIST_STATE_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "biome")]
 pub const BIOME_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
 pub(crate) const BIOME_REGISTER_PROTOCOL_MIN: u32 = 1;
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
 pub(crate) const BIOME_LOGIN_PROTOCOL_MIN: u32 = 1;
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
 pub(crate) const BIOME_USER_PROTOCOL_MIN: u32 = 1;
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
 pub(crate) const BIOME_LIST_USERS_PROTOCOL_MIN: u32 = 1;
 
-#[cfg(feature = "biome-key-management")]
+#[cfg(all(feature = "biome-key-management", feature = "rest-api"))]
 pub(crate) const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;


### PR DESCRIPTION
Add the requirement that the biome protocol min variables are only
available when the "rest-api" features is active.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>