### PR TITLE
Fix splinterd capitalization in doc comments

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -84,7 +84,7 @@ services:
 
             # check if splinterd-node-acme is available
             while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-node-acme:8085/status) -ne 200 ]] ; do
-               >&2 echo \"SplinterD is unavailable - sleeping\"
+               >&2 echo \"splinterd is unavailable - sleeping\"
                sleep 1
             done
 
@@ -169,7 +169,7 @@ services:
 
             # check if splinterd-node-bubba is available
             while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-node-bubba:8085/status) -ne 200 ]] ; do
-               >&2 echo \"SplinterD is unavailable - sleeping\"
+               >&2 echo \"splinterd is unavailable - sleeping\"
                sleep 1
             done
 

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -107,7 +107,7 @@ services:
 
             # check if splinterd-node-acme is available
             while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-node-acme:8085/status) -ne 200 ]] ; do
-               >&2 echo \"SplinterD is unavailable - sleeping\"
+               >&2 echo \"splinterd is unavailable - sleeping\"
                sleep 1
             done
 
@@ -216,7 +216,7 @@ services:
 
             # check if splinterd-node-bubba is available
             while [[ $$(curl --write-out %{http_code} --silent --output /dev/null http://splinterd-node-bubba:8085/status) -ne 200 ]] ; do
-               >&2 echo \"SplinterD is unavailable - sleeping\"
+               >&2 echo \"splinterd is unavailable - sleeping\"
                sleep 1
             done
 

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -16,8 +16,8 @@ openapi: '3.0.0'
 
 info:
   version: 0.3.13
-  title: SplinterD API
-  description: REST API for SplinterD
+  title: splinterd API
+  description: REST API for the Splinter daemon
 
 servers:
   - url: http://localhost:9000/api


### PR DESCRIPTION
Correct the remaining occurrences of SplinterD
in "doc-able" comments and error messages

Signed-off-by: Anne Chenette <chenette@bitwise.io>