### PR TITLE
Add compose file for building splinter-dev image

### DIFF
--- a/ci/splinter-dev.yaml
+++ b/ci/splinter-dev.yaml
@@ -1,0 +1,23 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: '3.7'
+
+services:
+  splinter-dev:
+    image: splintercommunity/splinter-dev:v1
+    build:
+      context: ..
+      dockerfile: ci/splinter-dev


### PR DESCRIPTION
Building with a compose file simplifies versioning the image because the
version can be included in the compose file rather than generated with a script.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>