### PR TITLE
Replace sync_channel with channel

### DIFF
--- a/libsplinter/src/network/connection_manager/pacemaker.rs
+++ b/libsplinter/src/network/connection_manager/pacemaker.rs
@@ -15,7 +15,7 @@
 use std;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc::SyncSender,
+    mpsc::Sender,
     Arc,
 };
 use std::thread;
@@ -41,7 +41,7 @@ impl Pacemaker {
     pub fn start<M>(
         &mut self,
         message: M,
-        cm_sender: SyncSender<M>,
+        cm_sender: Sender<M>,
     ) -> Result<(), ConnectionManagerError>
     where
         M: Send + Clone + 'static,


### PR DESCRIPTION
This is in an effort to simplify the use of channels
to all use mpsc::channel.

The amount of messages sent over the channels to the connection
manager are believed to be small.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>