### PR TITLE
Add Refresh token endpoint and update biome login endpoint

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -90,6 +90,7 @@ experimental = [
     "biome-credentials",
     "biome-key-management",
     "biome-notifications",
+    "biome-refresh-tokens",
     "biome-rest-api",
     "biome-user",
     "circuit-read",
@@ -115,6 +116,7 @@ biome = ["database"]
 biome-credentials = ["biome", "biome-user", "database", "bcrypt"]
 biome-key-management = ["biome", "database"]
 biome-notifications = ["biome", "database"]
+biome-refresh-tokens = []
 biome-rest-api = ["biome"]
 biome-user = ["biome", "database"]
 circuit-read = []

--- a/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-03-12-194828_create_refresh_tokens/down.sql
+++ b/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-03-12-194828_create_refresh_tokens/down.sql
@@ -1,0 +1,16 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS refresh_tokens;

--- a/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-03-12-194828_create_refresh_tokens/up.sql
+++ b/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-03-12-194828_create_refresh_tokens/up.sql
@@ -1,0 +1,21 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id                    BIGSERIAL     PRIMARY KEY,
+    user_id               TEXT          NOT NULL,
+    token                 TEXT          NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES splinter_user(id) ON DELETE CASCADE
+);

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -36,6 +36,9 @@ pub mod migrations;
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;
 
+#[cfg(feature = "biome-refresh-tokens")]
+pub mod refresh_tokens;
+
 #[cfg(all(feature = "rest-api", feature = "biome-rest-api"))]
 pub mod rest_api;
 mod user;

