### PR TITLE
Fix user DELETE route to match HTTP 1.1 spec

### DIFF
--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -111,6 +111,8 @@ impl RestResourceProvider for BiomeRestResourceManager {
                     Arc::new(AccessTokenIssuer::new(self.token_secret_manager.clone())),
                 ));
                 resources.push(make_user_routes(
+                    self.rest_config.clone(),
+                    self.token_secret_manager.clone(),
                     credentials_store.clone(),
                     self.user_store.clone(),
                 ));

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1021,6 +1021,54 @@ paths:
             application/json:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
+    delete:
+      tags:
+        - Biome
+      description: Delete a user
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+        - name: user_id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+      responses:
+        200:
+          description: User deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User deleted successfully"
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: Unauthorized request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        404:
+          description: User with {user_id} not found
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
 
   /biome/users/{user_id}/keys:
     get:


### PR DESCRIPTION
Fixes the `/biome/users/{id}` DELETE route to not take in
a request body, per HTTP 1.1 specificatiions. Instead, this
route is validated using JWT tokens.

Also adds passing the BiomeRestConfig and SecretManager to the
make_user_routes function to allow for the JWT token validation.

Signed-off-by: Shannyn Telander <telander@bitwise.io>