### PR TITLE
Add ProposalStore for getting/listing proposals

### DIFF
--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -47,9 +47,9 @@ impl RestResourceProvider for AdminService {
         resources.push(make_submit_route(self.commands()));
 
         #[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
-        resources.push(make_fetch_proposal_resource(self.commands()));
+        resources.push(make_fetch_proposal_resource(self.proposals()));
         #[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
-        resources.push(make_list_proposals_resource(self.commands()));
+        resources.push(make_list_proposals_resource(self.proposals()));
 
         resources
     }

--- a/libsplinter/src/admin/service/open_proposals.rs
+++ b/libsplinter/src/admin/service/open_proposals.rs
@@ -72,6 +72,7 @@ impl OpenProposals {
         self.proposal_registry.get_proposal(circuit_id)
     }
 
+    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> Proposals {
         self.proposal_registry.get_proposals()
     }
@@ -135,6 +136,7 @@ impl ProposalRegistry {
         }
     }
 
+    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> Proposals {
         Proposals {
             inner: Box::new(self.proposals.clone().into_iter()),
@@ -154,6 +156,7 @@ pub struct Proposals {
 }
 
 impl Proposals {
+    #[cfg(feature = "proposal-read")]
     pub fn total(&self) -> usize {
         self.size
     }

--- a/libsplinter/src/admin/service/proposal_store.rs
+++ b/libsplinter/src/admin/service/proposal_store.rs
@@ -1,0 +1,99 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use crate::protos::admin::CircuitProposal;
+
+use super::open_proposals::Proposals;
+use super::shared::AdminServiceShared;
+
+pub trait ProposalStore: Send + Sync + Clone {
+    fn proposals(&self) -> Result<Proposals, ProposalStoreError>;
+
+    fn proposal(&self, circuit_id: &str) -> Result<Option<CircuitProposal>, ProposalStoreError>;
+}
+
+#[derive(Debug)]
+pub struct ProposalStoreError {
+    context: String,
+    source: Option<Box<dyn std::error::Error + Send + 'static>>,
+}
+
+impl std::error::Error for ProposalStoreError {}
+
+impl ProposalStoreError {
+    pub fn new(context: &str) -> Self {
+        Self {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn from_source<T: std::error::Error + Send + 'static>(context: &str, source: T) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub fn context(&self) -> &str {
+        &self.context
+    }
+}
+
+impl std::fmt::Display for ProposalStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(ref source) = self.source {
+            write!(
+                f,
+                "ProposalStoreError: Source: {} Context: {}",
+                source, self.context
+            )
+        } else {
+            write!(f, "ProposalStoreError: Context {}", self.context)
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct AdminServiceProposals {
+    shared: Arc<Mutex<AdminServiceShared>>,
+}
+
+impl AdminServiceProposals {
+    pub fn new(shared: &Arc<Mutex<AdminServiceShared>>) -> Self {
+        Self {
+            shared: Arc::clone(shared),
+        }
+    }
+}
+
+impl ProposalStore for AdminServiceProposals {
+    fn proposals(&self) -> Result<Proposals, ProposalStoreError> {
+        Ok(self
+            .shared
+            .lock()
+            .map_err(|_| ProposalStoreError::new("Admin shared lock was lock poisoned"))?
+            .get_proposals())
+    }
+
+    fn proposal(&self, circuit_id: &str) -> Result<Option<CircuitProposal>, ProposalStoreError> {
+        self.shared
+            .lock()
+            .map_err(|_| ProposalStoreError::new("Admin shared lock was lock poisoned"))?
+            .get_proposal(circuit_id)
+            .map_err(|err| ProposalStoreError::from_source("Unable to get proposal", Box::new(err)))
+    }
+}

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -56,7 +56,9 @@ use crate::storage::sets::mem::DurableBTreeSet;
 use super::error::{AdminSharedError, MarshallingError};
 use super::mailbox::Mailbox;
 use super::messages;
-use super::open_proposals::{OpenProposals, Proposals};
+use super::open_proposals::OpenProposals;
+#[cfg(feature = "proposal-read")]
+use super::open_proposals::Proposals;
 use super::{admin_service_id, sha256, AdminServiceEventSubscriber, AdminSubscriberError, Events};
 
 const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
@@ -863,6 +865,7 @@ impl AdminServiceShared {
         Ok(self.open_proposals.get_proposal(circuit_id)?)
     }
 
+    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> Proposals {
         self.open_proposals.get_proposals()
     }


### PR DESCRIPTION
Previously, proposals were retrieved from the admin service by its REST
API using the AdminCommands trait. This commit splits the two methods
responsible for getting and listing open proposals off into their own
`ProposalStore` trait, which isolates this functionality.

An implementation of the the `ProposalStore` trait is provided by the
`AdminServiceProposals` struct, which simply wraps `AdminServiceShared`.

Additionally, these new traits/structs are moved behind the
`proposal-read` feature since they are only used by the proposal REST
API endpoints.

Signed-off-by: Logan Seeley <seeley@bitwise.io>