### PR TITLE
Implement reconnection retry for ConnectionManger 

### DIFF
--- a/libsplinter/src/network/connection_manager/error.rs
+++ b/libsplinter/src/network/connection_manager/error.rs
@@ -23,6 +23,7 @@ pub enum ConnectionManagerError {
     SendTimeoutError(String),
     ConnectionCreationError(String),
     ConnectionRemovalError(String),
+    ConnectionReconnectError(String),
     StatePoisoned,
 }
 
@@ -36,6 +37,7 @@ impl error::Error for ConnectionManagerError {
             ConnectionManagerError::SendTimeoutError(_) => None,
             ConnectionManagerError::ConnectionCreationError(_) => None,
             ConnectionManagerError::ConnectionRemovalError(_) => None,
+            ConnectionManagerError::ConnectionReconnectError(_) => None,
             ConnectionManagerError::StatePoisoned => None,
         }
     }
@@ -51,6 +53,7 @@ impl fmt::Display for ConnectionManagerError {
             ConnectionManagerError::SendTimeoutError(ref s) => write!(f, "{}", s),
             ConnectionManagerError::ConnectionCreationError(ref s) => write!(f, "{}", s),
             ConnectionManagerError::ConnectionRemovalError(ref s) => write!(f, "{}", s),
+            ConnectionManagerError::ConnectionReconnectError(ref s) => write!(f, "{}", s),
             ConnectionManagerError::StatePoisoned => {
                 write!(f, "Connection state has been poisoned")
             }

--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -14,8 +14,6 @@
 
 use std::sync::mpsc::SyncSender;
 
-use crate::network::connection_manager::error::ConnectionManagerError;
-
 pub enum CmMessage {
     Shutdown,
     Subscribe(SyncSender<ConnectionManagerNotification>),
@@ -61,22 +59,6 @@ pub enum CmResponseStatus {
 /// subscription handlers
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConnectionManagerNotification {
-    FatalError {
-        error: ConnectionManagerError,
-        message: String,
-    },
-    HeartbeatSent {
-        endpoint: String,
-    },
-    HeartbeatSendFail {
-        endpoint: String,
-        message: String,
-    },
-    ReconnectAttemptSuccess {
-        endpoint: String,
-    },
-    ReconnectAttemptFailed {
-        endpoint: String,
-        message: String,
-    },
+    Connected { endpoint: String },
+    Disconnected { endpoint: String },
 }


### PR DESCRIPTION
When a connection is discovered to be disconnected, the connection
manager will try to reconnect to the connection. If the
reconnection is not successful, the connection manager will wait
(with an exponential back off) until reconnection is successful.
The max retry frequency is configurable and defaults to 300 seconds.

This commit also simplifies ConnectionManagerNotification to
only include Connected and Disconnected. These messages will
be sent to subscribers when connection and reconnection is
successful. Disconnected is sent if a heartbeat fails and
reconnection is started.

This PR also makes the heartbeat interval configurable.