### PR TITLE
Update actix, tokio, futures, and actix dependecies in libsplinter

### DIFF
--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -40,20 +40,18 @@ ctrlc = "3.0"
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
 flexi_logger = "0.14"
-futures = "0.1"
 gameroom-database = { path = "../database" }
-hyper = "0.12"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2.0"
 protobuf = "2"
 sabre-sdk = "0.5"
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter", features = ["events"]}
-tokio = "0.1"
 transact = "0.2"
 uuid = { version = "0.7", features = ["v4"]}
 

--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -423,23 +423,16 @@ fn process_admin_event(
 
             let url_to_string = url.to_string();
             let private_key_to_string = private_key.to_string();
-            xo_ws.on_open(move |ctx| {
+            xo_ws.on_open(move |_| {
                 debug!("Starting XO State Delta Export");
-                let future = match setup_xo(
+
+                if let Err(err) = setup_xo(
                     &private_key_to_string,
                     scabbard_admin_keys.clone(),
                     &url_to_string,
                     &msg_proposal.circuit_id.clone(),
                     &service_id.clone(),
                 ) {
-                    Ok(f) => f,
-                    Err(err) => {
-                        error!("{}", err);
-                        return WsResponse::Close;
-                    }
-                };
-
-                if let Err(err) = ctx.igniter().send(future) {
                     error!("Failed to setup scabbard: {}", err);
                     WsResponse::Close
                 } else {

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -29,6 +29,7 @@ repository = "https://github.com/cargill/splinter"
 [dependencies]
 actix = { version = "0.9", optional = true, default-features = false }
 actix-http = { version = "1.0", optional = true }
+actix-rt = "1.0"
 actix-web = { version = "2.0", optional = true }
 actix-web-actors = { version = "2.0", optional = true }
 atomicwrites = "0.2"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -34,6 +34,7 @@ actix-web-actors = { version = "2.0", optional = true }
 atomicwrites = "0.2"
 awc = { version = "1.0", optional = true }
 bcrypt = {version = "0.6", optional = true}
+bytes = "0.5"
 byteorder = "1"
 bzip2 = { version = "0.3", optional = true }
 crossbeam-channel = "0.3"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -40,7 +40,7 @@ crossbeam-channel = "0.3"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
 futures = { version = "0.3", optional = true }
-hyper = { version = "0.12", optional = true }
+hyper = { version = "0.13", optional = true }
 jsonwebtoken = { version = "6.0", optional = true }
 log = "0.3.0"
 mio = "0.6"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -58,7 +58,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 tar = { version = "0.4", optional = true }
-tokio = { version = "0.1.22", optional = true }
+tokio = { version = "0.2.11", optional = true, features = ["stream", "time"] }
+tokio-util = { version = "0.2", optional = true, features = ["codec"] }
 transact = { version = "0.2", features = ["sawtooth-compat"] }
 url = "1.7.1"
 ursa = { version = "0.1", optional = true }
@@ -117,7 +118,7 @@ proposal-read = []
 connection-manager = ["matrix"]
 connection-manager-notification-iter-try-next = ["connection-manager"]
 database = ["diesel/postgres", "diesel_migrations"]
-events = ["actix-http", "futures", "hyper", "tokio", "awc"]
+events = ["actix-http", "futures", "hyper", "tokio", "awc", "tokio-util"]
 matrix = []
 node-registry-unified = []
 postgres = ["diesel/postgres"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -27,10 +27,10 @@ description = """\
 repository = "https://github.com/cargill/splinter"
 
 [dependencies]
-actix = { version = "0.8", optional = true, default-features = false }
-actix-http = { version = "0.2", optional = true, features = ["flate2-zlib"] }
-actix-web = { version = "1.0", optional = true, default-features = false, features = ["flate2-zlib"] }
-actix-web-actors = { version = "1.0", optional = true }
+actix = { version = "0.9", optional = true, default-features = false }
+actix-http = { version = "1.0", optional = true }
+actix-web = { version = "2.0", optional = true }
+actix-web-actors = { version = "2.0", optional = true }
 atomicwrites = "0.2"
 awc = { version = "0.2", optional = true }
 bcrypt = {version = "0.6", optional = true}
@@ -39,7 +39,7 @@ bzip2 = { version = "0.3", optional = true }
 crossbeam-channel = "0.3"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
-futures = { version = "0.1", optional = true }
+futures = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
 jsonwebtoken = { version = "6.0", optional = true }
 log = "0.3.0"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -32,7 +32,7 @@ actix-http = { version = "1.0", optional = true }
 actix-web = { version = "2.0", optional = true }
 actix-web-actors = { version = "2.0", optional = true }
 atomicwrites = "0.2"
-awc = { version = "0.2", optional = true }
+awc = { version = "1.0", optional = true }
 bcrypt = {version = "0.6", optional = true}
 byteorder = "1"
 bzip2 = { version = "0.3", optional = true }

--- a/libsplinter/src/admin/rest_api/actix/proposals_read_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_read_circuit_id.rs
@@ -16,13 +16,13 @@
 //! circuit ID.
 
 use actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
-use futures::Future;
+use futures::executor::block_on;
 
 use crate::admin::messages::CircuitProposal;
 use crate::admin::rest_api::error::ProposalFetchError;
 use crate::admin::service::proposal_store::ProposalStore;
 use crate::protocol;
-use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{Method, ProtocolVersionRangeGuard, Resource};
 
 pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store: PS) -> Resource {
     Resource::build("admin/proposals/{circuit_id}")
@@ -31,54 +31,48 @@ pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store:
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, move |r, _| {
-            fetch_proposal(r, web::Data::new(proposal_store.clone()))
+            block_on(fetch_proposal(r, web::Data::new(proposal_store.clone())))
         })
 }
 
-fn fetch_proposal<PS: ProposalStore + 'static>(
+async fn fetch_proposal<PS: ProposalStore + Clone + 'static>(
     request: HttpRequest,
     proposal_store: web::Data<PS>,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+) -> Result<HttpResponse, Error> {
     let circuit_id = request
         .match_info()
         .get("circuit_id")
         .unwrap_or("")
         .to_string();
-    Box::new(
-        web::block(move || {
-            let proposal = proposal_store
-                .proposal(&circuit_id)
-                .map_err(|err| ProposalFetchError::InternalError(err.to_string()))?;
-            if let Some(proposal) = proposal {
-                let proposal = CircuitProposal::from_proto(proposal)
-                    .map_err(|err| ProposalFetchError::InternalError(err.to_string()))?;
 
-                Ok(proposal)
-            } else {
-                Err(ProposalFetchError::NotFound(format!(
-                    "Unable to find proposal: {}",
-                    circuit_id
-                )))
-            }
-        })
-        .then(|res| match res {
-            Ok(proposal) => Ok(HttpResponse::Ok().json(proposal)),
-            Err(err) => match err {
-                BlockingError::Error(err) => match err {
-                    ProposalFetchError::InternalError(_) => {
-                        error!("{}", err);
-                        Ok(HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error()))
-                    }
-                    ProposalFetchError::NotFound(err) => {
-                        Ok(HttpResponse::NotFound().json(ErrorResponse::not_found(&err)))
-                    }
-                },
-                _ => {
+    match web::block(move || {
+        let proposal = proposal_store
+            .proposal(&circuit_id)
+            .map_err(|err| ProposalFetchError::InternalError(err.to_string()))?;
+        if let Some(proposal) = proposal {
+            let proposal = CircuitProposal::from_proto(proposal)
+                .map_err(|err| ProposalFetchError::InternalError(err.to_string()))?;
+
+            Ok(proposal)
+        } else {
+            Err(ProposalFetchError::NotFound(format!(
+                "Unable to find proposal: {}",
+                circuit_id
+            )))
+        }
+    })
+    .await
+    {
+        Ok(proposal) => Ok(HttpResponse::Ok().json(proposal)),
+        Err(err) => match err {
+            BlockingError::Error(err) => match err {
+                ProposalFetchError::InternalError(_) => {
                     error!("{}", err);
-                    Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()))
+                    Ok(HttpResponse::InternalServerError().into())
                 }
+                ProposalFetchError::NotFound(err) => Ok(HttpResponse::NotFound().json(err)),
             },
-        }),
-    )
+            _ => Ok(HttpResponse::InternalServerError().into()),
+        },
+    }
 }

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -14,12 +14,10 @@
 
 use std::sync::Arc;
 
-use crate::actix_web::HttpResponse;
-use crate::futures::{Future, IntoFuture};
+use crate::actix_web::{web::Payload, Error as ActixError, HttpRequest, HttpResponse};
+use crate::futures::executor::block_on;
 use crate::protocol;
-use crate::rest_api::{
-    into_bytes, ErrorResponse, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource,
-};
+use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
 use crate::biome::key_management::{
     store::{KeyStore, KeyStoreError},
@@ -43,234 +41,197 @@ pub fn make_key_management_route(
             protocol::BIOME_KEYS_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
         ))
-        .add_method(
-            Method::Post,
-            handle_post(
-                rest_config.clone(),
-                key_store.clone(),
-                secret_manager.clone(),
-            ),
-        )
-        .add_method(
-            Method::Get,
-            handle_get(
-                rest_config.clone(),
-                key_store.clone(),
-                secret_manager.clone(),
-            ),
-        )
-        .add_method(
-            Method::Patch,
-            handle_patch(rest_config, key_store, secret_manager),
-        )
+        .add_method(Method::Post, {
+            let rest_config = rest_config.clone();
+            let key_store = key_store.clone();
+            let secret_manager = secret_manager.clone();
+            move |request, payload| {
+                handle_post(
+                    rest_config.clone(),
+                    key_store.clone(),
+                    secret_manager.clone(),
+                    request,
+                    payload,
+                )
+            }
+        })
+        .add_method(Method::Get, {
+            let rest_config = rest_config.clone();
+            let key_store = key_store.clone();
+            let secret_manager = secret_manager.clone();
+            move |request, _| {
+                handle_get(
+                    rest_config.clone(),
+                    key_store.clone(),
+                    secret_manager.clone(),
+                    request,
+                )
+            }
+        })
+        .add_method(Method::Patch, {
+            let key_store = key_store.clone();
+            let secret_manager = secret_manager.clone();
+
+            move |request, payload| {
+                handle_patch(
+                    rest_config.clone(),
+                    key_store.clone(),
+                    secret_manager.clone(),
+                    request,
+                    payload,
+                )
+            }
+        })
 }
 
 fn handle_post(
     rest_config: Arc<BiomeRestConfig>,
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
-) -> HandlerFunction {
-    Box::new(move |request, payload| {
-        let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
+    request: HttpRequest,
+    payload: Payload,
+) -> Result<HttpResponse, ActixError> {
+    let user_id = match request.match_info().get("user_id") {
+        Some(id) => id.to_owned(),
+        None => {
+            error!("User ID is not in path request");
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
+        }
+    };
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
-            AuthorizationResult::Unauthorized(msg) => {
-                return Box::new(
-                    HttpResponse::Unauthorized()
-                        .json(ErrorResponse::unauthorized(&msg))
-                        .into_future(),
-                )
-            }
-            AuthorizationResult::Failed => {
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
+    match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
+        AuthorizationResult::Authorized => (),
+        AuthorizationResult::Unauthorized(msg) => {
+            return Ok(HttpResponse::Unauthorized().json(ErrorResponse::unauthorized(&msg)));
+        }
+        AuthorizationResult::Failed => {
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
+        }
+    }
+    let bytes = block_on(async { into_bytes(payload).await })?;
+
+    let new_key = match serde_json::from_slice::<NewKey>(&bytes) {
+        Ok(val) => val,
+        Err(err) => {
+            debug!("Error parsing payload {}", err);
+            return Ok(
+                HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                    "Failed to parse payload: {}",
+                    err
+                ))),
+            );
+        }
+    };
+    let key = Key::new(
+        &new_key.public_key,
+        &new_key.encrypted_private_key,
+        &user_id,
+        &new_key.display_name,
+    );
+
+    match key_store.add_key(key) {
+        Ok(()) => Ok(HttpResponse::Ok().json(json!({ "message": "Key added successfully" }))),
+        Err(err) => {
+            debug!("Failed to add new key to database {}", err);
+            match err {
+                KeyStoreError::DuplicateKeyError(msg) => {
+                    Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&msg)))
+                }
+                KeyStoreError::UserDoesNotExistError(msg) => {
+                    Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&msg)))
+                }
+                _ => Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error())),
             }
         }
-
-        Box::new(into_bytes(payload).and_then(move |bytes| {
-            let new_key = match serde_json::from_slice::<NewKey>(&bytes) {
-                Ok(val) => val,
-                Err(err) => {
-                    debug!("Error parsing payload {}", err);
-                    return HttpResponse::BadRequest()
-                        .json(ErrorResponse::bad_request(&format!(
-                            "Failed to parse payload: {}",
-                            err
-                        )))
-                        .into_future();
-                }
-            };
-            let key = Key::new(
-                &new_key.public_key,
-                &new_key.encrypted_private_key,
-                &user_id,
-                &new_key.display_name,
-            );
-
-            match key_store.add_key(key) {
-                Ok(()) => HttpResponse::Ok()
-                    .json(json!({ "message": "Key added successfully" }))
-                    .into_future(),
-                Err(err) => {
-                    debug!("Failed to add new key to database {}", err);
-                    match err {
-                        KeyStoreError::DuplicateKeyError(msg) => HttpResponse::BadRequest()
-                            .json(ErrorResponse::bad_request(&msg))
-                            .into_future(),
-                        KeyStoreError::UserDoesNotExistError(msg) => HttpResponse::BadRequest()
-                            .json(ErrorResponse::bad_request(&msg))
-                            .into_future(),
-                        _ => HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error())
-                            .into_future(),
-                    }
-                }
-            }
-        }))
-    })
+    }
 }
 
 fn handle_get(
     rest_config: Arc<BiomeRestConfig>,
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
-) -> HandlerFunction {
-    Box::new(move |request, _| {
-        let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
-
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
-            AuthorizationResult::Unauthorized(msg) => {
-                return Box::new(
-                    HttpResponse::Unauthorized()
-                        .json(ErrorResponse::unauthorized(&msg))
-                        .into_future(),
-                )
-            }
-            AuthorizationResult::Failed => {
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
+    request: HttpRequest,
+) -> Result<HttpResponse, ActixError> {
+    let user_id = match request.match_info().get("user_id") {
+        Some(id) => id.to_owned(),
+        None => {
+            error!("User ID is not in path request");
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
         }
+    };
 
-        match key_store.list_keys(Some(&user_id)) {
-            Ok(keys) => Box::new(
-                HttpResponse::Ok()
-                    .json(json!({ "data": keys }))
-                    .into_future(),
-            ),
-            Err(err) => {
-                debug!("Failed to fetch keys {}", err);
-                Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                )
-            }
+    match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
+        AuthorizationResult::Authorized => (),
+        AuthorizationResult::Unauthorized(msg) => {
+            return Ok(HttpResponse::Unauthorized().json(ErrorResponse::unauthorized(&msg)));
         }
-    })
+        AuthorizationResult::Failed => {
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
+        }
+    }
+
+    match key_store.list_keys(Some(&user_id)) {
+        Ok(keys) => Ok(HttpResponse::Ok().json(json!({ "data": keys }))),
+        Err(err) => {
+            debug!("Failed to fetch keys {}", err);
+            Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()))
+        }
+    }
 }
 
 fn handle_patch(
     rest_config: Arc<BiomeRestConfig>,
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
-) -> HandlerFunction {
-    Box::new(move |request, payload| {
-        let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
+    request: HttpRequest,
+    payload: Payload,
+) -> Result<HttpResponse, ActixError> {
+    let user_id = match request.match_info().get("user_id") {
+        Some(id) => id.to_owned(),
+        None => {
+            error!("User ID is not in path request");
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
+        }
+    };
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
-            AuthorizationResult::Unauthorized(msg) => {
-                return Box::new(
-                    HttpResponse::Unauthorized()
-                        .json(ErrorResponse::unauthorized(&msg))
-                        .into_future(),
-                )
-            }
-            AuthorizationResult::Failed => {
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
+    match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
+        AuthorizationResult::Authorized => (),
+        AuthorizationResult::Unauthorized(msg) => {
+            return Ok(HttpResponse::Unauthorized().json(ErrorResponse::unauthorized(&msg)));
+        }
+        AuthorizationResult::Failed => {
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()));
+        }
+    }
+
+    let bytes = block_on(async { into_bytes(payload).await })?;
+    let updated_key = match serde_json::from_slice::<UpdatedKey>(&bytes) {
+        Ok(val) => val,
+        Err(err) => {
+            debug!("Error parsing payload {}", err);
+            return Ok(
+                HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                    "Failed to parse payload: {}",
+                    err
+                ))),
+            );
+        }
+    };
+
+    match key_store.update_key(
+        &updated_key.public_key,
+        &user_id,
+        &updated_key.new_display_name,
+    ) {
+        Ok(()) => Ok(HttpResponse::Ok().json(json!({ "message": "Key updated successfully" }))),
+        Err(err) => {
+            debug!("Failed to update key {}", err);
+            match err {
+                KeyStoreError::NotFoundError(msg) => {
+                    Ok(HttpResponse::NotFound().json(ErrorResponse::not_found(&msg)))
+                }
+                _ => Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error())),
             }
         }
-
-        Box::new(into_bytes(payload).and_then(move |bytes| {
-            let updated_key = match serde_json::from_slice::<UpdatedKey>(&bytes) {
-                Ok(val) => val,
-                Err(err) => {
-                    debug!("Error parsing payload {}", err);
-                    return HttpResponse::BadRequest()
-                        .json(ErrorResponse::bad_request(&format!(
-                            "Failed to parse payload: {}",
-                            err
-                        )))
-                        .into_future();
-                }
-            };
-
-            match key_store.update_key(
-                &updated_key.public_key,
-                &user_id,
-                &updated_key.new_display_name,
-            ) {
-                Ok(()) => HttpResponse::Ok()
-                    .json(json!({ "message": "Key updated successfully" }))
-                    .into_future(),
-                Err(err) => {
-                    debug!("Failed to update key {}", err);
-                    match err {
-                        KeyStoreError::NotFoundError(msg) => HttpResponse::NotFound()
-                            .json(ErrorResponse::not_found(&msg))
-                            .into_future(),
-                        _ => HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error())
-                            .into_future(),
-                    }
-                }
-            }
-        }))
-    })
+    }
 }

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -592,13 +592,12 @@ pub fn get_authorization_token(request: &HttpRequest) -> Result<String, RequestE
 mod test {
     use super::*;
     use actix_http::Response;
-    use futures::IntoFuture;
 
     #[test]
     fn test_resource() {
         Resource::build("/test")
             .add_method(Method::Get, |_: HttpRequest, _: web::Payload| {
-                Box::new(Response::Ok().finish())
+                Ok(Response::Ok().finish())
             })
             .into_route();
     }
@@ -607,10 +606,10 @@ mod test {
     fn test_resource_with_guard() {
         Resource::build("/test-guarded")
             .add_request_guard(|_: &HttpRequest| {
-                Continuation::terminate(Response::BadRequest().finish())
+                Continuation::terminate(Ok(Response::BadRequest().finish()))
             })
             .add_method(Method::Get, |_: HttpRequest, _: web::Payload| {
-                Box::new(Response::Ok().finish())
+                Ok(Response::Ok().finish())
             })
             .into_route();
     }

--- a/libsplinter/src/service/rest_api.rs
+++ b/libsplinter/src/service/rest_api.rs
@@ -15,17 +15,12 @@
 use std::sync::Arc;
 
 use crate::actix_web::{web, Error as ActixError, HttpRequest, HttpResponse};
-use crate::futures::Future;
 use crate::rest_api::{Continuation, Method, RequestGuard};
 
 use super::Service;
 
 type Handler = Arc<
-    dyn Fn(
-            HttpRequest,
-            web::Payload,
-            &dyn Service,
-        ) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
+    dyn Fn(HttpRequest, web::Payload, &dyn Service) -> Result<HttpResponse, ActixError>
         + Send
         + Sync
         + 'static,

--- a/libsplinter/src/service/scabbard/rest_api.rs
+++ b/libsplinter/src/service/scabbard/rest_api.rs
@@ -16,11 +16,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::StreamExt;
 use transact::protocol::batch::BatchPair;
 use transact::protos::FromBytes;
 
-use crate::actix_web::{web, Error as ActixError, HttpResponse};
-use crate::futures::{stream::Stream, Future, IntoFuture};
+use crate::actix_web::{web, HttpResponse};
+use crate::futures::executor::block_on;
 use crate::protocol;
 use crate::rest_api::{
     new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Request,
@@ -59,13 +60,9 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                 Some(s) => s,
                 None => {
                     error!("Failed to downcast to scabbard service");
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({
-                                "message": "An internal error occurred"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })));
                 }
             };
 
@@ -73,13 +70,9 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                 match web::Query::<HashMap<String, String>>::from_query(request.query_string()) {
                     Ok(query) => query,
                     Err(_) => {
-                        return Box::new(
-                            HttpResponse::BadRequest()
-                                .json(json!({
-                                    "message": "Invalid query"
-                                }))
-                                .into_future(),
-                        )
+                        return Ok(HttpResponse::BadRequest().json(json!({
+                            "message": "Invalid query"
+                        })))
                     }
                 };
 
@@ -87,13 +80,9 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
 
             match last_seen_event_id {
                 Some(ref id) if id.trim().is_empty() => {
-                    return Box::new(
-                        HttpResponse::BadRequest()
-                            .json(json!({
-                                "message": "last_seen_event must not be empty",
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::BadRequest().json(json!({
+                        "message": "last_seen_event must not be empty",
+                    })));
                 }
                 Some(ref id) => debug!("Getting all state-delta events since {}", id),
                 None => debug!("Getting all state-delta events"),
@@ -103,11 +92,8 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                 Ok(events) => events,
                 Err(err) => {
                     error!("Unable to load unseen scabbard events: {}", err);
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({ "message": "An internal error occurred" }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError()
+                        .json(json!({ "message": "An internal error occurred" })));
                 }
             };
 
@@ -118,21 +104,15 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                         scabbard.add_state_subscriber(Box::new(WsStateSubscriber { sender }))
                     {
                         error!("Unable to add scabbard event sender: {}", err);
-                        return Box::new(
-                            HttpResponse::InternalServerError()
-                                .json(json!({ "message": "An internal error occurred" }))
-                                .into_future(),
-                        );
+                        return Ok(HttpResponse::InternalServerError()
+                            .json(json!({ "message": "An internal error occurred" })));
                     }
-                    Box::new(res.into_future())
+                    Ok(res.into())
                 }
                 Err(err) => {
                     error!("Failed to create websocket: {:?}", err);
-                    Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({ "message": "An internal error occurred" }))
-                            .into_future(),
-                    )
+                    Ok(HttpResponse::InternalServerError()
+                        .json(json!({ "message": "An internal error occurred" })))
                 }
             }
         }),
@@ -148,60 +128,45 @@ pub fn make_add_batches_to_queue_endpoint() -> ServiceEndpoint {
         service_type: SERVICE_TYPE.into(),
         route: "/batches".into(),
         method: Method::Post,
-        handler: Arc::new(move |_, payload, service| {
+        handler: Arc::new(move |_, mut payload, service| {
             let scabbard = match service.as_any().downcast_ref::<Scabbard>() {
                 Some(s) => s,
                 None => {
                     error!("Failed to downcast to scabbard service");
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({
-                                "message": "An internal error occurred"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })));
                 }
             }
             .clone();
+            let bytes = block_on(async {
+                let mut bytes = web::BytesMut::new();
+                while let Some(body) = payload.next().await {
+                    bytes.extend_from_slice(&body.unwrap());
+                }
+                bytes
+            });
+            let batches: Vec<BatchPair> = match Vec::from_bytes(&bytes) {
+                Ok(b) => b,
+                Err(_) => {
+                    return Ok(HttpResponse::BadRequest().json(json!({
+                        "message": "invalid body: not a valid list of batches"
+                    })))
+                }
+            };
 
-            Box::new(
-                payload
-                    .from_err::<ActixError>()
-                    .fold(web::BytesMut::new(), move |mut body, chunk| {
-                        body.extend_from_slice(&chunk);
-                        Ok::<_, ActixError>(body)
-                    })
-                    .into_future()
-                    .and_then(move |body| {
-                        let batches: Vec<BatchPair> = match Vec::from_bytes(&body) {
-                            Ok(b) => b,
-                            Err(_) => {
-                                return HttpResponse::BadRequest()
-                                    .json(json!({
-                                        "message": "invalid body: not a valid list of batches"
-                                    }))
-                                    .into_future()
-                            }
-                        };
-
-                        match scabbard.add_batches(batches) {
-                            Ok(Some(link)) => HttpResponse::Accepted().json(link).into_future(),
-                            Ok(None) => HttpResponse::BadRequest()
-                                .json(json!({
-                                    "message": "no valid batches provided"
-                                }))
-                                .into_future(),
-                            Err(err) => {
-                                error!("Failed to add batches: {}", err);
-                                HttpResponse::InternalServerError()
-                                    .json(json!({
-                                        "message": "An internal error occurred"
-                                    }))
-                                    .into_future()
-                            }
-                        }
-                    }),
-            )
+            match scabbard.add_batches(batches) {
+                Ok(Some(link)) => Ok(HttpResponse::Accepted().json(link)),
+                Ok(None) => Ok(HttpResponse::BadRequest().json(json!({
+                    "message": "no valid batches provided"
+                }))),
+                Err(err) => {
+                    error!("Failed to add batches: {}", err);
+                    Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })))
+                }
+            }
         }),
         request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_ADD_BATCHES_PROTOCOL_MIN,
@@ -220,13 +185,9 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 Some(s) => s,
                 None => {
                     error!("Failed to downcast to scabbard service");
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({
-                                "message": "An internal error occurred"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })));
                 }
             }
             .clone();
@@ -234,25 +195,17 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 if let Ok(q) = web::Query::from_query(req.query_string()) {
                     q
                 } else {
-                    return Box::new(
-                        HttpResponse::BadRequest()
-                            .json(json!({
-                                "message": "Invalid query"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::BadRequest().json(json!({
+                        "message": "Invalid query"
+                    })));
                 };
 
             let ids = if let Some(ids) = query.get("ids") {
                 ids.split(',').map(String::from).collect()
             } else {
-                return Box::new(
-                    HttpResponse::BadRequest()
-                        .json(json!({
-                            "message": "No batch IDs specified"
-                        }))
-                        .into_future(),
-                );
+                return Ok(HttpResponse::BadRequest().json(json!({
+                    "message": "No batch IDs specified"
+                })));
             };
 
             let wait = query
@@ -273,24 +226,16 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 Ok(iter) => iter,
                 Err(err) => {
                     error!("Failed to get batch statuses iterator: {}", err);
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({ "message": "An internal error occurred" }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError()
+                        .json(json!({ "message": "An internal error occurred" })));
                 }
             };
 
             match batch_info_iter.collect::<Result<Vec<_>, _>>() {
-                Ok(batch_infos) => Box::new(HttpResponse::Ok().json(batch_infos).into_future()),
-                Err(err) => Box::new(
-                    HttpResponse::RequestTimeout()
-                        .json(json!({
-                            "message":
-                                format!("Failed to get batch statuses before timeout: {}", err)
-                        }))
-                        .into_future(),
-                ),
+                Ok(batch_infos) => Ok(HttpResponse::Ok().json(batch_infos)),
+                Err(err) => Ok(HttpResponse::RequestTimeout().json(json!({
+                    "message": format!("Failed to get batch statuses before timeout: {}", err)
+                }))),
             }
         }),
         request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
@@ -311,13 +256,9 @@ pub fn make_get_state_at_address_endpoint() -> ServiceEndpoint {
                 Some(s) => s,
                 None => {
                     error!("Failed to downcast to scabbard service");
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({
-                                "message": "An internal error occurred"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })));
                 }
             };
 
@@ -326,20 +267,16 @@ pub fn make_get_state_at_address_endpoint() -> ServiceEndpoint {
                 .get("address")
                 .expect("address should not be none");
 
-            Box::new(match scabbard.get_state_at_address(address) {
-                Ok(Some(value)) => HttpResponse::Ok().json(value).into_future(),
-                Ok(None) => HttpResponse::NotFound()
-                    .json(json!({
-                        "message": "address not set"
-                    }))
-                    .into_future(),
+            Ok(match scabbard.get_state_at_address(address) {
+                Ok(Some(value)) => HttpResponse::Ok().json(value),
+                Ok(None) => HttpResponse::NotFound().json(json!({
+                    "message": "address not set"
+                })),
                 Err(err) => {
                     error!("Failed to get state at adddress: {}", err);
-                    HttpResponse::InternalServerError()
-                        .json(json!({
-                            "message": "An internal error occurred"
-                        }))
-                        .into_future()
+                    HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    }))
                 }
             })
         }),
@@ -361,13 +298,9 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
                 Some(s) => s,
                 None => {
                     error!("Failed to downcast to scabbard service");
-                    return Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(json!({
-                                "message": "An internal error occurred"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    })));
                 }
             };
 
@@ -375,18 +308,14 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
                 if let Ok(q) = web::Query::from_query(request.query_string()) {
                     q
                 } else {
-                    return Box::new(
-                        HttpResponse::BadRequest()
-                            .json(json!({
-                                "message": "Invalid query"
-                            }))
-                            .into_future(),
-                    );
+                    return Ok(HttpResponse::BadRequest().json(json!({
+                        "message": "Invalid query"
+                    })));
                 };
 
             let prefix = query.get("prefix").map(String::as_str);
 
-            Box::new(match scabbard.get_state_with_prefix(prefix) {
+            Ok(match scabbard.get_state_with_prefix(prefix) {
                 Ok(state_iter) => {
                     let res = state_iter
                         .map(|res| {
@@ -399,24 +328,20 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
                         })
                         .collect::<Result<Vec<_>, _>>();
                     match res {
-                        Ok(entries) => HttpResponse::Ok().json(entries).into_future(),
+                        Ok(entries) => HttpResponse::Ok().json(entries),
                         Err(err) => {
                             error!("Failed to convert state iterator: {}", err);
-                            HttpResponse::InternalServerError()
-                                .json(json!({
-                                    "message": "An internal error occurred"
-                                }))
-                                .into_future()
+                            HttpResponse::InternalServerError().json(json!({
+                                "message": "An internal error occurred"
+                            }))
                         }
                     }
                 }
                 Err(err) => {
                     error!("Failed to get state with prefix: {}", err);
-                    HttpResponse::InternalServerError()
-                        .json(json!({
-                            "message": "An internal error occurred"
-                        }))
-                        .into_future()
+                    HttpResponse::InternalServerError().json(json!({
+                        "message": "An internal error occurred"
+                    }))
                 }
             })
         }),

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -17,7 +17,6 @@ extern crate log;
 
 use splinter::{
     actix_web::HttpResponse,
-    futures::IntoFuture,
     rest_api::{Method, Resource, RestResourceProvider},
     service::{
         error::{ServiceDestroyError, ServiceError, ServiceStartError, ServiceStopError},
@@ -89,7 +88,6 @@ impl RestResourceProvider for HealthService {
 }
 
 fn make_status_resource() -> Resource {
-    Resource::build("/health/status").add_method(Method::Get, move |_, _| {
-        Box::new(HttpResponse::Ok().finish().into_future())
-    })
+    Resource::build("/health/status")
+        .add_method(Method::Get, move |_, _| Ok(HttpResponse::Ok().finish()))
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -442,9 +442,7 @@ impl SplinterDaemon {
                 error!("Unable to cleanly shut down Admin service: {}", err);
             }
 
-            if let Err(err) = rest_api_shutdown_handle.shutdown() {
-                error!("Unable to cleanly shut down REST API server: {}", err);
-            }
+            rest_api_shutdown_handle.shutdown();
         })
         .expect("Error setting Ctrl-C handler");
 

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use splinter::actix_web::{web, Error, HttpRequest, HttpResponse};
-use splinter::futures::{Future, IntoFuture};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Status {
@@ -22,28 +21,18 @@ struct Status {
     version: String,
 }
 
-pub fn get_status(
-    node_id: String,
-    endpoint: String,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+pub fn get_status(node_id: String, endpoint: String) -> Result<HttpResponse, Error> {
     let status = Status {
         node_id,
         endpoint,
         version: get_version(),
     };
 
-    Box::new(HttpResponse::Ok().json(status).into_future())
+    Ok(HttpResponse::Ok().json(status))
 }
 
-pub fn get_openapi(
-    _: HttpRequest,
-    _: web::Payload,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    Box::new(
-        HttpResponse::Ok()
-            .body(include_str!("../../api/static/openapi.yml"))
-            .into_future(),
-    )
+pub fn get_openapi(_: HttpRequest, _: web::Payload) -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().body(include_str!("../../api/static/openapi.yml")))
 }
 
 fn get_version() -> String {


### PR DESCRIPTION
This PR updates the tokio, futures, and actix libraries used by libsplinter. It also removes hyper, tokio, and futures from the gameroom daemon and replaces them with reqwest.