### PR TITLE
Add new rules to circuit template API

### DIFF
--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -49,6 +49,34 @@ impl CircuitCreateTemplate {
 
         Ok(builders)
     }
+
+    pub fn set_argument_value(
+        &mut self,
+        key: &str,
+        value: &str,
+    ) -> Result<(), CircuitTemplateError> {
+        let name = key.to_lowercase();
+        let (index, mut arg) = self
+            .arguments
+            .iter()
+            .enumerate()
+            .find_map(|(index, arg)| {
+                if arg.name() == name {
+                    Some((index, arg.clone()))
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| {
+                CircuitTemplateError::new(&format!(
+                    "Argument {} is not defined in the template",
+                    key
+                ))
+            })?;
+        arg.set_user_value(value);
+        self.arguments[index] = arg;
+        Ok(())
+    }
 }
 
 impl TryFrom<v1::CircuitCreateTemplate> for CircuitCreateTemplate {

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -77,6 +77,18 @@ impl CircuitCreateTemplate {
         self.arguments[index] = arg;
         Ok(())
     }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn arguments(&self) -> &[RuleArgument] {
+        &self.arguments
+    }
+
+    pub fn rules(&self) -> &Rules {
+        &self.rules
+    }
 }
 
 impl TryFrom<v1::CircuitCreateTemplate> for CircuitCreateTemplate {

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::{yaml_parser::v1, CircuitTemplateError, SplinterServiceBuilder};
+use super::Value;
+
+pub(super) struct CreateServices {
+    service_type: String,
+    service_args: Vec<ServiceArgument>,
+    first_service: String,
+}
+
+#[derive(Debug)]
+struct ServiceArgument {
+    key: String,
+    value: Value,
+}
+
+impl From<v1::CreateServices> for CreateServices {
+    fn from(yaml_create_services: v1::CreateServices) -> Self {
+        CreateServices {
+            service_type: yaml_create_services.service_type().to_string(),
+            service_args: yaml_create_services
+                .service_args()
+                .to_owned()
+                .into_iter()
+                .map(ServiceArgument::from)
+                .collect(),
+            first_service: yaml_create_services.first_service().to_string(),
+        }
+    }
+}
+
+impl From<v1::ServiceArgument> for ServiceArgument {
+    fn from(yaml_service_argument: v1::ServiceArgument) -> Self {
+        ServiceArgument {
+            key: yaml_service_argument.key().to_string(),
+            value: Value::from(yaml_service_argument.value().clone()),
+        }
+    }
+}

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -12,13 +12,95 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use super::super::{yaml_parser::v1, CircuitTemplateError, SplinterServiceBuilder};
-use super::Value;
+use super::{get_argument_value, is_arg, RuleArgument, Value};
+
+const ALL_OTHER_SERVICES: &str = "$(r:ALL_OTHER_SERVICES)";
+const NODES_ARG: &str = "$(a:NODES)";
+const PEER_SERVICES_ARG: &str = "peer-services";
 
 pub(super) struct CreateServices {
     service_type: String,
     service_args: Vec<ServiceArgument>,
     first_service: String,
+}
+
+impl CreateServices {
+    pub fn apply_rule(
+        &self,
+        template_arguments: &[RuleArgument],
+    ) -> Result<Vec<SplinterServiceBuilder>, CircuitTemplateError> {
+        let nodes = get_argument_value(NODES_ARG, template_arguments)?
+            .split(',')
+            .map(String::from)
+            .collect::<Vec<String>>();
+
+        if self.first_service.is_empty() {
+            return Err(CircuitTemplateError::new(
+                "The first_service field must be an non-empty string",
+            ));
+        }
+
+        let mut service_id = self.first_service.clone();
+        let mut service_builders = vec![];
+        for node in nodes {
+            let splinter_service_builder = SplinterServiceBuilder::new()
+                .with_service_id(&service_id)
+                .with_allowed_nodes(&[node])
+                .with_service_type(&self.service_type);
+
+            service_builders.push(splinter_service_builder);
+            service_id = get_next_service_id(&service_id)?;
+        }
+
+        let mut new_service_args = Vec::new();
+        for arg in self.service_args.iter() {
+            match &arg.value {
+                Value::Single(value) => {
+                    if arg.key == PEER_SERVICES_ARG && value == ALL_OTHER_SERVICES {
+                        service_builders = all_services(service_builders)?;
+                    } else {
+                        let value = if is_arg(&value) {
+                            get_argument_value(&value, template_arguments)?
+                        } else {
+                            value.clone()
+                        };
+                        new_service_args.push((arg.key.clone(), value));
+                    }
+                }
+                Value::List(values) => {
+                    let vals = values
+                        .iter()
+                        .try_fold::<_, _, Result<_, CircuitTemplateError>>(
+                            Vec::new(),
+                            |mut acc, value| {
+                                let value = if is_arg(&value) {
+                                    get_argument_value(&value, template_arguments)?
+                                } else {
+                                    value.to_string()
+                                };
+                                acc.push(format!("\"{}\"", value));
+                                Ok(acc)
+                            },
+                        )?;
+                    new_service_args.push((arg.key.clone(), format!("[{}]", vals.join(","))));
+                }
+            }
+        }
+
+        service_builders = service_builders
+            .into_iter()
+            .map(|builder| {
+                let mut service_args = builder.arguments().unwrap_or_default();
+                service_args.extend(new_service_args.clone());
+                builder.with_arguments(&service_args)
+            })
+            .collect::<Vec<SplinterServiceBuilder>>();
+
+        Ok(service_builders)
+    }
 }
 
 #[derive(Debug)]
@@ -48,5 +130,194 @@ impl From<v1::ServiceArgument> for ServiceArgument {
             key: yaml_service_argument.key().to_string(),
             value: Value::from(yaml_service_argument.value().clone()),
         }
+    }
+}
+
+fn add1_char(c: char) -> Result<char, CircuitTemplateError> {
+    let char_value = c as u32;
+    if char_value >= 'z' as u32 {
+        return Ok('0');
+    }
+    let next_char = std::char::from_u32(char_value + 1).ok_or_else(|| {
+        CircuitTemplateError::new("Failed to generate service id. Failed to convert char from u32.")
+    })?;
+    if !next_char.is_ascii_alphanumeric() {
+        return add1_char(next_char);
+    }
+    Ok(next_char)
+}
+
+fn get_next_service_id(current_id: &str) -> Result<String, CircuitTemplateError> {
+    generate_id(current_id, current_id.len() - 1)
+}
+
+fn generate_id(current_id: &str, index: usize) -> Result<String, CircuitTemplateError> {
+    let mut next_id = current_id.to_string();
+    let character = char::from_str(&next_id[index..=index]).map_err(|_| {
+        CircuitTemplateError::new(&format!(
+            "Failed to generate service id. Could not extract valid char from string {}",
+            next_id
+        ))
+    })?;
+    if !character.is_ascii_alphanumeric() {
+        return Err(CircuitTemplateError::new(&format!(
+            "The service id contains an invalid character: {}. \
+             Only ASCII alphanumeric characters are allowed",
+            character
+        )));
+    }
+    let next_char = add1_char(character)?;
+    next_id.replace_range(index..=index, &next_char.to_string());
+
+    if next_char == '0' {
+        if index == 0 {
+            return Err(CircuitTemplateError::new(
+                "Exceed number of services that can be built",
+            ));
+        }
+
+        return generate_id(&next_id, index - 1);
+    }
+    Ok(next_id)
+}
+
+fn all_services(
+    service_builders: Vec<SplinterServiceBuilder>,
+) -> Result<Vec<SplinterServiceBuilder>, CircuitTemplateError> {
+    let peers = service_builders.iter().map(|builder| {
+        let service_id = builder.service_id()
+            .ok_or_else(|| {
+                error!("The service_id must be set before the service argument PEER_SERVICES can be set");
+                CircuitTemplateError::new("Failed to parse template due to an internal error")
+            })?;
+        Ok(format!("\"{}\"", service_id))
+    }).collect::<Result<Vec<String>, CircuitTemplateError>>()?;
+    let services = service_builders
+        .into_iter()
+        .enumerate()
+        .map(|(index, builder)| {
+            let mut service_peers = peers.clone();
+            service_peers.remove(index);
+            let mut service_args = builder.arguments().unwrap_or_default();
+            service_args.push((
+                PEER_SERVICES_ARG.into(),
+                format!("[{}]", service_peers.join(",")),
+            ));
+            builder.with_arguments(&service_args)
+        })
+        .collect::<Vec<SplinterServiceBuilder>>();
+    Ok(services)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /*
+     * Test that CreateServices::apply_rules correcly sets ups
+     * the services builders
+     */
+    #[test]
+    fn test_create_service_apply_rules() {
+        let create_services = make_create_service();
+        let template_arguments = make_rule_arguments();
+
+        let service_builders = create_services
+            .apply_rule(&template_arguments)
+            .expect("Failled to apply rules");
+
+        assert_eq!(service_builders.len(), 2);
+
+        assert_eq!(
+            service_builders[0].allowed_nodes(),
+            Some(vec!["alpha-node-000".to_string()])
+        );
+        assert_eq!(service_builders[0].service_id(), Some("a000".to_string()));
+        assert_eq!(
+            service_builders[0].service_type(),
+            Some("scabbard".to_string())
+        );
+
+        let service_args = service_builders[0]
+            .arguments()
+            .expect("Services args were not set");
+        assert_eq!(service_args.len(), 2);
+        assert_eq!(
+            service_args[0],
+            (PEER_SERVICES_ARG.to_string(), "[\"a001\"]".to_string())
+        );
+        assert_eq!(
+            service_args[1],
+            ("admin-keys".to_string(), "[\"signer_key\"]".to_string())
+        );
+
+        assert_eq!(
+            service_builders[1].allowed_nodes(),
+            Some(vec!["beta-node-000".to_string()])
+        );
+        assert_eq!(service_builders[1].service_id(), Some("a001".to_string()));
+        assert_eq!(
+            service_builders[1].service_type(),
+            Some("scabbard".to_string())
+        );
+
+        let service_args = service_builders[1]
+            .arguments()
+            .expect("Services args were not set");
+        assert_eq!(service_args.len(), 2);
+        assert_eq!(
+            service_args[0],
+            (PEER_SERVICES_ARG.to_string(), "[\"a000\"]".to_string())
+        );
+        assert_eq!(
+            service_args[1],
+            ("admin-keys".to_string(), "[\"signer_key\"]".to_string())
+        );
+
+        // test that building services succeeds:
+        assert!(service_builders[0].clone().build().is_ok());
+        assert!(service_builders[1].clone().build().is_ok());
+    }
+
+    fn make_create_service() -> CreateServices {
+        let peer_services_arg = ServiceArgument {
+            key: PEER_SERVICES_ARG.to_string(),
+            value: Value::Single(ALL_OTHER_SERVICES.to_string()),
+        };
+        let admin_keys_arg = ServiceArgument {
+            key: "admin-keys".to_string(),
+            value: Value::List(vec!["$(a:ADMIN_KEYS)".to_string()]),
+        };
+
+        CreateServices {
+            service_type: "scabbard".to_string(),
+            service_args: vec![peer_services_arg, admin_keys_arg],
+            first_service: "a000".to_string(),
+        }
+    }
+
+    fn make_rule_arguments() -> Vec<RuleArgument> {
+        let admin_keys_templae_arg = RuleArgument {
+            name: "admin_keys".to_string(),
+            required: false,
+            default_value: Some("$(a:SIGNER_PUB_KEY)".to_string()),
+            user_value: None,
+        };
+
+        let nodes_templae_arg = RuleArgument {
+            name: "nodes".to_string(),
+            required: true,
+            default_value: None,
+            user_value: Some("alpha-node-000,beta-node-000".to_string()),
+        };
+
+        let signer_pub_key = RuleArgument {
+            name: "signer_pub_key".to_string(),
+            required: false,
+            default_value: None,
+            user_value: Some("signer_key".to_string()),
+        };
+
+        vec![admin_keys_templae_arg, nodes_templae_arg, signer_pub_key]
     }
 }

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod create_services;
 mod set_management_type;
 
 use std::convert::TryFrom;
 
 use super::{yaml_parser::v1, Builders, CircuitTemplateError};
