### PR TITLE
Scabbard batch status wait fix

### DIFF
--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -67,6 +67,7 @@ impl ServiceFactory for ScabbardFactory {
     ///   formatted as a serialized JSON array of strings
     /// - `peer_services`: list of other scabbard services on the same circuit that this service
     ///   will share state with
+    ///
     /// `args` may include the following optional entries:
     /// - `coordinator_timeout`: the length of time (in milliseconds) that the network has to
     ///   commit a proposal before the coordinator rejects it (if not provided, default is 30

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -186,11 +186,7 @@ impl Scabbard {
 
     pub fn get_batch_info(&self, ids: &[String]) -> Result<Vec<BatchInfo>, ScabbardError> {
         let mut state = self.state.lock().map_err(|_| ScabbardError::LockPoisoned)?;
-
-        Ok(ids
-            .iter()
-            .map(|signature| state.batch_history().get_batch_info(signature))
-            .collect::<Vec<_>>())
+        Ok(state.batch_history().get_batch_info(ids))
     }
 
     pub fn get_events_since(&self, event_id: Option<String>) -> Result<Events, ScabbardError> {

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -53,7 +53,7 @@ pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
 #[cfg(feature = "scabbard-get-state")]
 use state::StateIter;
-pub use state::{BatchInfo, BatchStatus, Events, StateChange, StateChangeEvent};
+pub use state::{BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent};
 use state::{ScabbardState, StateSubscriber};
 
 const SERVICE_TYPE: &str = "scabbard";
@@ -184,9 +184,23 @@ impl Scabbard {
         }
     }
 
-    pub fn get_batch_info(&self, ids: &[String]) -> Result<Vec<BatchInfo>, ScabbardError> {
+    /// Get the `BatchInfo` for each specified batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `ids`: List of batch IDs to get info on
+    /// * `wait`: If `Some`, wait up to the given time for all requested batches to complete
+    ///   (statuses will be either `Committed` or `Invalid`); if the timeout expires, an `Err`
+    ///   result will be given by the returned iterator. If `None`, return the `BatchInfo`s to
+    ///   complete.
+    ///
+    pub fn get_batch_info(
+        &self,
+        ids: HashSet<String>,
+        wait: Option<Duration>,
+    ) -> Result<BatchInfoIter, ScabbardError> {
         let mut state = self.state.lock().map_err(|_| ScabbardError::LockPoisoned)?;
-        Ok(state.batch_history().get_batch_info(ids))
+        Ok(state.batch_history().get_batch_info(ids, wait)?)
     }
 
     pub fn get_events_since(&self, event_id: Option<String>) -> Result<Events, ScabbardError> {

--- a/libsplinter/src/service/scabbard/rest_api.rs
+++ b/libsplinter/src/service/scabbard/rest_api.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use transact::protocol::batch::BatchPair;
 use transact::protos::FromBytes;
@@ -30,11 +28,10 @@ use crate::rest_api::{
 use crate::service::rest_api::ServiceEndpoint;
 
 use super::error::StateSubscriberError;
-use super::state::{BatchInfo, BatchStatus, StateChangeEvent, StateSubscriber};
+use super::state::{StateChangeEvent, StateSubscriber};
 use super::{Scabbard, SERVICE_TYPE};
 
 const DEFAULT_BATCH_STATUS_WAIT_SECS: u64 = 300;
-const BATCH_STATUS_RETRY_INTERVAL_MILLIS: u64 = 1000;
 
 struct WsStateSubscriber {
     sender: EventSender<StateChangeEvent>,
@@ -247,7 +244,7 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 };
 
             let ids = if let Some(ids) = query.get("ids") {
-                ids.split(',').map(String::from).collect::<Vec<_>>()
+                ids.split(',').map(String::from).collect()
             } else {
                 return Box::new(
                     HttpResponse::BadRequest()
@@ -272,33 +269,28 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 })
                 .map(Duration::from_secs);
 
-            let timeout = match wait {
-                Some(wait_time) => match Instant::now().checked_add(wait_time) {
-                    Some(t) => Some(t),
-                    None => {
-                        error!("Failed to determine wait time");
-                        return Box::new(
-                            HttpResponse::InternalServerError()
-                                .json(json!({
-                                    "message": "An internal error occurred"
-                                }))
-                                .into_future(),
-                        );
-                    }
-                },
-                None => None,
-            };
-
-            match get_statuses(&scabbard, &ids, timeout) {
-                Ok(statuses) => Box::new(HttpResponse::Ok().json(statuses).into_future()),
+            let batch_info_iter = match scabbard.get_batch_info(ids, wait) {
+                Ok(iter) => iter,
                 Err(err) => {
-                    error!("Failed to get batch statuses: {}", err);
-                    Box::new(
+                    error!("Failed to get batch statuses iterator: {}", err);
+                    return Box::new(
                         HttpResponse::InternalServerError()
                             .json(json!({ "message": "An internal error occurred" }))
                             .into_future(),
-                    )
+                    );
                 }
+            };
+
+            match batch_info_iter.collect::<Result<Vec<_>, _>>() {
+                Ok(batch_infos) => Box::new(HttpResponse::Ok().json(batch_infos).into_future()),
+                Err(err) => Box::new(
+                    HttpResponse::RequestTimeout()
+                        .json(json!({
+                            "message":
+                                format!("Failed to get batch statuses before timeout: {}", err)
+                        }))
+                        .into_future(),
+                ),
             }
         }),
         request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
@@ -433,33 +425,4 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],
     }
-}
-
-fn get_statuses(
-    scabbard: &Scabbard,
-    ids: &[String],
-    timeout: Option<Instant>,
-) -> Result<Vec<BatchInfo>, String> {
-    let batch_infos = scabbard
-        .get_batch_info(ids)
-        .map_err(|err| err.to_string())?;
-
-    if batch_infos
-        .iter()
-        .any(|info| info.status == BatchStatus::Pending)
-    {
-        if let Some(timeout) = timeout {
-            let now = Instant::now();
-            if now < timeout {
-                let normal_wait = Duration::from_millis(BATCH_STATUS_RETRY_INTERVAL_MILLIS);
-                let time_remaining = timeout - now;
-                sleep(min(normal_wait, time_remaining));
-                return get_statuses(scabbard, ids, Some(timeout));
-            } else {
-                return Err("batch(es) still pending after wait time expired".into());
-            }
-        }
-    }
-
-    Ok(batch_infos)
 }

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -52,12 +52,10 @@ use crate::protos::scabbard::{Setting, Setting_Entry};
 use super::error::{ScabbardStateError, StateSubscriberError};
 
 const EXECUTION_TIMEOUT: u64 = 300; // five minutes
-
 const CURRENT_STATE_ROOT_INDEX: &str = "current_state_root";
-
 const ITER_CACHE_SIZE: usize = 64;
-
 const COMPLETED_BATCH_INFO_ITER_RETRY_MILLIS: u64 = 100;
+const DEFAULT_BATCH_HISTORY_SIZE: usize = 100;
 
 #[cfg(feature = "scabbard-get-state")]
 pub type StateIter = dyn Iterator<Item = Result<(String, Vec<u8>), ScabbardStateError>>;
@@ -752,7 +750,7 @@ impl Default for BatchHistory {
     fn default() -> Self {
         Self {
             history: HashMap::new(),
-            limit: 100,
+            limit: DEFAULT_BATCH_HISTORY_SIZE,
             batch_subscribers: vec![],
         }
     }

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -628,16 +628,21 @@ impl BatchHistory {
         }
     }
 
-    pub fn get_batch_info(&self, signature: &str) -> BatchInfo {
-        if let Some(info) = self.history.get(signature) {
-            info.clone()
-        } else {
-            BatchInfo {
-                id: signature.to_string(),
-                status: BatchStatus::Unknown,
-                timestamp: SystemTime::now(),
-            }
-        }
+    pub fn get_batch_info(&self, signatures: &[String]) -> Vec<BatchInfo> {
+        signatures
+            .iter()
+            .map(|signature| {
+                if let Some(info) = self.history.get(signature) {
+                    info.clone()
+                } else {
+                    BatchInfo {
+                        id: signature.to_string(),
+                        status: BatchStatus::Unknown,
+                        timestamp: SystemTime::now(),
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
     }
 }
 

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, RwLock};
-use std::{fmt, path::Path, time::SystemTime};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{
+    mpsc::{channel, Receiver, RecvTimeoutError, Sender},
+    Arc, RwLock,
+};
+use std::time::{Duration, Instant, SystemTime};
+use std::{fmt, path::Path};
 
 use protobuf::Message;
 use sawtooth::store::lmdb::LmdbOrderedStore;
@@ -52,6 +56,8 @@ const EXECUTION_TIMEOUT: u64 = 300; // five minutes
 const CURRENT_STATE_ROOT_INDEX: &str = "current_state_root";
 
 const ITER_CACHE_SIZE: usize = 64;
+
+const COMPLETED_BATCH_INFO_ITER_RETRY_MILLIS: u64 = 100;
 
 #[cfg(feature = "scabbard-get-state")]
 pub type StateIter = dyn Iterator<Item = Result<(String, Vec<u8>), ScabbardStateError>>;
@@ -219,7 +225,7 @@ impl ScabbardState {
 
         // Get the results and shutdown the scheduler
         let batch_result = result_rx
-            .recv_timeout(std::time::Duration::from_secs(EXECUTION_TIMEOUT))
+            .recv_timeout(Duration::from_secs(EXECUTION_TIMEOUT))
             .map_err(|_| ScabbardStateError("failed to receive result in reasonable time".into()))?
             .ok_or_else(|| ScabbardStateError("no result returned from executor".into()))?;
 
@@ -581,6 +587,7 @@ impl BatchInfo {
 pub struct BatchHistory {
     history: HashMap<String, BatchInfo>,
     limit: usize,
+    batch_subscribers: Vec<(HashSet<String>, Sender<BatchInfo>)>,
 }
 
 impl BatchHistory {
@@ -608,21 +615,33 @@ impl BatchHistory {
     }
 
     fn update_batch_status(&mut self, signature: &str, status: BatchStatus) {
-        match self.history.get_mut(signature) {
+        let updated_batch_info = match self.history.get_mut(signature) {
             Some(info) if info.status == BatchStatus::Pending => {
                 info.set_status(status);
+                Some(info.clone())
             }
             Some(_) => {
                 debug!(
                     "Received status update for batch that was not pending: {:?}",
                     signature
                 );
+                None
             }
             None => {
                 debug!(
                     "Received status update for batch that is not in the history: {:?}",
                     signature
                 );
+                None
+            }
+        };
+
+        if let Some(info) = updated_batch_info {
+            match info.status {
+                BatchStatus::Invalid(_) | BatchStatus::Valid(_) => {
+                    self.send_completed_batch_info_to_subscribers(info)
+                }
+                _ => {}
             }
         }
     }
@@ -649,21 +668,83 @@ impl BatchHistory {
         }
     }
 
-    pub fn get_batch_info(&self, signatures: &[String]) -> Vec<BatchInfo> {
-        signatures
-            .iter()
-            .map(|signature| {
-                if let Some(info) = self.history.get(signature) {
-                    info.clone()
-                } else {
-                    BatchInfo {
-                        id: signature.to_string(),
-                        status: BatchStatus::Unknown,
-                        timestamp: SystemTime::now(),
+    pub fn get_batch_info(
+        &mut self,
+        ids: HashSet<String>,
+        wait: Option<Duration>,
+    ) -> Result<BatchInfoIter, ScabbardStateError> {
+        match wait {
+            Some(timeout) => self.completed_batch_info_iter(ids, timeout),
+            None => Ok(self.no_wait_batch_info_iter(&ids)),
+        }
+    }
+
+    fn no_wait_batch_info_iter(&self, ids: &HashSet<String>) -> BatchInfoIter {
+        Box::new(
+            ids.iter()
+                .map(|id| {
+                    Ok(if let Some(info) = self.history.get(id) {
+                        info.clone()
+                    } else {
+                        BatchInfo {
+                            id: id.to_string(),
+                            status: BatchStatus::Unknown,
+                            timestamp: SystemTime::now(),
+                        }
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter(),
+        )
+    }
+
+    fn completed_batch_info_iter(
+        &mut self,
+        mut ids: HashSet<String>,
+        timeout: Duration,
+    ) -> Result<BatchInfoIter, ScabbardStateError> {
+        // Get batches that are already completed
+        let iter = self
+            .no_wait_batch_info_iter(&ids)
+            .filter_map(|res| {
+                let info = res.ok()?;
+                match info.status {
+                    BatchStatus::Invalid(_) | BatchStatus::Committed(_) => {
+                        ids.remove(&info.id);
+                        Some(Ok(info))
                     }
+                    _ => None,
                 }
             })
             .collect::<Vec<_>>()
+            .into_iter();
+
+        let (sender, receiver) = channel();
+
+        self.batch_subscribers.push((ids.clone(), sender));
+
+        Ok(Box::new(
+            iter.chain(ChannelBatchInfoIter::new(receiver, timeout, ids)?),
+        ))
+    }
+
+    fn send_completed_batch_info_to_subscribers(&mut self, info: BatchInfo) {
+        self.batch_subscribers = self
+            .batch_subscribers
+            .drain(..)
+            .filter_map(|(mut pending_signatures, sender)| {
+                if pending_signatures.remove(&info.id) && sender.send(info.clone()).is_err() {
+                    // Receiver has been dropped
+                    return None;
+                }
+
+                if pending_signatures.is_empty() {
+                    None
+                } else {
+                    Some((pending_signatures, sender))
+                }
+            })
+            .collect();
     }
 }
 
@@ -672,6 +753,64 @@ impl Default for BatchHistory {
         Self {
             history: HashMap::new(),
             limit: 100,
+            batch_subscribers: vec![],
+        }
+    }
+}
+
+pub type BatchInfoIter = Box<dyn Iterator<Item = Result<BatchInfo, String>>>;
+
+pub struct ChannelBatchInfoIter {
+    receiver: Receiver<BatchInfo>,
+    retry_interval: Duration,
+    timeout: Instant,
+    pending_ids: HashSet<String>,
+}
+
+impl ChannelBatchInfoIter {
+    fn new(
+        receiver: Receiver<BatchInfo>,
+        timeout: Duration,
+        pending_ids: HashSet<String>,
+    ) -> Result<Self, ScabbardStateError> {
+        let timeout = Instant::now()
+            .checked_add(timeout)
+            .ok_or_else(|| ScabbardStateError("failed to schedule timeout".into()))?;
+
+        Ok(Self {
+            receiver,
+            retry_interval: Duration::from_millis(COMPLETED_BATCH_INFO_ITER_RETRY_MILLIS),
+            timeout,
+            pending_ids,
+        })
+    }
+}
+
+impl Iterator for ChannelBatchInfoIter {
+    type Item = Result<BatchInfo, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Check if all pending IDs have been returned
+            if self.pending_ids.is_empty() {
+                return None;
+            }
+            // Check if the timeout has expired
+            if Instant::now() >= self.timeout {
+                return Some(Err(format!(
+                    "timeout expired while waiting for incompleted batches: {:?}",
+                    self.pending_ids
+                )));
+            }
+            // Check for the next BatchInfo
+            match self.receiver.recv_timeout(self.retry_interval) {
+                Ok(batch_info) => {
+                    self.pending_ids.remove(&batch_info.id);
+                    return Some(Ok(batch_info));
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => return None,
+            }
         }
     }
 }

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -631,6 +631,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        408:
+          description: Batches did not complete before specified wait
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         500:
           description: Internal service error
           content:


### PR DESCRIPTION
Update the scabbard state to allow specifying a wait time for batches to
complete when getting batch statuses. An iterator is now returned by
this method that, if a timeout is specified, will only provide completed
batch infos. This change removes the need for the REST API to actively
poll for completed batches.