### PR TITLE
Initial circuit template API

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -91,6 +91,7 @@ experimental = [
     "biome-notifications",
     "biome-user",
     "circuit-read",
+    "circuit-template",
     "connection-manager",
     "connection-manager-notification-iter-try-next",
     "database",
@@ -111,6 +112,7 @@ biome-key-management = ["biome", "database"]
 biome-notifications = ["biome", "database"]
 biome-user = ["biome", "database"]
 circuit-read = []
+circuit-template = []
 proposal-read = []
 connection-manager = ["matrix"]
 connection-manager-notification-iter-try-next = ["connection-manager"]

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -16,6 +16,8 @@ pub mod directory;
 pub mod handlers;
 pub mod service;
 pub mod store;
+#[cfg(feature = "circuit-template")]
+pub mod template;
 
 use serde_derive::{Deserialize, Serialize};
 

--- a/libsplinter/src/circuit/template/error.rs
+++ b/libsplinter/src/circuit/template/error.rs
@@ -1,0 +1,53 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug)]
+pub struct CircuitTemplateError {
+    context: String,
+    source: Option<Box<dyn std::error::Error>>,
+}
+
+impl CircuitTemplateError {
+    pub fn new(context: &str) -> Self {
+        Self {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn new_with_source(context: &str, err: Box<dyn std::error::Error>) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(err),
+        }
+    }
+}
+
+impl std::error::Error for CircuitTemplateError {}
+
+impl std::fmt::Display for CircuitTemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+impl From<serde_yaml::Error> for CircuitTemplateError {
+    fn from(err: serde_yaml::Error) -> Self {
+        Self::new_with_source("Error deserializing template", err.into())
+    }
+}

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -16,7 +16,12 @@ mod error;
 mod rules;
 mod yaml_parser;
 
+use std::collections::HashMap;
+
 pub use error::CircuitTemplateError;
+
+use rules::CircuitCreateTemplate;
+use yaml_parser::CircuitTemplate;
 
 pub(self) use crate::admin::messages::{CreateCircuitBuilder, SplinterServiceBuilder};
 
