### PR TITLE
Handle OPTIONS and CORS Requests in splinterd

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -98,6 +98,7 @@ experimental = [
     "node-registry-unified",
     "postgres",
     "proposal-read",
+    "rest-api-cors",
     "scabbard-client",
     "scabbard-get-state",
     "zmq-transport",
@@ -119,6 +120,7 @@ node-registry-unified = []
 postgres = ["diesel/postgres"]
 rest-api = ["actix", "actix-http", "actix-web", "actix-web-actors", "futures", "percent-encoding"]
 rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
+rest-api-cors = []
 sawtooth-signing-compat = ["sawtooth-sdk"]
 scabbard-client = ["bzip2", "futures", "reqwest", "sawtooth-sdk", "tar"]
 scabbard-get-state = []

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -70,7 +70,7 @@ impl<T: store::CircuitStore + 'static> RestResourceProvider for CircuitResourceP
         // Allowing unused_mut because resources must be mutable if feature circuit-read is enabled
         #[allow(unused_mut)]
         let mut resources = Vec::new();
-        #[cfg(feature = "circuit-read")]
+        #[cfg(all(feature = "circuit-read", feature = "rest-api-actix"))]
         {
             resources.append(&mut vec![
                 make_fetch_circuit_resource(self.store.clone()),

--- a/libsplinter/src/rest_api/cors.rs
+++ b/libsplinter/src/rest_api/cors.rs
@@ -1,0 +1,131 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides CORS support for the REST API
+//!
+//! This is an experimental feature.  To enable, use the feature `"rest-api-cors"`.
+use actix_web::dev::*;
+use actix_web::{http::header, http::header::HeaderValue, Error as ActixError, HttpResponse};
+use futures::{
+    future::{ok, FutureResult},
+    Future, IntoFuture, Poll,
+};
+
+/// Configuration for CORS support
+#[derive(Clone)]
+pub struct Cors {
+    whitelist: Vec<String>,
+}
+
+impl Cors {
+    /// Initialize the CORS preflight check with a set of allowed domains.
+    pub fn new(whitelist: Vec<String>) -> Self {
+        Cors { whitelist }
+    }
+
+    /// Initialize the CORS preflight check with "*" domains.
+    pub fn new_allow_any() -> Self {
+        Cors::new(vec!["*".into()])
+    }
+}
+
+impl<S, B> Transform<S> for Cors
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = ActixError>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = S::Error;
+    type InitError = ();
+    type Transform = CorsMiddleware<S>;
+    type Future = FutureResult<Self::Transform, Self::InitError>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(CorsMiddleware {
+            service,
+            whitelist: self.whitelist.clone(),
+        })
+    }
+}
+
+#[doc(hidden)]
+pub struct CorsMiddleware<S> {
+    service: S,
+    whitelist: Vec<String>,
+}
+
+impl<S, B> Service for CorsMiddleware<S>
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = ActixError>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = S::Error;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready()
+    }
+
+    fn call(&mut self, req: ServiceRequest) -> Self::Future {
+        let origin_header = req.headers().get(header::ORIGIN).cloned();
+        let origin: Result<Option<String>, _> = origin_header
+            .as_ref()
+            .map(|h| h.to_str().map(String::from))
+            .transpose();
+
+        match (origin, origin_header) {
+            (Ok(Some(origin)), Some(origin_header)) => {
+                let request_headers = req
+                    .headers()
+                    .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+                    .cloned();
+                let allowed_origin = self
+                    .whitelist
+                    .iter()
+                    .any(|domain| domain == "*" || origin.contains(domain));
+                if allowed_origin {
+                    Box::new(self.service.call(req).map(move |mut res| {
+                        let headers = res.headers_mut();
+                        headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin_header);
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_METHODS,
+                            HeaderValue::from_static("*"),
+                        );
+                        headers.insert(
+                            header::ACCESS_CONTROL_ALLOW_HEADERS,
+                            request_headers.unwrap_or_else(|| HeaderValue::from_static("*")),
+                        );
+                        res
+                    }))
+                } else {
+                    Box::new(
+                        req.into_response(HttpResponse::PreconditionFailed().finish().into_body())
+                            .into_future(),
+                    )
+                }
+            }
+            (Ok(Some(_)), None) => unreachable!(),
+            (Ok(None), _) => Box::new(self.service.call(req)),
+            (Err(_), _) => Box::new(
+                req.into_response(HttpResponse::BadRequest().finish().into_body())
+                    .into_future(),
+            ),
+        }
+    }
+}

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -161,6 +161,19 @@ pub enum Method {
     Head,
 }
 
+impl std::fmt::Display for Method {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Method::Get => f.write_str("GET"),
+            Method::Post => f.write_str("POST"),
+            Method::Put => f.write_str("PUT"),
+            Method::Patch => f.write_str("PATCH"),
+            Method::Delete => f.write_str("DELETE"),
+            Method::Head => f.write_str("HEAD"),
+        }
+    }
+}
+
 /// `Resource` represents a RESTful endpoint.
 ///
 /// ```

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -51,6 +51,8 @@
 //!     .run();
 //! ```
 
+#[cfg(feature = "rest-api-cors")]
+pub mod cors;
 mod errors;
 mod events;
 pub mod paging;
@@ -467,6 +469,14 @@ impl RestApi {
             .spawn(move || {
                 let sys = actix::System::new("SplinterD-Rest-API");
                 let mut server = HttpServer::new(move || {
+                    // Actix's type definitions require this to be chained, otherwise, the generic
+                    // type of App is changed as the values are returned.
+                    #[cfg(feature = "rest-api-cors")]
+                    let mut app = App::new()
+                        .wrap(middleware::Logger::default())
+                        .wrap(cors::Cors::new_allow_any());
+
+                    #[cfg(not(feature = "rest-api-cors"))]
                     let mut app = App::new().wrap(middleware::Logger::default());
 
                     for resource in self.resources.clone() {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -61,6 +61,7 @@ experimental = [
     "circuit-read",
     "health",
     "proposal-read",
+    "rest-api-cors",
     "scabbard-get-state",
 ]
 
@@ -75,6 +76,7 @@ config-env-var = []
 config-toml = []
 database = ["splinter/database"]
 scabbard-get-state = ["splinter/scabbard-get-state"]
+rest-api-cors = ["splinter/rest-api-cors"]
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"


### PR DESCRIPTION
To test:

1) compile with experimental features enabled and run `splinterd` using your preferred method.
2) Run the following:
```
$ curl -i -X OPTIONS localhost:8088/admin/submit
HTTP/1.1 200 OK
content-length: 0
access-control-allow-origin: *
access-control-allow-methods: POST, OPTIONS
allow: POST, OPTIONS
date: Fri, 14 Feb 2020 15:28:33 GMT

$ curl -i -X OPTIONS localhost:8088/scabbard/foo/bar/batch_statuses
HTTP/1.1 200 OK
content-length: 0
allow: GET, OPTIONS
access-control-allow-origin: *
access-control-allow-methods: GET, OPTIONS
date: Fri, 14 Feb 2020 15:29:15 GMT
```

Note, that for the options request, it doesn't matter that there is no scabbard service at `foo::bar`.