### PR TITLE
Add a BiHashMap to Mesh for a unique id to mesh id

### DIFF
--- a/examples/private_counter/service/src/main.rs
+++ b/examples/private_counter/service/src/main.rs
@@ -360,6 +360,10 @@ fn run_service_loop(
                 error!("Network has disconnected");
                 break;
             }
+            Err(RecvTimeoutError::PoisonedLock) => {
+                error!("Mesh lock was poisoned");
+                break;
+            }
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::NoPeerError(err)) => {
                 warn!("Received NoPeerError: {}", err);

--- a/libsplinter/src/matrix.rs
+++ b/libsplinter/src/matrix.rs
@@ -20,12 +20,12 @@ use crate::transport::Connection;
 /// MatrixLifeCycle trait abstracts out adding and removing connections to a
 /// connection handler without requiring knowledge about sending or receiving messges.
 pub trait MatrixLifeCycle: Clone + Send {
-    fn add(&self, connection: Box<dyn Connection>) -> Result<usize, MatrixAddError>;
-    fn remove(&self, id: usize) -> Result<Box<dyn Connection>, MatrixRemoveError>;
+    fn add(&self, connection: Box<dyn Connection>, id: String) -> Result<usize, MatrixAddError>;
+    fn remove(&self, id: &str) -> Result<Box<dyn Connection>, MatrixRemoveError>;
 }
 
 pub trait MatrixSender: Clone + Send {
-    fn send(&self, id: usize, message: Vec<u8>) -> Result<(), MatrixSendError>;
+    fn send(&self, id: String, message: Vec<u8>) -> Result<(), MatrixSendError>;
 }
 
 #[derive(Debug)]

--- a/libsplinter/src/mesh/control.rs
+++ b/libsplinter/src/mesh/control.rs
@@ -74,6 +74,7 @@ pub enum AddError {
     Io(io::Error),
     SenderDisconnected(Box<dyn Connection>),
     ReceiverDisconnected,
+    PoisonedLock,
 }
 
 impl Error for AddError {
@@ -82,6 +83,7 @@ impl Error for AddError {
             AddError::Io(err) => Some(err),
             AddError::SenderDisconnected(_) => None,
             AddError::ReceiverDisconnected => None,
+            AddError::PoisonedLock => None,
         }
     }
 }
@@ -96,6 +98,7 @@ impl fmt::Display for AddError {
             AddError::ReceiverDisconnected => {
                 write!(f, "unable to add connection, receiver disconnected")
             }
+            AddError::PoisonedLock => write!(f, "MeshState lock was poisoned"),
         }
     }
 }
@@ -108,6 +111,7 @@ impl fmt::Debug for AddError {
                 write!(f, "AddError::SenderDisconnected(Box<dyn Connection>)")
             }
             AddError::ReceiverDisconnected => write!(f, "AddError::ReceiverDisconnected"),
+            AddError::PoisonedLock => write!(f, "AddError::PoisonedLock"),
         }
     }
 }
@@ -139,6 +143,7 @@ pub enum RemoveError {
     NotFound,
     SenderDisconnected(usize),
     ReceiverDisconnected,
+    PoisonedLock,
 }
 
 impl Error for RemoveError {
@@ -148,6 +153,7 @@ impl Error for RemoveError {
             RemoveError::NotFound => None,
             RemoveError::SenderDisconnected(_) => None,
             RemoveError::ReceiverDisconnected => None,
+            RemoveError::PoisonedLock => None,
         }
     }
 }
@@ -165,6 +171,7 @@ impl fmt::Display for RemoveError {
             RemoveError::ReceiverDisconnected => {
                 write!(f, "unable to remove connection, receiver disconnected")
             }
+            RemoveError::PoisonedLock => write!(f, "MeshState lock was poisoned"),
         }
     }
 }

--- a/libsplinter/src/mesh/incoming.rs
+++ b/libsplinter/src/mesh/incoming.rs
@@ -16,24 +16,24 @@ use crossbeam_channel;
 
 use std::time::Duration;
 
