### PR TITLE
Add feature guards to compile splinterd with `--no-default-features`

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -45,6 +45,7 @@ impl ConfigBuilder {
         }
     }
 
+    #[cfg(feature = "default")]
     /// Adds a PartialConfig to the ConfigBuilder object.
     ///
     /// # Arguments

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -21,6 +21,7 @@ mod default;
 mod env;
 mod error;
 mod partial;
+#[cfg(feature = "config-toml")]
 mod toml;
 
 use std::time::Duration;
@@ -325,6 +326,7 @@ impl Config {
     }
 }
 
+#[cfg(feature = "default")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,7 +337,7 @@ mod tests {
     use ::toml::{map::Map, to_string, Value};
     use clap::ArgMatches;
 
-    use crate::config::{DefaultConfig, EnvVarConfig, TomlConfig};
+    use crate::config::{CommandLineConfig, DefaultConfig, EnvVarConfig, TomlConfig};
 
     /// Path to example config toml file.
     static TEST_TOML: &str = "config_test.toml";

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -31,8 +31,6 @@ pub use crate::config::command_line::CommandLineConfig;
 pub use crate::config::default::DefaultConfig;
 #[cfg(feature = "config-env-var")]
 pub use crate::config::env::EnvVarConfig;
-#[cfg(not(feature = "config-toml"))]
-pub use crate::config::toml::from_file;
 #[cfg(feature = "config-toml")]
 pub use crate::config::toml::TomlConfig;
 pub use builder::{ConfigBuilder, PartialConfigBuilder};

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -53,6 +53,7 @@ pub struct PartialConfig {
 }
 
 impl PartialConfig {
+    #[allow(dead_code)]
     pub fn new(source: ConfigSource) -> Self {
         PartialConfig {
             source,
@@ -160,6 +161,7 @@ impl PartialConfig {
         self.state_dir.clone()
     }
 
+    #[allow(dead_code)]
     /// Adds a `storage` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -171,6 +173,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `transport` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -182,6 +185,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `cert_dir` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -193,6 +197,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `ca_certs` value to the  PartialConfig object.
     ///
     /// # Arguments
@@ -204,6 +209,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `client_cert` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -216,6 +222,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `client_key` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -227,6 +234,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `server_cert` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -239,6 +247,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `server_key` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -250,6 +259,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `service_endpoint` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -261,6 +271,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `network_endpoint` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -272,6 +283,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `peers` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -283,6 +295,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `node_id` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -294,6 +307,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `bind` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -318,6 +332,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `registry_backend` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -329,6 +344,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `registry_file` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -340,6 +356,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `heartbeat_interval` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -351,6 +368,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `timeout` value to the PartialConfig object.
     ///
     /// # Arguments
@@ -366,6 +384,7 @@ impl PartialConfig {
         self
     }
 
+    #[allow(dead_code)]
     /// Adds a `state_dir` value to the PartialConfig object.
     ///
     /// # Arguments

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -160,18 +160,6 @@ impl PartialConfig {
         self.state_dir.clone()
     }
 
-    #[cfg(not(feature = "config-toml"))]
-    /// Adds the `source` value to the PartialConfig object.
-    ///
-    /// # Arguments
-    ///
-    /// * `source` -  The method used to collect or the location of the configuration values.
-    ///
-    pub fn with_source(mut self, source: ConfigSource) -> Self {
-        self.source = source;
-        self
-    }
-
     /// Adds a `storage` value to the PartialConfig object.
     ///
     /// # Arguments

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "config-toml")]
 use crate::config::PartialConfigBuilder;
 use crate::config::{ConfigError, ConfigSource, PartialConfig};
 
-#[cfg(feature = "config-toml")]
 use serde_derive::Deserialize;
 
 use toml;
 
-#[cfg(feature = "config-toml")]
 /// Holds configuration values defined in a toml file.
 #[derive(Deserialize, Default, Debug)]
 pub struct TomlConfig {
@@ -47,7 +44,6 @@ pub struct TomlConfig {
     admin_service_coordinator_timeout: Option<u64>,
 }
 
-#[cfg(feature = "config-toml")]
 impl TomlConfig {
     pub fn new(toml: String, toml_path: String) -> Result<TomlConfig, ConfigError> {
         let mut toml_config = toml::from_str::<TomlConfig>(&toml).map_err(ConfigError::from)?;
@@ -56,7 +52,6 @@ impl TomlConfig {
     }
 }
 
-#[cfg(feature = "config-toml")]
 impl PartialConfigBuilder for TomlConfig {
     fn build(self) -> PartialConfig {
         let source = match self.source {
@@ -170,7 +165,6 @@ mod tests {
         assert_eq!(config.admin_service_coordinator_timeout(), None);
     }
 
-    #[cfg(feature = "config-toml")]
     #[test]
     /// This test verifies that a PartialConfig object, constructed from the TomlConfig module,
     /// contains the correct values using the following steps:


### PR DESCRIPTION
Adds (a lot) of feature guards to be able to compile and test splinterd with the `--no-default-features` option. 

This also removes the `from_file` function from the TomlConfig module, as it is not being used anywhere presently. 

Also adds `#[allow(dead_code)]` to the `with_*` methods in the PartialConfig module as these methods are not used outside of testing with the `--no-default-features` option, so without, it would result in a bunch of compilation warnings.  