### PR TITLE
Fix scabbard batch history

### DIFF
--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -564,14 +564,6 @@ impl ValidTransaction {
     }
 }
 
-impl From<TransactionReceipt> for ValidTransaction {
-    fn from(receipt: TransactionReceipt) -> Self {
-        Self {
-            transaction_id: receipt.transaction_id,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct InvalidTransaction {
     transaction_id: String,


### PR DESCRIPTION
Updates the scabbard `BatchHistory` struct, which is used to track batch
statuses, to insert batch updates if the batches are not already
present. Previously, if a batch wasn't pending, any updates would be
ignored; this meant that nodes that didn't receive the batch locally
(and instead received it over the network) would not have the batch's
status in their history.

To test, run the gameroom demo (being sure to build at least the splinterd image) and create a gameroom. Verify that the `Received commit for batch that is not in the history` message is not found in the logs of either splinter node.