### PR TITLE
Add pattern for writing and creating man pages for the splinter cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 /cli/target
 /cli/Cargo.lock
+/cli/packaging/man/*.1
 
 /examples/private_xo/target
 /examples/private_xo/Cargo.lock

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -99,3 +99,7 @@ biome-credentials = ["database-migrate-biome-credentials"]
 maintainer = "The Splinter Team"
 depends = "$auto"
 maintainer-scripts = "packaging/ubuntu"
+assets = [
+    ["packaging/man/*", "/usr/share/man/man1", "644"],
+    ["target/release/splinter", "/usr/bin/splinter", "755"]
+]

--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -48,5 +48,8 @@ COPY --from=builder /build/target/debian/splinter-cli_*.deb /tmp
 COPY --from=builder /commit-hash /commit-hash
 
 RUN apt-get update \
+ && apt-get install -y -q \
+   man \
+ && mandb \
  && dpkg --unpack /tmp/splinter-cli_*.deb \
  && apt-get -f -y install

--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -14,6 +14,12 @@
 
 FROM splintercommunity/splinter-dev as BUILDER
 
+ENV SPLINTER_FORCE_PANDOC=true
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    pandoc
+
 # Copy over source files
 COPY client /build/client
 COPY libsplinter /build/libsplinter

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -27,9 +27,8 @@ const PATH: &str = "PATH";
 /// and skip generating the manpages if it is not. If the build should fail if man pages cannot be
 /// generated set environment variable SPLINTER_FORCE_PANDOC=true
 fn main() -> Result<(), BuildError> {
-    let paths = env::var(PATH).map_err(|_| BuildError(
-        "Unable to read PATH environment variable".into(),
-    ))?;
+    let paths = env::var(PATH)
+        .map_err(|_| BuildError("Unable to read PATH environment variable".into()))?;
     let mut pandoc_exist = false;
     for path in paths.split(":") {
         for entry in fs::read_dir(path)

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,145 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::process::Command;
+
+const FORCE_PANDOC: &str = "SPLINTER_FORCE_PANDOC";
+const PATH: &str = "PATH";
+
+/// This build script will take the markdown files in the /man directory and convert them to
+/// man pages stored in packaging/man. This build script will check if pandoc is installed locally
+/// and skip generating the manpages if it is not. If the build should fail if man pages cannot be
+/// generated set environment variable SPLINTER_FORCE_PANDOC=true
+fn main() -> Result<(), BuildError> {
+    let paths = env::var(PATH).map_err(|_| BuildError(
+        "Unable to read PATH environment variable".into(),
+    ))?;
+    let mut pandoc_exist = false;
+    for path in paths.split(":") {
+        for entry in fs::read_dir(path)
+            .map_err(|err| BuildError(format!("Cannot check if pandoc is in PATH: {}", err)))?
+        {
+            let entry = entry
+                .map_err(|err| BuildError(format!("Cannot check if file is pandoc: {}", err)))?;
+            let path = entry.path();
+            if path.ends_with("pandoc") {
+                pandoc_exist = true;
+                break;
+            }
+        }
+    }
+
+    if !pandoc_exist {
+        if let Ok(var) = env::var(FORCE_PANDOC) {
+            if var.parse().map_err(|_| {
+                BuildError("Unable to read SPLINTER_FORCE_PANDOC environment variable".into())
+            })? {
+                return Err(BuildError(
+                    "Cannot generate man pages, pandoc is not installed".into(),
+                ));
+            }
+        } else {
+            println!("Skip generating man pages");
+            return Ok(());
+        }
+    }
+
+    let entries = match fs::read_dir("man/") {
+        Ok(entries) => {
+            match entries
+                .map(|res| res.map(|e| e.path()))
+                .collect::<Result<Vec<_>, io::Error>>()
+            {
+                Ok(entries) => entries,
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to retrieve entries for man pages: {}",
+                        err
+                    )))
+                }
+            }
+        }
+        Err(err) => {
+            return Err(BuildError(format!(
+                "Unable to read man pages directory: {}",
+                err
+            )))
+        }
+    };
+
+    println!("Markdown files found {:?}", entries);
+
+    for entry in entries {
+        // This conversion would only fail if the filename is not valid UTF-8
+        let markdown = &format!(
+            "{}",
+            entry
+                .to_str()
+                .ok_or_else(|| BuildError("Cannot get markdown file path".into()))?
+        );
+
+        let file = entry
+            .file_stem()
+            .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?;
+        let manpage = &format!(
+            "packaging/man/{}",
+            file.to_str()
+                .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?
+        );
+
+        if markdown.ends_with(".md") {
+            match Command::new("pandoc")
+                .args(&["--standalone", "--to", "man", &markdown, "-o", &manpage])
+                .status()
+            {
+                Ok(status) => {
+                    if status.success() {
+                        println!("Generated man page: {}", manpage);
+                    } else {
+                        println!("Unable to generate man page {} status {}", manpage, status);
+                    }
+                }
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to generate man page: {} {}",
+                        manpage, err
+                    )))
+                }
+            }
+        }
+    }
+    return Ok(());
+}
+
+pub struct BuildError(String);
+
+impl Error for BuildError {}
+
+// This is the output that will be used for print errors returned from main
+impl fmt::Debug for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/cli/man/TEMPLATE.1.md.example
+++ b/cli/man/TEMPLATE.1.md.example
@@ -1,0 +1,81 @@
+% COMMAND(1) Cargill, Incorporated | Splinter Commands
+
+<!--
+Template for a man page source file in Markdown format. The file should have the
+name of the command plus any subcommands (with dashes) with an extension of
+`1.md`. For example `splinter-cert-generate.1.md` is the Markdown file that
+generates the man page for `splinter cert generate`.
+-->
+NAME
+====
+
+**command-subcommand** — About blurb from command help
+
+SYNOPSIS
+========
+| **command** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Paragraph or two that describes what the command does, explains how it fits in
+the Splinter environment, provides big-picture information on who uses it and
+why (or when), and lists prerequisites or other considerations.
+
+FLAGS
+=====
+<!--
+List of flags (in alphabetical order) that describes what each flag does
+and the default value/behavior. If appropriate, explain
+how/when it's used, with tips, gotchas, and very short examples.
+-->
+
+`-h`, `--help`
+: Prints help information
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+<!--
+List of options (in alphabetical order) that describes what the option does,
+what arguments it takes, and the default value/behavior. If appropriate, explain
+how/when it's used, with tips, gotchas, and very short examples.
+-->
+
+`-e`, `--example <example>`
+: Description about example options
+
+
+EXAMPLES
+========
+<!--
+Show simple uses first, followed by more complex examples.For a very simple
+subcommand where an example isn't appropriate, delete the EXAMPLES section.
+-->
+
+ENVIRONMENT
+===========
+The following environment variables affect the execution of the command.
+
+<!--
+List each environment variable with a description; mention any related flags or
+options.
+-->
+
+**EXAMPLE_ENV_VAR**
+
+: Description of environment variable.  (See `--example`)
+
+SEE ALSO
+========
+<!--
+Related man pages or documentation (if possible)
+-->
+
+For more information, see the Splinter documentation at
+https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/cli/man/splinter-cert-generate.1.md
+++ b/cli/man/splinter-cert-generate.1.md
@@ -1,0 +1,95 @@
+% SPLINTER-CERT-GENERATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-cert-generate** — Generates test certificates and keys for running
+  splinterd with TLS (in insecure mode)
+
+SYNOPSIS
+========
+| **splinter cert generate** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Running Splinter in TLS mode requires valid X.509 certificates from a
+certificate authority. When developing against Splinter, you can use this
+command to generate development certificates and the associated keys for your
+development environment.
+
+The files are generated in the location specified by `--cert-dir`, the
+SPLINTER_CERT_DIR environment variable, or in the default location
+/etc/splinter/certs/.
+
+The following files are created:
+
+  client.crt, client.key, server.crt, server.key, generated_ca.pem,
+  generated_ca.key
+
+FLAGS
+=====
+`--force`
+: Overwrites files if they exist. If this flag is not provided and the file
+  exists, an error is returned.
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`--skip`
+: Checks if the files exists and generates the files that are missing. If this
+flag is not provided and the file exists, an error is returned.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-d`, `--cert-dir <cert_dir>`
+: Path to the directory certificates are created in. Defaults to
+  /etc/splinter/certs/. This location can also be changed with the
+  SPLINTER_CERT_DIR environment variable. This directory must exist.
+
+`--common-name <common_name>`
+: String that specifies a common name for the generated certificate (defaults to
+  localhost). Use this option if the splinterd URL uses a DNS address instead
+  of a numerical IP address.
+
+EXAMPLES
+========
+Generates test certificates and keys:
+
+  `$ splinter cert generate`
+
+To create missing certificates and keys when some files already exist, add the
+`--skip` flag. The command will ignore the existing files and create any files
+that are missing.
+
+  `$ splinter cert generate --skip`
+
+To recreate the certificates and keys from scratch, use the  `--force` flag to
+overwrite all existing files.
+
+  `$ splinter cert generate --force`
+
+ENVIRONMENT
+===========
+The following environment variables affect the execution of splinter cert
+generate:
+
+**SPLINTER_CERT_DIR**
+
+: The certificates and keys will be generated at the location specified by the
+  environment variable.  (See `--cert-dir`)
+
+SEE ALSO
+========
+For more information, see the Splinter documentation at
+https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/cli/packaging/man/README.md
+++ b/cli/packaging/man/README.md
@@ -1,0 +1,2 @@
+This is the directory where the generated man pages for the `splinter` CLI will
+be located.

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -63,6 +63,8 @@ COPY --from=builder /commit-hash /commit-hash
 
 RUN apt-get update \
  && apt-get install -y -q \
+    man \
     postgresql-client \
+ && mandb \
  && dpkg --unpack /tmp/splinter-*.deb \
  && apt-get -f -y install

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -16,6 +16,12 @@
 
 FROM splintercommunity/splinter-dev as BUILDER
 
+ENV SPLINTER_FORCE_PANDOC=true
+
+RUN apt-get update \
+ && apt-get install -y -q \
+    pandoc
+
 COPY cli /build/cli
 COPY libsplinter /build/libsplinter
 COPY services/health /build/services/health


### PR DESCRIPTION
This PR lays out how we can write documentation for cli commands. Each man page will have a markdown file in the provided TEMPLATE format. The markdown file will be converted to a man page with pandoc when the cli is built (script in build.rs file) and put in package/man. When the cli deb is built these files will be included in /user/share/man/man1. 

The build.rs file requires the pandoc is installed. If you do not want to generate the man pages set 
`export SPLINTER_NO_MAN_PAGES=true` If SPLINTER_NO_MAN_PAGES is set to false or does not exist the man pages will try to be generated.

The docker files for spllinterd and splinter cli have been updated to be able generate the man pages (installed pandoc) and installs the man pages in the containers (installed man and run mandb).

To test build splinterd or the splinter cli docker images and run. Docker exec into the container and run `man splinter-cert-generate` to see the man page for `splinter cert generate`