### PR TITLE
Fix games disappearing on refresh

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -46,7 +46,6 @@
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",
     "typescript": "^3.4.3",
-    "vue-template-compiler": "^2.6.10",
-    "vuex-module-decorators": "^0.9.9"
+    "vue-template-compiler": "^2.6.10"
   }
 }

--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -5,10 +5,10 @@
   "author": "Cargill Incorporated",
   "license": "Apache-2.0",
   "scripts": {
-    "serve": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='generic' vue-cli-service serve",
+    "serve": "npm run generate-proto-files ../../../libsplinter/protos && cross-env process.env.VUE_APP_BRAND='generic' vue-cli-service serve",
     "serve-generic": "npm run serve",
-    "serve-acme": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service serve",
-    "serve-bubba": "npm run generate-proto-files ../../../protos && cross-env process.env.VUE_APP_BRAND='bubba' vue-cli-service serve",
+    "serve-acme": "npm run generate-proto-files ../../../libsplinter/protos && cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service serve",
+    "serve-bubba": "npm run generate-proto-files ../../../libsplinter/protos && cross-env process.env.VUE_APP_BRAND='bubba' vue-cli-service serve",
     "build": "npm run generate-proto-files ./protos && cross-env process.env.VUE_APP_BRAND='generic' vue-cli-service build",
     "build-generic": "npm run build",
     "build-acme": "npm run generate-proto-files ./protos && cross-env process.env.VUE_APP_BRAND='acme' vue-cli-service build",

--- a/examples/gameroom/gameroom-app/src/components/InvitationCard.vue
+++ b/examples/gameroom/gameroom-app/src/components/InvitationCard.vue
@@ -65,7 +65,7 @@ limitations under the License.
 <script lang="ts">
 import { Vue, Prop, Component } from 'vue-property-decorator';
 import * as moment from 'moment';
-import { GameroomProposal } from '../store/models';
+import { GameroomProposal, Gameroom } from '../store/models';
 import gamerooms from '@/store/modules/gamerooms';
 
 @Component
@@ -76,8 +76,8 @@ export default class InvitationCard extends Vue {
   rejectSubmitting = false;
 
   get alias(): string {
-    const gameroom = gamerooms.gameroomList.find(
-      (gr) => gr.circuit_id === this.proposal.circuit_id);
+    const gameroom = this.$store.getters['gamerooms/gameroomList'].find(
+      (gr: Gameroom) => gr.circuit_id === this.proposal.circuit_id);
     if (gameroom) {
       return gameroom.alias;
     }

--- a/examples/gameroom/gameroom-app/src/components/sidebar/GameroomSidebar.vue
+++ b/examples/gameroom/gameroom-app/src/components/sidebar/GameroomSidebar.vue
@@ -31,15 +31,22 @@ limitations under the License.
 
 <script lang="ts">
 import { Vue, Prop, Component } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
 import SidebarSection from '@/components/sidebar/SidebarSection.vue';
-import { Section } from '@/store/models';
+import { Section, Gameroom } from '@/store/models';
 import gamerooms from '@/store/modules/gamerooms';
 
 @Component({
   components: { SidebarSection },
+  computed: {
+    ...mapGetters('gamerooms', {
+      activeGamerooms: 'activeGameroomList',
+    }),
+  },
 })
 export default class GameroomSidebar extends Vue {
   @Prop() sections!: Section[];
+  activeGamerooms!: Gameroom[];
 
   homeSection = {
     name: 'Home',
@@ -72,7 +79,7 @@ export default class GameroomSidebar extends Vue {
   };
 
   mounted() {
-    gamerooms.listGamerooms();
+    this.$store.dispatch('gamerooms/listGamerooms');
   }
 
   get home() {
@@ -91,7 +98,7 @@ export default class GameroomSidebar extends Vue {
   }
 
   get gameroomList() {
-    return gamerooms.activeGameroomList.map((gameroom) => {
+    return this.activeGamerooms.map((gameroom: Gameroom) => {
       return {
         id: gameroom.circuit_id,
         name: gameroom.alias,

--- a/examples/gameroom/gameroom-app/src/store/index.ts
+++ b/examples/gameroom/gameroom-app/src/store/index.ts
@@ -21,6 +21,7 @@ import votesModule from '@/store/modules/votes';
 import gamesModule from '@/store/modules/games';
 import proposalsModule from '@/store/modules/proposals';
 import pageLoadingModule from '@/store/modules/pageLoading';
+import gameroomsModule from '@/store/modules/gamerooms';
 
 import VuexPersistence from 'vuex-persist';
 
@@ -40,6 +41,7 @@ export default new Vuex.Store({
     selectedGameroom: selectedGameroomModule,
     proposals: proposalsModule,
     pageLoading: pageLoadingModule,
+    gamerooms: gameroomsModule,
   },
   plugins: [vuexLocal.plugin],
   state: {

--- a/examples/gameroom/gameroom-app/src/store/index.ts
+++ b/examples/gameroom/gameroom-app/src/store/index.ts
@@ -22,6 +22,7 @@ import gamesModule from '@/store/modules/games';
 import proposalsModule from '@/store/modules/proposals';
 import pageLoadingModule from '@/store/modules/pageLoading';
 import gameroomsModule from '@/store/modules/gamerooms';
+import nodesModule from '@/store/modules/nodes';
 
 import VuexPersistence from 'vuex-persist';
 
@@ -42,6 +43,7 @@ export default new Vuex.Store({
     proposals: proposalsModule,
     pageLoading: pageLoadingModule,
     gamerooms: gameroomsModule,
+    nodes: nodesModule,
   },
   plugins: [vuexLocal.plugin],
   state: {

--- a/examples/gameroom/gameroom-app/src/store/modules/nodes.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/nodes.ts
@@ -12,32 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { VuexModule, Module, getModule, Action, Mutation } from 'vuex-module-decorators';
-import store from '@/store';
 import { Node } from '@/store/models';
 import { listNodes } from '@/store/api';
 
+export interface NodeState {
+  nodes: Node[];
+}
 
-@Module({
+const nodeState = {
+  nodes: ([] as Node[]),
+};
+
+const getters = {
+  nodeList(state: NodeState): Node[] {
+    return state.nodes;
+  },
+};
+
+const actions = {
+  async listNodes({ commit }: any) {
+    const nodes = await listNodes();
+    commit('setNodes', nodes);
+  },
+};
+
+const mutations = {
+  setNodes(state: NodeState, nodes: Node[]) {
+    state.nodes = nodes;
+  },
+};
+
+export default {
   namespaced: true,
   name: 'nodes',
-  store,
-  dynamic: true,
-})
-class NodesModule extends VuexModule {
-  nodes: Node[] = [];
-
-  @Mutation
-  setNodes(nodes: Node[]) { this.nodes = nodes; }
-
-  @Action({ commit: 'setNodes' })
-  async listNodes() {
-    const nodes = await listNodes();
-    return nodes;
-  }
-
-  get nodeList() {
-    return this.nodes;
-  }
-}
-export default getModule(NodesModule);
+  state: nodeState,
+  getters,
+  actions,
+  mutations,
+};

--- a/examples/gameroom/gameroom-app/src/store/modules/notifications.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/notifications.ts
@@ -45,7 +45,7 @@ const actions = {
     const selectedGameroom = rootGetters['selectedGameroom/getGameroom'];
     await dispatch('gamerooms/listGamerooms', null, {root: true});
     await dispatch('proposals/listProposals', null, {root: true});
-    if (selectedGameroom) {
+    if (selectedGameroom.circuit_id) {
       await dispatch('games/listGames', selectedGameroom.circuit_id, {root: true});
     }
     commit('setNotifications', notifications);

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -145,7 +145,7 @@ export default class Dashboard extends Vue {
         this.submitting = true;
         const member = this.newGameroom.member ? this.newGameroom.member.identity : '';
         try {
-          await gamerooms.proposeGameroom({
+          this.$store.dispatch('gamerooms/proposeGameroom', {
             alias: this.newGameroom.alias,
             members: [member],
           });

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -70,6 +70,7 @@ limitations under the License.
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
 import GameroomSidebar from '@/components/sidebar/GameroomSidebar.vue';
 import Toast from '../components/Toast.vue';
 import Multiselect from 'vue-multiselect';
@@ -85,8 +86,14 @@ interface NewGameroom {
 
 @Component({
   components: { Modal, Multiselect, GameroomSidebar, Toast },
+  computed: {
+    ...mapGetters('nodes', {
+      nodeList: 'nodeList',
+    }),
+  },
 })
 export default class Dashboard extends Vue {
+  nodes!: Node[];
   displayModal = false;
   submitting = false;
   error = '';
@@ -98,11 +105,7 @@ export default class Dashboard extends Vue {
   };
 
   mounted() {
-    nodes.listNodes();
-  }
-
-  get nodeList() {
-    return nodes.nodeList;
+    this.$store.dispatch('nodes/listNodes');
   }
 
   get canSubmitNewGameroom() {


### PR DESCRIPTION
Adds a check to ensure that games are not refreshed if selectedGameroom state is empty. 

Removes the vuex-module-decorators dependency, which was causing issues with debugging and provides little benefit.

Updates the `npm run serve` script to fetch the protos from the correct directory.


To test, rebuild the gameroom-app-*  images if you have any and execute the following steps:

1.  Start gameroom by running `docker-compose -f examples/gameroom/docker-compose.yaml up --build` from the splinter root directory
2. Log in / register for acme and bubba using authorized keys (see gameroom readme)
3. On Acme website, invite bubba to gameroom
4. On Bubba website, accept invitation
5. On either website, navigate to the new gameroom's page from the sidebar or by clicking the notification
6. Create a few games
7. Refresh the page and ensure that the games still appear in the list
Before this fix, step 7 would fail
