### PR TITLE
Initial PeerManager Implementation

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -98,6 +98,7 @@ experimental = [
     "database",
     "json-web-tokens",
     "matrix",
+    "network-peer-manager",
     "network-ref-map",
     "node-registry-unified",
     "postgres",
@@ -123,6 +124,7 @@ database = ["diesel_migrations", "postgres"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 json-web-tokens = ["jsonwebtoken"]
 matrix = []
+network-peer-manager = ["connection-manager", "network-ref-map"]
 network-ref-map = []
 node-registry-unified = []
 postgres = ["diesel/postgres"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -98,6 +98,7 @@ experimental = [
     "database",
     "json-web-tokens",
     "matrix",
+    "network-ref-map",
     "node-registry-unified",
     "postgres",
     "proposal-read",
@@ -122,6 +123,7 @@ database = ["diesel_migrations", "postgres"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 json-web-tokens = ["jsonwebtoken"]
 matrix = []
+network-ref-map = []
 node-registry-unified = []
 postgres = ["diesel/postgres"]
 rest-api = [

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -415,6 +415,15 @@ where
             meta.last_connection_attempt = Instant::now();
             meta.reconnection_attempts += 1;
             self.connections.insert(endpoint.to_string(), meta);
+
+            // Notify subscribers of reconnection failure
+            notify_subscribers(
+                subscribers,
+                ConnectionManagerNotification::ReconnectionFailed {
+                    endpoint: endpoint.to_string(),
+                    attempts: reconnection_attempts,
+                },
+            );
         }
         Ok(())
     }
@@ -868,6 +877,7 @@ pub mod tests {
             .expect("Unable to request connection");
 
         let mut subscriber = connector.subscribe().expect("Cannot get subscriber");
+
         // receive reconnecting attempt
         let reconnecting_notification = subscriber
             .next()

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -25,6 +25,7 @@ use super::error::ConnectionManagerError;
 pub enum ConnectionManagerNotification {
     Connected { endpoint: String },
     Disconnected { endpoint: String },
+    ReconnectionFailed { endpoint: String, attempts: u64 },
 }
 
 pub struct NotificationIter {

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -18,6 +18,9 @@ pub mod dispatch;
 mod dispatch_proto;
 pub mod handlers;
 pub mod peer;
+
+#[cfg(feature = "network-ref-map")]
+pub(crate) mod ref_map;
 pub(crate) mod reply;
 pub mod sender;
 

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -19,6 +19,8 @@ mod dispatch_proto;
 pub mod handlers;
 pub mod peer;
 
+#[cfg(feature = "network-peer-manager")]
+pub mod peer_manager;
 #[cfg(feature = "network-ref-map")]
 pub(crate) mod ref_map;
 pub(crate) mod reply;

--- a/libsplinter/src/network/peer_manager/connector.rs
+++ b/libsplinter/src/network/peer_manager/connector.rs
@@ -1,0 +1,183 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::mpsc::{channel, Sender};
+
+use super::error::{
+    PeerListError, PeerManagerError, PeerRefAddError, PeerRefRemoveError, PeerRefUpdateError,
+};
+use super::notification::PeerNotificationIter;
+use super::PeerRef;
+use super::{PeerManagerMessage, PeerManagerRequest};
+
+/// The PeerManagerConnector will be used to make requests to the PeerManager.
+///
+/// The connector includes functions to add a new peer reference, update a peer and list the
+/// existing peers.
+#[derive(Clone, Debug)]
+pub struct PeerManagerConnector {
+    sender: Sender<PeerManagerMessage>,
+}
+
+impl PeerManagerConnector {
+    pub(crate) fn new(sender: Sender<PeerManagerMessage>) -> Self {
+        PeerManagerConnector { sender }
+    }
+
+    /// Request that a peer is added to the PeerManager. If a peer already exists, the peer's ref
+    /// count will be incremented
+    ///
+    /// # Arguments
+    ///
+    /// * `peer_id` -  The unique id for the peer.
+    /// * `endpoints` -  The list of endpoints associated with the peer. The list should be in
+    ///     preference order, with the first endpoint being the first attempted.
+    ///
+    /// Returns a PeerRef, that when dropped, will automatically send a removal request to the
+    /// PeerManager.
+    pub fn add_peer_ref(
+        &self,
+        peer_id: String,
+        endpoints: Vec<String>,
+    ) -> Result<PeerRef, PeerRefAddError> {
+        let (sender, recv) = channel();
+
+        let message = PeerManagerMessage::Request(PeerManagerRequest::AddPeer {
+            peer_id,
+            endpoints,
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerRefAddError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerRefAddError::ReceiveError(format!("{:?}", err)))?
+    }
+
+    /// Request that a peer is updated. If a peer already exists, update a peer id. Redirections
+    /// will be added to the peer map and reference count so the old PeerRef will still work.
+    ///
+    /// # Arguments
+    ///
+    /// * `old_peer_id` -  The old peer_id of the peer.
+    /// * `new_peer_id` -  The new peer_id of the peer.
+    pub fn update_peer_ref(
+        &self,
+        old_peer_id: &str,
+        new_peer_id: &str,
+    ) -> Result<(), PeerRefUpdateError> {
+        let (sender, recv) = channel();
+
+        let message = PeerManagerMessage::Request(PeerManagerRequest::UpdatePeer {
+            old_peer_id: old_peer_id.to_string(),
+            new_peer_id: new_peer_id.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerRefUpdateError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerRefUpdateError::ReceiveError(format!("{:?}", err)))?
+    }
+
+    /// Request the list of currently connected peers.
+    ///
+    /// Returns the list of peer ids.
+    pub fn list_peers(&self) -> Result<Vec<String>, PeerListError> {
+        let (sender, recv) = channel();
+        let message = PeerManagerMessage::Request(PeerManagerRequest::ListPeers { sender });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerListError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerListError::ReceiveError(format!("{:?}", err)))?
+    }
+
+    /// Subscribe to PeerManager notifications.
+    ///
+    /// Returns a PeerNotificationIter that can be used to receive notications about connected and
+    /// disconnected peers
+    pub fn subscribe(&self) -> Result<PeerNotificationIter, PeerManagerError> {
+        let (send, recv) = channel();
+        match self.sender.send(PeerManagerMessage::Subscribe(send)) {
+            Ok(()) => Ok(PeerNotificationIter { recv }),
+            Err(_) => Err(PeerManagerError::SendMessageError(
+                "The peer manager is no longer running".into(),
+            )),
+        }
+    }
+}
+
+/// The PeerRemover will be used in the PeerRef to decrement the reference count for a peer when
+/// the PeerRef is dropped.
+#[derive(Clone, Debug)]
+pub(crate) struct PeerRemover {
+    pub sender: Sender<PeerManagerMessage>,
+}
+
+impl PeerRemover {
+    /// This function will only be called when the PeerRef is dropped.
+    ///
+    /// Sends a request to the PeerManager to remove a peer.
+    ///
+    /// # Arguments
+    /// * `peer_id` - the peer_id of the PeerRef that has been dropped
+    pub fn remove_peer_ref(&self, peer_id: &str) -> Result<(), PeerRefRemoveError> {
+        let (sender, recv) = channel();
+
+        let message = PeerManagerMessage::Request(PeerManagerRequest::RemovePeer {
+            peer_id: peer_id.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerRefRemoveError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
+    }
+}
+
+impl PartialEq for PeerRemover {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}

--- a/libsplinter/src/network/peer_manager/error.rs
+++ b/libsplinter/src/network/peer_manager/error.rs
@@ -1,0 +1,133 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error, fmt};
+
+#[derive(Debug, PartialEq)]
+pub enum PeerManagerError {
+    StartUpError(String),
+    SendMessageError(String),
+    RetryEndpoints(String),
+}
+
+impl error::Error for PeerManagerError {}
+
+impl fmt::Display for PeerManagerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerManagerError::StartUpError(msg) => write!(f, "{}", msg),
+            PeerManagerError::SendMessageError(msg) => write!(f, "{}", msg),
+            PeerManagerError::RetryEndpoints(msg) => write!(
+                f,
+                "Error occured while trying to find new active endpoint: {}",
+                msg
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PeerRefAddError {
+    InternalError(String),
+    ReceiveError(String),
+    AddError(String),
+}
+
+impl error::Error for PeerRefAddError {}
+
+impl fmt::Display for PeerRefAddError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerRefAddError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
+            PeerRefAddError::ReceiveError(msg) => {
+                write!(f, "Unable to receive response from PeerManager: {}", msg)
+            }
+            PeerRefAddError::AddError(msg) => write!(f, "Unable to add peer: {}", msg),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PeerRefRemoveError {
+    InternalError(String),
+    ReceiveError(String),
+    RemoveError(String),
+}
+
+impl error::Error for PeerRefRemoveError {}
+
+impl fmt::Display for PeerRefRemoveError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerRefRemoveError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
+            PeerRefRemoveError::ReceiveError(msg) => {
+                write!(f, "Unable to receive response from PeerManager: {}", msg)
+            }
+            PeerRefRemoveError::RemoveError(msg) => write!(f, "Unable to remove peer: {}", msg),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PeerRefUpdateError {
+    InternalError(String),
+    ReceiveError(String),
+    UpdateError(String),
+}
+
+impl error::Error for PeerRefUpdateError {}
+
+impl fmt::Display for PeerRefUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerRefUpdateError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
+            PeerRefUpdateError::ReceiveError(msg) => {
+                write!(f, "Unable to receive response from PeerManager: {}", msg)
+            }
+            PeerRefUpdateError::UpdateError(msg) => write!(f, "Unable to update peer: {}", msg),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PeerListError {
+    InternalError(String),
+    ReceiveError(String),
+    ListError(String),
+}
+
+impl error::Error for PeerListError {}
+
+impl fmt::Display for PeerListError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerListError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
+            PeerListError::ReceiveError(msg) => {
+                write!(f, "Unable to receive response from PeerManager: {}", msg)
+            }
+            PeerListError::ListError(msg) => write!(f, "Unable to list peers: {}", msg),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PeerUpdateError(pub String);
+
+impl error::Error for PeerUpdateError {}
+
+impl fmt::Display for PeerUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unable to update peer, {}", self.0)
+    }
+}

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -1,0 +1,1039 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod connector;
+mod error;
+mod notification;
+mod peer_map;
+
+use std::sync::mpsc::{channel, Sender};
+use std::thread;
+
+use self::error::{
+    PeerListError, PeerManagerError, PeerRefAddError, PeerRefRemoveError, PeerRefUpdateError,
+};
+use crate::network::connection_manager::ConnectionManagerNotification;
+use crate::network::connection_manager::Connector;
+pub use crate::network::peer_manager::connector::PeerManagerConnector;
+use crate::network::peer_manager::connector::PeerRemover;
+pub use crate::network::peer_manager::notification::{
+    PeerManagerNotification, PeerNotificationIter,
+};
+use crate::network::peer_manager::peer_map::{PeerMap, PeerMetadata, PeerStatus};
+use crate::network::ref_map::RefMap;
+
+// the number of retry attempts for an active endpoint before the PeerManager will try other
+// endpoints associated with a peer
+const DEFAULT_MAXIMUM_RETRY_ATTEMPTS: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub(crate) enum PeerManagerMessage {
+    Shutdown,
+    Request(PeerManagerRequest),
+    Subscribe(Sender<PeerManagerNotification>),
+    InternalNotification(ConnectionManagerNotification),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PeerManagerRequest {
+    AddPeer {
+        peer_id: String,
+        endpoints: Vec<String>,
+        sender: Sender<Result<PeerRef, PeerRefAddError>>,
+    },
+    UpdatePeer {
+        old_peer_id: String,
+        new_peer_id: String,
+        sender: Sender<Result<(), PeerRefUpdateError>>,
+    },
+    RemovePeer {
+        peer_id: String,
+        sender: Sender<Result<(), PeerRefRemoveError>>,
+    },
+    ListPeers {
+        sender: Sender<Result<Vec<String>, PeerListError>>,
+    },
+}
+
+/// A PeerRef is used to keep track of peer references. When dropped, the PeerRef will send
+/// a request to the PeerManager to remove a reference to the peer, thus removing the peer if no
+/// more references exists.
+
+#[derive(Debug, PartialEq)]
+pub struct PeerRef {
+    peer_id: String,
+    peer_remover: PeerRemover,
+}
+
+impl PeerRef {
+    pub(super) fn new(peer_id: String, peer_remover: PeerRemover) -> Self {
+        PeerRef {
+            peer_id,
+            peer_remover,
+        }
+    }
+
+    pub fn peer_id(&mut self) -> &str {
+        &self.peer_id
+    }
+}
+
+impl Drop for PeerRef {
+    fn drop(&mut self) {
+        match self.peer_remover.remove_peer_ref(&self.peer_id) {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Unable to remove reference to {} on drop: {}",
+                self.peer_id, err
+            ),
+        }
+    }
+}
+
+/// The PeerManager is in charge of keeping track of peers and their ref count, as well as
+/// requesting connections from the ConnectionManager. If a peer has disconnected, the PeerManager
+/// will also try the peer's other endpoints until one is successful.
+pub struct PeerManager {
+    connection_manager_connector: Connector,
+    join_handle: Option<thread::JoinHandle<()>>,
+    sender: Option<Sender<PeerManagerMessage>>,
+    shutdown_handle: Option<ShutdownHandle>,
+    max_retry_attempts: Option<u64>,
+}
+
+impl PeerManager {
+    pub fn new(connector: Connector, max_retry_attempts: Option<u64>) -> Self {
+        PeerManager {
+            connection_manager_connector: connector,
+            join_handle: None,
+            sender: None,
+            shutdown_handle: None,
+            max_retry_attempts,
+        }
+    }
+
+    /// Start the PeerManager
+    ///
+    /// Returns a PeerManagerConnector that can be used to send requests to the PeerManager.
+    pub fn start(&mut self) -> Result<PeerManagerConnector, PeerManagerError> {
+        let (sender, recv) = channel();
+        if self.sender.is_some() {
+            return Err(PeerManagerError::StartUpError(
+                "PeerManager has already been started".to_string(),
+            ));
+        }
+        let connector = self.connection_manager_connector.clone();
+        let peer_remover = PeerRemover {
+            sender: sender.clone(),
+        };
+
+        let mut subscriber = connector.subscribe().expect("Cannot get subscriber");
+        let notification_sender = sender.clone();
+        // start thread to listen for notifications from the connection manager
+        thread::Builder::new()
+            .name("Peer Manager Notification".into())
+            .spawn(move || loop {
+                // convert connection mangager notification to peer manager notifications
+                // this enables it to be handled in the same thread as other peer manager messages
+                match subscriber.next() {
+                    Some(notification) => {
+                        match notification_sender
+                            .send(PeerManagerMessage::InternalNotification(notification))
+                        {
+                            Ok(_) => (),
+                            Err(_) => {
+                                info!("Peer Manager has shutdown");
+                                break;
+                            }
+                        }
+                    }
+                    None => {
+                        info!("ConnectionManager has shutdown");
+                        break;
+                    }
+                }
+            })
+            .map_err(|err| {
+                PeerManagerError::StartUpError(format!(
+                    "Unable to start PeerManager notification thread {}",
+                    err
+                ))
+            })?;
+
+        let max_retry_attempts = self
+            .max_retry_attempts
+            .unwrap_or(DEFAULT_MAXIMUM_RETRY_ATTEMPTS);
+        let join_handle = thread::Builder::new()
+            .name("Peer Manager".into())
+            .spawn(move || {
+                let mut peers = PeerMap::new();
+                let mut ref_map = RefMap::new();
+                let mut subscribers = Vec::new();
+                loop {
+                    match recv.recv() {
+                        Ok(PeerManagerMessage::Shutdown) => break,
+                        Ok(PeerManagerMessage::Request(request)) => {
+                            handle_request(
+                                request,
+                                connector.clone(),
+                                &mut peers,
+                                &peer_remover,
+                                &mut ref_map,
+                            );
+                        }
+                        Ok(PeerManagerMessage::Subscribe(sender)) => {
+                            subscribers.push(sender);
+                        }
+                        Ok(PeerManagerMessage::InternalNotification(notification)) => {
+                            handle_notifications(
+                                notification,
+                                &mut peers,
+                                connector.clone(),
+                                &mut subscribers,
+                                max_retry_attempts,
+                            )
+                        }
+                        Err(_) => {
+                            warn!("All senders have disconnected");
+                            break;
+                        }
+                    }
+                }
+            });
+
+        match join_handle {
+            Ok(join_handle) => {
+                self.join_handle = Some(join_handle);
+            }
+            Err(err) => {
+                return Err(PeerManagerError::StartUpError(format!(
+                    "Unable to start PeerManager thread {}",
+                    err
+                )))
+            }
+        }
+
+        self.shutdown_handle = Some(ShutdownHandle {
+            sender: sender.clone(),
+        });
+        self.sender = Some(sender.clone());
+        Ok(PeerManagerConnector::new(sender))
+    }
+
+    pub fn shutdown_handle(&self) -> Option<ShutdownHandle> {
+        self.shutdown_handle.clone()
+    }
+
+    pub fn await_shutdown(self) {
+        let join_handle = if let Some(jh) = self.join_handle {
+            jh
+        } else {
+            return;
+        };
+
+        if let Err(err) = join_handle.join() {
+            error!("Peer manager thread did not shutdown correctly: {:?}", err);
+        }
+    }
+
+    pub fn shutdown_and_wait(self) {
+        if let Some(sh) = self.shutdown_handle.clone() {
+            sh.shutdown();
+        } else {
+            return;
+        }
+
+        self.await_shutdown();
+    }
+}
+
+#[derive(Clone)]
+pub struct ShutdownHandle {
+    sender: Sender<PeerManagerMessage>,
+}
+
+impl ShutdownHandle {
+    pub fn shutdown(&self) {
+        if self.sender.send(PeerManagerMessage::Shutdown).is_err() {
+            warn!("Connection manager is no longer running");
+        }
+    }
+}
+
+fn handle_request(
+    request: PeerManagerRequest,
+    connector: Connector,
+    peers: &mut PeerMap,
+    peer_remover: &PeerRemover,
+    ref_map: &mut RefMap,
+) {
+    match request {
+        PeerManagerRequest::AddPeer {
+            peer_id,
+            endpoints,
+            sender,
+        } => {
+            if sender
+                .send(add_peer(
+                    peer_id,
+                    endpoints,
+                    connector,
+                    peers,
+                    peer_remover,
+                    ref_map,
+                ))
+                .is_err()
+            {
+                warn!("connector dropped before receiving result of adding peer");
+            }
+        }
+        PeerManagerRequest::UpdatePeer {
+            old_peer_id,
+            new_peer_id,
+            sender,
+        } => {
+            if sender
+                .send(update_peer(old_peer_id, new_peer_id, peers, ref_map))
+                .is_err()
+            {
+                warn!("connector dropped before receiving result of updating peer");
+            }
+        }
+        PeerManagerRequest::RemovePeer { peer_id, sender } => {
+            if sender
+                .send(remove_peer(peer_id, connector, peers, ref_map))
+                .is_err()
+            {
+                warn!("connector dropped before receiving result of removing peer");
+            }
+        }
+        PeerManagerRequest::ListPeers { sender } => {
+            if sender.send(Ok(peers.peer_ids())).is_err() {
+                warn!("connector dropped before receiving result of list peers");
+            }
+        }
+    };
+}
+
+fn add_peer(
+    peer_id: String,
+    endpoints: Vec<String>,
+    connector: Connector,
+    peers: &mut PeerMap,
+    peer_remover: &PeerRemover,
+    ref_map: &mut RefMap,
+) -> Result<PeerRef, PeerRefAddError> {
+    let new_ref_count = ref_map.add_ref(peer_id.to_string());
+
+    // if this is not a new peer, return success
+    if new_ref_count > 1 {
+        let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
+        return Ok(peer_ref);
+    };
+
+    debug!("Attempting to peer with {}", peer_id);
+    // If new, try to create a connection
+    for endpoint in endpoints.iter() {
+        match connector.request_connection(&endpoint) {
+            Ok(()) => {
+                debug!("Peer {} connected via {}", peer_id, endpoint);
+                peers.insert(peer_id.clone(), endpoints.clone(), endpoint.to_string());
+                let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
+                return Ok(peer_ref);
+            }
+            Err(err) => {
+                warn!("Unable to connect to endpoint {}: {}", endpoint, err);
+                continue;
+            }
+        }
+    }
+
+    warn!("Unable to peer with {}", peer_id);
+    // remove the reference created above
+    ref_map.remove_ref(&peer_id);
+    // unable to connect to any of the endpoints provided
+    Err(PeerRefAddError::AddError(format!(
+        "Unable to connect any endpoint that was provided for peer {}",
+        peer_id
+    )))
+}
+
+fn update_peer(
+    peer_id: String,
+    new_peer_id: String,
+    peers: &mut PeerMap,
+    ref_map: &mut RefMap,
+) -> Result<(), PeerRefUpdateError> {
+    // update the ref_map, so old PeerRef can still be used to drop references
+    if ref_map
+        .update_ref(peer_id.clone(), new_peer_id.clone())
+        .is_err()
+    {
+        return Err(PeerRefUpdateError::UpdateError(format!(
+            "Unable to update peer, {} does not exist",
+            peer_id
+        )));
+    }
+
+    // update the peer in the peer map
+    match peers.update_peer_id(peer_id.clone(), new_peer_id.clone()) {
+        Ok(()) => {
+            debug!("Updated peer id from {} to {}", peer_id, new_peer_id);
+            Ok(())
+        }
+        Err(_) => Err(PeerRefUpdateError::UpdateError(format!(
+            "Unable to update peer, {} does not exist",
+            peer_id
+        ))),
+    }
+}
+
+fn remove_peer(
+    peer_id: String,
+    connector: Connector,
+    peers: &mut PeerMap,
+    ref_map: &mut RefMap,
+) -> Result<(), PeerRefRemoveError> {
+    debug!("Removing peer: {}", peer_id);
+    // remove the reference
+    let removed_peer = ref_map.remove_ref(&peer_id);
+    if let Some(removed_peer) = removed_peer {
+        let active_endpoint = peers.remove(&removed_peer).ok_or_else(|| {
+            PeerRefRemoveError::RemoveError(format!(
+                "Peer {} has already been removed from the peer map",
+                peer_id
+            ))
+        })?;
+
+        match connector.remove_connection(&active_endpoint) {
+            Ok(Some(_)) => {
+                debug!(
+                    "Peer {} has been removed and connection {} has been closed",
+                    peer_id, active_endpoint
+                );
+                Ok(())
+            }
+            Ok(None) => Err(PeerRefRemoveError::RemoveError(
+                "No connection to remove, something has gone wrong".to_string(),
+            )),
+            Err(err) => Err(PeerRefRemoveError::RemoveError(format!("{}", err))),
+        }
+    } else {
+        // if the peer has not been fully removed, return OK
+        Ok(())
+    }
+}
+
+// If a connection has reached the retry limit before it could be reestablished, the peer manager
+// will try the peer's other endpoints.
+fn retry_endpoints(
+    peer_metadata: &mut PeerMetadata,
+    connector: Connector,
+) -> Result<bool, PeerManagerError> {
+    debug!("Trying to find active endpoint for {}", peer_metadata.id);
+    for endpoint in peer_metadata.endpoints.iter() {
+        match connector.request_connection(&endpoint) {
+            Ok(()) => {
+                debug!("Peered with {}: {}", peer_metadata.id, endpoint);
+                if endpoint != &peer_metadata.active_endpoint {
+                    // Remove old active endpoint from peer_manager
+                    match connector.remove_connection(&peer_metadata.active_endpoint) {
+                        Ok(Some(_)) => (),
+                        Ok(None) => (),
+                        Err(err) => {
+                            return Err(PeerManagerError::RetryEndpoints(format!(
+                                "Unable to remove active endpoint {} from connection manager: {}",
+                                &peer_metadata.active_endpoint, err
+                            )))
+                        }
+                    }
+                }
+                peer_metadata.active_endpoint = endpoint.to_string();
+                return Ok(true);
+            }
+            Err(err) => {
+                warn!("Unable to connect to endpoint {}: {}", endpoint, err);
+                continue;
+            }
+        }
+    }
+
+    warn!(
+        "Unable to find new active endpoint for peer {}",
+        peer_metadata.id
+    );
+    // unable to connect to any of the endpoints provided
+    Ok(false)
+}
+
+fn handle_notifications(
+    notification: ConnectionManagerNotification,
+    peers: &mut PeerMap,
+    connector: Connector,
+    subscribers: &mut Vec<Sender<PeerManagerNotification>>,
+    max_retry_attempts: u64,
+) {
+    match notification {
+        // If a connection has been successful, forward notification to subscribers
+        ConnectionManagerNotification::Connected { endpoint } => {
+            // if we have a corresponding peer for for endpoint, send notification; otherwise
+            // ignore
+            if let Some(mut peer_metadata) = peers.get_peer_from_endpoint(&endpoint).cloned() {
+                let notification = PeerManagerNotification::Connected {
+                    peer: peer_metadata.id.to_string(),
+                };
+                subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
+                // if a peer was previously disconnected, remove from disconnected list
+                peer_metadata.status = PeerStatus::Connected;
+                if let Err(err) = peers.update_peer(peer_metadata) {
+                    error!("Unable to update peer: {}", err);
+                }
+            }
+        }
+        // If a connection has disconnected, forward notification to subscribers
+        ConnectionManagerNotification::Disconnected { endpoint } => {
+            if let Some(mut peer_metadata) = peers.get_peer_from_endpoint(&endpoint).cloned() {
+                let notification = PeerManagerNotification::Disconnected {
+                    peer: peer_metadata.id.to_string(),
+                };
+                subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
+                // set peer to disconnected
+                peer_metadata.status = PeerStatus::Disconnected { retry_attempts: 1 };
+                if let Err(err) = peers.update_peer(peer_metadata) {
+                    error!("Unable to update peer: {}", err);
+                }
+            }
+        }
+        ConnectionManagerNotification::ReconnectionFailed { endpoint, attempts } => {
+            // Check if the disconnected peer has reached the retry limit, if so try to find a
+            // different endpoint that can be connected to
+            if let Some(mut peer_metadata) = peers.get_peer_from_endpoint(&endpoint).cloned() {
+                if attempts >= max_retry_attempts {
+                    match retry_endpoints(&mut peer_metadata, connector) {
+                        Ok(true) => {
+                            peer_metadata.status = PeerStatus::Connected;
+                            let notification = PeerManagerNotification::Connected {
+                                peer: peer_metadata.id.to_string(),
+                            };
+                            subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
+                        }
+                        // if a new endpoint could not be found, reset timeout and try again later
+                        Ok(false) => {
+                            peer_metadata.status = PeerStatus::Disconnected {
+                                retry_attempts: attempts,
+                            };
+                        }
+                        Err(err) => {
+                            error!("Error returned from retry_endpoints: {}", err);
+                            peer_metadata.status = PeerStatus::Disconnected {
+                                retry_attempts: attempts,
+                            };
+                        }
+                    }
+                    if let Err(err) = peers.update_peer(peer_metadata) {
+                        error!("Unable to update peer: {}", err);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::mesh::Mesh;
+    use crate::network::connection_manager::ConnectionManager;
+    use crate::protos::network::{NetworkMessage, NetworkMessageType};
+    use crate::transport::inproc::InprocTransport;
+    use crate::transport::raw::RawTransport;
+    use crate::transport::Transport;
+
+    // Test that a call to add_peer_ref returns the correct PeerRef
+    //
+    // 1. add test_peer
+    // 2. verify that the returned PeerRef contains the test_peer id
+    #[test]
+    fn test_peer_manager_add_peer() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let peer_ref = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that a call to add_peer_ref with a peer with multiple endpoints is successful, even if
+    // the first endpoint is not available
+    //
+    // 1. add test_peer with two endpoints. The first endpoint will fail and cause the peer
+    //    manager to try the second
+    // 2. verify that the returned PeerRef contains the test_peer id
+    #[test]
+    fn test_peer_manager_add_peer_endpoints() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let peer_ref = peer_connector
+            .add_peer_ref(
+                "test_peer".to_string(),
+                vec![
+                    "inproc://bad_endpoint".to_string(),
+                    "inproc://test".to_string(),
+                ],
+            )
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that the same peer can be added multiple times.
+    //
+    // 1. add test_peer
+    // 2. add the same peer, and see it is successful
+    #[test]
+    fn test_peer_manager_add_peer_multiple_times() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let peer_ref = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+
+        let peer_ref = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that list_peer returns the correct list of peers
+    //
+    // 1. add test_peer
+    // 2. add next_peer
+    // 3. call list_peers
+    // 4. verify that the sorted list of peers contains both test_peer and next_peer
+    #[test]
+    fn test_peer_manager_list_peer() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mut listener = transport.listen("inproc://test_2").unwrap();
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let peer_ref_1 = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref_1.peer_id, "test_peer");
+
+        let peer_ref_2 = peer_connector
+            .add_peer_ref("next_peer".to_string(), vec!["inproc://test_2".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref_2.peer_id, "next_peer");
+
+        let mut peer_list = peer_connector
+            .list_peers()
+            .expect("Unable to get peer list");
+
+        peer_list.sort();
+
+        assert_eq!(
+            peer_list,
+            vec!["next_peer".to_string(), "test_peer".to_string()]
+        );
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that if a peer is updated, it is properly put in the list_peer list
+    //
+    // 1. add test_peer
+    // 2. update test_peer to have a new id, new_peer
+    // 3. call list_peers
+    // 4. verify that list peers contains only new_peer
+    #[test]
+    fn test_peer_manager_update_peer() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let peer_ref = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+
+        peer_connector
+            .update_peer_ref("test_peer", "new_peer")
+            .expect("Unable to update peer id");
+
+        let peer_list = peer_connector
+            .list_peers()
+            .expect("Unable to get peer list");
+
+        assert_eq!(peer_list, vec!["new_peer".to_string()]);
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that when a PeerRef is dropped, a remove peer request is properly sent and the peer
+    // is removed
+    //
+    // 1. add test_peer
+    // 2. call list peers
+    // 3. verify that the peer list contains test_peer
+    // 4. drop the PeerRef
+    // 5. call list peers
+    // 6. verify that the new peer list is empty
+    #[test]
+    fn test_peer_manager_drop_peer_ref() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+
+        {
+            let peer_ref = peer_connector
+                .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+                .expect("Unable to add peer");
+
+            assert_eq!(peer_ref.peer_id, "test_peer");
+
+            let peer_list = peer_connector
+                .list_peers()
+                .expect("Unable to get peer list");
+
+            assert_eq!(peer_list, vec!["test_peer".to_string()]);
+        }
+        // drop peer_ref
+
+        let peer_list = peer_connector
+            .list_peers()
+            .expect("Unable to get peer list");
+
+        assert_eq!(peer_list, Vec::<String>::new());
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that if a peer is updated, an old peer_ref (with the old peer id) can still remove
+    // a reference for that peer.
+    //
+    // 1. add test_peer
+    // 2. update test_peer id to new_peer
+    // 3. call list peers
+    // 4. verify that the peer list contains new_peer
+    // 5. Add reference to new_peer, and verify new_peer is the only peer in the peer lst
+    // 6. drop the PeerRef for new_peer
+    // 7. call list peers
+    // 8. verify that the peer list still contains new_peer
+    // 9. drop the originally PeerREf for test_peer
+    // 10. call list peers and verify that it is empty
+    #[test]
+    fn test_peer_manager_drop_updated_peer_ref() {
+        let mut transport = Box::new(InprocTransport::default());
+        let mut listener = transport.listen("inproc://test").unwrap();
+
+        thread::spawn(move || {
+            listener.accept().unwrap();
+        });
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+
+        {
+            // create peer_ref with peer_id test_peer
+            let peer_ref = peer_connector
+                .add_peer_ref("test_peer".to_string(), vec!["inproc://test".to_string()])
+                .expect("Unable to add peer");
+
+            assert_eq!(peer_ref.peer_id, "test_peer");
+
+            // update peer id
+            peer_connector
+                .update_peer_ref("test_peer", "new_peer")
+                .expect("Unable to update peer id");
+
+            let peer_list = peer_connector
+                .list_peers()
+                .expect("Unable to get peer list");
+
+            assert_eq!(peer_list, vec!["new_peer".to_string()]);
+
+            {
+                // add another reference to new_peer
+                let peer_ref_2 = peer_connector
+                    .add_peer_ref("new_peer".to_string(), vec!["inproc://test".to_string()])
+                    .expect("Unable to add peer");
+
+                assert_eq!(peer_ref_2.peer_id, "new_peer");
+
+                // verify that only 1 peer is listed
+                let peer_list = peer_connector
+                    .list_peers()
+                    .expect("Unable to get peer list");
+
+                assert_eq!(peer_list, vec!["new_peer".to_string()]);
+            }
+            // drop peer ref 2, reference has peer id "new_peer"
+
+            // verify that new_peer has not been removed
+            let peer_list = peer_connector
+                .list_peers()
+                .expect("Unable to get peer list");
+
+            assert_eq!(peer_list, vec!["new_peer".to_string()]);
+        }
+        // drop peer ref with old peer id test_peer
+
+        // verify that the peer has been removed
+        let peer_list = peer_connector
+            .list_peers()
+            .expect("Unable to get peer list");
+
+        assert_eq!(peer_list, Vec::<String>::new());
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that if a peer's endpoint disconnects and does not reconnect during a set timeout, the
+    // PeerManager will retry the peers list of endpoints trying to find an endpoint that is
+    // available.
+    //
+    // 1. add test_peer, this will connected to the first endpoint
+    // 2. verify that the test_peer connection receives a heartbeat
+    // 3. disconnect the connection made to test_peer
+    // 4. verify that subscribers will receive a Disconnected notification
+    // 5. drop the listener for the first endpoint to force the attempt on the second endpoint
+    // 6. verify that subscribers will receive a Connected notfication when the new active endpoint
+    //    is successfully connected to.
+    #[test]
+    fn test_peer_manager_update_active_endpoint() {
+        let mut transport = Box::new(RawTransport::default());
+        let mut listener = transport
+            .listen("tcp://localhost:0")
+            .expect("Cannot listen for connections");
+        let endpoint = listener.endpoint();
+        let mesh1 = Mesh::new(512, 128);
+        let mesh2 = Mesh::new(512, 128);
+
+        let mut listener2 = transport
+            .listen("tcp://localhost:0")
+            .expect("Cannot listen for connections");
+        let endpoint2 = listener2.endpoint();
+
+        thread::spawn(move || {
+            // accept incoming connection and add it to mesh2
+            let conn = listener.accept().expect("Cannot accept connection");
+            let id = mesh2.add(conn).expect("Cannot add connection to mesh");
+            // Verify mesh received heartbeat
+            let envelope = mesh2.recv().expect("Cannot receive message");
+            let heartbeat: NetworkMessage = protobuf::parse_from_bytes(&envelope.payload())
+                .expect("Cannot parse NetworkMessage");
+            assert_eq!(
+                heartbeat.get_message_type(),
+                NetworkMessageType::NETWORK_HEARTBEAT
+            );
+            // remove connection to cause reconnection attempt
+            let mut connection = mesh2
+                .remove(id)
+                .expect("Cannot remove connection from mesh");
+            connection
+                .disconnect()
+                .expect("Connection failed to disconnect");
+            // force drop of first listener
+            drop(listener);
+            // wait for the peer manager to switch endpoints
+            let conn = listener2.accept().expect("Unable to accept connection");
+            mesh2.add(conn).expect("Cannot add connection to mesh");
+            mesh2.recv().expect("Cannot receive message");
+        });
+
+        let mut cm = ConnectionManager::new(
+            mesh1.get_life_cycle(),
+            mesh1.get_sender(),
+            transport,
+            Some(1),
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, Some(1));
+        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+        let mut subscriber = peer_connector.subscribe().expect("Unable to subscribe");
+        let peer_ref = peer_connector
+            .add_peer_ref("test_peer".to_string(), vec![endpoint, endpoint2])
+            .expect("Unable to add peer");
+
+        assert_eq!(peer_ref.peer_id, "test_peer");
+
+        // receive reconnecting attempt
+        let disconnected_notification = subscriber
+            .next()
+            .expect("Cannot get message from subscriber");
+        assert!(
+            disconnected_notification
+                == PeerManagerNotification::Disconnected {
+                    peer: "test_peer".to_string(),
+                }
+        );
+
+        // receive notifications that the peer is connected to new endpoint
+        let connected_notification = subscriber
+            .next()
+            .expect("Cannot get message from subscriber");
+
+        assert!(
+            connected_notification
+                == PeerManagerNotification::Connected {
+                    peer: "test_peer".to_string(),
+                }
+        );
+
+        peer_manager.shutdown_and_wait();
+        cm.shutdown_and_wait();
+    }
+
+    // Test that the PeerManager can be started and stopped
+    #[test]
+    fn test_peer_manager_shutdown() {
+        let transport = Box::new(InprocTransport::default());
+
+        let mesh = Mesh::new(512, 128);
+        let mut cm = ConnectionManager::new(
+            mesh.get_life_cycle(),
+            mesh.get_sender(),
+            transport,
+            None,
+            None,
+        );
+        let connector = cm.start().unwrap();
+        let mut peer_manager = PeerManager::new(connector, None);
+        peer_manager.start().expect("Cannot start peer_manager");
+
+        peer_manager.shutdown_and_wait();
+    }
+}

--- a/libsplinter/src/network/peer_manager/notification.rs
+++ b/libsplinter/src/network/peer_manager/notification.rs
@@ -1,0 +1,113 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::error::PeerManagerError;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+/// Messages that will be dispatched to all
+/// subscription handlers
+#[derive(Debug, PartialEq, Clone)]
+pub enum PeerManagerNotification {
+    Connected { peer: String },
+    Disconnected { peer: String },
+}
+
+/// PeerNotificationIter is used to receive notfications from the PeerManager. The notifications
+/// include:
+/// - PeerManagerNotification::Disconnected: peer disconnected and reconnection
+///     is being attempted.
+/// - PeerManagerNotification::Connected: reconnection to peer was successful
+pub struct PeerNotificationIter {
+    pub(super) recv: Receiver<PeerManagerNotification>,
+}
+
+impl PeerNotificationIter {
+    pub fn try_next(&self) -> Result<Option<PeerManagerNotification>, PeerManagerError> {
+        match self.recv.try_recv() {
+            Ok(notifications) => Ok(Some(notifications)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(PeerManagerError::SendMessageError(
+                "The peer manager is no longer running".into(),
+            )),
+        }
+    }
+}
+
+impl Iterator for PeerNotificationIter {
+    type Item = PeerManagerNotification;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.recv.recv() {
+            Ok(notification) => Some(notification),
+            Err(_) => {
+                // This is expected if the peer manager shuts down before
+                // this end
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    /// Tests that notifier iterator correctly exists when sender
+    /// is dropped.
+    ///
+    /// Procedure:
+    ///
+    /// The test creates a channel and a notifier, then it
+    /// creates a thread that sends Connected notifications to
+    /// the notifier.
+    ///
+    /// Asserts:
+    ///
+    /// The notifications sent are received by the NotificationIter
+    /// correctly
+    ///
+    /// That the total number of notifications sent equals 5
+    #[test]
+    fn test_peer_manager_notifications() {
+        let (send, recv) = channel();
+
+        let notifcation_iter = PeerNotificationIter { recv };
+
+        let join_handle = thread::spawn(move || {
+            for i in 0..5 {
+                send.send(PeerManagerNotification::Connected {
+                    peer: format!("test_peer{}", i),
+                })
+                .unwrap();
+            }
+        });
+
+        let mut notifications_sent = 0;
+        for notifcation in notifcation_iter {
+            assert_eq!(
+                notifcation,
+                PeerManagerNotification::Connected {
+                    peer: format!("test_peer{}", notifications_sent),
+                }
+            );
+            notifications_sent += 1;
+        }
+
+        assert_eq!(notifications_sent, 5);
+
+        join_handle.join().unwrap();
+    }
+}

--- a/libsplinter/src/network/peer_manager/peer_map.rs
+++ b/libsplinter/src/network/peer_manager/peer_map.rs
@@ -1,0 +1,382 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use super::error::PeerUpdateError;
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum PeerStatus {
+    Connected,
+    Disconnected { retry_attempts: u64 },
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct PeerMetadata {
+    pub id: String,
+    pub endpoints: Vec<String>,
+    pub active_endpoint: String,
+    pub status: PeerStatus,
+}
+
+pub struct PeerMap {
+    peers: HashMap<String, PeerMetadata>,
+    redirects: HashMap<String, String>,
+    // Endpoint to peer id
+    endpoints: HashMap<String, String>,
+}
+
+/// A map of Peer IDs to peer metadata, which also maintains a redirect table for updated peer IDs.
+///
+/// Peer metadata includes the peer_id, the list of endpoints and the current active endpoint.
+impl PeerMap {
+    pub fn new() -> Self {
+        PeerMap {
+            peers: HashMap::new(),
+            redirects: HashMap::new(),
+            endpoints: HashMap::new(),
+        }
+    }
+
+    /// Returns the current list of peer ids.
+    ///
+    /// This list does not include any of the redirected peer ids.
+    pub fn peer_ids(&self) -> Vec<String> {
+        self.peers
+            .iter()
+            .map(|(_, metadata)| metadata.id.to_string())
+            .collect()
+    }
+
+    /// Insert a new peer id and endpoints
+    pub fn insert(&mut self, peer_id: String, endpoints: Vec<String>, active_endpoint: String) {
+        let peer_metadata = PeerMetadata {
+            id: peer_id.clone(),
+            endpoints: endpoints.clone(),
+            active_endpoint,
+            status: PeerStatus::Connected,
+        };
+
+        self.peers.insert(peer_id.clone(), peer_metadata);
+
+        for endpoint in endpoints {
+            self.endpoints.insert(endpoint, peer_id.clone());
+        }
+    }
+
+    /// Remove a peer id, its endpoint and all of its redirects. Returns the active_endpoint of
+    /// the peer.
+    pub fn remove(&mut self, peer_id: &str) -> Option<String> {
+        self.redirects
+            .retain(|_, target_peer_id| target_peer_id != peer_id);
+        if let Some(peer_metadata) = self.peers.remove(&peer_id.to_string()) {
+            for endpoint in peer_metadata.endpoints.iter() {
+                self.endpoints.remove(endpoint);
+            }
+
+            Some(peer_metadata.active_endpoint)
+        } else {
+            None
+        }
+    }
+
+    /// Updates a peer id, and creates a redirect for the old id to the given new one.
+    ///
+    /// Additionally, it updates all of the old redirects to point to the given new one.
+    pub fn update_peer_id(
+        &mut self,
+        old_peer_id: String,
+        new_peer_id: String,
+    ) -> Result<(), PeerUpdateError> {
+        if let Some(mut peer_metadata) = self.peers.remove(&old_peer_id) {
+            // let mut new_peer_metadata = peer_metadata.clone();
+            for endpoint in peer_metadata.endpoints.iter() {
+                self.endpoints
+                    .insert(endpoint.to_string(), new_peer_id.clone());
+            }
+
+            peer_metadata.id = new_peer_id.clone();
+            self.peers.insert(new_peer_id.clone(), peer_metadata);
+
+            // update the old forwards
+            for (_, v) in self
+                .redirects
+                .iter_mut()
+                .filter(|(_, v)| **v == old_peer_id)
+            {
+                *v = new_peer_id.clone()
+            }
+
+            self.redirects.insert(old_peer_id, new_peer_id);
+
+            Ok(())
+        } else {
+            Err(PeerUpdateError(format!(
+                "Unable to update {} to {}",
+                old_peer_id, new_peer_id
+            )))
+        }
+    }
+
+    /// Updates an existing peer, all fields can be updated except peer_id.
+    pub fn update_peer(&mut self, peer_metadata: PeerMetadata) -> Result<(), PeerUpdateError> {
+        // Only valid if the peer already exists
+        if self.peers.contains_key(&peer_metadata.id) {
+            for endpoint in peer_metadata.endpoints.iter() {
+                self.endpoints
+                    .insert(endpoint.to_string(), peer_metadata.id.clone());
+            }
+
+            self.peers
+                .insert(peer_metadata.id.to_string(), peer_metadata);
+
+            Ok(())
+        } else {
+            Err(PeerUpdateError(format!(
+                "Unable to update peer {}, does not exist",
+                peer_metadata.id
+            )))
+        }
+    }
+
+    /// Returns the endpoint for the given peer id
+    pub fn get_peer_from_endpoint(&self, endpoint: &str) -> Option<&PeerMetadata> {
+        if let Some(peer) = self.endpoints.get(endpoint) {
+            self.peers.get(peer)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    // Test that peer_ids() are returned correctly
+    //  1. Test that an empty peer_map returns an empty vec of peer IDs
+    //  2. Add two peers and test that their id are returned from peer_ids()
+    //  3. Update the first peer and test the updated peer id is returned in place of the old id.
+    #[test]
+    fn test_get_peer_ids() {
+        let mut peer_map = PeerMap::new();
+
+        let peers = peer_map.peer_ids();
+        assert_eq!(peers, Vec::<String>::new());
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+
+        peer_map.insert(
+            "next_peer".to_string(),
+            vec!["endpoint1".to_string(), "endpoint2".to_string()],
+            "next_endpoint1".to_string(),
+        );
+
+        let mut peers = peer_map.peer_ids();
+        peers.sort();
+        assert_eq!(
+            peers,
+            vec!["next_peer".to_string(), "test_peer".to_string()]
+        );
+
+        peer_map
+            .update_peer_id("test_peer".to_string(), "new_peer".to_string())
+            .expect("Unable to update peer id");
+
+        let mut peers = peer_map.peer_ids();
+        peers.sort();
+        assert_eq!(peers, vec!["new_peer".to_string(), "next_peer".to_string()]);
+    }
+
+    // Test that peer_metadata() return the correct PeerMetadata for the provided id
+    //  1. Test that None is retured for a peer ID that does not exist
+    //  2. Insert a peer
+    //  3. Validate the expected PeerMetadata is returned from peer_metadata()
+    #[test]
+    fn test_get_peer_by_endpoint() {
+        let mut peer_map = PeerMap::new();
+
+        let peer_metadata = peer_map.get_peer_from_endpoint("bad_endpoint");
+        assert_eq!(peer_metadata, None);
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+
+        let peer_metadata = peer_map.get_peer_from_endpoint("test_endpoint1");
+        assert_eq!(
+            peer_metadata,
+            Some(&PeerMetadata {
+                id: "test_peer".to_string(),
+                endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+                active_endpoint: "test_endpoint2".to_string(),
+                status: PeerStatus::Connected
+            })
+        );
+
+        let peer_metadata = peer_map.get_peer_from_endpoint("test_endpoint2");
+        assert_eq!(
+            peer_metadata,
+            Some(&PeerMetadata {
+                id: "test_peer".to_string(),
+                endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+                active_endpoint: "test_endpoint2".to_string(),
+                status: PeerStatus::Connected
+            })
+        );
+    }
+
+    // Test that a peer can properly be added
+    //  1. Insert a peer
+    //  2. Check that the peer is in self.peers
+    //  3. Check that the correct metadata is returned from self.peers.get()
+    #[test]
+    fn test_insert_peer() {
+        let mut peer_map = PeerMap::new();
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+        assert!(peer_map.peers.contains_key("test_peer"));
+
+        let peer_metadata = peer_map.peers.get("test_peer");
+        assert_eq!(
+            peer_metadata,
+            Some(&PeerMetadata {
+                id: "test_peer".to_string(),
+                endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+                active_endpoint: "test_endpoint2".to_string(),
+                status: PeerStatus::Connected
+            })
+        );
+    }
+
+    // Test that a peer can be properly removed
+    //  1. Test that removing a peer_id that is not in the peer map will return None
+    //  2. Insert peer test_peer and verify id is in self.peers
+    //  3. Verify that the correct active endpoint is returned when removing test_peer
+    #[test]
+    fn test_remove_peer() {
+        let mut peer_map = PeerMap::new();
+
+        let active_endpoint = peer_map.remove("test_peer");
+
+        assert_eq!(active_endpoint, None,);
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+        assert!(peer_map.peers.contains_key("test_peer"));
+
+        let active_endpoint = peer_map.remove("test_peer");
+        assert!(!peer_map.peers.contains_key("test_peer"));
+
+        assert_eq!(active_endpoint, Some("test_endpoint2".to_string()),);
+    }
+
+    // Test that update_peer_id() works correctly
+    //  1. Test that an error is returned if the old peer id does not exist
+    //  2. Insert test_peer and check it is in self.peers
+    //  3. Update test_peer to have the id new_peer
+    //  4. Verify that peers contains new_peer and redirects contains a redirect from test_peer
+    //     to new_peer
+    #[test]
+    fn test_update_peer_id() {
+        let mut peer_map = PeerMap::new();
+
+        if let Ok(()) = peer_map.update_peer_id("test_peer".to_string(), "new_peer".to_string()) {
+            panic!("Should not be able to update peer because old peer does not exist")
+        }
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+        assert!(peer_map.peers.contains_key("test_peer"));
+
+        peer_map
+            .update_peer_id("test_peer".to_string(), "new_peer".to_string())
+            .expect("Unable to update peer id");
+
+        assert!(peer_map.peers.contains_key("new_peer"));
+        assert!(peer_map.redirects.contains_key("test_peer"));
+    }
+
+    // Test that a peer can be updated
+    //  1. Check that an error is returned if the peer does not exist
+    //  2. Insert test_peer with active endpoint test_endpoint2
+    //  3. Update the active enpdoint for test_peer to test_endpoint1 and set the status to
+    //     disconnected
+    //  4. Check that the peer's metadata now points to test_endpoint1 and the peer is disconnected
+    #[test]
+    fn test_get_update_active_endpoint() {
+        let mut peer_map = PeerMap::new();
+        let no_peer_metadata = PeerMetadata {
+            id: "test_peer".to_string(),
+            endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            active_endpoint: "test_endpoint1".to_string(),
+            status: PeerStatus::Connected,
+        };
+
+        if let Ok(()) = peer_map.update_peer(no_peer_metadata) {
+            panic!("Should not have been able to update peer because test_peer does not exist")
+        }
+
+        peer_map.insert(
+            "test_peer".to_string(),
+            vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
+            "test_endpoint2".to_string(),
+        );
+        assert!(peer_map.peers.contains_key("test_peer"));
+
+        let mut peer_metadata = peer_map
+            .get_peer_from_endpoint("test_endpoint2")
+            .cloned()
+            .expect("Unable to retrieve peer metadata with endpoint");
+
+        peer_metadata.active_endpoint = "test_endpoint1".to_string();
+        peer_metadata.endpoints.push("new_endpoint".to_string());
+        peer_metadata.status = PeerStatus::Disconnected { retry_attempts: 5 };
+
+        peer_map
+            .update_peer(peer_metadata)
+            .expect("Unable to update endpoint");
+
+        let peer_metadata = peer_map.peers.get("test_peer");
+        assert_eq!(
+            peer_metadata,
+            Some(&PeerMetadata {
+                id: "test_peer".to_string(),
+                endpoints: vec![
+                    "test_endpoint1".to_string(),
+                    "test_endpoint2".to_string(),
+                    "new_endpoint".to_string()
+                ],
+                active_endpoint: "test_endpoint1".to_string(),
+                status: PeerStatus::Disconnected { retry_attempts: 5 },
+            })
+        );
+    }
+}

--- a/libsplinter/src/network/ref_map.rs
+++ b/libsplinter/src/network/ref_map.rs
@@ -1,0 +1,215 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::{error, fmt};
+
+/// A map that will keep track of the number of times an id has been added, and only remove the
+/// id once the reference count is 0.
+///
+/// The RefMap also keeps track of redirects. This allows ids to be changed while keeping the same
+/// reference count.
+pub struct RefMap {
+    // id to reference count
+    references: HashMap<String, u64>,
+    redirects: HashMap<String, String>,
+}
+
+impl RefMap {
+    pub fn new() -> Self {
+        RefMap {
+            references: HashMap::new(),
+            redirects: HashMap::new(),
+        }
+    }
+
+    pub fn add_ref(&mut self, id: String) -> u64 {
+        // check if id is for a current id or a redirect
+        let ref_id = {
+            if let Some(ref_id) = self.redirects.get(&id) {
+                ref_id.clone()
+            } else {
+                id
+            }
+        };
+
+        if let Some(ref_count) = self.references.remove(&ref_id) {
+            let new_ref_count = ref_count + 1;
+            self.references.insert(ref_id, new_ref_count);
+            new_ref_count
+        } else {
+            self.references.insert(ref_id, 1);
+            1
+        }
+    }
+
+    pub fn update_ref(&mut self, old_id: String, new_id: String) -> Result<(), RefUpdateError> {
+        if let Some(ref_count) = self.references.remove(&old_id) {
+            self.references.insert(new_id.clone(), ref_count);
+
+            // update the old forwards
+            for (_, v) in self.redirects.iter_mut().filter(|(_, v)| **v == old_id) {
+                *v = new_id.clone()
+            }
+
+            self.redirects.insert(old_id, new_id);
+
+            Ok(())
+        } else {
+            Err(RefUpdateError { id: new_id })
+        }
+    }
+
+    /// remove_ref, return id if the peer id was removed
+    ///
+    /// This method will panic if the id does not exist.
+    pub fn remove_ref(&mut self, id: &str) -> Option<String> {
+        // check if id is for a current id or a redirect
+        let ref_id = {
+            if !self.references.contains_key(id) {
+                // if the the id is for an old reference, find updated id
+                if let Some(ref_id) = self.redirects.get(id) {
+                    ref_id.to_string()
+                } else {
+                    // if the id is not in the reference or redirects, the reference does not exist
+                    panic!("Trying to remove a reference that does not exist: {}", id)
+                }
+            } else {
+                id.to_string()
+            }
+        };
+
+        let ref_count = match self.references.remove(&ref_id) {
+            Some(ref_count) => ref_count,
+            None => panic!("Trying to remove a reference that does not exist: {}", id),
+        };
+
+        if ref_count == 1 {
+            self.references.remove(&ref_id);
+            self.redirects.retain(|_, target_id| target_id != id);
+            Some(ref_id)
+        } else {
+            self.references.insert(ref_id, ref_count - 1);
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RefUpdateError {
+    pub id: String,
+}
+
+impl error::Error for RefUpdateError {}
+
+impl fmt::Display for RefUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unable to update ref id for {}", self.id)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    // Test that the reference count is set to 1 if the id is new. If the same id is added, again
+    // the reference count is incremented.
+    #[test]
+    fn test_add_ref() {
+        let mut ref_map = RefMap::new();
+        let ref_count = ref_map.add_ref("test_id".to_string());
+        assert_eq!(ref_count, 1);
+
+        let ref_count = ref_map.add_ref("test_id".to_string());
+        assert_eq!(ref_count, 2);
+
+        let ref_count = ref_map.add_ref("test_id_2".to_string());
+        assert_eq!(ref_count, 1);
+    }
+
+    // Test that when removing a reference, if the ref count is greater than 1, the ref count is
+    // is decremented and None is retured to notify that caller that the reference has not be fully
+    // removed.
+    //
+    // Then test that if the ref count is 1, the reference is removed and the id is retured, to
+    // tell the caller the reference has been removed.
+    #[test]
+    fn test_remove_ref() {
+        let mut ref_map = RefMap::new();
+        let ref_count = ref_map.add_ref("test_id".to_string());
+        assert_eq!(ref_count, 1);
+
+        let ref_count = ref_map.add_ref("test_id".to_string());
+        assert_eq!(ref_count, 2);
+
+        let id = ref_map.remove_ref("test_id");
+        assert_eq!(id, None);
+
+        assert_eq!(ref_map.references.get("test_id").cloned(), Some(1 as u64));
+
+        let id = ref_map.remove_ref("test_id");
+        assert_eq!(id, Some("test_id".to_string()));
+        assert_eq!(ref_map.references.get("test_id"), None);
+    }
+
+    // That that if a remove_ref is removed, when the reference does not exist, a panic occurs
+    #[test]
+    #[should_panic]
+    fn test_remove_ref_panic() {
+        let mut ref_map = RefMap::new();
+        ref_map.remove_ref("test_id");
+    }
+
+    // Test that if a reference is updated, the new reference can be used to increase the ref count.
+    // Then verify that both ids can be used to remove the reference, returning the updated id on
+    // full removal.
+    #[test]
+    fn test_update_ref() {
+        let mut ref_map = RefMap::new();
+        let ref_count = ref_map.add_ref("old_id".to_string());
+        assert_eq!(ref_count, 1);
+
+        ref_map
+            .update_ref("old_id".to_string(), "new_id".to_string())
+            .expect("Unable to update reference");
+
+        let ref_count = ref_map.add_ref("new_id".to_string());
+        assert_eq!(ref_count, 2);
+
+        let id = ref_map.remove_ref("old_id");
+        assert_eq!(id, None);
+
+        let id = ref_map.remove_ref("new_id");
+        assert_eq!(id, Some("new_id".to_string()));
+    }
+
+    // Test that if an id is updated and then removed, the old id will still panic because the
+    // reference has been removed.
+    #[test]
+    #[should_panic]
+    fn test_update_ref_panic() {
+        let mut ref_map = RefMap::new();
+        let ref_count = ref_map.add_ref("old_id".to_string());
+        assert_eq!(ref_count, 1);
+
+        ref_map
+            .update_ref("old_id".to_string(), "new_id".to_string())
+            .expect("Unable to update reference");
+
+        let id = ref_map.remove_ref("new_id");
+        assert_eq!(id, Some("new_id".to_string()));
+
+        ref_map.remove_ref("old_id");
+    }
+}


### PR DESCRIPTION
The PeerManager is the component of the system that will know
about peers. It has a connector to the connection manager and
will request the creation and removal of connection that
are associated with a peer. The PeerManager is also in charge
of keeping track of reference counts of the peers, as well as
the metadata about a peer, such as its id, a list of endpoints
and which endpoint is currently active.

The PeerManager can be communicated with by using the
PeerManagerConnnector. The connector allows the following
request:

- add_peer_ref - adds a new peer or adds a reference count for
	an existing one. Returns a PeerRef object that when
	dropped will automatically send a removal request to
	the peer_manger.
- update_peer_ref - Update the peer id of an already created
	peer to a new id.
- list_peers - get a list of all currently connected peers
- subscribe - Subscribe to notifications about peers. Returns
	a PeerNotificationIter that will send connected and
	disconnected messages about peers.

The PeerManager also monitors notifications from the
ConnectionManager. If a connection disconnects, the PeerManager
will wait for specified amount of time and if the connection
does not reconnect the peers other endpoints will be tried. If
successful the peers active endpoint is replaced. There is only
every one connection per peer active at a time.

Blocked by #569 