### PR TITLE
Set the log level for low level crates to Warn

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -438,6 +438,10 @@ fn run() -> Result<(), CliError> {
 
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);
+    log_spec_builder.module("reqwest", log::LevelFilter::Warn);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("mio", log::LevelFilter::Warn);
+    log_spec_builder.module("want", log::LevelFilter::Warn);
 
     Logger::with(log_spec_builder.build())
         .format(log_format)


### PR DESCRIPTION
All of the modules set where seen when providing -vv.
These messages are not useful to see on the cli, unless
something goes wrong.

Example of the log messages that were being printed before:

```
(ThreadId(1)) park without timeout
registering; token=Token(18446744073709551615); interests=Readable
registering with poller
(ThreadId(2)) start runtime::block_on
wait at most 30s
(ThreadId(1)) park timeout 29.999992405s
checkout waiting for idle connection: "http://127.0.0.1:8080"
Http::connect; scheme=Some("http"), host=Some("127.0.0.1"), port=Some(Port(8080))
connecting to 127.0.0.1:8080
registering with poller
registering; token=Token(0); interests=Readable | Writable | Error | Hup
connected to Some(V4(127.0.0.1:8080))
client handshake HTTP/1
handshake complete, spawning background dispatcher task
signal: Want
signal found waiting giver, notifying
flushed({role=client}): State { reading: Init, writing: Init, keep_alive: Busy }
poll_want: taker wants!
checkout dropped for "http://127.0.0.1:8080"
Client::encode method=GET, body=None
detected no usage of vectored write, flattening
flushed 94 bytes
```