--- a/libsplinter/src/biome/refresh_tokens/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines a basic representation of a user and provides an API to manage credentials.
+
+pub mod store;

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod models;
+mod operations;
+mod schema;
+
+use crate::biome::refresh_tokens::store::{RefreshTokenError, RefreshTokenStore};
+use crate::database::ConnectionPool;
+use operations::{
+    add_token::RefreshTokenStoreAddTokenOperation,
+    fetch_token::RefreshTokenStoreFetchTokenOperation,
+    remove_token::RefreshTokenStoreRemoveTokenOperation,
+    update_token::RefreshTokenStoreUpdateTokenOperation, RefreshTokenStoreOperations,
+};
+
+pub struct DieselRefreshTokenStore {
+    connection_pool: ConnectionPool,
+}
+
+impl RefreshTokenStore for DieselRefreshTokenStore {
+    fn add_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError> {
+        RefreshTokenStoreOperations::new(&*self.connection_pool.get()?).add_token(user_id, token)
+    }
+    fn remove_token(&self, user_id: &str) -> Result<(), RefreshTokenError> {
+        RefreshTokenStoreOperations::new(&*self.connection_pool.get()?).remove_token(user_id)
+    }
+    fn update_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError> {
+        RefreshTokenStoreOperations::new(&*self.connection_pool.get()?).update_token(user_id, token)
+    }
+    fn fetch_token(&self, user_id: &str) -> Result<String, RefreshTokenError> {
+        RefreshTokenStoreOperations::new(&*self.connection_pool.get()?).fetch_token(user_id)
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/models.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/models.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::schema::refresh_tokens;
+
+#[derive(Queryable, Identifiable, PartialEq, Debug)]
+#[table_name = "refresh_tokens"]
+#[primary_key(id)]
+pub struct RefreshToken {
+    pub id: i64,
+    pub user_id: String,
+    pub token: String,
+}
+
+#[derive(AsChangeset, Insertable, PartialEq, Debug)]
+#[table_name = "refresh_tokens"]
+pub struct NewRefreshToken<'a> {
+    pub user_id: &'a str,
+    pub token: &'a str,
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/operations/add_token.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/operations/add_token.rs
@@ -1,0 +1,58 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RefreshTokenStoreOperations;
+use crate::biome::refresh_tokens::store::{
+    diesel::{models::NewRefreshToken, schema::refresh_tokens},
+    RefreshTokenError,
+};
+use crate::biome::user::store::diesel::{models::UserModel, schema::splinter_user};
+use diesel::{dsl::insert_into, prelude::*, result::Error::NotFound};
+
+pub(in crate::biome) trait RefreshTokenStoreAddTokenOperation {
+    fn add_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError>;
+}
+
+impl<'a, C> RefreshTokenStoreAddTokenOperation for RefreshTokenStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn add_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError> {
+        splinter_user::table
+            .filter(splinter_user::id.eq(&user_id))
+            .first::<UserModel>(self.conn)
+            .map_err(|err| {
+                if err == NotFound {
+                    RefreshTokenError::QueryError {
+                        context: "Failed to check if user exists".into(),
+                        source: Box::new(err),
+                    }
+                } else {
+                    RefreshTokenError::NotFoundError(format!("User {} not found", user_id))
+                }
+            })?;
+
+        insert_into(refresh_tokens::table)
+            .values(NewRefreshToken { user_id, token })
+            .execute(self.conn)
+            .map_err(|err| RefreshTokenError::OperationError {
+                context: "Failed to create token".to_string(),
+                source: Box::new(err),
+            })?;
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/operations/fetch_token.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/operations/fetch_token.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RefreshTokenStoreOperations;
+use crate::biome::refresh_tokens::store::{
+    diesel::{models::RefreshToken, schema::refresh_tokens},
+    RefreshTokenError,
+};
+use diesel::{prelude::*, result::Error::NotFound};
+
+pub(in crate::biome) trait RefreshTokenStoreFetchTokenOperation {
+    fn fetch_token(&self, user_id: &str) -> Result<String, RefreshTokenError>;
+}
+
+impl<'a, C> RefreshTokenStoreFetchTokenOperation for RefreshTokenStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn fetch_token(&self, user_id: &str) -> Result<String, RefreshTokenError> {
+        refresh_tokens::table
+            .select(refresh_tokens::all_columns)
+            .filter(refresh_tokens::user_id.eq(user_id))
+            .first::<RefreshToken>(self.conn)
+            .map(|t| t.token)
+            .map_err(|err| {
+                if err == NotFound {
+                    RefreshTokenError::NotFoundError(format!(
+                        "No refresh token for user {} found",
+                        user_id
+                    ))
+                } else {
+                    RefreshTokenError::OperationError {
+                        context: format!(
+                            "Failed to update retrieve refresh token for user {}",
+                            user_id
+                        ),
+                        source: Box::new(err),
+                    }
+                }
+            })
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/operations/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_token;
+pub(super) mod fetch_token;
+pub(super) mod remove_token;
+pub(super) mod update_token;
+
+pub(super) struct RefreshTokenStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> RefreshTokenStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        RefreshTokenStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/operations/remove_token.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/operations/remove_token.rs
@@ -1,0 +1,51 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RefreshTokenStoreOperations;
+use crate::biome::refresh_tokens::store::{diesel::schema::refresh_tokens, RefreshTokenError};
+use diesel::{dsl::delete, prelude::*, result::Error::NotFound};
+
+pub(in crate::biome) trait RefreshTokenStoreRemoveTokenOperation {
+    fn remove_token(&self, user_id: &str) -> Result<(), RefreshTokenError>;
+}
+
+impl<'a, C> RefreshTokenStoreRemoveTokenOperation for RefreshTokenStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn remove_token(&self, user_id: &str) -> Result<(), RefreshTokenError> {
+        delete(refresh_tokens::table)
+            .filter(refresh_tokens::user_id.eq(&user_id))
+            .execute(self.conn)
+            .map_err(|err| {
+                if err == NotFound {
+                    RefreshTokenError::NotFoundError(format!(
+                        "No refresh token for user {} found",
+                        user_id
+                    ))
+                } else {
+                    RefreshTokenError::OperationError {
+                        context: format!("Failed to delete token for user {}", user_id),
+                        source: Box::new(err),
+                    }
+                }
+            })?;
+
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/operations/update_token.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/operations/update_token.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RefreshTokenStoreOperations;
+use crate::biome::refresh_tokens::store::{
+    diesel::{models::NewRefreshToken, schema::refresh_tokens},
+    RefreshTokenError,
+};
+
+use diesel::{dsl::update, prelude::*, result::Error::NotFound};
+
+pub(in crate::biome) trait RefreshTokenStoreUpdateTokenOperation {
+    fn update_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError>;
+}
+
+impl<'a, C> RefreshTokenStoreUpdateTokenOperation for RefreshTokenStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn update_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError> {
+        update(refresh_tokens::table)
+            .filter(refresh_tokens::user_id.eq(&user_id))
+            .set(NewRefreshToken { user_id, token })
+            .execute(self.conn)
+            .map_err(|err| {
+                if err == NotFound {
+                    RefreshTokenError::NotFoundError(format!(
+                        "No refresh token for user {} found",
+                        user_id
+                    ))
+                } else {
+                    RefreshTokenError::OperationError {
+                        context: format!("Failed to update token for user {}", user_id),
+                        source: Box::new(err),
+                    }
+                }
+            })?;
+
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/diesel/schema.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/schema.rs
@@ -1,0 +1,21 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    refresh_tokens (id) {
+        id -> Int8,
+        user_id -> Text,
+        token -> Text,
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/error.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/error.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::database::error::DatabaseError;
+
+#[derive(Debug)]
+pub enum RefreshTokenError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents database query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the database
+    StorageError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents an issue connecting to the database
+    ConnectionError(Box<dyn Error>),
+
+    // Represents the specific case where a query returns no records
+    NotFoundError(String),
+}
+
+impl Error for RefreshTokenError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RefreshTokenError::OperationError { source, .. } => Some(&**source),
+            RefreshTokenError::QueryError { source, .. } => Some(&**source),
+            RefreshTokenError::StorageError { source, .. } => Some(&**source),
+            RefreshTokenError::ConnectionError(err) => Some(&**err),
+            RefreshTokenError::NotFoundError(_) => None,
+        }
+    }
+}
+impl fmt::Display for RefreshTokenError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RefreshTokenError::OperationError { context, source } => {
+                write!(f, "failed to perform operation: {}: {}", context, source)
+            }
+            RefreshTokenError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            RefreshTokenError::StorageError { context, source } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            RefreshTokenError::ConnectionError(ref s) => {
+                write!(f, "failed to connect to underlying storage: {}", s)
+            }
+            RefreshTokenError::NotFoundError(ref s) => write!(f, "refresh token not found: {}", s),
+        }
+    }
+}
+
+impl From<DatabaseError> for RefreshTokenError {
+    fn from(err: DatabaseError) -> RefreshTokenError {
+        match err {
+            DatabaseError::ConnectionError(_) => RefreshTokenError::ConnectionError(Box::new(err)),
+            _ => RefreshTokenError::StorageError {
+                context: "The database returned an error".to_string(),
+                source: Box::new(err),
+            },
+        }
+    }
+}

