### PR TITLE
Validate circuit vote before attempting consensus

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/submit.rs
+++ b/libsplinter/src/admin/rest_api/actix/submit.rs
@@ -35,11 +35,14 @@ pub fn make_submit_route<A: AdminCommands + Clone + 'static>(admin_commands: A) 
                         Ok(()) => HttpResponse::Accepted().finish().into_future(),
                         Err(AdminServiceError::ServiceError(
                             ServiceError::UnableToHandleMessage(err),
-                        )) => HttpResponse::BadRequest()
-                            .json(json!({
-                                "message": format!("Unable to handle message: {}", err)
-                            }))
-                            .into_future(),
+                        )) => {
+                            debug!("{}", err);
+                            HttpResponse::BadRequest()
+                                .json(json!({
+                                    "message": format!("Unable to handle message: {}", err)
+                                }))
+                                .into_future()
+                        }
                         Err(AdminServiceError::ServiceError(
                             ServiceError::InvalidMessageFormat(err),
                         )) => HttpResponse::BadRequest()

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -489,7 +489,7 @@ impl AdminServiceShared {
                     .get_proposal(proposal_vote.get_circuit_id())
                     .map_err(|err| {
                         AdminSharedError::ValidationFailed(format!(
-                            "error occured when trying to get proposal {}",
+                            "error occurred when trying to get proposal {}",
                             err
                         ))
                     })?
@@ -585,7 +585,7 @@ impl AdminServiceShared {
             .get_proposal(circuit_id)
             .map_err(|err| {
                 ServiceError::UnableToHandleMessage(Box::new(AdminSharedError::ValidationFailed(
-                    format!("error occured when trying to get proposal {}", err),
+                    format!("error occurred when trying to get proposal {}", err),
                 )))
             })?
             .ok_or_else(|| {

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -666,6 +666,38 @@ impl AdminServiceShared {
                 self.propose_circuit(payload, "local".to_string())
             }
             CircuitManagementPayload_Action::CIRCUIT_PROPOSAL_VOTE => {
+                let proposal_vote = payload.get_circuit_proposal_vote();
+
+                // validate vote proposal
+                // check that the circuit proposal exists
+                let circuit_proposal = self
+                    .get_proposal(proposal_vote.get_circuit_id())
+                    .map_err(|err| {
+                        ServiceError::UnableToHandleMessage(Box::new(
+                            AdminSharedError::ValidationFailed(format!(
+                                "error occurred when trying to get proposal {}",
+                                err
+                            )),
+                        ))
+                    })?
+                    .ok_or_else(|| {
+                        ServiceError::UnableToHandleMessage(Box::new(
+                            AdminSharedError::ValidationFailed(format!(
+                                "Received vote for a proposal that does not exist: circuit id {}",
+                                proposal_vote.circuit_id
+                            )),
+                        ))
+                    })?;
+
+                let signer_public_key = header.get_requester();
+                self.validate_circuit_vote(
+                    proposal_vote,
+                    signer_public_key,
+                    &circuit_proposal,
+                    header.get_requester_node_id(),
+                )
+                .map_err(|err| ServiceError::UnableToHandleMessage(Box::new(err)))?;
+
                 self.propose_vote(payload, "local".to_string())
             }
             CircuitManagementPayload_Action::ACTION_UNSET => {


### PR DESCRIPTION
Like circuit proposals, validate the contents of a circuit vote before it can be submitted to the consensus system.  This allows the client to detect rejected  votes at submission time, instead of at consensus time, long after the HTTP request has completed.

Additionally

- fix a typo
- ignore IO errors when scanning the path for pandoc

To test:

1. Build gameroom with standard flags
2. Create Alice, with her key in the registry as normal
3. Propose a gameroom
4. Create Charlie, with a new key
5. Accept the invite
6. An error message should be displayed immediately