+
+use create_services::CreateServices;
 use set_management_type::CircuitManagement;
 
 pub struct Rules {
     set_management_type: Option<CircuitManagement>,
+    create_services: Option<CreateServices>,
 }
 
 impl Rules {
@@ -45,6 +49,9 @@ impl From<v1::Rules> for Rules {
             set_management_type: rules
                 .set_management_type()
                 .map(|val| CircuitManagement::from(val.clone())),
+            create_services: rules
+                .create_services()
+                .map(|val| CreateServices::from(val.clone())),
         }
     }
 }
@@ -107,5 +114,20 @@ fn strip_arg_marker(key: &str) -> Result<String, CircuitTemplateError> {
             "{} is not a valid argument name",
             key
         )))
+    }
+}
+
+#[derive(Debug)]
+enum Value {
+    Single(String),
+    List(Vec<String>),
+}
+
+impl From<v1::Value> for Value {
+    fn from(value: v1::Value) -> Self {
+        match value {
+            v1::Value::Single(value) => Self::Single(value),
+            v1::Value::List(values) => Self::List(values),
+        }
     }
 }

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -33,12 +33,20 @@ impl Rules {
         builders: &mut Builders,
         template_arguments: &[RuleArgument],
     ) -> Result<(), CircuitTemplateError> {
+        let mut service_builders = builders.service_builders();
+
         let mut circuit_builder = builders.create_circuit_builder();
 
         if let Some(circuit_management) = &self.set_management_type {
             circuit_builder = circuit_management.apply_rule(circuit_builder)?;
         }
+
+        if let Some(create_services) = &self.create_services {
+            service_builders.extend(create_services.apply_rule(template_arguments)?);
+        }
+
         builders.set_create_circuit_builder(circuit_builder);
+        builders.set_service_builders(service_builders);
         Ok(())
     }
 }

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -14,6 +14,7 @@
 
 mod create_services;
 mod set_management_type;
