### PR TITLE
Implement a variety of fixes to circuit-read 

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -86,11 +86,11 @@ fn list_circuits<T: CircuitStore + 'static>(
         None => DEFAULT_LIMIT,
     };
 
-    let mut link = format!("{}?", req.uri().path());
+    let mut link = req.uri().path().to_string();
 
     let filters = match query.get("filter") {
         Some(value) => {
-            link.push_str(&format!("filter={}&", value));
+            link.push_str(&format!("?filter={}&", value));
             Some(value.to_string())
         }
         None => None,

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -240,6 +240,58 @@ mod tests {
         )
     }
 
+    #[test]
+    /// Tests a GET /circuits?limit=1 request returns the expected circuit.
+    fn test_list_circuit_with_limit() {
+        let splinter_state = filled_splinter_state();
+
+        let mut app = test::init_service(App::new().data(splinter_state.clone()).service(
+            web::resource("/circuits").route(web::get().to_async(list_circuits::<SplinterState>)),
+        ));
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/circuits?limit={}", 1))
+            .header(header::CONTENT_TYPE, "application/json")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let circuits: ListCircuitsResponse =
+            serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+        assert_eq!(circuits.data, vec![get_circuit_1()]);
+        assert_eq!(
+            circuits.paging,
+            create_test_paging_response(0, 1, 1, 0, 1, 2, "/circuits?")
+        )
+    }
+
+    #[test]
+    /// Tests a GET /circuits?offset=1 request returns the expected circuit.
+    fn test_list_circuit_with_offset() {
+        let splinter_state = filled_splinter_state();
+
+        let mut app = test::init_service(App::new().data(splinter_state.clone()).service(
+            web::resource("/circuits").route(web::get().to_async(list_circuits::<SplinterState>)),
+        ));
+
+        let req = test::TestRequest::get()
+            .uri(&format!("/circuits?offset={}", 1))
+            .header(header::CONTENT_TYPE, "application/json")
+            .to_request();
+
+        let resp = test::call_service(&mut app, req);
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let circuits: ListCircuitsResponse =
+            serde_yaml::from_slice(&test::read_body(resp)).unwrap();
+        assert_eq!(circuits.data, vec![get_circuit_2()]);
+        assert_eq!(
+            circuits.paging,
+            create_test_paging_response(1, 100, 0, 0, 0, 2, "/circuits?")
+        )
+    }
+
     fn create_test_paging_response(
         offset: usize,
         limit: usize,

--- a/libsplinter/src/admin/rest_api/error.rs
+++ b/libsplinter/src/admin/rest_api/error.rs
@@ -14,14 +14,17 @@
 
 use std::error::Error;
 
+#[cfg(feature = "circuit-read")]
 use crate::circuit::store;
 
+#[cfg(feature = "proposal-read")]
 #[derive(Debug)]
 pub enum ProposalRouteError {
     NotFound(String),
     InternalError(String),
 }
 
+#[cfg(feature = "proposal-read")]
 impl Error for ProposalRouteError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -31,6 +34,7 @@ impl Error for ProposalRouteError {
     }
 }
 
+#[cfg(feature = "proposal-read")]
 impl std::fmt::Display for ProposalRouteError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -40,12 +44,14 @@ impl std::fmt::Display for ProposalRouteError {
     }
 }
 
+#[cfg(feature = "circuit-read")]
 #[derive(Debug)]
 pub enum CircuitRouteError {
     NotFound(String),
     CircuitStoreError(store::CircuitStoreError),
 }
 
+#[cfg(feature = "circuit-read")]
 impl Error for CircuitRouteError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -55,6 +61,7 @@ impl Error for CircuitRouteError {
     }
 }
 
+#[cfg(feature = "circuit-read")]
 impl std::fmt::Display for CircuitRouteError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -64,6 +71,7 @@ impl std::fmt::Display for CircuitRouteError {
     }
 }
 
