### PR TITLE
Remove default value from metadata-encoding argument

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,9 +255,8 @@ fn run() -> Result<(), CliError> {
                     .long("metadata-encoding")
                     .takes_value(true)
                     .possible_values(&["json", "string"])
-                    .default_value("string")
                     .requires("metadata")
-                    .help("Set the encoding for the application metadata"),
+                    .help("Set the encoding for the application metadata. Default value: string"),
             );
 
         #[cfg(feature = "circuit-auth-type")]


### PR DESCRIPTION
The presence of the default value set via clap together with the
requires field was causing the metadata argument to always be required.
As metadata is an optional argument that is not the desired behavior.
Removing the default value set via clap fixes that problem. The default
value for metadata-encoding is enforced by the circuit create action.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>