+mod set_metadata;
 
 use std::convert::TryFrom;
 
@@ -21,10 +22,12 @@ use super::{yaml_parser::v1, Builders, CircuitTemplateError};
 
 use create_services::CreateServices;
 use set_management_type::CircuitManagement;
+use set_metadata::SetMetadata;
 
 pub struct Rules {
     set_management_type: Option<CircuitManagement>,
     create_services: Option<CreateServices>,
+    set_metadata: Option<SetMetadata>,
 }
 
 impl Rules {
@@ -60,6 +63,9 @@ impl From<v1::Rules> for Rules {
             create_services: rules
                 .create_services()
                 .map(|val| CreateServices::from(val.clone())),
+            set_metadata: rules
+                .set_metadata()
+                .map(|val| SetMetadata::from(val.clone())),
         }
     }
 }

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -48,6 +48,10 @@ impl Rules {
             service_builders.extend(create_services.apply_rule(template_arguments)?);
         }
 
+        if let Some(set_metadata) = &self.set_metadata {
+            circuit_builder = set_metadata.apply_rule(circuit_builder, template_arguments)?;
+        }
+
         builders.set_create_circuit_builder(circuit_builder);
         builders.set_service_builders(service_builders);
         Ok(())

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod set_management_type;
 use std::collections::HashMap;
 