+#[cfg(feature = "circuit-read")]
 impl From<store::CircuitStoreError> for CircuitRouteError {
     fn from(err: store::CircuitStoreError) -> Self {
         CircuitRouteError::CircuitStoreError(err)

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -14,7 +14,7 @@
 
 #[cfg(feature = "rest-api-actix")]
 mod actix;
-#[cfg(feature = "proposal-read")]
+#[cfg(any(feature = "circuit-read", feature = "proposal-read"))]
 mod error;
 mod resources;
 

--- a/libsplinter/src/admin/rest_api/resources/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/circuits.rs
@@ -16,7 +16,7 @@ use crate::circuit::{AuthorizationType, DurabilityType, PersistenceType, Roster,
 use crate::rest_api::paging::Paging;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct CircuitResponse {
+pub(crate) struct CircuitResponse {
     pub id: String,
     pub auth: AuthorizationType,
     pub members: Vec<String>,
@@ -28,7 +28,7 @@ pub struct CircuitResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct ListCircuitsResponse {
+pub(crate) struct ListCircuitsResponse {
     pub data: Vec<CircuitResponse>,
     pub paging: Paging,
 }

--- a/libsplinter/src/admin/rest_api/resources/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/circuits_circuit_id.rs
@@ -15,7 +15,7 @@
 use crate::circuit::{AuthorizationType, DurabilityType, PersistenceType, Roster, RouteType};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct CircuitResponse {
+pub(crate) struct CircuitResponse {
     pub id: String,
     pub auth: AuthorizationType,
     pub members: Vec<String>,

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -97,8 +97,6 @@ impl CircuitErrorHandler {
 mod tests {
     use protobuf::Message;
 
-    use std::sync::Arc;
-
     use super::*;
     use crate::channel::mock::MockSender;
     use crate::channel::Sender;

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -247,7 +247,6 @@ impl From<protobuf::error::ProtobufError> for DispatchError {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::channel::mock::MockSender;

--- a/libsplinter/src/rest_api/paging.rs
+++ b/libsplinter/src/rest_api/paging.rs
@@ -37,7 +37,14 @@ pub fn get_response_paging_info(
     let limit = limit.unwrap_or(DEFAULT_LIMIT);
     let offset = offset.unwrap_or(DEFAULT_OFFSET);
 
-    let base_link = format!("{}limit={}&", link, limit);
+    let base_link = {
+        // if the link does not already contain ? add it to the end
+        if !link.contains('?') {
+            format!("{}?limit={}&", link, limit)
+        } else {
+            format!("{}limit={}&", link, limit)
+        }
+    };
 
     let current_link = format!("{}offset={}", base_link, offset);
 


### PR DESCRIPTION
Fixes these issues raised when reviewing the code: 

 REST API Error responses to the user should be standardized. The Json response returned should use similar format for all of them, some are a string, some are a struct {"message": "error message"}, should match documentation (recommend use the response models in the rest_api module)
 -Used ErrorResponse from rest_api mod.

In circuit_read.rs, ListCircuitsResponse, CircuitResponse should not be public
  -Made them pub(crate)

The actix_web and futures libraries are pulled in from the crate’s re-export, which may not exist in the future; these should probably just be pulled in from their respective crates directly.
  - This was already done with the actix feature

 In fetch_circuit, a request without a circuit ID will return the same error as a request with a circuit ID that does not exist; this should return a different (ultimately, an invalid request).
  - This is not valid because /circuit/ would return not found because it is not a valid route
 
In fetch_circuit, the fetched circuit is cloned (state.circuit(&circuit_id).cloned()), then each of the fields is cloned (e.g. auth: circuit.auth().clone(),). Since these are all just references, these clones should be unnecessary. May be able to remove some clones from query_list_circuits as well.
   - This was no longer an issue after the addition of CircuitStore

When returning InternalServerError, the error should always be logged and/or included in the response. 
    - Error logs added to missing locations
 
In list_circuits, the returned link will have an empty query string if no filters are provided in the request; if no filters are provided, the returned link should have no query string (? should be moved to push_str).
   - Fixed

query_list_circuits has some duplication that can probably be eliminated by reorganizing it.
   - Reorganized to reduce duplication


Also fixed a feature issue where Errors were not available if only using circuit-read and removed some warnings from tests.


Also adds tests for offset and limit.