### PR TITLE
Add /biome/users/{user_id}/keys/{pub_key} GET and DELETE routes

### DIFF
--- a/libsplinter/src/biome/key_management/store/diesel/operations/fetch_key.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/fetch_key.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::models::KeyModel;
+use super::super::schema::keys;
+use super::KeyStoreOperations;
+use crate::biome::key_management::{store::KeyStoreError, Key};
+
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in super::super) trait KeyStoreFetchKeyOperation {
+    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError>;
+}
+
+impl<'a, C> KeyStoreFetchKeyOperation for KeyStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {
+        let key = keys::table
+            .filter(
+                keys::public_key
+                    .eq(public_key)
+                    .and(keys::user_id.eq(user_id)),
+            )
+            .first::<KeyModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| KeyStoreError::QueryError {
+                context: "Failed to fetch key by user ID and public key".to_string(),
+                source: Box::new(err),
+            })?
+            .ok_or_else(|| {
+                KeyStoreError::NotFoundError(format!(
+                    "Failed to find key with public key: {} and user id: {}",
+                    public_key, user_id
+                ))
+            })?;
+        Ok(Key::from(key))
+    }
+}

--- a/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(super) mod fetch_key;
 pub(super) mod insert_key;
 pub(super) mod list_keys;
 pub(super) mod update_key;

--- a/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod fetch_key;
 pub(super) mod insert_key;
 pub(super) mod list_keys;
+pub(super) mod remove_key;
 pub(super) mod update_key;
 
 pub(super) struct KeyStoreOperations<'a, C> {

--- a/libsplinter/src/biome/key_management/store/diesel/operations/remove_key.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/remove_key.rs
@@ -1,0 +1,70 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::models::KeyModel;
+use super::super::schema::keys;
+use super::KeyStoreOperations;
+use crate::biome::key_management::{store::KeyStoreError, Key};
+
+use diesel::{dsl::delete, prelude::*, result::Error::NotFound};
+
+pub(in super::super) trait KeyStoreRemoveKeyOperation {
+    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError>;
+}
+
+impl<'a, C> KeyStoreRemoveKeyOperation for KeyStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {
+        let key = keys::table
+            .filter(
+                keys::public_key
+                    .eq(public_key)
+                    .and(keys::user_id.eq(user_id)),
+            )
+            .first::<KeyModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| KeyStoreError::QueryError {
+                context: "Failed to fetch key by user ID and public key".to_string(),
+                source: Box::new(err),
+            })?
+            .ok_or_else(|| {
+                KeyStoreError::NotFoundError(format!(
+                    "Failed to find key with public key: {} and user id: {}",
+                    public_key, user_id
+                ))
+            })?;
+
+        delete(
+            keys::table.filter(
+                keys::public_key
+                    .eq(public_key)
+                    .and(keys::user_id.eq(user_id)),
+            ),
+        )
+        .execute(self.conn)
+        .map(|_| ())
+        .map_err(|err| KeyStoreError::OperationError {
+            context: "Failed to delete key".to_string(),
+            source: Box::new(err),
+        })?;
+
+        Ok(Key::from(key))
+    }
+}

--- a/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
@@ -19,6 +19,7 @@ embed_migrations!("./src/biome/key_management/store/diesel/postgres/migrations")
 use diesel::pg::PgConnection;
 
 use super::super::{KeyStore, KeyStoreError};
+use super::operations::fetch_key::KeyStoreFetchKeyOperation as _;
 use super::operations::insert_key::KeyStoreInsertKeyOperation as _;
 use super::operations::list_keys::KeyStoreListKeysOperation as _;
 use super::operations::list_keys::KeyStoreListKeysWithUserIDOperation as _;
@@ -82,8 +83,8 @@ impl KeyStore<Key> for PostgresKeyStore {
         unimplemented!()
     }
 