-use crate::mesh::Envelope;
+use super::InternalEnvelope;
 
 /// Handle for receiving envelopes from the mesh
 #[derive(Clone)]
 pub struct Incoming {
-    rx: crossbeam_channel::Receiver<Envelope>,
+    rx: crossbeam_channel::Receiver<InternalEnvelope>,
 }
 
 impl Incoming {
-    pub(super) fn new(rx: crossbeam_channel::Receiver<Envelope>) -> Self {
+    pub(super) fn new(rx: crossbeam_channel::Receiver<InternalEnvelope>) -> Self {
         Incoming { rx }
     }
 
-    pub fn recv(&self) -> Result<Envelope, RecvError> {
+    pub fn recv(&self) -> Result<InternalEnvelope, RecvError> {
         self.rx.recv().map_err(|_| RecvError {})
     }
 
-    pub fn recv_timeout(&self, timeout: Duration) -> Result<Envelope, RecvTimeoutError> {
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<InternalEnvelope, RecvTimeoutError> {
         Ok(self.rx.recv_timeout(timeout)?)
     }
 }

--- a/libsplinter/src/mesh/matrix.rs
+++ b/libsplinter/src/mesh/matrix.rs
@@ -31,8 +31,8 @@ impl MeshLifeCycle {
 }
 
 impl MatrixLifeCycle for MeshLifeCycle {
-    fn add(&self, connection: Box<dyn Connection>) -> Result<usize, MatrixAddError> {
-        self.mesh.add(connection).map_err(|err| {
+    fn add(&self, connection: Box<dyn Connection>, id: String) -> Result<usize, MatrixAddError> {
+        self.mesh.add(connection, id).map_err(|err| {
             MatrixAddError::new(
                 "Unable to add connection to Matrix.".to_string(),
                 Some(Box::new(err)),
@@ -40,7 +40,7 @@ impl MatrixLifeCycle for MeshLifeCycle {
         })
     }
 
-    fn remove(&self, id: usize) -> Result<Box<dyn Connection>, MatrixRemoveError> {
+    fn remove(&self, id: &str) -> Result<Box<dyn Connection>, MatrixRemoveError> {
         self.mesh.remove(id).map_err(|err| {
             MatrixRemoveError::new(
                 "Unable to remove connection from Matrix.".to_string(),
@@ -62,7 +62,7 @@ impl MeshMatrixSender {
 }
 
 impl MatrixSender for MeshMatrixSender {
-    fn send(&self, id: usize, message: Vec<u8>) -> Result<(), MatrixSendError> {
+    fn send(&self, id: String, message: Vec<u8>) -> Result<(), MatrixSendError> {
         let envelope = Envelope::new(id, message);
         self.mesh.send(envelope).map_err(|err| {
             MatrixSendError::new(

--- a/libsplinter/src/mesh/outgoing.rs
+++ b/libsplinter/src/mesh/outgoing.rs
@@ -16,22 +16,22 @@ use mio_extras::channel::{SyncSender, TrySendError};
 
 use std::io;
 
-use crate::mesh::Envelope;
+use super::InternalEnvelope;
 
 /// Handle for sending to a specific connection in the mesh
 #[derive(Clone)]
 pub struct Outgoing {
     id: usize,
-    tx: SyncSender<Envelope>,
+    tx: SyncSender<InternalEnvelope>,
 }
 
 impl Outgoing {
-    pub(super) fn new(id: usize, tx: SyncSender<Envelope>) -> Self {
+    pub(super) fn new(id: usize, tx: SyncSender<InternalEnvelope>) -> Self {
         Outgoing { id, tx }
     }
 
     pub fn send(&self, payload: Vec<u8>) -> Result<(), SendError> {
-        self.tx.try_send(Envelope::new(self.id, payload))?;
+        self.tx.try_send(InternalEnvelope::new(self.id, payload))?;
         Ok(())
     }
 
@@ -47,8 +47,8 @@ pub enum SendError {
     Disconnected(Vec<u8>),
 }
 
-impl From<TrySendError<Envelope>> for SendError {
-    fn from(err: TrySendError<Envelope>) -> Self {
+impl From<TrySendError<InternalEnvelope>> for SendError {
+    fn from(err: TrySendError<InternalEnvelope>) -> Self {
         match err {
             TrySendError::Full(envelope) => SendError::Full(envelope.payload),
             TrySendError::Disconnected(envelope) => SendError::Disconnected(envelope.payload),

--- a/libsplinter/src/mesh/reactor.rs
+++ b/libsplinter/src/mesh/reactor.rs
@@ -27,7 +27,7 @@ use crate::mesh::{
     incoming::Incoming,
     outgoing::Outgoing,
     pool::Pool,
-    Envelope,
+    InternalEnvelope,
 };
 use crate::transport::Connection;
 
@@ -38,7 +38,7 @@ pub struct Reactor {
     pool: Pool,
     ctrl_rx: mio_channel::Receiver<ControlRequest>,
     ctrl_token: Token,
-    incoming_tx: crossbeam_channel::Sender<Envelope>,
+    incoming_tx: crossbeam_channel::Sender<InternalEnvelope>,
     outgoing_capacity: usize,
 }
 
@@ -50,7 +50,7 @@ enum Turn {
 impl Reactor {
     fn new(
         ctrl_rx: mio_channel::Receiver<ControlRequest>,
-        incoming_tx: crossbeam_channel::Sender<Envelope>,
+        incoming_tx: crossbeam_channel::Sender<InternalEnvelope>,
         outgoing_capacity: usize,
     ) -> Self {
         let mut pool = Pool::new();

--- a/libsplinter/src/network/peer_manager/peer_map.rs
+++ b/libsplinter/src/network/peer_manager/peer_map.rs
@@ -25,6 +25,7 @@ pub enum PeerStatus {
 #[derive(Clone, PartialEq, Debug)]
 pub struct PeerMetadata {
     pub id: String,
+    pub connection_id: String,
     pub endpoints: Vec<String>,
     pub active_endpoint: String,
     pub status: PeerStatus,
@@ -60,12 +61,19 @@ impl PeerMap {
     }
 
     /// Insert a new peer id and endpoints
-    pub fn insert(&mut self, peer_id: String, endpoints: Vec<String>, active_endpoint: String) {
+    pub fn insert(
+        &mut self,
+        peer_id: String,
+        connection_id: String,
+        endpoints: Vec<String>,
+        active_endpoint: String,
+    ) {
         let peer_metadata = PeerMetadata {
             id: peer_id.clone(),
             endpoints: endpoints.clone(),
             active_endpoint,
             status: PeerStatus::Connected,
+            connection_id,
         };
 
         self.peers.insert(peer_id.clone(), peer_metadata);
@@ -177,12 +185,14 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id_1".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
 
         peer_map.insert(
             "next_peer".to_string(),
+            "connection_id_2".to_string(),
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
         );
@@ -216,6 +226,7 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
@@ -225,6 +236,7 @@ pub mod tests {
             peer_metadata,
             Some(&PeerMetadata {
                 id: "test_peer".to_string(),
+                connection_id: "connection_id".to_string(),
                 endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
                 active_endpoint: "test_endpoint2".to_string(),
                 status: PeerStatus::Connected
@@ -236,6 +248,7 @@ pub mod tests {
             peer_metadata,
             Some(&PeerMetadata {
                 id: "test_peer".to_string(),
+                connection_id: "connection_id".to_string(),
                 endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
                 active_endpoint: "test_endpoint2".to_string(),
                 status: PeerStatus::Connected
@@ -253,6 +266,7 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
@@ -263,6 +277,7 @@ pub mod tests {
             peer_metadata,
             Some(&PeerMetadata {
                 id: "test_peer".to_string(),
+                connection_id: "connection_id".to_string(),
                 endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
                 active_endpoint: "test_endpoint2".to_string(),
                 status: PeerStatus::Connected
@@ -284,6 +299,7 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
@@ -311,6 +327,7 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
@@ -335,6 +352,7 @@ pub mod tests {
         let mut peer_map = PeerMap::new();
         let no_peer_metadata = PeerMetadata {
             id: "test_peer".to_string(),
+            connection_id: "connection_id".to_string(),
             endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             active_endpoint: "test_endpoint1".to_string(),
             status: PeerStatus::Connected,
@@ -346,6 +364,7 @@ pub mod tests {
 
         peer_map.insert(
             "test_peer".to_string(),
+            "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
         );
@@ -374,6 +393,7 @@ pub mod tests {
                     "test_endpoint2".to_string(),
                     "new_endpoint".to_string()
                 ],
+                connection_id: "connection_id".to_string(),
                 active_endpoint: "test_endpoint1".to_string(),
                 status: PeerStatus::Disconnected { retry_attempts: 5 },
             })


### PR DESCRIPTION
This change enables components using mesh to not have
to know about the internal mesh id used in polling the
connections. This also allows reconnection with out having
to replace the id returned from mesh.

This commit updates mesh and all places mesh is used. It
also removes the use of rwlock unwrap macros and instead
returns a PoisonedLock error instead.

This will simplify the data future inteconnects will need
to keep track of.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>