### PR TITLE
Remove CmResponse from Connector public api

### DIFF
--- a/libsplinter/src/network/connection_manager/messages.rs
+++ b/libsplinter/src/network/connection_manager/messages.rs
@@ -12,49 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::mpsc::SyncSender;
-
-pub enum CmMessage {
-    Shutdown,
-    Subscribe(SyncSender<ConnectionManagerNotification>),
-    Request(CmRequest),
-    SendHeartbeats,
-}
-
-pub struct CmRequest {
-    pub sender: SyncSender<CmResponse>,
-    pub payload: CmPayload,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum CmPayload {
-    AddConnection { endpoint: String },
-    RemoveConnection { endpoint: String },
-    ListConnections,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum CmResponse {
-    AddConnection {
-        status: CmResponseStatus,
-        error_message: Option<String>,
-    },
-    RemoveConnection {
-        status: CmResponseStatus,
-        error_message: Option<String>,
-    },
-    ListConnections {
-        endpoints: Vec<String>,
-    },
-}
-
-#[derive(Debug, PartialEq)]
-pub enum CmResponseStatus {
-    OK,
-    Error,
-    ConnectionNotFound,
-}
-
 /// Messages that will be dispatched to all
 /// subscription handlers
 #[derive(Debug, PartialEq, Clone)]

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -1,0 +1,62 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::mpsc::Receiver;
+#[cfg(feature = "connection-manager-notification-iter-try-next")]
+use std::sync::mpsc::TryRecvError;
+
+#[cfg(feature = "connection-manager-notification-iter-try-next")]
+use super::error::ConnectionManagerError;
+
+/// Messages that will be dispatched to all
+/// subscription handlers
+#[derive(Debug, PartialEq, Clone)]
+pub enum ConnectionManagerNotification {
+    Connected { endpoint: String },
+    Disconnected { endpoint: String },
+}
+
+pub struct NotificationIter {
+    pub(super) recv: Receiver<ConnectionManagerNotification>,
+}
+
+#[cfg(feature = "connection-manager-notification-iter-try-next")]
+impl NotificationIter {
+    pub fn try_next(
+        &self,
+    ) -> Result<Option<ConnectionManagerNotification>, ConnectionManagerError> {
+        match self.recv.try_recv() {
+            Ok(notifications) => Ok(Some(notifications)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(ConnectionManagerError::SendMessageError(
+                "The connection manager is no longer running".into(),
+            )),
+        }
+    }
+}
+
+impl Iterator for NotificationIter {
+    type Item = ConnectionManagerNotification;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.recv.recv() {
+            Ok(notification) => Some(notification),
+            Err(_) => {
+                // This is expected if the connection manager shuts down before
+                // this end
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
CmMessage is an internal message that is used to send messages from a client (via the Connector) to the background thread.  With this change, the connector's methods return idiomatic Rust responses, such as results and options. This simplifies the use of the connectors function at the call site.

To facilitate this change, each request contains a sender that is specific to the response returned. As a result, CmRequest and CmPayload have been merged into a single CmRequest enum.

The CmMessage and its associated structs have been moved into the mod and have been made private.  These messages are internal only.

The Pacemaker has been modified to be message agnostic, and does not need to know about the internal messages being sent.

Additionally, move the notification items to their own module, and remove the messages module.