### PR TITLE
Fix-up config logging

### DIFF
--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -252,38 +252,36 @@ impl Config {
             self.transport(),
             self.transport_source()
         );
-        if self.transport() == "tls" {
-            debug!(
-                "Config: ca_certs: {} (source: {:?})",
-                self.ca_certs(),
-                self.ca_certs_source()
-            );
-            debug!(
-                "Config: cert_dir: {} (source: {:?})",
-                self.cert_dir(),
-                self.cert_dir_source()
-            );
-            debug!(
-                "Config: client_cert: {} (source: {:?})",
-                self.client_cert(),
-                self.client_cert_source()
-            );
-            debug!(
-                "Config: client_key: {} (source: {:?})",
-                self.client_key(),
-                self.client_key_source()
-            );
-            debug!(
-                "Config: server_cert: {} (source: {:?})",
-                self.server_cert(),
-                self.server_cert_source()
-            );
-            debug!(
-                "Config: server_key: {} (source: {:?})",
-                self.server_key(),
-                self.server_key_source()
-            );
-        }
+        debug!(
+            "Config: ca_certs: {} (source: {:?})",
+            self.ca_certs(),
+            self.ca_certs_source()
+        );
+        debug!(
+            "Config: cert_dir: {} (source: {:?})",
+            self.cert_dir(),
+            self.cert_dir_source()
+        );
+        debug!(
+            "Config: client_cert: {} (source: {:?})",
+            self.client_cert(),
+            self.client_cert_source()
+        );
+        debug!(
+            "Config: client_key: {} (source: {:?})",
+            self.client_key(),
+            self.client_key_source()
+        );
+        debug!(
+            "Config: server_cert: {} (source: {:?})",
+            self.server_cert(),
+            self.server_cert_source()
+        );
+        debug!(
+            "Config: server_key: {} (source: {:?})",
+            self.server_key(),
+            self.server_key_source()
+        );
         debug!(
             "Config: service_endpoint: {} (source: {:?})",
             self.service_endpoint(),

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -14,6 +14,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::fs;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -920,14 +921,20 @@ fn create_node_registry(
     registry_config: &RegistryConfig,
 ) -> Result<Box<dyn RwNodeRegistry>, RestApiServerError> {
     match registry_config {
-        RegistryConfig::File { registry_file } => Ok(Box::new(
-            node_registry::yaml::YamlNodeRegistry::new(&registry_file).map_err(|err| {
-                RestApiServerError::StartUpError(format!(
-                    "Failed to initialize YamlNodeRegistry: {}",
-                    err
-                ))
-            })?,
-        )),
+        RegistryConfig::File { registry_file } => {
+            debug!(
+                "Creating node registry with registry file: {:?}",
+                fs::canonicalize(&registry_file)?
+            );
+            Ok(Box::new(
+                node_registry::yaml::YamlNodeRegistry::new(&registry_file).map_err(|err| {
+                    RestApiServerError::StartUpError(format!(
+                        "Failed to initialize YamlNodeRegistry: {}",
+                        err
+                    ))
+                })?,
+            ))
+        }
         RegistryConfig::NoOp => Ok(Box::new(node_registry::noop::NoOpNodeRegistry)),
     }
 }

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -27,6 +27,7 @@ pub enum UserError {
     MissingArgument(String),
     InvalidArgument(String),
     ConfigError(ConfigError),
+    IoError(io::Error),
     DaemonError {
         context: String,
         source: Option<Box<dyn Error>>,
@@ -49,6 +50,7 @@ impl Error for UserError {
             UserError::MissingArgument(_) => None,
             UserError::InvalidArgument(_) => None,
             UserError::ConfigError(err) => Some(err),
+            UserError::IoError(err) => Some(err),
             UserError::DaemonError { source, .. } => {
                 if let Some(ref err) = source {
                     Some(&**err)
@@ -69,6 +71,7 @@ impl fmt::Display for UserError {
             UserError::ConfigError(msg) => {
                 write!(f, "error occurred building config object: {}", msg)
             }
+            UserError::IoError(err) => write!(f, "encountered an IoError: {}", err),
             UserError::DaemonError { context, source } => {
                 if let Some(ref err) = source {
                     write!(f, "{}: {}", context, err)
@@ -77,6 +80,12 @@ impl fmt::Display for UserError {
                 }
             }
         }
+    }
+}
+
+impl From<io::Error> for UserError {
+    fn from(io_error: io::Error) -> Self {
+        UserError::IoError(io_error)
     }
 }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -68,6 +68,7 @@ fn create_config(_toml_path: Option<&str>, _matches: ArgMatches) -> Result<Confi
     #[cfg(feature = "config-toml")]
     {
         if let Some(file) = _toml_path {
+            debug!("Loading config toml file: {:?}", fs::canonicalize(file)?);
             let toml_string = fs::read_to_string(file).map_err(|err| ConfigError::ReadError {
                 file: String::from(file),
                 err,
@@ -207,8 +208,6 @@ fn main() {
 }
 
 fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
-    debug!("Loading configuration file");
-
     // get provided config file or search default location
     let config_file = matches
         .value_of("config")
@@ -280,6 +279,10 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     }
 
     if Path::new(&config.registry_file()).is_file() && registry_backend == "FILE" {
+        debug!(
+            "Using registry file: {:?}",
+            fs::canonicalize(&config.registry_file())?
+        );
         daemon_builder = daemon_builder
             .with_registry_backend(Some(String::from(registry_backend)))
             .with_registry_file(String::from(config.registry_file()));

--- a/splinterd/src/transport.rs
+++ b/splinterd/src/transport.rs
@@ -32,6 +32,10 @@ pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTr
                     client_cert
                 )));
             }
+            debug!(
+                "Using client certificate file: {:?}",
+                fs::canonicalize(&client_cert)?
+            );
 
             let server_cert = config.server_cert();
             if !Path::new(&server_cert).is_file() {
@@ -40,6 +44,10 @@ pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTr
                     server_cert
                 )));
             }
+            debug!(
+                "Using server certificate file: {:?}",
+                fs::canonicalize(&server_cert)?
+            );
 
             let server_key_file = config.server_key();
             if !Path::new(&server_key_file).is_file() {
@@ -48,6 +56,10 @@ pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTr
                     server_key_file
                 )));
             }
+            debug!(
+                "Using server key file: {:?}",
+                fs::canonicalize(&server_key_file)?
+            );
 
             let client_key_file = config.client_key();
             if !Path::new(&client_key_file).is_file() {
@@ -56,6 +68,10 @@ pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTr
                     client_key_file
                 )));
             }
+            debug!(
+                "Using client key file: {:?}",
+                fs::canonicalize(&client_key_file)?
+            );
 
             let insecure = config.insecure();
             if insecure {
@@ -73,7 +89,10 @@ pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTr
                         )));
                     }
                     match fs::canonicalize(&ca_file)?.to_str() {
-                        Some(ca_path) => Some(ca_path.to_string()),
+                        Some(ca_path) => {
+                            debug!("Using ca certs file: {:?}", ca_path);
+                            Some(ca_path.to_string())
+                        }
                         None => {
                             return Err(GetTransportError::CertError(
                                 "CA path is not a valid path".to_string(),


### PR DESCRIPTION
Cleans up the conditionals in the config logging to give a completely raw output for the config values and adds logging of the fully qualified file path whenever one is used / opened throught splinterd. 