### PR TITLE
Fix json-web-tokens feature guards

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials"))]
+#[cfg(all(
+    feature = "json-web-tokens",
+    any(feature = "biome-key-management", feature = "biome-credentials")
+))]
 pub(crate) mod authorize;
-#[cfg(feature = "biome-key-management")]
+#[cfg(all(feature = "biome-key-management", feature = "json-web-tokens"))]
 pub(super) mod key_management;
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
 pub(super) mod login;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod register;
-#[cfg(feature = "biome-credentials")]
+#[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
 pub(super) mod user;

--- a/libsplinter/src/biome/rest_api/resources/mod.rs
+++ b/libsplinter/src/biome/rest_api/resources/mod.rs
@@ -14,7 +14,10 @@
 
 //! Provides structures for the REST resources.
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials"))]
+#[cfg(all(
+    feature = "json-web-tokens",
+    any(feature = "biome-key-management", feature = "biome-credentials")
+))]
 pub(in super::super) mod authorize;
 #[cfg(feature = "biome-credentials")]
 pub(in super::super) mod credentials;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -56,11 +56,7 @@ pub(crate) const SCABBARD_LIST_STATE_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "biome")]
 pub const BIOME_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(all(
-    feature = "biome-credentials",
-    feature = "rest-api",
-    feature = "json-web-tokens"
-))]
+#[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
 pub(crate) const BIOME_REGISTER_PROTOCOL_MIN: u32 = 1;
 #[cfg(all(
     feature = "biome-credentials",


### PR DESCRIPTION
Adds json-web-tokens feature guards to the biome rest_api
module's usage of the biome-key-management and biome-
credentials REST API routes and resources, and removes the
protocol module's incorrect guarding of the BIOME_REGISTER_
PROTOCOL_MIN behind the json-web-tokens feature.

Signed-off-by: Shannyn Telander <telander@bitwise.io>