### PR TITLE
Add inbound connections to ConnectionManager

### DIFF
--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -46,7 +46,7 @@ enum CmMessage {
 }
 
 enum CmRequest {
-    AddConnection {
+    RequestOutboundConnection {
         endpoint: String,
         connection_id: String,
         sender: Sender<Result<(), ConnectionManagerError>>,
@@ -202,7 +202,7 @@ impl Connector {
     ) -> Result<(), ConnectionManagerError> {
         let (sender, recv) = channel();
         self.sender
-            .send(CmMessage::Request(CmRequest::AddConnection {
+            .send(CmMessage::Request(CmRequest::RequestOutboundConnection {
                 sender,
                 endpoint: endpoint.to_string(),
                 connection_id: id.to_string(),
@@ -610,7 +610,7 @@ fn handle_request<T: MatrixLifeCycle, U: MatrixSender>(
     subscribers: &mut Vec<Sender<ConnectionManagerNotification>>,
 ) {
     match req {
-        CmRequest::AddConnection {
+        CmRequest::RequestOutboundConnection {
             endpoint,
             sender,
             connection_id,

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -36,7 +36,6 @@ const DEFAULT_HEARTBEAT_INTERVAL: u64 = 10;
 const INITIAL_RETRY_FREQUENCY: u64 = 10;
 const DEFAULT_MAXIMUM_RETRY_FREQUENCY: u64 = 300;
 
-#[derive(Clone)]
 enum CmMessage {
     Shutdown,
     Subscribe(Sender<ConnectionManagerNotification>),
@@ -44,7 +43,6 @@ enum CmMessage {
     SendHeartbeats,
 }
 
-#[derive(Clone)]
 enum CmRequest {
     AddConnection {
         endpoint: String,
@@ -134,7 +132,7 @@ where
             })?;
 
         self.pacemaker
-            .start(CmMessage::SendHeartbeats, sender.clone())?;
+            .start(sender.clone(), || CmMessage::SendHeartbeats)?;
         self.join_handle = Some(join_handle);
         self.shutdown_handle = Some(ShutdownHandle {
             sender: sender.clone(),

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -22,9 +22,20 @@ use super::error::ConnectionManagerError;
 /// Messages that will be dispatched to all subscription handlers
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConnectionManagerNotification {
-    Connected { endpoint: String },
-    Disconnected { endpoint: String },
-    ReconnectionFailed { endpoint: String, attempts: u64 },
+    Connected {
+        endpoint: String,
+    },
+    InboundConnection {
+        endpoint: String,
+        connection_id: String,
+    },
+    Disconnected {
+        endpoint: String,
+    },
+    ReconnectionFailed {
+        endpoint: String,
+        attempts: u64,
+    },
 }
 
 /// An iterator over ConnectionManagerNotification values

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -19,8 +19,7 @@ use std::sync::mpsc::TryRecvError;
 #[cfg(feature = "connection-manager-notification-iter-try-next")]
 use super::error::ConnectionManagerError;
 
-/// Messages that will be dispatched to all
-/// subscription handlers
+/// Messages that will be dispatched to all subscription handlers
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConnectionManagerNotification {
     Connected { endpoint: String },
@@ -28,12 +27,14 @@ pub enum ConnectionManagerNotification {
     ReconnectionFailed { endpoint: String, attempts: u64 },
 }
 
+/// An iterator over ConnectionManagerNotification values
 pub struct NotificationIter {
     pub(super) recv: Receiver<ConnectionManagerNotification>,
 }
 
 #[cfg(feature = "connection-manager-notification-iter-try-next")]
 impl NotificationIter {
+    /// Try to get the next notificaion, if it is available.
     pub fn try_next(
         &self,
     ) -> Result<Option<ConnectionManagerNotification>, ConnectionManagerError> {

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -555,6 +555,7 @@ fn handle_notifications(
                 }
             }
         }
+        ConnectionManagerNotification::InboundConnection { .. } => (),
     }
 }
 


### PR DESCRIPTION
This PR adds the ability for the `ConnectionManager` to receive inbound connections and notify listeners when a connection is added.  

The internals of `ConnectionManager` now differentiate between outbound and inbound connections, where outbound connections are eligible for re-connection and heartbeats.  Inbound connections are not eligible - this is left to the remote end to manage these activities.