-use super::{yaml_parser::v1, CircuitTemplateError};
-use super::{Builders, CreateCircuitBuilder};
+use super::{yaml_parser::v1, Builders, CircuitTemplateError};
+use set_management_type::CircuitManagement;
 
 pub struct CircuitCreateTemplate {
     _version: String,
@@ -74,13 +75,13 @@ impl Rules {
         builders: &mut Builders,
         _arguments: &HashMap<String, String>,
     ) -> Result<(), CircuitTemplateError> {
-        let mut create_service_builder = builders.create_circuit_builder();
+        let mut circuit_builder = builders.create_circuit_builder();
 
         if let Some(circuit_management) = &self.set_management_type {
-            create_service_builder = circuit_management.apply_rule(create_service_builder)?;
+            circuit_builder = circuit_management.apply_rule(circuit_builder)?;
         }
 
-        builders.set_create_circuit_builder(create_service_builder);
+        builders.set_create_circuit_builder(circuit_builder);
         Ok(())
     }
 }
@@ -91,27 +92,6 @@ impl From<v1::Rules> for Rules {
             set_management_type: rules
                 .set_management_type()
                 .map(|val| CircuitManagement::from(val.clone())),
-        }
-    }
-}
-
-struct CircuitManagement {
-    management_type: String,
-}
-
-impl CircuitManagement {
-    fn apply_rule(
-        &self,
-        builder: CreateCircuitBuilder,
-    ) -> Result<CreateCircuitBuilder, CircuitTemplateError> {
-        Ok(builder.with_circuit_management_type(&self.management_type))
-    }
-}
-
-impl From<v1::CircuitManagement> for CircuitManagement {
-    fn from(yaml_circuit_management: v1::CircuitManagement) -> Self {
-        CircuitManagement {
-            management_type: yaml_circuit_management.management_type().to_string(),
         }
     }
 }