-    fn fetch_key(&self, _public_key: &str, _user_id: &str) -> Result<Key, KeyStoreError> {
-        unimplemented!()
+    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {
+        KeyStoreOperations::new(&*self.connection_pool.get()?).fetch_key(public_key, user_id)
     }
 
     fn list_keys(&self, user_id: Option<&str>) -> Result<Vec<Key>, KeyStoreError> {

--- a/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
@@ -23,6 +23,7 @@ use super::operations::fetch_key::KeyStoreFetchKeyOperation as _;
 use super::operations::insert_key::KeyStoreInsertKeyOperation as _;
 use super::operations::list_keys::KeyStoreListKeysOperation as _;
 use super::operations::list_keys::KeyStoreListKeysWithUserIDOperation as _;
+use super::operations::remove_key::KeyStoreRemoveKeyOperation as _;
 use super::operations::update_key::KeyStoreUpdateKeyOperation as _;
 use super::operations::KeyStoreOperations;
 
@@ -79,8 +80,8 @@ impl KeyStore<Key> for PostgresKeyStore {
         )
     }
 
-    fn remove_key(&self, _public_key: &str, _user_id: &str) -> Result<Key, KeyStoreError> {
-        unimplemented!()
+    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {
+        KeyStoreOperations::new(&*self.connection_pool.get()?).remove_key(public_key, user_id)
     }
 
     fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -63,8 +63,8 @@ pub trait KeyStore<T>: Sync + Send {
     ///
     /// # Arguments
     ///
-    /// * `public_key`: The public key of the key record to be removed.
-    /// * `user_id`: The ID owner of the key record to be removed.
+    /// * `public_key`: The public key of the key record to be fetched.
+    /// * `user_id`: The ID owner of the key record to be fetched.
     ///
     fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<T, KeyStoreError>;
 

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -53,7 +53,9 @@ use crate::database::ConnectionPool;
 use crate::rest_api::{Resource, RestResourceProvider};
 
 #[cfg(all(feature = "biome-key-management", feature = "rest-api-actix"))]
-use self::actix::key_management::make_key_management_route;
+use self::actix::key_management::{
+    make_key_management_route, make_key_management_route_with_public_key,
+};
 
 #[cfg(feature = "biome-key-management")]
 use super::key_management::store::PostgresKeyStore;
@@ -126,11 +128,18 @@ impl RestResourceProvider for BiomeRestResourceManager {
             }
         };
         #[cfg(all(feature = "biome-key-management", feature = "rest-api-actix"))]
-        resources.push(make_key_management_route(
-            self.rest_config.clone(),
-            self.key_store.clone(),
-            self.token_secret_manager.clone(),
-        ));
+        {
+            resources.push(make_key_management_route(
+                self.rest_config.clone(),
+                self.key_store.clone(),
+                self.token_secret_manager.clone(),
+            ));
+            resources.push(make_key_management_route_with_public_key(
+                self.rest_config.clone(),
+                self.key_store.clone(),
+                self.token_secret_manager.clone(),
+            ));
+        }
         resources
     }
 }

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1245,6 +1245,119 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
+  /biome/users/{user_id}/keys/{public_key}:
+    get:
+      tags:
+      - Biome
+      description: Fetch key of a user
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+        - name: user_id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+        - name: public_key
+          in: path
+          description: Public key of the user
+          required: true
+          schema:
+            type: string
+            example: "026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118"
+      responses:
+        200:
+          description: User's key
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/BiomeUserKey'
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: User not authorized
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        404:
+          description: Resource not found
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+    delete:
+      tags:
+      - Biome
+      description: Delete key of a user
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+        - name: user_id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+        - name: public_key
+          in: path
+          description: Public key of the user
+          required: true
+          schema:
+            type: string
+            example: "026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118"
+      responses:
+        200:
+          description: User's key deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User deleted successfully"
+                  data:
+                    $ref: '#/components/schemas/BiomeUserKey'
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: User not authorized
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        404:
+          description: Resource not found
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+
 components:
   parameters:
     protocol_version:


### PR DESCRIPTION
Adds implementations for the `fetch_key` and `remove_key` methods to the KeyStore as well as the corresponding endpoints. This adds a new endpoint `/biome/users/{user_id}/keys/{pub_key}` which has a GET and a DELETE endpoint. 