### PR TITLE
Use RestApiBuilder in circuit-read tests

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -66,6 +66,7 @@ uuid = { version = "0.7", features = ["v4"]}
 zmq = { version = "0.9", optional = true }
 
 [dev-dependencies]
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 serial_test = "0.3"
 tempdir = "0.3"
 

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -97,7 +97,7 @@ impl RestResourceProvider for BiomeRestResourceManager {
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "biome-credentials")]
+        #[cfg(all(feature = "biome-credentials", feature = "rest-api-actix"))]
         match &self.credentials_store {
             Some(credentials_store) => {
                 resources.push(make_register_route(

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -20,6 +20,7 @@ use actix_web::Error as ActixError;
 /// Error module for `rest_api`.
 #[derive(Debug)]
 pub enum RestApiServerError {
+    BindError(String),
     StartUpError(String),
     MissingField(String),
     StdError(std::io::Error),
@@ -34,6 +35,7 @@ impl From<std::io::Error> for RestApiServerError {
 impl Error for RestApiServerError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            RestApiServerError::BindError(_) => None,
             RestApiServerError::StartUpError(_) => None,
             RestApiServerError::StdError(err) => Some(err),
             RestApiServerError::MissingField(_) => None,
@@ -44,6 +46,7 @@ impl Error for RestApiServerError {
 impl fmt::Display for RestApiServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            RestApiServerError::BindError(e) => write!(f, "Bind Error: {}", e),
             RestApiServerError::StartUpError(e) => write!(f, "Start-up Error: {}", e),
             RestApiServerError::StdError(e) => write!(f, "Std Error: {}", e),
             RestApiServerError::MissingField(field) => {


### PR DESCRIPTION
Updates the tests for the `/admin/circuits` endpoints to not use the
actix-specific testing code. This change will allow us to carry the unit
tests over if we decide to re-implement the REST API without actix.

Signed-off-by: Logan Seeley <seeley@bitwise.io>