### PR TITLE
Mutable user store and Arc Removal

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -38,7 +38,7 @@ use super::super::resources::credentials::{NewUser, UsernamePassword};
 ///   }
 pub fn make_register_route(
     credentials_store: Arc<SplinterCredentialsStore>,
-    user_store: Arc<SplinterUserStore>,
+    user_store: SplinterUserStore,
     rest_config: Arc<BiomeRestConfig>,
 ) -> Resource {
     Resource::build("/biome/register")
@@ -48,7 +48,7 @@ pub fn make_register_route(
         ))
         .add_method(Method::Post, move |_, payload| {
             let credentials_store = credentials_store.clone();
-            let user_store = user_store.clone();
+            let mut user_store = user_store.clone();
             let rest_config = rest_config.clone();
             Box::new(into_bytes(payload).and_then(move |bytes| {
                 let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -58,7 +58,7 @@ pub fn make_user_routes(
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
     credentials_store: Arc<SplinterCredentialsStore>,
-    user_store: Arc<SplinterUserStore>,
+    user_store: SplinterUserStore,
 ) -> Resource {
     let credentials_store_modify = credentials_store.clone();
     let credentials_store_fetch = credentials_store;
@@ -138,7 +138,7 @@ fn add_modify_user_method(
     request: HttpRequest,
     payload: Payload,
     credentials_store: Arc<SplinterCredentialsStore>,
-    user_store: Arc<SplinterUserStore>,
+    mut user_store: SplinterUserStore,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let user_id = if let Some(t) = request.match_info().get("id") {
         t.to_string()
@@ -267,7 +267,7 @@ fn add_delete_user_method(
     request: HttpRequest,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
-    user_store: Arc<SplinterUserStore>,
+    mut user_store: SplinterUserStore,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let user_id = if let Some(t) = request.match_info().get("id") {
         t.to_string()

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -92,7 +92,7 @@ use crate::rest_api::sessions::AccessTokenIssuer;
 pub struct BiomeRestResourceManager {
     // Disable lint warning, for now this is only used if the biome-credentials feature is enabled
     #[allow(dead_code)]
-    user_store: Arc<SplinterUserStore>,
+    user_store: SplinterUserStore,
     #[cfg(all(feature = "biome-key-management", feature = "json-web-tokens"))]
     key_store: Arc<PostgresKeyStore>,
     // Disable lint warning, for now this is only used if the biome-credentials feature is enabled
@@ -282,7 +282,7 @@ impl BiomeRestResourceManagerBuilder {
         });
 
         Ok(BiomeRestResourceManager {
-            user_store: Arc::new(user_store),
+            user_store,
             #[cfg(all(feature = "biome-key-management", feature = "json-web-tokens"))]
             key_store: Arc::new(key_store),
             rest_config: Arc::new(rest_config),

--- a/libsplinter/src/biome/user/store/diesel/mod.rs
+++ b/libsplinter/src/biome/user/store/diesel/mod.rs
@@ -42,15 +42,15 @@ impl SplinterUserStore {
 }
 
 impl UserStore<SplinterUser> for SplinterUserStore {
-    fn add_user(&self, user: SplinterUser) -> Result<(), UserStoreError> {
+    fn add_user(&mut self, user: SplinterUser) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).add_user(user.into())
     }
 
-    fn update_user(&self, updated_user: SplinterUser) -> Result<(), UserStoreError> {
+    fn update_user(&mut self, updated_user: SplinterUser) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).update_user(updated_user)
     }
 
-    fn remove_user(&self, id: &str) -> Result<(), UserStoreError> {
+    fn remove_user(&mut self, id: &str) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).delete_user(id)
     }
 

--- a/libsplinter/src/biome/user/store/diesel/mod.rs
+++ b/libsplinter/src/biome/user/store/diesel/mod.rs
@@ -24,6 +24,7 @@ use operations::update_user::UserStoreUpdateUserOperation as _;
 use operations::UserStoreOperations;
 
 /// Manages creating, updating and fetching SplinterUser from the databae
+#[derive(Clone)]
 pub struct SplinterUserStore {
     connection_pool: ConnectionPool,
 }

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -94,3 +94,13 @@ pub trait UserStore<T>: Send + Sync {
     ///
     fn list_users(&self) -> Result<Vec<T>, UserStoreError>;
 }
+
+pub trait CloneBoxUserStore<T>: UserStore<T> {
+    fn clone_box(&self) -> Box<dyn CloneBoxUserStore<T>>;
+}
+
+impl<T> Clone for Box<dyn CloneBoxUserStore<T>> {
+    fn clone(&self) -> Box<dyn CloneBoxUserStore<T>> {
+        self.clone_box()
+    }
+}

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -56,7 +56,7 @@ impl From<UserModel> for SplinterUser {
 
 /// Defines methods for CRUD operations and fetching and listing users
 /// without defining a storage strategy
-pub trait UserStore<T> {
+pub trait UserStore<T>: Send + Sync {
     /// Adds a user to the underlying storage
     ///
     /// # Arguments

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -64,7 +64,7 @@ pub trait UserStore<T> {
     ///  * `user` - The user to be added
     ///
     ///
-    fn add_user(&self, user: T) -> Result<(), UserStoreError>;
+    fn add_user(&mut self, user: T) -> Result<(), UserStoreError>;
 
     /// Updates a user information in the underling storage
     ///
@@ -72,7 +72,7 @@ pub trait UserStore<T> {
     ///
     ///  * `user` - The user with the updated information
     ///
-    fn update_user(&self, updated_user: T) -> Result<(), UserStoreError>;
+    fn update_user(&mut self, updated_user: T) -> Result<(), UserStoreError>;
 
     /// Removes a user from the underlying storage
     ///
@@ -80,7 +80,7 @@ pub trait UserStore<T> {
     ///
     ///  * `id` - The unique id of the user to be removed
     ///
-    fn remove_user(&self, id: &str) -> Result<(), UserStoreError>;
+    fn remove_user(&mut self, id: &str) -> Result<(), UserStoreError>;
 
     /// Fetches a user from the underlying storage
     ///


### PR DESCRIPTION
PR that makes `add_user`, `remove_user`, and `update_user` take a mutable reference to self and remove `Arc` wrappings of `SplinterUserStore`