@@ -26,6 +31,24 @@ pub struct Builders {
 }
 
 impl Builders {
+    pub fn try_from_template_file(
+        path: &str,
+        arguments: &HashMap<String, String>,
+    ) -> Result<Builders, CircuitTemplateError> {
+        let template = CircuitTemplate::load_from_file(path)?;
+        let mut builders = Builders {
+            create_circuit_builder: CreateCircuitBuilder::new(),
+            service_builders: vec![],
+        };
+        match template {
+            CircuitTemplate::V1(template) => {
+                let template_rules = CircuitCreateTemplate::from(template);
+                template_rules.apply_rules(&mut builders, &arguments)?;
+            }
+        }
+        Ok(builders)
+    }
+
     pub fn set_create_circuit_builder(&mut self, builder: CreateCircuitBuilder) {
         self.create_circuit_builder = builder;
     }
@@ -40,5 +63,58 @@ impl Builders {
 
     pub fn service_builders(&self) -> Vec<SplinterServiceBuilder> {
         self.service_builders.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use tempdir::TempDir;
+
+    static EXAMPLE_TEMPLATE_YAML: &[u8; 165] = br##"version: v1
+args:
+    - name: admin-keys
+      required: true
+      default: $(a:SIGNER_PUB_KEY)
+rules:
+    set-management-type:
+        management-type: "gameroom" "##;
+
+    /*
+     * Verifies that Builders can be parsed from template v1 and correctly
+     * applies the set-management-type rule
+     */
+    #[test]
+    fn test_builds_template_v1() {
+        let temp_dir = TempDir::new("test_builds_template_v1").unwrap();
+        let temp_dir = temp_dir.path().to_path_buf();
+        let file_path = get_file_path(temp_dir);
+
+        write_yaml_file(&file_path, EXAMPLE_TEMPLATE_YAML);
+
+        let builders = Builders::try_from_template_file(&file_path, &HashMap::new())
+            .expect("Error getting builders from templates");
+        let circuit_create_builder = builders.create_circuit_builder();
+        assert_eq!(
+            circuit_create_builder.circuit_management_type(),
+            Some("gameroom".to_string())
+        );
+    }
+
+    fn get_file_path(mut temp_dir: PathBuf) -> String {
+        temp_dir.push("example_template.yaml");
+        let path = temp_dir.to_str().unwrap().to_string();
+        path
+    }
+
+    fn write_yaml_file(file_path: &str, data: &[u8]) {
+        let mut file = File::create(file_path).expect("Error creating test template yaml file.");
+
+        file.write_all(data)
+            .expect("Error writing example template yaml.");
     }
 }

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -17,3 +17,28 @@ mod rules;
 mod yaml_parser;
 
 pub use error::CircuitTemplateError;
+
+pub(self) use crate::admin::messages::{CreateCircuitBuilder, SplinterServiceBuilder};
+
+pub struct Builders {
+    create_circuit_builder: CreateCircuitBuilder,
+    service_builders: Vec<SplinterServiceBuilder>,
+}
+
+impl Builders {
+    pub fn set_create_circuit_builder(&mut self, builder: CreateCircuitBuilder) {
+        self.create_circuit_builder = builder;
+    }
+
+    pub fn set_service_builders(&mut self, builders: Vec<SplinterServiceBuilder>) {
+        self.service_builders = builders;
+    }
+
+    pub fn create_circuit_builder(&self) -> CreateCircuitBuilder {
+        self.create_circuit_builder.clone()
+    }
+
+    pub fn service_builders(&self) -> Vec<SplinterServiceBuilder> {
+        self.service_builders.clone()
+    }
+}

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 mod error;
+mod yaml_parser;
 
 pub use error::CircuitTemplateError;

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod error;
+mod rules;
 mod yaml_parser;
 
 pub use error::CircuitTemplateError;

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -11,3 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+mod error;
+
+pub use error::CircuitTemplateError;

--- a/libsplinter/src/circuit/template/rules.rs
+++ b/libsplinter/src/circuit/template/rules.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::yaml_parser::v1;
+
+pub struct CircuitCreateTemplate {
+    _version: String,
+    _args: Vec<RuleArgument>,
+    rules: Rules,
+}
+
+impl From<v1::CircuitCreateTemplate> for CircuitCreateTemplate {
+    fn from(create_circuit_template: v1::CircuitCreateTemplate) -> Self {
+        CircuitCreateTemplate {
+            _version: create_circuit_template.version().to_string(),
+            _args: create_circuit_template
+                .args()
+                .to_owned()
+                .into_iter()
+                .map(RuleArgument::from)
+                .collect(),
+            rules: Rules::from(create_circuit_template.rules().clone()),
+        }
+    }
+}
+
+struct RuleArgument {
+    _name: String,
+    _required: bool,
+    _default_value: Option<String>,
+}
+
+impl From<v1::RuleArgument> for RuleArgument {
+    fn from(arguments: v1::RuleArgument) -> Self {
+        RuleArgument {
+            _name: arguments.name().to_string(),
+            _required: arguments.required(),
+            _default_value: arguments.default_value().map(String::from),
+        }
+    }
+}
+
+struct Rules {
+    set_management_type: Option<CircuitManagement>,
+}
+
+impl From<v1::Rules> for Rules {
+    fn from(rules: v1::Rules) -> Self {
+        Rules {
+            set_management_type: rules
+                .set_management_type()
+                .map(|val| CircuitManagement::from(val.clone())),
+        }
+    }
+}
+
+struct CircuitManagement {
+    management_type: String,
+}
+
+impl From<v1::CircuitManagement> for CircuitManagement {
+    fn from(yaml_circuit_management: v1::CircuitManagement) -> Self {
+        CircuitManagement {
+            management_type: yaml_circuit_management.management_type().to_string(),
+        }
+    }
+}

--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod v1;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use super::CircuitTemplateError;
+
+#[derive(Deserialize, Debug)]
+struct TemplateVersionGuard {
+    version: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub enum CircuitTemplate {
+    V1(v1::CircuitCreateTemplate),
+}
+
+impl CircuitTemplate {
+    pub fn load_from_file(file_path: &str) -> Result<Self, CircuitTemplateError> {
+        let path = Path::new(file_path);
+        if !path.is_file() {
+            return Err(CircuitTemplateError::new(&format!(
+                "File does not exist or is inaccessible: {}",
+                file_path
+            )));
+        }
+        let file = File::open(path).map_err(|err| {
+            CircuitTemplateError::new_with_source("Error opening template file", err.into())
+        })?;
+
+        let template = Self::deserialize(file)?;
+        Ok(template)
+    }
+
+    fn deserialize(mut reader: impl Read) -> Result<Self, CircuitTemplateError> {
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data).map_err(|err| {
+            CircuitTemplateError::new_with_source(
+                "Error reading data from template file",
+                err.into(),
+            )
+        })?;
+
+        let version_guard: TemplateVersionGuard = serde_yaml::from_slice(&data)?;
+        match version_guard.version.as_ref() {
+            "v1" => {
+                let template: v1::CircuitCreateTemplate = serde_yaml::from_slice(&data)?;
+                Ok(Self::V1(template))
+            }
+            _ => Err(CircuitTemplateError::new(&format!(
+                "Invalid template version: {}. The supported versions are: v1",
+                version_guard.version
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use tempdir::TempDir;
+
+    static EXAMPLE_TEMPLATE_YAML: &[u8; 166] = br##"version: v1
+args:
+    - name: admin-keys
+      required: false
+      default: $(a:SIGNER_PUB_KEY)
+rules:
+    set-management-type:
+        management-type: "gameroom" "##;
+
+    /*
+     * Verifies load_template correctly loads a template version 1
+     */
+    #[test]
+    fn test_parse_template_v1() {
+        // create temp directoy
+        let temp_dir = TempDir::new("test_parse_template_v1").unwrap();
+        let temp_dir = temp_dir.path().to_path_buf();
+        let file_path = get_file_path(temp_dir);
+
+        write_yaml_file(&file_path, EXAMPLE_TEMPLATE_YAML);
+
+        let template_version =
+            CircuitTemplate::load_from_file(&file_path).expect("failed to load template");
+        match template_version {
+            CircuitTemplate::V1(template) => {
+                assert_eq!(template.version(), "v1");
+                let args = template.args();
+                for arg in args {
+                    assert_eq!(arg.name(), "admin-keys");
+                    assert_eq!(arg.required(), false);
+                    assert_eq!(
+                        arg.default_value(),
+                        Some(&"$(a:SIGNER_PUB_KEY)".to_string())
+                    );
+                }
+
+                let management_type = template
+                    .rules()
+                    .set_management_type()
+                    .expect("Management type was not deserialize correctly");
+                assert_eq!(management_type.management_type(), "gameroom");
+            }
+        }
+    }
+
+    fn get_file_path(mut temp_dir: PathBuf) -> String {
+        temp_dir.push("example_template.yaml");
+        let path = temp_dir.to_str().unwrap().to_string();
+        path
+    }
+
+    fn write_yaml_file(file_path: &str, data: &[u8]) {
+        let mut file = File::create(file_path).expect("Error creating test template yaml file.");
+
+        file.write_all(data)
+            .expect("Error writing example template yaml.");
+    }
+}

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -1,0 +1,80 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CircuitCreateTemplate {
+    version: String,
+    args: Vec<RuleArgument>,
+    rules: Rules,
+}
+
+impl CircuitCreateTemplate {
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn args(&self) -> &[RuleArgument] {
+        &self.args
+    }
+
+    pub fn rules(&self) -> &Rules {
+        &self.rules
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct RuleArgument {
+    name: String,
+    required: bool,
+    #[serde(rename = "default")]
+    default_value: Option<String>,
+}
+
+impl RuleArgument {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn required(&self) -> bool {
+        self.required
+    }
+
+    pub fn default_value(&self) -> Option<&String> {
+        self.default_value.as_ref()
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Rules {
+    set_management_type: Option<CircuitManagement>,
+}
+
+impl Rules {
+    pub fn set_management_type(&self) -> Option<&CircuitManagement> {
+        self.set_management_type.as_ref()
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CircuitManagement {
+    management_type: String,
+}
+
+impl CircuitManagement {
+    pub fn management_type(&self) -> &str {
+        &self.management_type
+    }
+}


### PR DESCRIPTION
#### Overview
This is an initial stab at the circuit template API. It defines 
- a parser for a template YAML file, that in the future will be able to handle different template versions. It can apply the rules defined in an YAML file, and returns a CreateCircuitBuilder and SplinterServiceBuilders, with the relevant fields sets.
- a rule that sets the management type for a circuit. 

A sample template YAML file: 
```yaml
version: v1
args:
    - name: admin-keys
      required: false
      default: $(a:SIGNER_PUB_KEY)
rules:
    set-management-type:
        management-type: "gameroom"
```

#### To test
In the libsplinter directory run:

`cargo test template --features circuit-template`
