### PR TITLE
Rename circuits iterator

### DIFF
--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::circuit::directory::CircuitDirectory;
 use crate::circuit::service::{Service, ServiceId, SplinterNode};
-use crate::circuit::store::{CircuitFilter, CircuitStore, CircuitStoreError, Circuits};
+use crate::circuit::store::{CircuitFilter, CircuitIter, CircuitStore, CircuitStoreError};
 use crate::storage::get_storage;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -571,7 +571,7 @@ impl SplinterState {
 }
 
 impl CircuitStore for SplinterState {
-    fn circuits(&self, filter: Option<CircuitFilter>) -> Result<Circuits, CircuitStoreError> {
+    fn circuits(&self, filter: Option<CircuitFilter>) -> Result<CircuitIter, CircuitStoreError> {
         let circuits = self
             .circuits()
             .map_err(|err| CircuitStoreError::new(err.context()))?;
@@ -589,11 +589,11 @@ impl CircuitStore for SplinterState {
                 }
             }));
 
-            Ok(Circuits::new(total as u64, iter))
+            Ok(CircuitIter::new(total as u64, iter))
         } else {
             let total = circuits.len();
             let iter = Box::new(circuits.into_iter().map(|(_, circuit)| circuit));
-            Ok(Circuits::new(total as u64, iter))
+            Ok(CircuitIter::new(total as u64, iter))
         }
     }
 

--- a/libsplinter/src/circuit/store.rs
+++ b/libsplinter/src/circuit/store.rs
@@ -39,18 +39,18 @@ pub trait CircuitStore: Send + Sync + Clone {
     /// Return an iterator over the circuits in this store.
     ///
     /// A circuit filter may optionally provided, to reduces the results.
-    fn circuits(&self, filter: Option<CircuitFilter>) -> Result<Circuits, CircuitStoreError>;
+    fn circuits(&self, filter: Option<CircuitFilter>) -> Result<CircuitIter, CircuitStoreError>;
 
     fn circuit(&self, circuit_name: &str) -> Result<Option<Circuit>, CircuitStoreError>;
 }
 
 /// An iterator over circuits, with a well-known count of values.
-pub struct Circuits {
+pub struct CircuitIter {
     inner: Box<dyn Iterator<Item = Circuit> + Send>,
     total: u64,
 }
 
-impl Circuits {
+impl CircuitIter {
     /// Construct the new iterator with the given total and an inner iterator.
     pub(crate) fn new(total: u64, inner: Box<dyn Iterator<Item = Circuit> + Send>) -> Self {
         Self { inner, total }
@@ -62,7 +62,7 @@ impl Circuits {
     }
 }
 
-impl Iterator for Circuits {
+impl Iterator for CircuitIter {
     type Item = Circuit;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Rename the `Circuits` iterator to `CircuitIter`.  The name "Circuits" implies a collection, where as "CircuitIter" is more precise.