### PR TITLE
Allow filtering circuit proposals by member

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -155,10 +155,19 @@ impl<'a> SplinterRestClient<'a> {
     pub fn list_proposals(
         &self,
         management_type_filter: Option<&str>,
+        member_filter: Option<&str>,
     ) -> Result<ProposalListSlice, CliError> {
-        let mut request = format!("{}/admin/proposals", self.url);
+        let mut filters = vec![];
         if let Some(management_type) = management_type_filter {
-            request = format!("{}?management_type={}", &request, &management_type);
+            filters.push(format!("management_type={}", management_type));
+        }
+        if let Some(member) = member_filter {
+            filters.push(format!("member={}", member));
+        }
+
+        let mut request = format!("{}/admin/proposals", self.url);
+        if !filters.is_empty() {
+            request.push_str(&format!("?{}", filters.join("&")));
         }
 
         Client::new()

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -152,10 +152,13 @@ impl<'a> SplinterRestClient<'a> {
             })
     }
 
-    pub fn list_proposals(&self, filter: Option<&str>) -> Result<ProposalListSlice, CliError> {
+    pub fn list_proposals(
+        &self,
+        management_type_filter: Option<&str>,
+    ) -> Result<ProposalListSlice, CliError> {
         let mut request = format!("{}/admin/proposals", self.url);
-        if let Some(filter) = filter {
-            request = format!("{}?filter={}", &request, &filter);
+        if let Some(management_type) = management_type_filter {
+            request = format!("{}?management_type={}", &request, &management_type);
         }
 
         Client::new()

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -564,18 +564,22 @@ impl Action for CircuitProposalsAction {
 
         let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
 
-        let filter = args.value_of("management_type");
+        let management_type_filter = args.value_of("management_type");
 
         let format = args.value_of("format").unwrap_or("human");
 
-        list_proposals(url, filter, format)
+        list_proposals(url, management_type_filter, format)
     }
 }
 
-fn list_proposals(url: &str, filter: Option<&str>, format: &str) -> Result<(), CliError> {
+fn list_proposals(
+    url: &str,
+    management_type_filter: Option<&str>,
+    format: &str,
+) -> Result<(), CliError> {
     let client = api::SplinterRestClient::new(url);
 
-    let proposals = client.list_proposals(filter)?;
+    let proposals = client.list_proposals(management_type_filter)?;
     let mut data = Vec::new();
     data.push(vec![
         "ID".to_string(),

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -566,20 +566,23 @@ impl Action for CircuitProposalsAction {
 
         let management_type_filter = args.value_of("management_type");
 
+        let member_filter = args.value_of("member");
+
         let format = args.value_of("format").unwrap_or("human");
 
-        list_proposals(url, management_type_filter, format)
+        list_proposals(url, management_type_filter, member_filter, format)
     }
 }
 
 fn list_proposals(
     url: &str,
     management_type_filter: Option<&str>,
+    member_filter: Option<&str>,
     format: &str,
 ) -> Result<(), CliError> {
     let client = api::SplinterRestClient::new(url);
 
-    let proposals = client.list_proposals(management_type_filter)?;
+    let proposals = client.list_proposals(management_type_filter, member_filter)?;
     let mut data = Vec::new();
     data.push(vec![
         "ID".to_string(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -458,11 +458,19 @@ fn run() -> Result<(), CliError> {
                     )
                     .arg(
                         Arg::with_name("management_type")
-                            .short("m")
                             .long("management-type")
                             .long_help(
                                 "Filter the circuit proposals by the circuit \
                                  management type of the circuits",
+                            )
+                            .takes_value(true),
+                    )
+                    .arg(
+                        Arg::with_name("member")
+                            .long("member")
+                            .long_help(
+                                "Only show proposals whose circuits have the given node ID as \
+                                 a member",
                             )
                             .takes_value(true),
                     )

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
 
     use reqwest::{blocking::Client, StatusCode, Url};
+    use serde_json::{to_value, Value as JsonValue};
 
     use crate::circuit::{
         directory::CircuitDirectory, AuthorizationType, Circuit, DurabilityType, PersistenceType,
@@ -179,14 +180,28 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let circuits: ListCircuitsResponse = resp.json().expect("Failed to deserialize body");
+        let circuits: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            circuits.data,
-            vec![get_circuit_1().into(), get_circuit_2().into()]
+            circuits.get("data").expect("no data field in response"),
+            &to_value(vec![
+                CircuitResponse::from(&get_circuit_1()),
+                CircuitResponse::from(&get_circuit_2())
+            ])
+            .expect("failed to convert expected data"),
         );
         assert_eq!(
-            circuits.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 2, "/admin/circuits?")
+            circuits.get("paging").expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                2,
+                "/admin/circuits?",
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -204,12 +219,26 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let circuits: ListCircuitsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(circuits.data, vec![get_circuit_1().into()]);
-        let link = format!("/admin/circuits?filter=node_1&");
+        let circuits: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            circuits.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 1, &link)
+            circuits.get("data").expect("no data field in response"),
+            &to_value(vec![CircuitResponse::from(&get_circuit_1())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            circuits.get("paging").expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                1,
+                &format!("/admin/circuits?filter=node_1&"),
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -227,11 +256,26 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let circuits: ListCircuitsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(circuits.data, vec![get_circuit_1().into()]);
+        let circuits: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            circuits.paging,
-            create_test_paging_response(0, 1, 1, 0, 1, 2, "/admin/circuits?")
+            circuits.get("data").expect("no data field in response"),
+            &to_value(vec![CircuitResponse::from(&get_circuit_1())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            circuits.get("paging").expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                1,
+                1,
+                0,
+                1,
+                2,
+                "/admin/circuits?",
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -249,11 +293,26 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let circuits: ListCircuitsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(circuits.data, vec![get_circuit_2().into()]);
+        let circuits: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            circuits.paging,
-            create_test_paging_response(1, 100, 0, 0, 0, 2, "/admin/circuits?")
+            circuits.get("data").expect("no data field in response"),
+            &to_value(vec![CircuitResponse::from(&get_circuit_2())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            circuits.get("paging").expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                1,
+                100,
+                0,
+                0,
+                0,
+                2,
+                "/admin/circuits?"
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -79,6 +79,7 @@ mod tests {
     use super::*;
 
     use reqwest::{blocking::Client, StatusCode, Url};
+    use serde_json::{to_value, Value as JsonValue};
 
     use crate::circuit::{
         directory::CircuitDirectory, AuthorizationType, Circuit, DurabilityType, PersistenceType,
@@ -105,8 +106,13 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let circuit: CircuitResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(circuit, get_circuit_1().into());
+        let circuit: JsonValue = resp.json().expect("Failed to deserialize body");
+
+        assert_eq!(
+            circuit,
+            to_value(CircuitResponse::from(&get_circuit_1()))
+                .expect("failed to convert expected circuit"),
+        );
     }
 
     #[test]

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -165,6 +165,7 @@ mod tests {
     use super::*;
 
     use reqwest::{blocking::Client, StatusCode, Url};
+    use serde_json::{to_value, Value as JsonValue};
 
     use crate::admin::{
         messages::{
@@ -191,18 +192,32 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.data,
-            vec![
-                get_proposal_1().into(),
-                get_proposal_2().into(),
-                get_proposal_3().into()
-            ]
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![
+                ProposalResponse::from(&get_proposal_1()),
+                ProposalResponse::from(&get_proposal_2()),
+                ProposalResponse::from(&get_proposal_3()),
+            ])
+            .expect("failed to convert expected data"),
         );
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 3, "/admin/proposals?")
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                3,
+                "/admin/proposals?"
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -224,12 +239,28 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(proposals.data, vec![get_proposal_1().into()]);
-        let link = format!("/admin/proposals?management_type=mgmt_type_1&");
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 1, &link)
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![ProposalResponse::from(&get_proposal_1())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                1,
+                &format!("/admin/proposals?management_type=mgmt_type_1&")
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -251,15 +282,31 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.data,
-            vec![get_proposal_1().into(), get_proposal_3().into()]
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![
+                ProposalResponse::from(&get_proposal_1()),
+                ProposalResponse::from(&get_proposal_3())
+            ])
+            .expect("failed to convert expected data"),
         );
-        let link = format!("/admin/proposals?member=node_id&");
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 2, &link)
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                2,
+                &format!("/admin/proposals?member=node_id&")
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -281,12 +328,28 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(proposals.data, vec![get_proposal_3().into()]);
-        let link = format!("/admin/proposals?management_type=mgmt_type_2&member=node_id&");
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(0, 100, 0, 0, 0, 1, &link)
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![ProposalResponse::from(&get_proposal_3())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                100,
+                0,
+                0,
+                0,
+                1,
+                &format!("/admin/proposals?management_type=mgmt_type_2&member=node_id&")
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -304,11 +367,28 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(proposals.data, vec![get_proposal_1().into()]);
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(0, 1, 1, 0, 2, 3, "/admin/proposals?")
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![ProposalResponse::from(&get_proposal_1())])
+                .expect("failed to convert expected data"),
+        );
+
+        assert_eq!(
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                0,
+                1,
+                1,
+                0,
+                2,
+                3,
+                "/admin/proposals?"
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 
@@ -326,14 +406,31 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposals: ListProposalsResponse = resp.json().expect("Failed to deserialize body");
+        let proposals: JsonValue = resp.json().expect("Failed to deserialize body");
+
         assert_eq!(
-            proposals.data,
-            vec![get_proposal_2().into(), get_proposal_3().into()]
+            proposals.get("data").expect("no data field in response"),
+            &to_value(vec![
+                ProposalResponse::from(&get_proposal_2()),
+                ProposalResponse::from(&get_proposal_3())
+            ])
+            .expect("failed to convert expected data"),
         );
+
         assert_eq!(
-            proposals.paging,
-            create_test_paging_response(1, 100, 0, 0, 0, 3, "/admin/proposals?")
+            proposals
+                .get("paging")
+                .expect("no paging field in response"),
+            &to_value(create_test_paging_response(
+                1,
+                100,
+                0,
+                0,
+                0,
+                3,
+                "/admin/proposals?"
+            ))
+            .expect("failed to convert expected paging")
         )
     }
 

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -175,7 +175,7 @@ mod tests {
             AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType, PersistenceType,
             ProposalType, RouteType,
         },
-        service::{open_proposals::ProposalIter, proposal_store::ProposalStoreError},
+        service::proposal_store::{ProposalIter, ProposalStoreError},
     };
     use crate::rest_api::{
         paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -87,7 +87,7 @@ mod tests {
             AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType, PersistenceType,
             ProposalType, RouteType,
         },
-        service::proposal_store::{ProposalIter, ProposalStoreError},
+        service::proposal_store::{ProposalFilter, ProposalIter, ProposalStoreError},
     };
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 
@@ -137,7 +137,10 @@ mod tests {
     struct MockProposalStore;
 
     impl ProposalStore for MockProposalStore {
-        fn proposals(&self) -> Result<ProposalIter, ProposalStoreError> {
+        fn proposals(
+            &self,
+            _filters: Vec<ProposalFilter>,
+        ) -> Result<ProposalIter, ProposalStoreError> {
             unimplemented!()
         }
 

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -87,7 +87,7 @@ mod tests {
             AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType, PersistenceType,
             ProposalType, RouteType,
         },
-        service::{open_proposals::ProposalIter, proposal_store::ProposalStoreError},
+        service::proposal_store::{ProposalIter, ProposalStoreError},
     };
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -81,6 +81,7 @@ mod tests {
     use super::*;
 
     use reqwest::{blocking::Client, StatusCode, Url};
+    use serde_json::{to_value, Value as JsonValue};
 
     use crate::admin::{
         messages::{
@@ -109,8 +110,13 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
-        let proposal: ProposalResponse = resp.json().expect("Failed to deserialize body");
-        assert_eq!(proposal, get_proposal().into());
+        let proposal: JsonValue = resp.json().expect("Failed to deserialize body");
+
+        assert_eq!(
+            proposal,
+            to_value(ProposalResponse::from(&get_proposal()))
+                .expect("failed to convert expected data")
+        );
     }
 
     #[test]

--- a/libsplinter/src/admin/service/open_proposals.rs
+++ b/libsplinter/src/admin/service/open_proposals.rs
@@ -73,7 +73,7 @@ impl OpenProposals {
     }
 
     #[cfg(feature = "proposal-read")]
-    pub fn get_proposals(&self) -> ProposalIter {
+    pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
         self.proposal_registry.get_proposals()
     }
 
@@ -137,54 +137,11 @@ impl ProposalRegistry {
     }
 
     #[cfg(feature = "proposal-read")]
-    pub fn get_proposals(&self) -> ProposalIter {
-        ProposalIter::new(
-            Box::new(
-                self.proposals
-                    .clone()
-                    .into_iter()
-                    .map(|(_, proposal)| proposal),
-            ),
-            self.proposals.len(),
-        )
+    pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
+        self.proposals.clone()
     }
 
     pub fn has_proposal(&self, circuit_id: &str) -> bool {
         self.proposals.contains_key(circuit_id)
-    }
-}
-
-#[cfg(feature = "proposal-read")]
-/// An iterator over CircuitProposals, with a well-known count of values.
-pub struct ProposalIter {
-    inner: Box<dyn Iterator<Item = messages::CircuitProposal>>,
-    size: usize,
-}
-
-#[cfg(feature = "proposal-read")]
-impl ProposalIter {
-    pub fn new(iter: Box<dyn Iterator<Item = messages::CircuitProposal>>, count: usize) -> Self {
-        Self {
-            inner: iter,
-            size: count,
-        }
-    }
-
-    #[cfg(feature = "proposal-read")]
-    pub fn total(&self) -> usize {
-        self.size
-    }
-}
-
-#[cfg(feature = "proposal-read")]
-impl Iterator for ProposalIter {
-    type Item = messages::CircuitProposal;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.size, Some(self.size))
     }
 }

--- a/libsplinter/src/admin/service/proposal_store.rs
+++ b/libsplinter/src/admin/service/proposal_store.rs
@@ -24,6 +24,8 @@ use super::shared::AdminServiceShared;
 pub enum ProposalFilter {
     /// Matches any proposals whose circuits have the given management type.
     WithManagementType(String),
+    /// Matches any proposals whose circuits have the given node as a member.
+    WithMember(String),
 }
 
 impl ProposalFilter {
@@ -33,6 +35,11 @@ impl ProposalFilter {
             ProposalFilter::WithManagementType(ref management_type) => {
                 &proposal.circuit.circuit_management_type == management_type
             }
+            ProposalFilter::WithMember(ref member_id) => proposal
+                .circuit
+                .members
+                .iter()
+                .any(|member| &member.node_id == member_id),
         }
     }
 }

--- a/libsplinter/src/admin/service/proposal_store.rs
+++ b/libsplinter/src/admin/service/proposal_store.rs
@@ -15,18 +15,15 @@
 use std::sync::{Arc, Mutex};
 
 use super::messages::CircuitProposal;
-#[cfg(feature = "proposal-read")]
 use super::open_proposals::ProposalIter;
 use super::shared::AdminServiceShared;
 
-#[cfg(feature = "proposal-read")]
 pub trait ProposalStore: Send + Sync + Clone {
     fn proposals(&self) -> Result<ProposalIter, ProposalStoreError>;
 
     fn proposal(&self, circuit_id: &str) -> Result<Option<CircuitProposal>, ProposalStoreError>;
 }
 
-#[cfg(feature = "proposal-read")]
 #[derive(Debug)]
 pub struct ProposalStoreError {
     context: String,
@@ -82,7 +79,6 @@ impl AdminServiceProposals {
     }
 }
 
-#[cfg(feature = "proposal-read")]
 impl ProposalStore for AdminServiceProposals {
     fn proposals(&self) -> Result<ProposalIter, ProposalStoreError> {
         Ok(self

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -57,8 +57,6 @@ use super::error::{AdminSharedError, MarshallingError};
 use super::mailbox::Mailbox;
 use super::messages;
 use super::open_proposals::OpenProposals;
-#[cfg(feature = "proposal-read")]
-use super::open_proposals::ProposalIter;
 use super::{admin_service_id, sha256, AdminServiceEventSubscriber, AdminSubscriberError, Events};
 
 const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
@@ -898,7 +896,7 @@ impl AdminServiceShared {
     }
 
     #[cfg(feature = "proposal-read")]
-    pub fn get_proposals(&self) -> ProposalIter {
+    pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
         self.open_proposals.get_proposals()
     }
 

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -51,7 +51,9 @@ paths:
         This endpoint can be used to view all of the circuit proposals that the
         node is a proposed member of. If a circuit management type is provided
         via the "management_type" query parameter, only circuit proposals that
-        have the given circuit management type will be returned; if no filter is
+        have the given circuit management type will be returned. If a node ID is
+        provided via the "member" query parameter, only circuit proposals that
+        have the given node as a member will be returned. If no filter is
         provided, all of the node's circuit proposals will be returned.
       tags:
         - Proposals
@@ -76,6 +78,14 @@ paths:
           description: |-
             Only show proposed circuits matching the given circuit management
             type
+          required: false
+          schema:
+            type: string
+        - name: member
+          in: query
+          description: |-
+            Only show proposed circuits that have a member with the given node
+            ID
           required: false
           schema:
             type: string

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -50,8 +50,8 @@ paths:
       description: |
         This endpoint can be used to view all of the circuit proposals that the
         node is a proposed member of. If a circuit management type is provided
-        via the "filter" query parameter, only circuit proposals that have the
-        given circuit management type will be returned; if no filter is
+        via the "management_type" query parameter, only circuit proposals that
+        have the given circuit management type will be returned; if no filter is
         provided, all of the node's circuit proposals will be returned.
       tags:
         - Proposals
@@ -71,9 +71,11 @@ paths:
           schema:
             type: integer
             default: 100
-        - name: filter
+        - name: management_type
           in: query
-          description: Circuit management type of the proposed circuits
+          description: |-
+            Only show proposed circuits matching the given circuit management
+            type
           required: false
           schema:
             type: string


### PR DESCRIPTION
Adds the `member` filter as a query parameter to the `GET /admin/proposals` endpoint and as an argument to the `splinter circuit proposals` CLI command. Also renames to the existing `filter` option to `management_type` to differentiate.