### PR TITLE
Add capability to use templates in circuit create CLI command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -63,7 +63,7 @@ experimental = [
 ]
 
 circuit = ["reqwest", "serde_json", "splinter/sawtooth-signing-compat", "dirs"]
-circuit-auth-type = []
+circuit-auth-type = ["circuit"]
 circuit-template = ["splinter/circuit-template", "circuit"]
 database-migrate-biome = [
     "splinter/biome-credentials",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -88,5 +88,6 @@ depends = "$auto"
 maintainer-scripts = "packaging/ubuntu"
 assets = [
     ["packaging/man/*", "/usr/share/man/man1", "644"],
-    ["target/release/splinter", "/usr/bin/splinter", "755"]
+    ["target/release/splinter", "/usr/bin/splinter", "755"],
+    ["packaging/scabbard_circuit_template.yaml", "/usr/share/splinter/circuit-templates/scabbard.yaml", "644"]
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,7 @@ stable = ["default"]
 
 experimental = [
     "circuit",
+    "circuit-template",
     "health",
     "database",
     "database-migrate-biome",
@@ -63,6 +64,7 @@ experimental = [
 
 circuit = ["reqwest", "serde_json", "splinter/sawtooth-signing-compat", "dirs"]
 circuit-auth-type = []
+circuit-template = ["splinter/circuit-template", "circuit"]
 database-migrate-biome = [
     "splinter/biome-credentials",
     "splinter/biome-key-management",

--- a/cli/packaging/scabbard_circuit_template.yaml
+++ b/cli/packaging/scabbard_circuit_template.yaml
@@ -1,0 +1,22 @@
+version: v1
+args:
+    - name: $(a:ADMIN_KEYS)
+      required: false
+      default: $(a:SIGNER_PUB_KEY)
+      description: >-
+        Public keys used to verify transactions in the scabbard service
+    - name: $(a:NODES)
+      required: true
+      description: "List of node IDs"
+    - name: $(a:SIGNER_PUB_KEY)
+      required: false
+      description: "Public key of the signer"
+rules:
+    create-services:
+        service-type: 'scabbard'
+        service-args:
+        - key: 'admin_keys'
+          value: [$(a:ADMIN_KEYS)]
+        - key: 'peer_services'
+          value: '$(r:ALL_OTHER_SERVICES)'
+        first-service: 'a000'

--- a/cli/packaging/ubuntu/postinst
+++ b/cli/packaging/ubuntu/postinst
@@ -18,6 +18,13 @@ case "$1" in
     # This value is present only during upgrades
     if [ -z "$2" ]; then
         ln -s /usr/bin/splinter /usr/bin/splinter-cli
+
+        if [ ! -d /usr/share/splinter/circuit-templates ]; then
+          mkdir -p /usr/share/splinter/circuit-templates
+        fi
+        chmod 755 /usr/share/splinter/circuit-templates
+        chmod 640 /usr/share/splinter/circuit-templates/*.yaml
+
     else
         true
     fi

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -16,6 +16,8 @@ mod api;
 mod builder;
 pub mod defaults;
 mod payload;
+#[cfg(feature = "circuit-template")]
+pub mod template;
 
 #[cfg(feature = "circuit-template")]
 use std::collections::HashMap;

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -143,6 +143,16 @@ impl Action for CircuitCreateAction {
         let requester_node = client.fetch_node_id()?;
         let private_key_hex = read_private_key(key)?;
 
+        if args.is_present("dry_run") {
+            println!(
+                "\n{}",
+                serde_yaml::to_string(&create_circuit).map_err(|err| CliError::ActionError(
+                    format!("Cannot format circuit into yaml: {}", err)
+                ))?
+            );
+            return Ok(());
+        }
+
         let signed_payload =
             payload::make_signed_payload(&requester_node, &private_key_hex, create_circuit)?;
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -17,12 +17,16 @@ mod builder;
 pub mod defaults;
 mod payload;
 
+#[cfg(feature = "circuit-template")]
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 
 use clap::ArgMatches;
 
 use crate::error::CliError;
+#[cfg(feature = "circuit-template")]
+use crate::template::CircuitTemplate;
 
 use super::Action;
 use crate::action::DEFAULT_ENDPOINT;
@@ -59,15 +63,38 @@ impl Action for CircuitCreateAction {
             }
         }
 
-        let services = match args.values_of("service") {
-            Some(services) => services,
-            None => return Err(CliError::ActionError("Service is required".into())),
-        };
+        #[cfg(feature = "circuit-template")]
+        {
+            if let Some(template_name) = args.value_of("template") {
+                let mut template = CircuitTemplate::load(template_name)?;
 
-        for service in services {
-            let (service_id, allowed_nodes) = parse_service(service)?;
-            builder.add_service(&service_id, &allowed_nodes);
+                let user_args = match args.values_of("template_arg") {
+                    Some(template_args) => {
+                        parse_template_args(&template_args.collect::<Vec<&str>>())?
+                    }
+                    None => HashMap::new(),
+                };
+                template.add_arguments(&user_args);
+                template.set_nodes(&builder.get_node_ids());
+                let template_builders = template.into_builders()?;
+                builder.add_services(&template_builders.service_builders());
+                builder.set_create_circuit_builder(&template_builders.create_circuit_builder());
+            }
         }
+
+        match args.values_of("service") {
+            Some(services) => {
+                for service in services {
+                    let (service_id, allowed_nodes) = parse_service(service)?;
+                    builder.add_service(&service_id, &allowed_nodes);
+                }
+            }
+            None => {
+                if args.value_of("template").is_none() {
+                    return Err(CliError::ActionError("Service is required".into()));
+                }
+            }
+        };
 
         if let Some(service_arguments) = args.values_of("service_argument") {
             for service_argument in service_arguments {
@@ -233,6 +260,43 @@ fn parse_application_metadata_json(metadata: &str) -> Result<String, CliError> {
     }
 
     Ok(format!("\"{}\":{}", key, value))
+}
+
+#[cfg(feature = "circuit-template")]
+fn parse_template_args(args: &[&str]) -> Result<HashMap<String, String>, CliError> {
+    args.iter().try_fold(HashMap::new(), |mut acc, arg| {
+        let mut iter = arg.split('=');
+        let key = iter
+            .next()
+            .ok_or_else(|| {
+                CliError::ActionError(format!(
+                    "Invalid template argument. Expected value in form <key>=<value> found {}",
+                    arg
+                ))
+            })?
+            .to_string();
+
+        let value = iter
+            .next()
+            .ok_or_else(|| {
+                CliError::ActionError(format!(
+                    "Invalid template argument. Expected value in form <key>=<value> found {}",
+                    arg
+                ))
+            })?
+            .to_string();
+
+        if key.is_empty() || value.is_empty() {
+            return Err(CliError::ActionError(format!(
+                "Invalid template argument. Key or value cannot be empty.\
+                 Expected value in form <key>=<value> found {}",
+                arg
+            )));
+        }
+
+        acc.insert(key, value);
+        Ok(acc)
+    })
 }
 
 fn parse_service_argument(service_argument: &str) -> Result<(String, (String, String)), CliError> {

--- a/cli/src/action/circuit/template.rs
+++ b/cli/src/action/circuit/template.rs
@@ -1,0 +1,82 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+
+use crate::error::CliError;
+use crate::template::CircuitTemplate;
+
+use super::Action;
+
+pub struct ListCircuitTemplates;
+
+impl Action for ListCircuitTemplates {
+    fn run<'a>(&mut self, _: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let templates = CircuitTemplate::list_available_templates()?;
+
+        println!("Available templates:");
+        for name in templates {
+            println!("{}", name);
+        }
+        Ok(())
+    }
+}
+
+pub struct ShowCircuitTemplate;
+
+impl Action for ShowCircuitTemplate {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let template_name = match args.value_of("name") {
+            Some(name) => name,
+            None => return Err(CliError::ActionError("Name is required".into())),
+        };
+
+        let template = CircuitTemplate::load_raw(template_name)?;
+
+        println!("{}", template);
+
+        Ok(())
+    }
+}
+
+pub struct ListCircuitTemplateArguments;
+
+impl Action for ListCircuitTemplateArguments {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
+        let template_name = match args.value_of("name") {
+            Some(name) => name,
+            None => return Err(CliError::ActionError("Name is required".into())),
+        };
+
+        let template = CircuitTemplate::load(template_name)?;
+
+        let arguments = template.arguments();
+        for argument in arguments {
+            println!("\nname: {}", argument.name());
+            println!("required: {}", argument.required());
+            println!(
+                "default_value: {}",
+                argument.default_value().unwrap_or(&"Not set".to_string())
+            );
+            println!(
+                "description: {}",
+                argument.description().unwrap_or(&"Not set".to_string())
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -306,6 +306,12 @@ fn run() -> Result<(), CliError> {
                     .possible_values(&["json", "string"])
                     .requires("metadata")
                     .help("Set the encoding for the application metadata. Default value: string"),
+            )
+            .arg(
+                Arg::with_name("dry_run")
+                    .long("dry-run")
+                    .short("n")
+                    .help("Print the circuit definition without submitting the proposal"),
             );
 
         #[cfg(feature = "circuit-auth-type")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,9 @@ mod action;
 mod error;
 mod store;
 
+#[cfg(feature = "circuit-template")]
+mod template;
+
 use clap::{clap_app, AppSettings, Arg, SubCommand};
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
 use log::Record;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,7 +255,7 @@ fn run() -> Result<(), CliError> {
                     .takes_value(true)
                     .multiple(true)
                     .min_values(2)
-                    .required(true)
+                    .required_unless("template")
                     .long_help(
                         "Service ID and allowed node. \
                          Format <service-id>::<allowed_nodes>",
@@ -326,6 +326,23 @@ fn run() -> Result<(), CliError> {
                 .takes_value(true)
                 .help("Authorization type for the circuit"),
         );
+
+        #[cfg(feature = "circuit-template")]
+        let create_circuit = create_circuit
+            .arg(
+                Arg::with_name("template")
+                    .long("template")
+                    .takes_value(true)
+                    .help("Template name to be applied to circuit"),
+            )
+            .arg(
+                Arg::with_name("template_arg")
+                    .long("template-arg")
+                    .multiple(true)
+                    .takes_value(true)
+                    .requires("template")
+                    .help("Arguments for the template argument. Format <key>=<value>"),
+            );
 
         app = app.subcommand(
             SubCommand::with_name("circuit")

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -1,0 +1,119 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use splinter::circuit::template::{
+    Builders, CircuitCreateTemplate, CircuitTemplateError, CircuitTemplateManager, RuleArgument,
+};
+
+use crate::error::CliError;
+
+const NODES_ARG: &str = "nodes";
+
+pub struct CircuitTemplate {
+    template: CircuitCreateTemplate,
+    arguments: HashMap<String, String>,
+}
+
+impl CircuitTemplate {
+    pub fn list_available_templates() -> Result<Vec<String>, CliError> {
+        let manager = CircuitTemplateManager::default();
+        let templates = manager.list_available_templates()?;
+        Ok(templates)
+    }
+
+    /// Loads a YAML circuit template file into a YAML string
+    pub fn load_raw(name: &str) -> Result<String, CliError> {
+        let manager = CircuitTemplateManager::default();
+        let template_yaml = manager.load_raw_yaml(name)?;
+        Ok(template_yaml)
+    }
+
+    /// Loads a YAML circuit template file and returns a CircuitTemplate that can be used to
+    /// build CircuitCreate messages.
+    pub fn load(name: &str) -> Result<Self, CliError> {
+        let manager = CircuitTemplateManager::default();
+        let possible_values = manager.list_available_templates()?;
+        if !possible_values.iter().any(|val| val == name) {
+            return Err(CliError::ActionError(format!(
+                "Template with name {} was not found. Available templates: {:?}",
+                name, possible_values
+            )));
+        }
+        let template = manager.load(name)?;
+        Ok(CircuitTemplate {
+            template,
+            arguments: HashMap::new(),
+        })
+    }
+
+    fn check_missing_required_arguments(&self) -> Vec<String> {
+        self.template
+            .arguments()
+            .iter()
+            .filter_map(|template_argument| {
+                if template_argument.required()
+                    && self.arguments.get(template_argument.name()).is_none()
+                {
+                    Some(template_argument.name().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn set_nodes(&mut self, nodes: &[String]) {
+        if self
+            .template
+            .arguments()
+            .iter()
+            .any(|arg| arg.name() == NODES_ARG)
+        {
+            self.arguments
+                .insert(NODES_ARG.to_string(), nodes.join(","));
+        }
+    }
+
+    pub fn add_arguments(&mut self, user_arguments: &HashMap<String, String>) {
+        self.arguments.extend(user_arguments.clone())
+    }
+
+    pub fn arguments(&self) -> &[RuleArgument] {
+        self.template.arguments()
+    }
+
+    pub fn into_builders(mut self) -> Result<Builders, CliError> {
+        let missing_args = self.check_missing_required_arguments();
+        if !missing_args.is_empty() {
+            return Err(CliError::ActionError(format!(
+                "Required arguments were not set: {}",
+                missing_args.join(", ")
+            )));
+        }
+
+        for (key, value) in self.arguments.iter() {
+            self.template.set_argument_value(key, value)?;
+        }
+
+        Ok(self.template.into_builders()?)
+    }
+}
+
+impl From<CircuitTemplateError> for CliError {
+    fn from(err: CircuitTemplateError) -> CliError {
+        CliError::ActionError(format!("Failed to process template: {}", err))
+    }
+}

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -75,7 +75,8 @@ depends = "$auto"
 assets = [
     ["packaging/systemd/gameroomd.service", "/lib/systemd/system/gameroomd.service", "644"],
     ["packaging/systemd/gameroomd", "/etc/default/gameroomd", "644"],
-    ["target/release/gameroomd", "/usr/bin/gameroomd", "755"]
+    ["target/release/gameroomd", "/usr/bin/gameroomd", "755"],
+    ["packaging/gameroom_circuit_template.yaml", "/usr/share/splinter/circuit-templates/gameroom.yaml", "644"]
 ]
 conf-files = [
     "/etc/default/gameroomd",

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -15,6 +15,8 @@
 FROM splintercommunity/splinter-dev:v1 as BUILDER
 
 # Copy over source files
+
+COPY cli /build/cli
 COPY examples/gameroom/cli /build/examples/gameroom/cli
 COPY examples/gameroom/database /build/examples/gameroom/database
 COPY examples/gameroom/daemon/ /build/examples/gameroom/daemon
@@ -34,6 +36,14 @@ ARG CARGO_ARGS
 RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
 
+# Build splinter-cli
+WORKDIR /build/cli
+ARG REPO_VERSION
+ARG CARGO_ARGS
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
+RUN mv /build/target/debian/splinter-cli*.deb /tmp
+
 # Log the commit hash
 COPY .git/ /tmp/.git/
 WORKDIR /tmp
@@ -52,10 +62,12 @@ RUN apt-get update \
     unzip
 
 COPY --from=BUILDER /build/target/debian/gameroom*.deb /tmp/
+COPY --from=BUILDER /tmp/splinter-*.deb /tmp/
 COPY --from=BUILDER /commit-hash /commit-hash
 
 RUN apt-get update \
  && dpkg --unpack /tmp/gameroom*.deb \
+ && dpkg --unpack /tmp/splinter*.deb \
  && apt-get -f -y install
 
 # Fetch the XO smart contract

--- a/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
+++ b/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
@@ -1,0 +1,34 @@
+version: v1
+args:
+    - name: $(a:ADMIN_KEYS)
+      required: false
+      default: $(a:SIGNER_PUB_KEY)
+      description: >-
+        Public keys used to verify transactions in the scabbard service
+    - name: $(a:NODES)
+      required: true
+      description: "List of node IDs"
+    - name: $(a:SIGNER_PUB_KEY)
+      required: false
+      description: "Public key of the signer"
+    - name: $(a:GAMEROOM_NAME)
+      required: true
+      description: "Name of the gameroom"
+rules:
+    set-management-type:
+        management-type: "gameroom"
+    create-services:
+        service-type: 'scabbard'
+        service-args:
+        - key: 'admin_keys'
+          value: [$(a:ADMIN_KEYS)]
+        - key: 'peer_services'
+          value: '$(r:ALL_OTHER_SERVICES)'
+        first-service: 'a000'
+    set-metadata:
+        encoding: json
+        metadata:
+            - key: "scabbard_admin_keys"
+              value: ["$(a:ADMIN_KEYS)"]
+            - key: "alias"
+              value: "$(a:GAMEROOM_NAME)"

--- a/examples/gameroom/daemon/packaging/ubuntu/postinst
+++ b/examples/gameroom/daemon/packaging/ubuntu/postinst
@@ -36,6 +36,12 @@ case "$1" in
         chown root:$group /var/lib/gameroomd/
         chmod 775 /var/lib/gameroomd/
 
+        if [ ! -d /usr/share/splinter/circuit-templates ]; then
+          mkdir -p /usr/share/splinter/circuit-templates
+        fi
+        chmod 755 /usr/share/splinter/circuit-templates
+        chmod 640 /usr/share/splinter/circuit-templates/*.yaml
+
     else
         true
     fi

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -17,13 +17,97 @@ mod rules;
 mod yaml_parser;
 
 use std::convert::TryFrom;
+use std::path::Path;
 
 pub use error::CircuitTemplateError;
 
-use rules::{RuleArgument, Rules};
+pub use rules::RuleArgument;
+use rules::Rules;
+
 use yaml_parser::{v1, CircuitTemplate};
 
 pub(self) use crate::admin::messages::{CreateCircuitBuilder, SplinterServiceBuilder};
+
+pub const DEFAULT_TEMPLATE_DIR: &str = "/usr/share/splinter/circuit-templates";
+
+pub struct CircuitTemplateManager {
+    path: String,
+}
+
+impl Default for CircuitTemplateManager {
+    fn default() -> Self {
+        CircuitTemplateManager {
+            path: DEFAULT_TEMPLATE_DIR.to_string(),
+        }
+    }
+}
+
+impl CircuitTemplateManager {
+    pub fn new(path: &str) -> Result<CircuitTemplateManager, CircuitTemplateError> {
+        if !Path::new(&path).is_dir() {
+            Err(CircuitTemplateError::new(&format!(
+                "{} is not a valid directory",
+                path
+            )))
+        } else {
+            Ok(CircuitTemplateManager {
+                path: path.to_string(),
+            })
+        }
+    }
+
+    /// Loads a YAML circuit template file into a CircuitCreateTemplate
+    pub fn load(&self, name: &str) -> Result<CircuitCreateTemplate, CircuitTemplateError> {
+        let path = format!("{}/{}.yaml", self.path, name);
+        CircuitCreateTemplate::from_yaml_file(&path)
+    }
+
+    /// Loads a YAML circuit template file into a YAML string
+    pub fn load_raw_yaml(&self, name: &str) -> Result<String, CircuitTemplateError> {
+        let path = format!("{}/{}.yaml", self.path, name);
+        let template = CircuitTemplate::load_from_file(&path)?;
+        match template {
+            CircuitTemplate::V1(template) => serde_yaml::to_string(&template).map_err(|err| {
+                CircuitTemplateError::new_with_source(
+                    "Failed to load template to yaml string",
+                    Box::new(err),
+                )
+            }),
+        }
+    }
+
+    pub fn list_available_templates(&self) -> Result<Vec<String>, CircuitTemplateError> {
+        let path = Path::new(&self.path);
+
+        path.read_dir()
+            .map_err(|err| {
+                CircuitTemplateError::new_with_source(
+                    &format!("Failed to read files in {}", self.path),
+                    Box::new(err),
+                )
+            })?
+            .map(|entry| {
+                let file = entry.map_err(|err| {
+                    CircuitTemplateError::new_with_source(
+                        &format!("Failed to read file in {}", self.path),
+                        Box::new(err),
+                    )
+                })?;
+                Ok(file
+                    .file_name()
+                    .into_string()
+                    .map_err(|_| {
+                        CircuitTemplateError::new(&format!(
+                            "Failed to read file name {}",
+                            self.path
+                        ))
+                    })?
+                    .trim_end_matches(".yaml")
+                    .to_string())
+            })
+            .collect::<Result<_, CircuitTemplateError>>()
+    }
+}
 
 pub struct CircuitCreateTemplate {
     version: String,

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -158,7 +158,7 @@ rules:
         service-args:
         - key: 'admin-keys'
           value: [$(a:ADMIN_KEYS)]
-        - key: 'peer-services'
+        - key: 'peer_services'
           value: '$(r:ALL_OTHER_SERVICES)'
         first-service: 'a000'
     set-metadata:
@@ -234,7 +234,7 @@ rules:
             .any(|(key, value)| key == "admin-keys" && value == "[\"signer_key\"]"));
         assert!(alpha_service_args
             .iter()
-            .any(|(key, value)| key == "peer-services" && value == "[\"a001\"]"));
+            .any(|(key, value)| key == "peer_services" && value == "[\"a001\"]"));
 
         let service_beta_node = service_builders
             .iter()
@@ -255,7 +255,7 @@ rules:
             .any(|(key, value)| key == "admin-keys" && value == "[\"signer_key\"]"));
         assert!(beta_service_args
             .iter()
-            .any(|(key, value)| key == "peer-services" && value == "[\"a000\"]"));
+            .any(|(key, value)| key == "peer_services" && value == "[\"a000\"]"));
     }
 
     fn get_file_path(mut temp_dir: PathBuf) -> String {

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -211,7 +211,7 @@ rules:
         .expect("Failed to parse metadata to string");
         assert_eq!(
             metadata,
-            "{[\"scabbard_admin_keys\":[\"signer_key\"],\"alias\":\"my gameroom\"]}"
+            "{\"scabbard_admin_keys\":[\"signer_key\"],\"alias\":\"my gameroom\"}"
         );
 
         let service_builders = builders.service_builders();

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -19,7 +19,7 @@ use super::{get_argument_value, is_arg, RuleArgument, Value};
 
 const ALL_OTHER_SERVICES: &str = "$(r:ALL_OTHER_SERVICES)";
 const NODES_ARG: &str = "$(a:NODES)";
-const PEER_SERVICES_ARG: &str = "peer-services";
+const PEER_SERVICES_ARG: &str = "peer_services";
 
 pub(super) struct CreateServices {
     service_type: String,

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -292,6 +292,7 @@ mod test {
             name: "admin_keys".to_string(),
             required: false,
             default_value: Some("$(a:SIGNER_PUB_KEY)".to_string()),
+            description: None,
             user_value: None,
         };
 
@@ -299,6 +300,7 @@ mod test {
             name: "nodes".to_string(),
             required: true,
             default_value: None,
+            description: None,
             user_value: Some("alpha-node-000,beta-node-000".to_string()),
         };
 
@@ -306,6 +308,7 @@ mod test {
             name: "signer_pub_key".to_string(),
             required: false,
             default_value: None,
+            description: None,
             user_value: Some("signer_key".to_string()),
         };
 

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -79,6 +79,7 @@ pub struct RuleArgument {
     name: String,
     required: bool,
     default_value: Option<String>,
+    description: Option<String>,
     user_value: Option<String>,
 }
 
@@ -93,6 +94,10 @@ impl RuleArgument {
 
     pub fn default_value(&self) -> Option<&String> {
         self.default_value.as_ref()
+    }
+
+    pub fn description(&self) -> Option<&String> {
+        self.description.as_ref()
     }
 
     pub fn user_value(&self) -> Option<&String> {
@@ -111,6 +116,7 @@ impl TryFrom<v1::RuleArgument> for RuleArgument {
             name: strip_arg_marker(arguments.name())?,
             required: arguments.required(),
             default_value: arguments.default_value().map(String::from),
+            description: arguments.description().map(String::from),
             user_value: None,
         })
     }

--- a/libsplinter/src/circuit/template/rules/set_metadata.rs
+++ b/libsplinter/src/circuit/template/rules/set_metadata.rs
@@ -60,7 +60,7 @@ impl SetMetadata {
                     })
                     .collect::<Result<Vec<String>, CircuitTemplateError>>()?;
 
-                let json_metadata = format!("{{[{}]}}", metadata.join(","));
+                let json_metadata = format!("{{{}}}", metadata.join(","));
 
                 Ok(builder.with_application_metadata(&json_metadata.as_bytes()))
             }

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CircuitCreateTemplate {
     version: String,
     args: Vec<RuleArgument>,
@@ -33,12 +33,14 @@ impl CircuitCreateTemplate {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuleArgument {
     name: String,
     required: bool,
     #[serde(rename = "default")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     default_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
 }
 
@@ -60,11 +62,14 @@ impl RuleArgument {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Rules {
+    #[serde(skip_serializing_if = "Option::is_none")]
     set_management_type: Option<CircuitManagement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     create_services: Option<CreateServices>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     set_metadata: Option<SetMetadata>,
 }
 
@@ -82,7 +87,7 @@ impl Rules {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CircuitManagement {
     management_type: String,
@@ -94,7 +99,7 @@ impl CircuitManagement {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CreateServices {
     service_type: String,
@@ -116,7 +121,7 @@ impl CreateServices {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceArgument {
     key: String,
     value: Value,
@@ -132,7 +137,7 @@ impl ServiceArgument {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetMetadata {
     #[serde(flatten)]
     metadata: Metadata,
@@ -144,14 +149,14 @@ impl SetMetadata {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "encoding")]
 #[serde(rename_all(deserialize = "camelCase"))]
 pub enum Metadata {
     Json { metadata: Vec<JsonMetadata> },
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JsonMetadata {
     key: String,
     value: Value,
@@ -167,7 +172,7 @@ impl JsonMetadata {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Value {
     Single(String),

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -39,6 +39,7 @@ pub struct RuleArgument {
     required: bool,
     #[serde(rename = "default")]
     default_value: Option<String>,
+    description: Option<String>,
 }
 
 impl RuleArgument {
@@ -52,6 +53,10 @@ impl RuleArgument {
 
     pub fn default_value(&self) -> Option<&String> {
         self.default_value.as_ref()
+    }
+
+    pub fn description(&self) -> Option<&String> {
+        self.description.as_ref()
     }
 }
 


### PR DESCRIPTION
#### Overview
This PR: 
- Adds the capability to use templates in the circuit create CLI command. 
- Adds two templates, one for gameroom circuits and one for circuits that have scabbard as a service
- Adds a `--dry-run` option for the `circuit create` command, allowing the user to see the circuit definition that would be created via the command, without submitting it.
- Adds the splinter CLI to the gameroom daemon

#### Testing
1. Start the Gameroom example docker network, with experimental features enabled. In the /splinter directory run:
   ```
      export 'CARGO_ARGS=-- --features experimental'
      docker-compose -f examples/gameroom/docker-compose.yaml up --build
   ```

2. Get the private and public keys for alice:

   ```
   docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash
   cat /key_registry/alice.priv
   cat /key_registry/alice.pub
   ```
3. Copy alice's key to gameroom daemong :

   ```
   docker-compose -f examples/gameroom/docker-compose.yaml exec gameroomd-acme bash
   echo  '90430da9ec24ee62d58571d5b1d4a0e36293f75e45a5c59cb71ff5c78f7c72a5'  > alice.priv
   echo  '029150e180d57a8d5babde0ea6ae86193fcef7d40ae145b571b0654bf23071b169' >  alice.pub
   ```
4. Send command to create circuit using the gameroom template:

```
splinter -vv circuit create \
    --url http://splinterd-node-acme:8085 \
    --key alice.priv \
    --node acme-node-000::tls://splinterd-node-acme:8044 \
    --node bubba-node-000::tls://splinterd-node-bubba:8044  \
    --template gameroom \
    --template-arg "signer_pub_key=$(cat alice.pub)" \
    --template-arg "gameroom_name=my gameroom"
```

5. Send command to create circuit using the scabbard template:

```
splinter -vv circuit create \
    --url http://splinterd-node-acme:8085 \
    --key alice.priv \
    --node acme-node-000::tls://splinterd-node-acme:8044 \
    --node bubba-node-000::tls://splinterd-node-bubba:8044  \
    --template scabbard \
    --management gameroom \
    --metadata-encoding json \
    --metadata alias=great_gameroom \
    --metadata scabbard_admin_keys=[\"$(cat alice.pub)\"] \
    --template-arg "signer_pub_key=$(cat alice.pub)"
```

6. To see that the proposals were created successfully, check the logs or run:
```
splinter circuit proposals --url http://splinterd-node-acme:8085
```

7. To list available templates run:
```
$ splinter circuit template list

Available templates: scabbard, gameroom
```

8. To see a template run
```
$ splinter circuit template show gameroom

---
version: v1
args:
  - name: "$(a:ADMIN_KEYS)"
    required: false
    default: "$(a:SIGNER_PUB_KEY)"
    description: "Public keys used to verify transactions in the scabbard service\n"
  - name: "$(a:NODES)"
    required: true
    description: List of node IDs
  - name: "$(a:SIGNER_PUB_KEY)"
    required: false
    description: Public key of the signer
  - name: "$(a:GAMEROOM_NAME)"
    required: true
    description: Name of the gameroom
rules:
  set-management-type:
    management-type: gameroom
  create-services:
    service-type: scabbard
    service-args:
      - key: admin_keys
        value:
          - "$(a:ADMIN_KEYS)"
      - key: peer_services
        value: "$(r:ALL_OTHER_SERVICES)"
    first-service: a000
  set-metadata:
    encoding: Json
    metadata:
      - key: scabbard_admin_keys
        value:
          - "$(a:ADMIN_KEYS)"
      - key: alias
        value: "$(a:GAMEROOM_NAME)"
```
```
$ splinter circuit template show scabbard

---
version: v1
args:
  - name: "$(a:ADMIN_KEYS)"
    required: false
    default: "$(a:SIGNER_PUB_KEY)"
    description: "Public keys used to verify transactions in the scabbard service\n"
  - name: "$(a:NODES)"
    required: true
    description: List of node IDs
  - name: "$(a:SIGNER_PUB_KEY)"
    required: false
    description: Public key of the signer
rules:
  create-services:
    service-type: scabbard
    service-args:
      - key: admin_keys
        value:
          - "$(a:ADMIN_KEYS)"
      - key: peer_services
        value: "$(r:ALL_OTHER_SERVICES)"
    first-service: a000
```

9. To only see  the user arguments required by the template use:

```
$ splinter circuit template arguments gameroom 

name: admin_keys
required: false
default_value: $(a:SIGNER_PUB_KEY)
description: Public keys used to verify transactions in the scabbard service

name: nodes
required: true
default_value: Not set
description: List of node IDs

name: signer_pub_key
required: false
default_value: Not set
description: Public key of the signer

name: gameroom_name
required: true
default_value: Not set
description: Name of the gameroom
```
```
$ splinter circuit template arguments scabbard 

name: admin_keys
required: false
default_value: $(a:SIGNER_PUB_KEY)
description: Public keys used to verify transactions in the scabbard service

name: nodes
required: true
default_value: Not set
description: List of node IDs

name: signer_pub_key
required: false
default_value: Not set
description: Public key of the signer
```