### PR TITLE
Validate scabbard keys

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -101,6 +101,7 @@ experimental = [
     "rest-api-cors",
     "scabbard-client",
     "scabbard-get-state",
+    "service-arg-validation",
     "zmq-transport",
 ]
 
@@ -124,6 +125,7 @@ rest-api-cors = []
 sawtooth-signing-compat = ["sawtooth-sdk"]
 scabbard-client = ["bzip2", "futures", "reqwest", "sawtooth-sdk", "tar"]
 scabbard-get-state = []
+service-arg-validation = []
 zmq-transport = ["zmq"]
 
 # The following features are broken and should not be used.

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -20,6 +20,8 @@ mod open_proposals;
 mod shared;
 
 use std::any::Any;
+#[cfg(feature = "service-arg-validation")]
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
@@ -38,6 +40,8 @@ use crate::orchestrator::ServiceOrchestrator;
 use crate::protos::admin::{
     AdminMessage, AdminMessage_Type, CircuitManagementPayload, CircuitProposal,
 };
+#[cfg(feature = "service-arg-validation")]
+use crate::service::validation::ServiceArgValidator;
 use crate::service::{
     error::{ServiceDestroyError, ServiceError, ServiceStartError, ServiceStopError},
     Service, ServiceMessageContext, ServiceNetworkRegistry,
@@ -122,6 +126,10 @@ impl AdminService {
     pub fn new(
         node_id: &str,
         orchestrator: ServiceOrchestrator,
+        #[cfg(feature = "service-arg-validation")] service_arg_validators: HashMap<
+            String,
+            Box<dyn ServiceArgValidator + Send>,
+        >,
         peer_connector: PeerConnector,
         authorization_inquistor: Box<dyn AuthorizationInquisitor>,
         splinter_state: SplinterState,
@@ -141,6 +149,8 @@ impl AdminService {
             admin_service_shared: Arc::new(Mutex::new(AdminServiceShared::new(
                 node_id.to_string(),
                 orchestrator,
+                #[cfg(feature = "service-arg-validation")]
+                service_arg_validators,
                 peer_connector,
                 authorization_inquistor,
                 splinter_state,
@@ -513,6 +523,8 @@ mod tests {
         let mut admin_service = AdminService::new(
             "test-node".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -36,6 +36,8 @@ use crate::network::{
     peer::PeerConnector,
 };
 use crate::orchestrator::{ServiceDefinition, ServiceOrchestrator, ShutdownServiceError};
+#[cfg(feature = "service-arg-validation")]
+use crate::protos::admin::SplinterService;
 use crate::protos::admin::{
     AdminMessage, AdminMessage_Type, Circuit, CircuitManagementPayload,
     CircuitManagementPayload_Action, CircuitManagementPayload_Header, CircuitProposal,
@@ -44,6 +46,9 @@ use crate::protos::admin::{
     Circuit_PersistenceType, Circuit_RouteType, MemberReady, SplinterNode,
 };
 use crate::service::error::ServiceError;
+#[cfg(feature = "service-arg-validation")]
+use crate::service::validation::ServiceArgValidator;
+
 use crate::service::ServiceNetworkSender;
 use crate::signing::SignatureVerifier;
 use crate::storage::sets::mem::DurableBTreeSet;
@@ -148,6 +153,9 @@ pub struct AdminServiceShared {
     uninitialized_circuits: HashMap<String, UninitializedCircuit>,
     // orchestrator used to initialize and shutdown services
     orchestrator: ServiceOrchestrator,
+    // map of service arg validators, by service type
+    #[cfg(feature = "service-arg-validation")]
+    service_arg_validators: HashMap<String, Box<dyn ServiceArgValidator + Send>>,
     // list of services that have been initialized using the orchestrator
     running_services: HashSet<ServiceDefinition>,
     // peer connector used to connect to new members listed in a circuit
@@ -187,6 +195,10 @@ impl AdminServiceShared {
     pub fn new(
         node_id: String,
         orchestrator: ServiceOrchestrator,
+        #[cfg(feature = "service-arg-validation")] service_arg_validators: HashMap<
+            String,
+            Box<dyn ServiceArgValidator + Send>,
+        >,
         peer_connector: PeerConnector,
         auth_inquisitor: Box<dyn AuthorizationInquisitor>,
         splinter_state: SplinterState,
@@ -221,6 +233,8 @@ impl AdminServiceShared {
             open_proposals,
             uninitialized_circuits: Default::default(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            service_arg_validators,
             running_services: HashSet::new(),
             peer_connector,
             auth_inquisitor,
@@ -1639,6 +1653,8 @@ mod tests {
         let mut shared = AdminServiceShared::new(
             "my_peer_id".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1719,6 +1735,8 @@ mod tests {
         let mut shared = AdminServiceShared::new(
             "my_peer_id".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1788,6 +1806,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1816,6 +1836,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1845,6 +1867,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1883,6 +1907,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1921,6 +1947,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -1962,6 +1990,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2000,6 +2030,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2043,6 +2075,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2075,6 +2109,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2109,6 +2145,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2147,6 +2185,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2192,6 +2232,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2237,6 +2279,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2278,6 +2322,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2319,6 +2365,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2352,6 +2400,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2385,6 +2435,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2418,6 +2470,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2451,6 +2505,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2485,6 +2541,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2516,6 +2574,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2551,6 +2611,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2584,6 +2646,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2626,6 +2690,8 @@ mod tests {
         let admin_shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2663,6 +2729,8 @@ mod tests {
         let shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2715,6 +2783,8 @@ mod tests {
         let shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2769,6 +2839,8 @@ mod tests {
         let shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,
@@ -2825,6 +2897,8 @@ mod tests {
         let shared = AdminServiceShared::new(
             "node_a".into(),
             orchestrator,
+            #[cfg(feature = "service-arg-validation")]
+            HashMap::new(),
             peer_connector,
             Box::new(MockAuthInquisitor),
             state,

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -652,6 +652,15 @@ impl AdminServiceShared {
 
         match header.get_action() {
             CircuitManagementPayload_Action::CIRCUIT_CREATE_REQUEST => {
+                let signer_public_key = header.get_requester();
+                let requester_node_id = header.get_requester_node_id();
+                self.validate_create_circuit(
+                    payload.get_circuit_create_request().get_circuit(),
+                    signer_public_key,
+                    requester_node_id,
+                )
+                .map_err(|err| ServiceError::UnableToHandleMessage(Box::new(err)))?;
+
                 self.propose_circuit(payload, "local".to_string())
             }
             CircuitManagementPayload_Action::CIRCUIT_PROPOSAL_VOTE => {

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -43,6 +43,8 @@ mod registry;
 mod rest_api;
 pub mod scabbard;
 mod sender;
+#[cfg(feature = "service-arg-validation")]
+pub mod validation;
 
 use std::any::Any;
 

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -49,6 +49,8 @@ use super::{
 
 use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
+#[cfg(feature = "service-arg-validation")]
+pub use factory::ScabbardArgValidator;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
 #[cfg(feature = "scabbard-get-state")]

--- a/libsplinter/src/service/validation.rs
+++ b/libsplinter/src/service/validation.rs
@@ -1,0 +1,138 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Service Argument validation
+
+use std::collections::HashMap;
+use std::error;
+use std::fmt;
+
+/// An error message indicating an issue with a set of service arguments.
+#[derive(Debug, PartialEq)]
+pub struct ServiceArgValidationError(pub String);
+
+impl error::Error for ServiceArgValidationError {}
+
+impl fmt::Display for ServiceArgValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Invalid service arguments: {}", self.0)
+    }
+}
+
+type Args = HashMap<String, String>;
+type ValidationResult = Result<(), ServiceArgValidationError>;
+
+/// Validates the arguments for a service
+pub trait ServiceArgValidator {
+    /// Validate the given arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an ServiceArgValidationError if the implementation determines that the arguments
+    /// are invalid.
+    fn validate(&self, args: &Args) -> ValidationResult;
+}
+
+// Implement the trait on all boxed-dyn ServiceArgValidators
+impl ServiceArgValidator for Box<dyn ServiceArgValidator> {
+    fn validate(&self, args: &Args) -> ValidationResult {
+        (**self).validate(args)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct ContainsFoo;
+
+    impl ServiceArgValidator for ContainsFoo {
+        fn validate(&self, args: &Args) -> ValidationResult {
+            if !args.contains_key("foo") {
+                return Err(ServiceArgValidationError(r#""foo" is missing"#.into()));
+            }
+
+            Ok(())
+        }
+    }
+
+    struct BarNotEmpty;
+
+    impl ServiceArgValidator for BarNotEmpty {
+        fn validate(&self, args: &Args) -> ValidationResult {
+            if args.get("bar").map(|v| v.is_empty()).unwrap_or(true) {
+                return Err(ServiceArgValidationError(
+                    r#""bar" is missing or empty"#.into(),
+                ));
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Test that a valid set of arguments passes both validations.
+    #[test]
+    fn test_valid() {
+        let validators: Vec<Box<dyn ServiceArgValidator>> =
+            vec![Box::new(ContainsFoo), Box::new(BarNotEmpty)];
+
+        let mut args: Args = HashMap::new();
+        args.insert("foo".into(), "one".into());
+        args.insert("bar".into(), "yes".into());
+
+        assert!(validators
+            .iter()
+            .map(|v| v.validate(&args))
+            .all(|r| r.is_ok()))
+    }
+
+    /// Test that a set of arguments missing the "foo" argument will fail with an error.
+    #[test]
+    fn test_fail_contains_validation() {
+        let validators: Vec<Box<dyn ServiceArgValidator>> =
+            vec![Box::new(ContainsFoo), Box::new(BarNotEmpty)];
+
+        let mut args: Args = HashMap::new();
+        args.insert("bar".into(), "yes".into());
+
+        assert_eq!(
+            Some(Err(ServiceArgValidationError(r#""foo" is missing"#.into()))),
+            validators
+                .iter()
+                .map(|v| v.validate(&args))
+                .find(|r| r.is_err())
+        );
+    }
+
+    /// Test that a set of arguments with an invalid "bar" argument will fail with an error.
+    #[test]
+    fn test_fail_not_empty_validation() {
+        let validators: Vec<Box<dyn ServiceArgValidator>> =
+            vec![Box::new(ContainsFoo), Box::new(BarNotEmpty)];
+
+        let mut args: Args = HashMap::new();
+        args.insert("foo".into(), "one".into());
+        args.insert("bar".into(), "".into());
+
+        assert_eq!(
+            Some(Err(ServiceArgValidationError(
+                r#""bar" is missing or empty"#.into()
+            ))),
+            validators
+                .iter()
+                .map(|v| v.validate(&args))
+                .find(|r| r.is_err())
+        );
+    }
+}

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -63,6 +63,7 @@ experimental = [
     "proposal-read",
     "rest-api-cors",
     "scabbard-get-state",
+    "service-arg-validation"
 ]
 
 biome = ["splinter/biome", "database"]
@@ -75,8 +76,9 @@ config-command-line = []
 config-env-var = []
 config-toml = []
 database = ["splinter/database"]
-scabbard-get-state = ["splinter/scabbard-get-state"]
 rest-api-cors = ["splinter/rest-api-cors"]
+scabbard-get-state = ["splinter/scabbard-get-state"]
+service-arg-validation = ["splinter/service-arg-validation"]
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"


### PR DESCRIPTION
Validate that a circuit proposal has valid service arguments, using the new, experimental, trait `ServiceArgValidator`.  These validations run when either receiving a proposal directly or from a peer during consensus.

This can be tested by building splinterd with experimental features turned on, and submitting a circuit request with bad scabbard arguments.  For example:

```
$ cargo run --manifest-path cli/Cargo.toml --features experimental -- \
    -vv circuit create -k alice.priv --url http://localhost:8088 \
    --node acme-node-000::tls://splinterd-node-acme:8044 \
    --node bubba-node-000::tls://splinterd-node-bubba:8044 \
    --service game-scabbard-a::acme-node-000 \
    --service game-scabbard-b::acme-node-000 \
    --service-type *::scabbard \
    --management gameroom \
    --service-peer-group game-scabbard-a,game-scabbard-b \
    --service-arg=*::admin_keys=foo
```
Or drop the peer group argument as another test.