### PR TITLE
Fix Biome PATCH keys route

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -256,8 +256,8 @@ fn handle_patch(
             };
 
             match key_store.update_key(
-                &updated_key.public_key,
                 &user_id,
+                &updated_key.public_key,
                 &updated_key.new_display_name,
             ) {
                 Ok(()) => HttpResponse::Ok()


### PR DESCRIPTION
This fixes a typo that was causing the /biome/users/<user_id>/keys
PATCH action to work incorrectly.

Signed-off-by: Davey Newhall <newhall@bitwise.io>