### PR TITLE
Properly log when splinterd is starting in insecure mode

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -454,8 +454,9 @@ fn get_transport(
                 )));
             }
 
+            let insecure = matches.is_present("insecure");
             let ca_file = {
-                if matches.is_present("insecure") {
+                if insecure {
                     None
                 } else {
                     let ca_file = config.ca_certs();
@@ -484,7 +485,7 @@ fn get_transport(
                 String::from(server_cert),
             )?;
 
-            Ok((Box::new(transport), false))
+            Ok((Box::new(transport), insecure))
         }
         "raw" => Ok((Box::new(RawTransport::default()), true)),
         _ => Err(GetTransportError::NotSupportedError(format!(


### PR DESCRIPTION
Before, "Starting TlsTransport in insecure mode" would only
be logged if --generate-cert was used. But this should be
printed whenever --insecure is provided.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>