--- a/libsplinter/src/circuit/template/rules/set_management_type.rs
+++ b/libsplinter/src/circuit/template/rules/set_management_type.rs
@@ -1,0 +1,36 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
+
+pub(super) struct CircuitManagement {
+    management_type: String,
+}
+
+impl CircuitManagement {
+    pub fn apply_rule(
+        &self,
+        builder: CreateCircuitBuilder,
+    ) -> Result<CreateCircuitBuilder, CircuitTemplateError> {
+        Ok(builder.with_circuit_management_type(&self.management_type))
+    }
+}
+
+impl From<v1::CircuitManagement> for CircuitManagement {
+    fn from(yaml_circuit_management: v1::CircuitManagement) -> Self {
+        CircuitManagement {
+            management_type: yaml_circuit_management.management_type().to_string(),
+        }
+    }
+}

--- a/libsplinter/src/circuit/template/rules/set_metadata.rs
+++ b/libsplinter/src/circuit/template/rules/set_metadata.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::yaml_parser::v1;
+use super::Value;
+
+pub(super) struct SetMetadata {
+    metadata: Metadata,
+}
+
+impl From<v1::SetMetadata> for SetMetadata {
+    fn from(set_metadata: v1::SetMetadata) -> Self {
+        SetMetadata {
+            metadata: Metadata::from(set_metadata.metadata().clone()),
+        }
+    }
+}
+
+pub(super) enum Metadata {
+    Json { metadata: Vec<JsonMetadata> },
+}
+
+impl From<v1::Metadata> for Metadata {
+    fn from(metadata: v1::Metadata) -> Self {
+        match metadata {
+            v1::Metadata::Json { metadata } => Metadata::Json {
+                metadata: metadata.into_iter().map(JsonMetadata::from).collect(),
+            },
+        }
+    }
+}
+
+pub(super) struct JsonMetadata {
+    key: String,
+    value: Value,
+}
+
+impl From<v1::JsonMetadata> for JsonMetadata {
+    fn from(metadata: v1::JsonMetadata) -> Self {
+        JsonMetadata {
+            key: metadata.key().to_string(),
+            value: Value::from(metadata.value().clone()),
+        }
+    }
+}

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -60,6 +60,7 @@ impl RuleArgument {
 pub struct Rules {
     set_management_type: Option<CircuitManagement>,
     create_services: Option<CreateServices>,
+    set_metadata: Option<SetMetadata>,
 }
 
 impl Rules {
@@ -69,6 +70,10 @@ impl Rules {
 
     pub fn create_services(&self) -> Option<&CreateServices> {
         self.create_services.as_ref()
+    }
+
+    pub fn set_metadata(&self) -> Option<&SetMetadata> {
+        self.set_metadata.as_ref()
     }
 }
 
@@ -113,6 +118,41 @@ pub struct ServiceArgument {
 }
 
 impl ServiceArgument {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &Value {
+        &self.value
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SetMetadata {
+    #[serde(flatten)]
+    metadata: Metadata,
+}
+
+impl SetMetadata {
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "encoding")]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub enum Metadata {
+    Json { metadata: Vec<JsonMetadata> },
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsonMetadata {
+    key: String,
+    value: Value,
+}
+
+impl JsonMetadata {
     pub fn key(&self) -> &str {
         &self.key
     }

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -59,11 +59,16 @@ impl RuleArgument {
 #[serde(rename_all = "kebab-case")]
 pub struct Rules {
     set_management_type: Option<CircuitManagement>,
+    create_services: Option<CreateServices>,
 }
 
 impl Rules {
     pub fn set_management_type(&self) -> Option<&CircuitManagement> {
         self.set_management_type.as_ref()
+    }
+
+    pub fn create_services(&self) -> Option<&CreateServices> {
+        self.create_services.as_ref()
     }
 }
 
@@ -77,4 +82,49 @@ impl CircuitManagement {
     pub fn management_type(&self) -> &str {
         &self.management_type
     }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct CreateServices {
+    service_type: String,
+    service_args: Vec<ServiceArgument>,
+    first_service: String,
+}
+
+impl CreateServices {
+    pub fn service_type(&self) -> &str {
+        &self.service_type
+    }
+
+    pub fn service_args(&self) -> &[ServiceArgument] {
+        &self.service_args
+    }
+
+    pub fn first_service(&self) -> &str {
+        &self.first_service
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ServiceArgument {
+    key: String,
+    value: Value,
+}
+
+impl ServiceArgument {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &Value {
+        &self.value
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum Value {
+    Single(String),
+    List(Vec<String>),
 }


### PR DESCRIPTION
### Overview
Add rules for creating services and set application metadata to circuit template API:
- The rule `create-services`, will create a service for each node in the circuit. 
  - The services type will be set to the value of `service-type`. 
  - The service ids are generated starting from the value provided in`first-service`. The following id's will be the following base62 string.  
  - The arguments in the service definition are set via the `service-args` field. If `peer-services` is one of the arguments and the value is set to `$(cs:ALL_OTHER_SERVICES)`, the `peer-services` argument will be set to the id of all other services created by this rule. 

- The rule `set-metadata` sets the application metadata field in the circuit proposal. The `encoding` field determines how the metadata should be serialized, before it is set in the circuit proposal. Currently only json is supported.

This PR also updates the API so that users can load a template into a CircuitCreateTemplate object and work with before turning it into builders to create a circuit.
  
### Example template: 
```yaml
version: v1
args:
    - name: $(a:ADMIN_KEYS)
      required: false
      default: $(a:SIGNER_PUB_KEY)
    - name: $(a::NODES)
      required: true
    - name: $(a:SIGNER_PUB_KEY)
      required: false
    - name: $(a:GAMEROOM_NAME)
      required: true
rules:
    set-management-type:
        management-type: "gameroom"
    create-services:
        service-type: 'scabbard'
        service-args:
        - key: 'admin_keys'
          value: [$(a:ADMIN_KEYS)]
        - key: 'peer_services'
          value: '$(r:ALL_OTHER_SERVICES)'
        first-service: 'a000'
    set-metadata:
        encoding: json
        metadata:
            - key: "scabbard_admin_keys"
              value: ["$(a:ADMIN_KEYS)"]
            - key: "alias"
              value: "$(a:GAMEROOM_NAME)"

```

### To run tests:

```
cd libsplinter
cargo test template --features circuit-template
```