### PR TITLE
Add response body to biome key management routes

### DIFF
--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -19,12 +19,11 @@ pub mod store;
 use store::diesel::models::KeyModel;
 
 // Represents a public and private key pair
-#[derive(Serialize)]
 pub struct Key {
-    public_key: String,
-    encrypted_private_key: String,
-    user_id: String,
-    display_name: String,
+    pub public_key: String,
+    pub encrypted_private_key: String,
+    pub user_id: String,
+    pub display_name: String,
 }
 
 impl Key {
@@ -64,6 +63,7 @@ impl From<KeyModel> for Key {
         }
     }
 }
+
 impl Into<KeyModel> for Key {
     fn into(self) -> KeyModel {
         KeyModel {

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -19,6 +19,7 @@ pub mod store;
 use store::diesel::models::KeyModel;
 
 // Represents a public and private key pair
+#[derive(Clone)]
 pub struct Key {
     pub public_key: String,
     pub encrypted_private_key: String,

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -29,7 +29,7 @@ use crate::biome::rest_api::BiomeRestConfig;
 use crate::biome::secrets::SecretManager;
 
 use super::super::resources::authorize::AuthorizationResult;
-use super::super::resources::key_management::{NewKey, UpdatedKey};
+use super::super::resources::key_management::{NewKey, ResponseKey, UpdatedKey};
 use super::authorize::authorize_user;
 
 /// Defines the `/biome/users/{user_id}/keys` REST resource for managing keys
@@ -187,7 +187,7 @@ fn handle_get(
         match key_store.list_keys(Some(&user_id)) {
             Ok(keys) => Box::new(
                 HttpResponse::Ok()
-                    .json(json!({ "data": keys }))
+                    .json(json!({ "data": keys.iter().map(ResponseKey::from).collect::<Vec<ResponseKey>>() }))
                     .into_future(),
             ),
             Err(err) => {

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -122,10 +122,11 @@ fn handle_post(
                 &user_id,
                 &new_key.display_name,
             );
+            let response_key = ResponseKey::from(&key);
 
-            match key_store.add_key(key) {
+            match key_store.add_key(key.clone()) {
                 Ok(()) => HttpResponse::Ok()
-                    .json(json!({ "message": "Key added successfully" }))
+                    .json(json!({ "message": "Key added successfully", "data": response_key }))
                     .into_future(),
                 Err(err) => {
                     debug!("Failed to add new key to database {}", err);

--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "biome-key-management")]
+#[cfg(any(feature = "biome-key-management", feature = "biome-credentials"))]
 pub(crate) mod authorize;
 #[cfg(feature = "biome-key-management")]
 pub(super) mod key_management;

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -27,7 +27,7 @@ use crate::biome::credentials::store::{
 use crate::biome::rest_api::BiomeRestConfig;
 use crate::biome::user::store::{diesel::SplinterUserStore, SplinterUser, UserStore};
 
-use super::super::resources::credentials::UsernamePassword;
+use super::super::resources::credentials::{NewUser, UsernamePassword};
 
 /// Defines a REST endpoint to add a user and credentials to the database
 ///
@@ -85,9 +85,18 @@ pub fn make_register_route(
                         };
 
                         match credentials_store.add_credentials(credentials) {
-                            Ok(()) => HttpResponse::Ok()
-                                .json(json!({ "message": "User created successfully" }))
-                                .into_future(),
+                            Ok(()) => {
+                                let new_user = NewUser {
+                                    user_id: &user_id,
+                                    username: &username_password.username,
+                                };
+                                HttpResponse::Ok()
+                                    .json(json!({
+                                        "message": "User created successfully",
+                                        "data": new_user,
+                                    }))
+                                    .into_future()
+                            }
                             Err(err) => {
                                 debug!("Failed to add new credentials to database {}", err);
                                 match err {

--- a/libsplinter/src/biome/rest_api/resources/credentials.rs
+++ b/libsplinter/src/biome/rest_api/resources/credentials.rs
@@ -19,3 +19,9 @@ pub(crate) struct UsernamePassword {
     pub username: String,
     pub hashed_password: String,
 }
+
+#[derive(Serialize)]
+pub(crate) struct NewUser<'a> {
+    pub user_id: &'a str,
+    pub username: &'a str,
+}

--- a/libsplinter/src/biome/rest_api/resources/key_management.rs
+++ b/libsplinter/src/biome/rest_api/resources/key_management.rs
@@ -14,6 +14,8 @@
 
 //! Defines structures used in key management.
 
+use crate::biome::key_management::Key;
+
 #[derive(Deserialize)]
 pub(crate) struct NewKey {
     pub public_key: String,
@@ -25,4 +27,23 @@ pub(crate) struct NewKey {
 pub(crate) struct UpdatedKey {
     pub public_key: String,
     pub new_display_name: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ResponseKey<'a> {
+    public_key: &'a str,
+    user_id: &'a str,
+    display_name: &'a str,
+    encrypted_private_key: &'a str,
+}
+
+impl<'a> From<&'a Key> for ResponseKey<'a> {
+    fn from(key: &'a Key) -> Self {
+        ResponseKey {
+            public_key: &key.public_key,
+            user_id: &key.user_id,
+            display_name: &key.display_name,
+            encrypted_private_key: &key.encrypted_private_key,
+        }
+    }
 }

--- a/libsplinter/src/biome/rest_api/resources/mod.rs
+++ b/libsplinter/src/biome/rest_api/resources/mod.rs
@@ -14,7 +14,7 @@
 
 //! Provides structures for the REST resources.
 
-#[cfg(feature = "biome-key-management")]
+#[cfg(any(feature = "biome-key-management", feature = "biome-credentials"))]
 pub(in super::super) mod authorize;
 #[cfg(feature = "biome-credentials")]
 pub(in super::super) mod credentials;

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -823,6 +823,8 @@ paths:
                   message:
                     type: string
                     example: "User created successfully"
+                  data:
+                    ref: '#/components/schemas/BiomeNewUser'
         400:
           description: Invalid request
           content:
@@ -1543,6 +1545,19 @@ components:
           type: string
           description: "Internal unique identifier for the user"
           example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+
+    BiomeCredentials:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: "Internal unique identifier for the user"
+          example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+        username:
+          type: string
+          description: "Username of a user"
+          example: "bob@biome.com"
+
 
 tags:
   - name: Biome

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1223,7 +1223,9 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "User deleted successfully"
+                    example: "Key added successfully"
+                  data:
+                    $ref: '#/components/schemas/BiomeUserKey'
         400:
           description: Invalid request
           content:


### PR DESCRIPTION
Adds response bodies to the `/biome/users/{user_id}/keys` POST route and the  `/biome/register` POST route. 