### PR TITLE
Clean up loading spinner implementation

### DIFF
--- a/examples/gameroom/gameroom-app/src/components/Loading.vue
+++ b/examples/gameroom/gameroom-app/src/components/Loading.vue
@@ -1,0 +1,35 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div class="loading">
+    <div class="spinner large" />
+    <h3 class="message">{{ message }}</h3>
+  </div>
+</template>
+
+script lang=<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class Loading extends Vue {
+  @Prop() message!: string;
+}
+</script>
+
+<style lang="scss" scoped>
+  @import '@/scss/components/_loading.scss';
+</style>

--- a/examples/gameroom/gameroom-app/src/router.ts
+++ b/examples/gameroom/gameroom-app/src/router.ts
@@ -60,6 +60,7 @@ const router = new Router({
           component: () => import('@/views/DashboardHome.vue'),
           meta: {
             requiresAuth: true,
+            loadingMessage: 'Loading dashboard',
           },
         },
         {
@@ -68,6 +69,7 @@ const router = new Router({
           component: () => import('@/views/Invitations.vue'),
           meta: {
             requiresAuth: true,
+            loadingMessage: 'Loading invitations',
           },
         },
         {
@@ -76,6 +78,7 @@ const router = new Router({
           component: () => import('@/views/GameroomDetail.vue'),
           meta: {
             requiresAuth: true,
+            loadingMessage: 'Loading gameroom',
           },
         },
         {
@@ -97,6 +100,7 @@ const router = new Router({
 });
 
 router.beforeEach((to, from, next) => {
+  store.commit('pageLoading/setPageLoading', to.meta.loadingMessage);
   if (to.meta.requiresAuth) {
     if (!store.getters['user/isLoggedIn']) {
       return next({ name: 'login' });
@@ -105,6 +109,10 @@ router.beforeEach((to, from, next) => {
     }
   }
   next();
+});
+
+router.afterEach((to, from) => {
+  store.commit('pageLoading/setPageLoadingComplete');
 });
 
 export default router;

--- a/examples/gameroom/gameroom-app/src/scss/components/_gameroom-details.scss
+++ b/examples/gameroom/gameroom-app/src/scss/components/_gameroom-details.scss
@@ -84,10 +84,6 @@
     }
   }
 
-  .spinner-gameroom {
-    border-top-color: $color-primary-light;
-  }
-
   .tab-buttons {
     display: flex;
     margin-top: 1rem;

--- a/examples/gameroom/gameroom-app/src/scss/components/_loading.scss
+++ b/examples/gameroom/gameroom-app/src/scss/components/_loading.scss
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.dashboard-container {
+.loading {
   display: flex;
-  height: 100vh;
-  width: 100%;
-
-  .sidebar {
-    flex: 0 0 auto;
-  }
-
-  .dashboard-view {
-    display: flex;
-    flex: 1 1 auto;
-    overflow: hidden;
-  }
+  flex-direction: column;
+  margin: auto;
+  align-items: center;
 }

--- a/examples/gameroom/gameroom-app/src/store/modules/pageLoading.ts
+++ b/examples/gameroom/gameroom-app/src/store/modules/pageLoading.ts
@@ -14,22 +14,31 @@
 
 export interface PageLoading {
   pageLoading: boolean;
+  pageLoadingMessage: string;
 }
 
 const pageLoading = {
   pageLoading: false,
-
+  pageLoadingMessage: '',
 };
 
 const getters = {
   isPageLoading(state: PageLoading): boolean {
     return state.pageLoading;
   },
+  pageLoadingMessage(state: PageLoading): string {
+    return state.pageLoadingMessage;
+  },
 };
 
 const mutations = {
-  setPageLoading(state: PageLoading, loading: boolean) {
-    state.pageLoading = loading;
+  setPageLoading(state: PageLoading, message: string = 'Loading') {
+    state.pageLoading = true;
+    state.pageLoadingMessage = message;
+  },
+  setPageLoadingComplete(state: PageLoading) {
+    state.pageLoading = false;
+    state.pageLoadingMessage = '';
   },
 };
 

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -63,8 +63,10 @@ limitations under the License.
     <gameroom-sidebar
       v-on:show-new-gameroom-modal="showNewGameroomModal()"
       class="sidebar" />
-    <router-view v-on:error="setError" v-on:success="setSuccess" class="dashboard-view" />
-    <div class='spinner loading-spinner'  :class="[{'loading': loading}]"  ></div>
+    <div v-if="isPageLoading" class='dashboard-view'>
+      <loading :message="pageLoadingMessage" />
+    </div>
+    <router-view v-else v-on:error="setError" v-on:success="setSuccess" class="dashboard-view" />
   </div>
 </template>
 
@@ -78,6 +80,7 @@ import gamerooms from '@/store/modules/gamerooms';
 import nodes from '@/store/modules/nodes';
 import { Node } from '@/store/models';
 import Modal from '@/components/Modal.vue';
+import Loading from '@/components/Loading.vue';
 
 interface NewGameroom {
   alias: string;
@@ -85,10 +88,14 @@ interface NewGameroom {
 }
 
 @Component({
-  components: { Modal, Multiselect, GameroomSidebar, Toast },
+  components: { Modal, Multiselect, GameroomSidebar, Toast, Loading },
   computed: {
     ...mapGetters('nodes', {
       nodeList: 'nodeList',
+    }),
+    ...mapGetters('pageLoading', {
+      isPageLoading: 'isPageLoading',
+      pageLoadingMessage: 'pageLoadingMessage',
     }),
   },
 })
@@ -115,10 +122,6 @@ export default class Dashboard extends Vue {
       return true;
     }
     return false;
-  }
-
-  get loading() {
-    return this.$store.getters['pageLoading/isPageLoading'];
   }
 
   setError(message: string) {

--- a/examples/gameroom/gameroom-app/src/views/GameDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameDetail.vue
@@ -88,15 +88,8 @@ export default class GameDetail extends Vue {
   }
 }
 
-function setPageLoading(loading: boolean) {
-  store.commit('pageLoading/setPageLoading', loading);
-}
-
 function setSelectedGameroom(to: any, next: any) {
-  setPageLoading(true);
-
   store.dispatch('selectedGameroom/updateSelectedGameroom', to.params.id).catch((e) => {
-      setPageLoading(false);
       next({ name: 'not-found' });
   });
 }
@@ -105,9 +98,6 @@ function listGames(to: any, next: any) {
   store.dispatch('games/listGames', to.params.id).then(() => {
       const selectedGame = store.getters['games/getGames'].find(
         (game: Game) => game.game_name_hash === to.params.gameNameHash);
-
-      setPageLoading(false);
-
       if (selectedGame) {
         next();
       } else {


### PR DESCRIPTION
- Implements a new component, `Loading`, which renders a spinner and a message supplied by a prop. This standardizes the approach to loading indicators throughout gameroom.
- Updates the vuex page loading store to store a message.
- Trigger a loading indicator when pages are being lazy loaded or data has to be fetched before the page can fully load

This eliminates the following issues:
- Previously, a spinner that was positioned at the bottom of the page was bumping the margins of the website which caused scrollbars to flash on and off on some browsers. This has been replaced by the `Loading` component which renders in the middle of the screen.
- Previously, data would cascade on to the page, which could cause unintended empty spaces where data should be. This was especially evident on slower connections. Now the loading indicator will display until data is ready to be displayed.

To test:
1. start up Gameroom in docker as normal.
2. create a gameroom and several games.
3. Navigate around to different pages to ensure that there is a smooth experience. You will notice that navigating to different gamerooms will trigger the loader for a brief period while the games for that gameroom are fetched.

If you are on chrome (there is probably a way to do this on firefox too, but I am not sure):
1. Open devtools and select the device toolbar (phone/tablet icon on the top left).
2. Expand the page to a size supported by gameroom.
3. Go to the 'Online' dropdown and select mid-tier mobile or low-tier mobile. This simulates a slower network.
4. Navigate around and ensure that things are loading properly.