--- a/libsplinter/src/biome/refresh_tokens/store/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/mod.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod diesel;
+mod error;
+
+pub use error::RefreshTokenError;
+
+/// Defines methods for CRUD operations for handling refresh tokens
+pub trait RefreshTokenStore: Send + Sync {
+    /// Adds a refresh to token to underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///   * `user_id` - The user whom which the token is for
+    ///   * `token` - A refresh token for user
+    ///
+    fn add_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError>;
+
+    /// Removes a token in underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///   * `user_id` - The user whom which the token is for
+    ///
+    fn remove_token(&self, user_id: &str) -> Result<(), RefreshTokenError>;
+
+    /// Update a refresh to token to underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///   * `user_id` - The user whom which the token is for
+    ///   * `token` - A refresh token for user
+    ///
+    fn update_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError>;
+
+    /// Fetch a token from underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///   * `user_id` - The user whom which the token is for
+    ///
+    fn fetch_token(&self, user_id: &str) -> Result<String, RefreshTokenError>;
+}

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -25,10 +25,10 @@ use crate::biome::rest_api::resources::key_management::{NewKey, ResponseKey, Upd
 use crate::biome::rest_api::BiomeRestConfig;
 use crate::futures::{Future, IntoFuture};
 use crate::protocol;
-use crate::rest_api::secrets::SecretManager;
 use crate::rest_api::{
     into_bytes, ErrorResponse, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource,
 };
+use crate::rest_api::{secrets::SecretManager, sessions::default_validation};
 
 /// Defines a REST endpoint for managing keys including inserting, listing and updating keys
 pub fn make_key_management_route(
@@ -71,20 +71,10 @@ fn handle_post(
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
+        let validation = default_validation(&rest_config.issuer());
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
             AuthorizationResult::Unauthorized(msg) => {
                 return Box::new(
                     HttpResponse::Unauthorized()
@@ -99,7 +89,7 @@ fn handle_post(
                         .into_future(),
                 );
             }
-        }
+        };
 
         Box::new(into_bytes(payload).and_then(move |bytes| {
             let new_key = match serde_json::from_slice::<NewKey>(&bytes) {
@@ -153,20 +143,10 @@ fn handle_get(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
+        let validation = default_validation(&rest_config.issuer());
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
             AuthorizationResult::Unauthorized(msg) => {
                 return Box::new(
                     HttpResponse::Unauthorized()
@@ -181,7 +161,7 @@ fn handle_get(
                         .into_future(),
                 );
             }
-        }
+        };
 
         match key_store.list_keys(Some(&user_id)) {
             Ok(keys) => Box::new(
@@ -209,20 +189,10 @@ fn handle_patch(
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::InternalServerError()
-                        .json(ErrorResponse::internal_error())
-                        .into_future(),
-                );
-            }
-        };
+        let validation = default_validation(&rest_config.issuer());
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
             AuthorizationResult::Unauthorized(msg) => {
                 return Box::new(
                     HttpResponse::Unauthorized()
@@ -237,7 +207,7 @@ fn handle_patch(
                         .into_future(),
                 );
             }
-        }
+        };
 
         Box::new(into_bytes(payload).and_then(move |bytes| {
             let updated_key = match serde_json::from_slice::<UpdatedKey>(&bytes) {
@@ -310,19 +280,7 @@ fn handle_fetch(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::BadRequest()
-                        .json(ErrorResponse::bad_request(
-                            &"Failed to process request: no user id".to_string(),
-                        ))
-                        .into_future(),
-                );
-            }
-        };
+        let validation = default_validation(&rest_config.issuer());
 
         let public_key = match request.match_info().get("public_key") {
             Some(id) => id.to_owned(),
@@ -338,8 +296,8 @@ fn handle_fetch(
             }
         };
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
             AuthorizationResult::Unauthorized(msg) => {
                 return Box::new(
                     HttpResponse::Unauthorized()
@@ -354,7 +312,7 @@ fn handle_fetch(
                         .into_future(),
                 );
             }
-        }
+        };
 
         match key_store.fetch_key(&user_id, &public_key) {
             Ok(key) => Box::new(
@@ -392,19 +350,7 @@ fn handle_delete(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
-            Some(id) => id.to_owned(),
-            None => {
-                error!("User ID is not in path request");
-                return Box::new(
-                    HttpResponse::BadRequest()
-                        .json(ErrorResponse::bad_request(
-                            &"Failed to process request: no user id".to_string(),
-                        ))
-                        .into_future(),
-                );
-            }
-        };
+        let validation = default_validation(&rest_config.issuer());
 
         let public_key = match request.match_info().get("public_key") {
             Some(id) => id.to_owned(),
@@ -420,8 +366,8 @@ fn handle_delete(
             }
         };
 
-        match authorize_user(&request, &user_id, &secret_manager, &rest_config) {
-            AuthorizationResult::Authorized => (),
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
             AuthorizationResult::Unauthorized(msg) => {
                 return Box::new(
                     HttpResponse::Unauthorized()
@@ -436,7 +382,7 @@ fn handle_delete(
                         .into_future(),
                 );
             }
-        }
+        };
 
         match key_store.remove_key(&user_id, &public_key) {
             Ok(key) => Box::new(

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -36,7 +36,7 @@ pub fn make_key_management_route(
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
-    Resource::build("/biome/users/{user_id}/keys")
+    Resource::build("/biome/users/keys")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_KEYS_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
@@ -253,7 +253,7 @@ pub fn make_key_management_route_with_public_key(
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
-    Resource::build("/biome/users/{user_id}/keys/{public_key}")
+    Resource::build("/biome/users/keys/{public_key}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_KEYS_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,

--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
+#[cfg(feature = "biome-refresh-tokens")]
+use crate::biome::refresh_tokens::store::RefreshTokenStore;
 use crate::futures::{Future, IntoFuture};
 use crate::protocol;
 use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
@@ -35,6 +37,7 @@ use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
 ///   }
 pub fn make_login_route(
     credentials_store: Arc<SplinterCredentialsStore>,
+    #[cfg(feature = "biome-refresh-tokens")] refresh_token_store: Arc<dyn RefreshTokenStore>,
     rest_config: Arc<BiomeRestConfig>,
     token_issuer: Arc<AccessTokenIssuer>,
 ) -> Resource {
@@ -47,6 +50,8 @@ pub fn make_login_route(
             let credentials_store = credentials_store.clone();
             let rest_config = rest_config.clone();
             let token_issuer = token_issuer.clone();
+            #[cfg(feature = "biome-refresh-tokens")]
+            let refresh_token_store = refresh_token_store.clone();
             Box::new(into_bytes(payload).and_then(move |bytes| {
                 let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
                     Ok(val) => val,
@@ -61,56 +66,116 @@ pub fn make_login_route(
                     }
                 };
 
-                let credentials =
-                    match credentials_store.fetch_credential_by_username(&username_password.username) {
-                        Ok(credentials) => credentials,
-                        Err(err) => {
-                            debug!("Failed to fetch credentials {}", err);
-                            match err {
-                                CredentialsStoreError::NotFoundError(_) => {
-                                    return HttpResponse::BadRequest()
-                                        .json(ErrorResponse::bad_request(&format!(
-                                            "Username not found: {}",
-                                            username_password.username
-                                        )))
-                                        .into_future();
-                                }
-                                _ => {
-                                    return HttpResponse::InternalServerError()
-                                        .json(ErrorResponse::internal_error())
-                                        .into_future()
-                                }
+                let credentials = match credentials_store
+                    .fetch_credential_by_username(&username_password.username)
+                {
+                    Ok(credentials) => credentials,
+                    Err(err) => {
+                        debug!("Failed to fetch credentials {}", err);
+                        match err {
+                            CredentialsStoreError::NotFoundError(_) => {
+                                return HttpResponse::BadRequest()
+                                    .json(ErrorResponse::bad_request(&format!(
+                                        "Username not found: {}",
+                                        username_password.username
+                                    )))
+                                    .into_future();
+                            }
+                            _ => {
+                                return HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future()
                             }
                         }
-                    };
+                    }
+                };
 
                 match credentials.verify_password(&username_password.hashed_password) {
                     Ok(is_valid) => {
                         if is_valid {
-                            let claim_builder: ClaimsBuilder = Default::default();
-                            let claim = match claim_builder.with_user_id(&credentials.user_id)
+                            let claim_builder = ClaimsBuilder::default();
+                            let claim = match claim_builder
+                                .with_user_id(&credentials.user_id)
                                 .with_issuer(&rest_config.issuer())
                                 .with_duration(rest_config.access_token_duration())
-                                .build() {
-                                    Ok(claim) => claim,
-                                    Err(err) => {
-                                        debug!("Failed to build claim {}", err);
-                                        return HttpResponse::InternalServerError()
-                                            .json(ErrorResponse::internal_error())
-                                            .into_future()}
-                                    };
+                                .build()
+                            {
+                                Ok(claim) => claim,
+                                Err(err) => {
+                                    debug!("Failed to build claim {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future();
+                                }
+                            };
 
                             let token = match token_issuer.issue_token_with_claims(claim) {
-                                    Ok(token) => token,
+                                Ok(token) => token,
+                                Err(err) => {
+                                    debug!("Failed to issue token {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future();
+                                }
+                            };
+
+                            #[cfg(feature = "biome-refresh-tokens")]
+                            {
+                                let refresh_claims = match ClaimsBuilder::default()
+                                    .with_issuer(&rest_config.issuer())
+                                    .with_duration(rest_config.refresh_token_duration())
+                                    .build()
+                                {
+                                    Ok(claims) => claims,
                                     Err(err) => {
-                                        debug!("Failed to issue token {}", err);
+                                        debug!("Failed to build refresh claim {}", err);
                                         return HttpResponse::InternalServerError()
                                             .json(ErrorResponse::internal_error())
-                                            .into_future()}
-                                    };
-                            HttpResponse::Ok()
-                                .json(json!({ "message": "Successful login", "user_id": credentials.user_id ,"token": token  }))
-                                .into_future()
+                                            .into_future();
+                                    }
+                                };
+
+                                let refresh_token = match token_issuer
+                                    .issue_refresh_token_with_claims(refresh_claims)
+                                {
+                                    Ok(token) => token,
+                                    Err(err) => {
+                                        debug!("Failed to issue refresh token {}", err);
+                                        return HttpResponse::InternalServerError()
+                                            .json(ErrorResponse::internal_error())
+                                            .into_future();
+                                    }
+                                };
+
+                                if let Err(err) = refresh_token_store
+                                    .add_token(&credentials.user_id, &refresh_token)
+                                {
+                                    debug!("Failed to store refresh token {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future();
+                                }
+
+                                HttpResponse::Ok()
+                                    .json(json!({
+                                        "message": "Successful login",
+                                        "user_id": credentials.user_id,
+                                        "token": token,
+                                        "refresh_token": refresh_token,
+                                    }))
+                                    .into_future()
+                            }
+
+                            #[cfg(not(feature = "biome-refresh-tokens"))]
+                            {
+                                HttpResponse::Ok()
+                                    .json(json!({
+                                        "message": "Successful login",
+                                        "user_id": credentials.user_id,
+                                        "token": token,
+                                    }))
+                                    .into_future()
+                            }
                         } else {
                             HttpResponse::BadRequest()
                                 .json(ErrorResponse::bad_request("Invalid password"))

--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -23,6 +23,12 @@ pub(super) mod key_management;
 pub(super) mod login;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod register;
+#[cfg(all(
+    feature = "biome-credentials",
+    feature = "biome-refresh-tokens",
+    feature = "json-web-tokens"
+))]
+pub(super) mod token;
 #[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
 pub(super) mod user;
 #[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]

--- a/libsplinter/src/biome/rest_api/actix/token.rs
+++ b/libsplinter/src/biome/rest_api/actix/token.rs
@@ -1,0 +1,174 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::HttpResponse;
+use crate::biome::{
+    refresh_tokens::store::{RefreshTokenError, RefreshTokenStore},
+    rest_api::{
+        actix::authorize::{authorize_user, validate_claims},
+        config::BiomeRestConfig,
+        resources::{authorize::AuthorizationResult, token::RefreshToken},
+    },
+};
+use crate::futures::{Future, IntoFuture};
+use crate::protocol;
+use crate::rest_api::secrets::SecretManager;
+use crate::rest_api::{
+    into_bytes,
+    sessions::{
+        default_validation, ignore_exp_validation, AccessTokenIssuer, ClaimsBuilder, TokenIssuer,
+    },
+    ErrorResponse, Method, ProtocolVersionRangeGuard, Resource,
+};
+
+/// Defines a REST endpoint for request a new authorization token
+///
+/// The payload should be in the JSON format:
+///   {
+///       "refresh_token": <refresh token for requesting a auth token>
+///   }
+///
+/// Endpoint returns a payload containing a new auth token
+///   {
+///     "token": <new auth token>
+///   }
+///
+pub fn make_token_route(
+    refresh_token_store: Arc<dyn RefreshTokenStore>,
+    secret_manager: Arc<dyn SecretManager>,
+    refresh_token_secret_manager: Arc<dyn SecretManager>,
+    token_issuer: Arc<AccessTokenIssuer>,
+    rest_config: Arc<BiomeRestConfig>,
+) -> Resource {
+    Resource::build("/biome/token")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_LOGIN_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ))
+        .add_method(Method::Post, move |req, payload| {
+            let validation = ignore_exp_validation(&rest_config.issuer());
+            let refresh_token_validation = default_validation(&rest_config.issuer());
+            let secret_manager = secret_manager.clone();
+            let refresh_token_secret_manager = refresh_token_secret_manager.clone();
+            let refresh_token_store = refresh_token_store.clone();
+            let token_issuer = token_issuer.clone();
+            let rest_config = rest_config.clone();
+            Box::new(into_bytes(payload).and_then(move |bytes| {
+                let claims = match authorize_user(&req, &secret_manager, &validation) {
+                    AuthorizationResult::Authorized(claims) => claims,
+                    AuthorizationResult::Unauthorized(msg) => {
+                        return HttpResponse::Unauthorized()
+                            .json(ErrorResponse::unauthorized(&msg))
+                            .into_future();
+                    }
+                    AuthorizationResult::Failed => {
+                        return HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future();
+                    }
+                };
+
+                let refresh_token = match serde_json::from_slice::<RefreshToken>(&bytes) {
+                    Ok(refresh_token) => refresh_token.token,
+                    Err(err) => {
+                        error!("Malformed payload {}", err);
+                        return HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&format!(
+                                "Malformed payload {}",
+                                err
+                            )))
+                            .into_future();
+                    }
+                };
+
+                let refresh_token_from_db = match refresh_token_store.fetch_token(&claims.user_id())
+                {
+                    Ok(token) => token,
+                    Err(RefreshTokenError::NotFoundError(msg)) => {
+                        return HttpResponse::Forbidden()
+                            .json(ErrorResponse::forbidden(&msg))
+                            .into_future();
+                    }
+                    Err(err) => {
+                        error!("Failed to retrieve user refresh token {}", err);
+                        return HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future();
+                    }
+                };
+
+                if refresh_token != refresh_token_from_db {
+                    return HttpResponse::Forbidden()
+                        .json(ErrorResponse::forbidden("Invalid Refresh Token"))
+                        .into_future();
+                }
+
+                match validate_claims(
+                    &refresh_token,
+                    &refresh_token_secret_manager,
+                    &refresh_token_validation,
+                ) {
+                    AuthorizationResult::Authorized(_) => (),
+                    AuthorizationResult::Unauthorized(msg) => {
+                        if let Err(err) = refresh_token_store.remove_token(&claims.user_id()) {
+                            error!("Failed to delete refresh token {}", err);
+                            return HttpResponse::InternalServerError()
+                                .json(ErrorResponse::internal_error())
+                                .into_future();
+                        } else {
+                            return HttpResponse::Unauthorized()
+                                .json(ErrorResponse::unauthorized(&msg))
+                                .into_future();
+                        }
+                    }
+                    AuthorizationResult::Failed => {
+                        return HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future();
+                    }
+                }
+                let claim_builder = ClaimsBuilder::default();
+                let claim = match claim_builder
+                    .with_user_id(&claims.user_id())
+                    .with_issuer(&rest_config.issuer())
+                    .with_duration(rest_config.access_token_duration())
+                    .build()
+                {
+                    Ok(claim) => claim,
+                    Err(err) => {
+                        error!("Failed to build claim {}", err);
+                        return HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future();
+                    }
+                };
+
+                let token = match token_issuer.issue_token_with_claims(claim) {
+                    Ok(token) => token,
+                    Err(err) => {
+                        error!("Failed to issue token {}", err);
+                        return HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future();
+                    }
+                };
+
+                HttpResponse::Ok()
+                    .json(json!({ "token": token }))
+                    .into_future()
+            }))
+        })
+}

--- a/libsplinter/src/biome/rest_api/config.rs
+++ b/libsplinter/src/biome/rest_api/config.rs
@@ -29,7 +29,7 @@ pub struct BiomeRestConfig {
     /// Duration of JWT tokens issued by this service
     access_token_duration: Duration,
     #[cfg(feature = "biome-credentials")]
-    /// Cost for encripting users password
+    /// Cost for encrypting user's password
     password_encryption_cost: PasswordEncryptionCost,
 }
 

--- a/libsplinter/src/biome/rest_api/config.rs
+++ b/libsplinter/src/biome/rest_api/config.rs
@@ -97,17 +97,19 @@ impl BiomeRestConfigBuilder {
         if self.issuer.is_none() {
             debug!("Using default value for issuer");
         }
-        let issuer = self.issuer.unwrap_or_default();
+        let issuer = self.issuer.unwrap_or_else(|| DEFAULT_ISSUER.to_string());
 
         if self.access_token_duration.is_none() {
             debug!("Using default value for access_token_duration");
         }
-        let access_token_duration = self.access_token_duration.unwrap_or_default();
+        let access_token_duration = self
+            .access_token_duration
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_DURATION));
 
         #[cfg(feature = "biome-credentials")]
         let password_encryption_cost: PasswordEncryptionCost = self
             .password_encryption_cost
-            .unwrap_or_default()
+            .unwrap_or_else(|| "high".to_string())
             .parse()
             .map_err(BiomeRestConfigBuilderError::InvalidValue)?;
 

--- a/libsplinter/src/biome/rest_api/config.rs
+++ b/libsplinter/src/biome/rest_api/config.rs
@@ -20,6 +20,8 @@ use crate::biome::credentials::store::PasswordEncryptionCost;
 
 const DEFAULT_ISSUER: &str = "self-issued";
 const DEFAULT_DURATION: u64 = 5400; // in seconds = 90 minutes
+#[cfg(feature = "biome-refresh-tokens")]
+const DEFAULT_REFRESH_DURATION: u64 = 5_184_000; // in seconds = 60 days
 
 /// Configuration for Biome REST resources
 #[derive(Deserialize, Debug)]
@@ -28,6 +30,9 @@ pub struct BiomeRestConfig {
     issuer: String,
     /// Duration of JWT tokens issued by this service
     access_token_duration: Duration,
+    /// Duration of refresh tokens issued by this service
+    #[cfg(feature = "biome-refresh-tokens")]
+    refresh_token_duration: Duration,
     #[cfg(feature = "biome-credentials")]
     /// Cost for encrypting user's password
     password_encryption_cost: PasswordEncryptionCost,
@@ -42,6 +47,11 @@ impl BiomeRestConfig {
         self.access_token_duration.to_owned()
     }
 
+    #[cfg(feature = "biome-refresh-tokens")]
+    pub fn refresh_token_duration(&self) -> Duration {
+        self.refresh_token_duration.to_owned()
+    }
+
     #[cfg(feature = "biome-credentials")]
     pub fn password_encryption_cost(&self) -> PasswordEncryptionCost {
         self.password_encryption_cost.clone()
@@ -52,6 +62,8 @@ impl BiomeRestConfig {
 pub struct BiomeRestConfigBuilder {
     issuer: Option<String>,
     access_token_duration: Option<Duration>,
+    #[cfg(feature = "biome-refresh-tokens")]
+    refresh_token_duration: Option<Duration>,
     #[cfg(feature = "biome-credentials")]
     password_encryption_cost: Option<String>,
 }
@@ -61,6 +73,8 @@ impl Default for BiomeRestConfigBuilder {
         BiomeRestConfigBuilder {
             issuer: Some(DEFAULT_ISSUER.to_string()),
             access_token_duration: Some(Duration::from_secs(DEFAULT_DURATION)),
+            #[cfg(feature = "biome-refresh-tokens")]
+            refresh_token_duration: Some(Duration::from_secs(DEFAULT_REFRESH_DURATION)),
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost: Some("high".to_string()),
         }
@@ -72,6 +86,8 @@ impl BiomeRestConfigBuilder {
         BiomeRestConfigBuilder {
             issuer: None,
             access_token_duration: None,
+            #[cfg(feature = "biome-refresh-tokens")]
+            refresh_token_duration: None,
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost: None,
         }
@@ -84,6 +100,12 @@ impl BiomeRestConfigBuilder {
 
     pub fn with_access_token_duration_in_secs(mut self, duration: u64) -> Self {
         self.access_token_duration = Some(Duration::from_secs(duration));
+        self
+    }
+
+    #[cfg(feature = "biome-refresh-tokens")]
+    pub fn with_refresh_token_duration_in_secs(mut self, duration: u64) -> Self {
+        self.refresh_token_duration = Some(Duration::from_secs(duration));
         self
     }
 
@@ -105,6 +127,10 @@ impl BiomeRestConfigBuilder {
         let access_token_duration = self
             .access_token_duration
             .unwrap_or_else(|| Duration::from_secs(DEFAULT_DURATION));
+        #[cfg(feature = "biome-refresh-tokens")]
+        let refresh_token_duration = self
+            .refresh_token_duration
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_REFRESH_DURATION));
 
         #[cfg(feature = "biome-credentials")]
         let password_encryption_cost: PasswordEncryptionCost = self
@@ -116,6 +142,8 @@ impl BiomeRestConfigBuilder {
         Ok(BiomeRestConfig {
             issuer,
             access_token_duration,
+            #[cfg(feature = "biome-refresh-tokens")]
+            refresh_token_duration,
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost,
         })

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -76,6 +76,13 @@ pub use error::BiomeRestResourceManagerBuilderError;
 use self::actix::register::make_register_route;
 #[cfg(all(
     feature = "biome-credentials",
+    feature = "biome-refresh-tokens",
+    feature = "json-web-tokens",
+    feature = "rest-api-actix"
+))]
+use self::actix::token::make_token_route;
+#[cfg(all(
+    feature = "biome-credentials",
     feature = "rest-api-actix",
     feature = "json-web-tokens"
 ))]
@@ -162,6 +169,16 @@ impl RestResourceProvider for BiomeRestResourceManager {
                             self.token_secret_manager.clone(),
                             self.refresh_token_secret_manager.clone(),
                         )),
+                    ));
+                    resources.push(make_token_route(
+                        self.refresh_token_store.clone(),
+                        self.token_secret_manager.clone(),
+                        self.refresh_token_secret_manager.clone(),
+                        Arc::new(AccessTokenIssuer::new(
+                            self.token_secret_manager.clone(),
+                            self.refresh_token_secret_manager.clone(),
+                        )),
+                        self.rest_config.clone(),
                     ));
                 }
 

--- a/libsplinter/src/biome/rest_api/resources/authorize.rs
+++ b/libsplinter/src/biome/rest_api/resources/authorize.rs
@@ -14,8 +14,10 @@
 
 //! Defines results from user authorization.
 
+use crate::rest_api::sessions::Claims;
+
 pub(crate) enum AuthorizationResult {
-    Authorized,
+    Authorized(Claims),
     Unauthorized(String),
     Failed,
 }

--- a/libsplinter/src/biome/rest_api/resources/token.rs
+++ b/libsplinter/src/biome/rest_api/resources/token.rs
@@ -12,16 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides structures for the REST resources.
-
-#[cfg(all(
-    feature = "json-web-tokens",
-    any(feature = "biome-key-management", feature = "biome-credentials")
-))]
-pub(in crate::biome::rest_api) mod authorize;
-#[cfg(feature = "biome-credentials")]
-pub(in crate::biome::rest_api) mod credentials;
-#[cfg(feature = "biome-key-management")]
-pub(in crate::biome::rest_api) mod key_management;
-#[cfg(feature = "biome-refresh-tokens")]
-pub(in crate::biome::rest_api) mod token;
+#[derive(Deserialize)]
+pub struct RefreshToken {
+    pub token: String,
+}

--- a/libsplinter/src/biome/user/store/diesel/mod.rs
+++ b/libsplinter/src/biome/user/store/diesel/mod.rs
@@ -14,7 +14,7 @@
 
 pub(in crate::biome) mod models;
 mod operations;
-mod schema;
+pub(in crate::biome) mod schema;
 
 use super::{SplinterUser, UserStore, UserStoreError};
 use crate::database::ConnectionPool;

--- a/libsplinter/src/rest_api/response_models.rs
+++ b/libsplinter/src/rest_api/response_models.rs
@@ -47,4 +47,11 @@ impl ErrorResponse {
             message: message.to_string(),
         }
     }
+
+    pub fn forbidden(message: &str) -> ErrorResponse {
+        ErrorResponse {
+            code: "403".to_string(),
+            message: message.to_string(),
+        }
+    }
 }

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -78,7 +78,7 @@ where
     extra_validation(claims)
 }
 
-fn default_validation(issuer: &str) -> Validation {
+pub(crate) fn default_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();
     validation.leeway = DEFAULT_LEEWAY;
     validation.iss = Some(issuer.to_string());

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -72,15 +72,15 @@ pub fn validate_token<F>(
 where
     F: Fn(Claims) -> Result<(), TokenValidationError>,
 {
-    let validation = default_validation(DEFAULT_LEEWAY, issuer);
+    let validation = default_validation(issuer);
     let claims = decode::<Claims>(&token, secret.as_ref(), &validation)?.claims;
 
     extra_validation(claims)
 }
 
-fn default_validation(leeway: i64, issuer: &str) -> Validation {
+fn default_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();
-    validation.leeway = leeway;
+    validation.leeway = DEFAULT_LEEWAY;
     validation.iss = Some(issuer.to_string());
     validation
 }

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -18,7 +18,7 @@ mod claims;
 mod error;
 mod token_issuer;
 
-use jsonwebtoken::{decode, Validation};
+use jsonwebtoken::Validation;
 use serde::Serialize;
 
 pub use claims::{Claims, ClaimsBuilder};
@@ -33,50 +33,6 @@ pub trait TokenIssuer<T: Serialize> {
     fn issue_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
 }
 
-/// Deserializes a JWT token, checks that a sigures is valid and checks that the claims are
-/// valid. It also and performs the extra validation provided by the caller.
-///
-/// # Arguments
-///
-///  * `token` - The serialized token to be validated
-///  * `secret` - The secret to be used to validate the token signature
-///  * `issuer` - The expected value for the token issuer
-///  * `extra_validation` - Closure that performs extra validation, returns Ok(()) if the claims
-///  are valid or an error if they are not.
-///
-/// ```
-/// use splinter::rest_api::sessions::{validate_token, TokenValidationError};
-///
-/// let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\
-///              eyJ1c2VyX2lkIjoiY2RmMTIwNzAtNjk1Mi00NTNmLWFiNmMtYjRlMzllZmM3YzA4IiwiZXhwIjo0MTMzO\
-///              Dk0NDAwLCJpc3MiOiJzZWxmLWlzc3VlZCIsImFkbWluIjoidHJ1ZSJ9.\
-///              km0hcHqWC7HFy02x2V-4QrKArNpzy4fXpBpqdL70e48";
-///
-/// validate_token(token, "super_secret", "self-issued", |claims| {
-///     let custom_claims = claims.custom_claims();
-///     let is_admin = custom_claims.get("admin").ok_or_else(|| {
-///         TokenValidationError::InvalidClaim("User is not an admin".to_string())
-///     })?;
-///     match is_admin.as_ref() {
-///         "true" => Ok(()),
-///         _ =>  Err(TokenValidationError::InvalidClaim("User is not an admin".to_string()))
-///     }
-/// }).unwrap();
-/// ```
-pub fn validate_token<F>(
-    token: &str,
-    secret: &str,
-    issuer: &str,
-    extra_validation: F,
-) -> Result<(), TokenValidationError>
-where
-    F: Fn(Claims) -> Result<(), TokenValidationError>,
-{
-    let validation = default_validation(issuer);
-    let claims = decode::<Claims>(&token, secret.as_ref(), &validation)?.claims;
-
-    extra_validation(claims)
-}
 
 pub(crate) fn default_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -31,8 +31,10 @@ const DEFAULT_LEEWAY: i64 = 10; // default leeway in seconds.
 pub trait TokenIssuer<T: Serialize> {
     /// Issues a JWT token with the given claims
     fn issue_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
-}
 
+    #[cfg(feature = "biome-refresh-tokens")]
+    fn issue_refresh_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
+}
 
 pub(crate) fn default_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -42,3 +42,13 @@ pub(crate) fn default_validation(issuer: &str) -> Validation {
     validation.iss = Some(issuer.to_string());
     validation
 }
+
+/// Validates authorization token but ignores the expiration date
+#[cfg(feature = "biome-refresh-tokens")]
+pub(crate) fn ignore_exp_validation(issuer: &str) -> Validation {
+    let mut validation = Validation::default();
+    validation.leeway = DEFAULT_LEEWAY;
+    validation.iss = Some(issuer.to_string());
+    validation.validate_exp = false;
+    validation
+}

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -68,8 +68,9 @@ experimental = [
 ]
 
 biome = ["splinter/biome", "database"]
-biome-credentials = ["splinter/biome-credentials", "json-web-tokens", "biome"]
-biome-key-management = ["splinter/biome-key-management", "json-web-tokens", "biome"]
+biome-credentials = ["splinter/biome-credentials", "biome-refresh-tokens", "json-web-tokens", "biome"]
+biome-key-management = ["splinter/biome-key-management", "biome-refresh-tokens", "json-web-tokens", "biome"]
+biome-refresh-tokens = ["splinter/biome-refresh-tokens"]
 biome-rest-api = ["splinter/biome-rest-api"]
 circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -897,12 +897,80 @@ paths:
                       IjoiZjM1YWFjYzEtYTljZC00ZWRhLWI2ZDAtMmVmYWRkZjBjOGE0Iiwia\
                       XNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_x\
                       riYX7qryl08ZEp86t5HD_AEVPEUXY70Ehc"
+                  refresh_token:
+                    type: string
+                    description: "JWT refresh token used for obtaining a new access to token"
+                    example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lk\
+                      IjoiZjM1YWFjYzEtYTljZC00ZWRhLWI2ZDAtMmVmYWRkZjBjOGE0Iiwia\
+                      XNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_x\
+                      riYX7qryl08ZEp86t5HD_AEVPEUXY70Ehc"
         400:
           description: Invalid request
           content:
             application/json:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+  /biome/token:
+    post:
+      tags:
+        - Biome
+      description: Issues a new access token
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                refresh_token:
+                  description: a refresh token issues by biome
+
+              required:
+                - refresh_token
+              example:
+                refresh_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lk\
+                  IjoiZjM1YWFjYzEtYTljZC00ZWRhLWI2ZDAtMmVmYWRkZjBjOGE0Iiwia\
+                  XNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_x\
+                  riYX7qryl08ZEp86t5HD_AEVPEUXY70Ehc"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: "JWT access token used for authorizing access to protected resources"
+                    example: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lk\
+                      IjoiZjM1YWFjYzEtYTljZC00ZWRhLWI2ZDAtMmVmYWRkZjBjOGE0Iiwia\
+                      XNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_x\
+                      riYX7qryl08ZEp86t5HD_AEVPEUXY70Ehc"
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: Access token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBiome'
+        403:
+          description: Refresh token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBiome'
         500:
           description: Internal server error occurred
           content:
@@ -1159,20 +1227,13 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
-  /biome/users/{user_id}/keys:
+  /biome/users/keys:
     get:
       tags:
       - Biome
       description: List keys of a user
       parameters:
         - $ref: "#/components/parameters/protocol_version"
-        - name: user_id
-          in: path
-          description: ID of the user
-          required: true
-          schema:
-            type: string
-            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
       responses:
         200:
           description: User's keys
@@ -1206,13 +1267,6 @@ paths:
       description: Update a key's display name
       parameters:
         - $ref: "#/components/parameters/protocol_version"
-        - name: user_id
-          in: path
-          description: ID of the user
-          required: true
-          schema:
-            type: string
-            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
       requestBody:
         content:
           application/json:
@@ -1271,13 +1325,6 @@ paths:
       description: Add a new key for user
       parameters:
         - $ref: "#/components/parameters/protocol_version"
-        - name: user_id
-          in: path
-          description: ID of the user
-          required: true
-          schema:
-            type: string
-            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
       requestBody:
         content:
           application/json:
@@ -1315,20 +1362,13 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
-  /biome/users/{user_id}/keys/{public_key}:
+  /biome/users/keys/{public_key}:
     get:
       tags:
       - Biome
       description: Fetch key of a user
       parameters:
         - $ref: "#/components/parameters/protocol_version"
-        - name: user_id
-          in: path
-          description: ID of the user
-          required: true
-          schema:
-            type: string
-            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
         - name: public_key
           in: path
           description: Public key of the user

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -836,7 +836,9 @@ paths:
                     type: string
                     example: "User created successfully"
                   data:
-                    ref: '#/components/schemas/BiomeNewUser'
+                    type: object
+                    example:
+                      ref: '#/components/schemas/BiomeNewUser'
         400:
           description: Invalid request
           content:


### PR DESCRIPTION
In this PR

1. Add new endpoint for requesting new authentication tokens `POST /biome/refresh`

The purpose of this endpoint is to offer a way to get new auth tokens after the a client's auth token has expired.

2. Adds refresh token database tables
3. Adds RefreshTokenStore trait
4. Adds SplinterRefrshTokenStore object
5. Updates `POST /biome/login` to return a refresh token
6. Removes `user_id` from key_management path
7. Refactors `authorize_users` to accept a validation object and not a user id