### PR TITLE
Add admin prefix to circuits, keys, and nodes routes

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -79,7 +79,7 @@ impl<'a> SplinterRestClient<'a> {
     }
 
     pub fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, CliError> {
-        let mut request = format!("{}/circuits", self.url);
+        let mut request = format!("{}/admin/circuits", self.url);
         if let Some(filter) = filter {
             request = format!("{}?filter={}", &request, &filter);
         }
@@ -118,7 +118,7 @@ impl<'a> SplinterRestClient<'a> {
 
     pub fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<CircuitSlice>, CliError> {
         Client::new()
-            .get(&format!("{}/circuits/{}", self.url, circuit_id))
+            .get(&format!("{}/admin/circuits/{}", self.url, circuit_id))
             .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
             .send()
             .map_err(|err| CliError::ActionError(err.to_string()))

--- a/examples/gameroom/daemon/src/config.rs
+++ b/examples/gameroom/daemon/src/config.rs
@@ -155,7 +155,7 @@ pub fn get_node(splinterd_url: &str) -> Result<Node, GetNodeError> {
                 Ok(node_id)
             })
             .and_then(move |node_id| {
-                let uri = match format!("{}/nodes/{}", splinterd_url, node_id).parse::<Uri>() {
+                let uri = match format!("{}/admin/nodes/{}", splinterd_url, node_id).parse::<Uri>() {
                         Ok(uri) => uri,
                         Err(err) => return
                             Either::A(

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -229,7 +229,11 @@ async fn fetch_node_information(
 ) -> Result<Vec<Node>, RestApiResponseError> {
     let node_ids = node_ids.to_owned();
     let mut response = client
-        .get(&format!("{}/nodes?limit={}", splinterd_url, std::i64::MAX))
+        .get(&format!(
+            "{}/admin/nodes?limit={}",
+            splinterd_url,
+            std::i64::MAX
+        ))
         .header(
             "SplinterProtocolVersion",
             protocol::ADMIN_PROTOCOL_VERSION.to_string(),

--- a/examples/gameroom/daemon/src/rest_api/routes/key.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/key.rs
@@ -25,7 +25,11 @@ pub async fn fetch_key_info(
     let public_key = public_key.into_inner();
 
     let mut response = client
-        .get(format!("{}/keys/{}", splinterd_url.get_ref(), public_key))
+        .get(format!(
+            "{}/admin/keys/{}",
+            splinterd_url.get_ref(),
+            public_key
+        ))
         .header(
             "SplinterProtocolVersion",
             protocol::ADMIN_PROTOCOL_VERSION.to_string(),

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -23,7 +23,7 @@ use super::super::error::CircuitRouteError;
 use super::super::resources::circuits_circuit_id::CircuitResponse;
 
 pub fn make_fetch_circuit_resource<T: CircuitStore + 'static>(store: T) -> Resource {
-    Resource::build("/circuits/{circuit_id}")
+    Resource::build("/admin/circuits/{circuit_id}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::ADMIN_FETCH_CIRCUIT_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
@@ -99,19 +99,19 @@ mod tests {
     use crate::storage::get_storage;
 
     #[test]
-    /// Tests a GET /circuit/{identity} request returns the expected circuit.
+    /// Tests a GET /admin/circuit/{identity} request returns the expected circuit.
     fn test_fetch_circuit_ok() {
         let splinter_state = filled_splinter_state();
 
         let mut app = test::init_service(
             App::new().data(splinter_state.clone()).service(
-                web::resource("/circuits/{circuit_id}")
+                web::resource("/admin/circuits/{circuit_id}")
                     .route(web::get().to_async(fetch_circuit::<SplinterState>)),
             ),
         );
 
         let req = test::TestRequest::get()
-            .uri(&format!("/circuits/{}", get_circuit_1().id))
+            .uri(&format!("/admin/circuits/{}", get_circuit_1().id))
             .to_request();
 
         let resp = test::call_service(&mut app, req);
@@ -122,19 +122,19 @@ mod tests {
     }
 
     #[test]
-    /// Tests a GET /circuits/{identity} request returns NotFound when an invalid identity is
+    /// Tests a GET /admin/circuits/{identity} request returns NotFound when an invalid identity is
     /// passed
     fn test_fetch_circuit_not_found() {
         let splinter_state = filled_splinter_state();
         let mut app = test::init_service(
             App::new().data(splinter_state.clone()).service(
-                web::resource("/circuits/{circuit_id}")
+                web::resource("/admin/circuits/{circuit_id}")
                     .route(web::get().to_async(fetch_circuit::<SplinterState>)),
             ),
         );
 
         let req = test::TestRequest::get()
-            .uri("/circuit/Circuit-not-valid")
+            .uri("/admin/circuit/Circuit-not-valid")
             .to_request();
 
         let resp = test::call_service(&mut app, req);

--- a/libsplinter/src/keys/rest_api.rs
+++ b/libsplinter/src/keys/rest_api.rs
@@ -78,7 +78,7 @@ impl RestResourceProvider for KeyRegistryManager {
 }
 
 fn make_fetch_key_resource(key_registry: Box<dyn KeyRegistry>) -> Resource {
-    Resource::build("/keys/{public_key}")
+    Resource::build("/admin/keys/{public_key}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::ADMIN_FETCH_KEY_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
@@ -113,7 +113,7 @@ fn make_fetch_key_resource(key_registry: Box<dyn KeyRegistry>) -> Resource {
 }
 
 fn make_list_key_resources(key_registry: Box<dyn KeyRegistry>) -> Resource {
-    Resource::build("/keys")
+    Resource::build("/admin/keys")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::ADMIN_LIST_KEYS_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -196,7 +196,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /circuits:
+  /admin/circuits:
     get:
       tags:
           - Circuits
@@ -245,7 +245,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /circuits/{circuit_id}:
+  /admin/circuits/{circuit_id}:
     get:
       tags:
         - Circuits

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -353,7 +353,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /nodes:
+  /admin/nodes:
     post:
       tags:
         - Node Registry
@@ -445,7 +445,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /nodes/{identity}:
+  /admin/nodes/{identity}:
     get:
       tags:
         - Node Registry
@@ -1429,14 +1429,14 @@ components:
         last:
           type: string
       example:
-        current: /nodes?offset=10&limit=10
+        current: /admin/nodes?offset=10&limit=10
         offset: 10
         limit: 10
         total: 50
-        first: /nodes?offset=0&limit=10
-        prev: /nodes?offset=0&limit=10
-        next: /nodes?offset=20&limit=10
-        last: /nodes?offset=40&limit=10
+        first: /admin/nodes?offset=0&limit=10
+        prev: /admin/nodes?offset=0&limit=10
+        next: /admin/nodes?offset=20&limit=10
+        last: /admin/nodes?offset=40&limit=10
 
     BiomeUserKey:
       type: object

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -275,7 +275,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /keys:
+  /admin/keys:
     get:
       tags:
         - Key Registry
@@ -317,7 +317,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /keys/{public_key}:
+  /admin/keys/{public_key}:
     get:
       tags:
         - Key Registry


### PR DESCRIPTION
Adds the `admin` prefix to circuits route, to keep it consistent with the other routes defined in the admin module. Also adds that prefix to the keys and nodes routes as these routes will eventually be moved to the admin module. 

Also updates documentation, the Splinter CLI and Gameroom example to match these new endpoints.