### PR TITLE
Add /biome/verify route

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -25,3 +25,5 @@ pub(super) mod login;
 pub(super) mod register;
 #[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
 pub(super) mod user;
+#[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
+pub(super) mod verify;

--- a/libsplinter/src/biome/rest_api/actix/verify.rs
+++ b/libsplinter/src/biome/rest_api/actix/verify.rs
@@ -1,0 +1,126 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::HttpResponse;
+use crate::futures::{Future, IntoFuture};
+use crate::protocol;
+use crate::rest_api::secrets::SecretManager;
+use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+
+use crate::biome::credentials::store::{
+    diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
+};
+use crate::biome::rest_api::config::BiomeRestConfig;
+
+use super::super::resources::authorize::AuthorizationResult;
+use super::super::resources::credentials::UsernamePassword;
+use super::authorize::authorize_user;
+
+/// Defines a REST endpoint to verify a user's password
+///
+/// The payload should be in the JSON format:
+///   {
+///       "username": <existing username of the user>
+///       "hashed_password": <hash of the user's existing password>
+///   }
+pub fn make_verify_route(
+    credentials_store: Arc<SplinterCredentialsStore>,
+    rest_config: Arc<BiomeRestConfig>,
+    secret_manager: Arc<dyn SecretManager>,
+) -> Resource {
+    Resource::build("/biome/verify")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_VERIFY_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ))
+        .add_method(Method::Post, move |request, payload| {
+            let credentials_store = credentials_store.clone();
+            let rest_config = rest_config.clone();
+            let secret_manager = secret_manager.clone();
+            Box::new(into_bytes(payload).and_then(move |bytes| {
+                let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        debug!("Error parsing payload: {}", err);
+                        return HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&format!(
+                                "Failed to parse payload: {}",
+                                err
+                            )))
+                            .into_future();
+                    }
+                };
+
+                let credentials =
+                    match credentials_store.fetch_credential_by_username(&username_password.username) {
+                        Ok(credentials) => credentials,
+                        Err(err) => {
+                            debug!("Failed to fetch credentials: {}", err);
+                            match err {
+                                CredentialsStoreError::NotFoundError(_) => {
+                                    return HttpResponse::BadRequest()
+                                        .json(ErrorResponse::bad_request(&format!(
+                                            "Username not found: {}",
+                                            username_password.username
+                                        )))
+                                        .into_future()
+                                }
+                                _ => {
+                                    error!("Failed to fetch credentials: {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future()
+                                }
+                            }
+                        }
+                    };
+
+                match authorize_user(&request, &credentials.user_id, &secret_manager, &rest_config) {
+                    AuthorizationResult::Authorized => {
+                        match credentials.verify_password(&username_password.hashed_password) {
+                            Ok(true) => {
+                                    HttpResponse::Ok()
+                                        .json(json!({ "message": "Successful verification", "user_id": credentials.user_id }))
+                                        .into_future()
+                                    }
+                            Ok(false) => {
+                                HttpResponse::BadRequest()
+                                    .json(ErrorResponse::bad_request("Invalid password"))
+                                    .into_future()
+                            }
+                            Err(err) => {
+                                error!("Failed to verify password: {}", err);
+                                HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future()
+                            }
+                        }
+                    }
+                    AuthorizationResult::Unauthorized(msg) => {
+                        HttpResponse::Unauthorized()
+                                .json(ErrorResponse::unauthorized(&msg))
+                                .into_future()
+                    }
+                    AuthorizationResult::Failed => {
+                        error!("Failed to authorize user");
+                            HttpResponse::InternalServerError()
+                                .json(ErrorResponse::internal_error())
+                                .into_future()
+                    }
+                }
+            }))
+        })
+}

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -80,6 +80,7 @@ use self::actix::register::make_register_route;
 use self::actix::{
     login::make_login_route,
     user::{make_list_route, make_user_routes},
+    verify::make_verify_route,
 };
 #[cfg(feature = "biome-credentials")]
 use super::credentials::store::diesel::SplinterCredentialsStore;
@@ -135,6 +136,11 @@ impl RestResourceProvider for BiomeRestResourceManager {
                     self.user_store.clone(),
                 ));
                 resources.push(make_list_route(credentials_store.clone()));
+                resources.push(make_verify_route(
+                    credentials_store.clone(),
+                    self.rest_config.clone(),
+                    self.token_secret_manager.clone(),
+                ));
             }
             None => {
                 debug!(

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -76,6 +76,8 @@ pub(crate) const BIOME_USER_PROTOCOL_MIN: u32 = 1;
     feature = "json-web-tokens"
 ))]
 pub(crate) const BIOME_LIST_USERS_PROTOCOL_MIN: u32 = 1;
+#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
+pub(crate) const BIOME_VERIFY_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(all(
     feature = "biome-key-management",

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -898,6 +898,64 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
+  /biome/verify:
+    post:
+      tags:
+        - Biome
+      description: Verifies a user with username and password credentials
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                username:
+                  description: username of user
+                hashed_password:
+                  description: |
+                    Hashed password to be used for user authentication
+              required:
+                - username
+                - hashed_password
+              example:
+                username: alice@acme.com
+                hashed_password: |-
+                  8945622435187243046536949706b5272644c71336c7254563679727565494b376d4b3554696b734662685962652f6v52562e437a70462f6552489c8b
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Successful verification"
+                  user_id:
+                    type: string
+                    description: "Internal unique identifier for the user"
+                    example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: Unauthorized request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+
   /biome/users:
     get:
       tags:


### PR DESCRIPTION
Adds a /biome/verify REST endpoint to verify a user's password.
Also documents this endpoint in the openapi spec.

Signed-off-by: Shannyn Telander <telander@bitwise.io>