### PR TITLE
Update Dockerfiles to use splinter-dev:v2

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
 

--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -16,10 +16,6 @@ FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
 
-RUN apt-get update \
- && apt-get install -y -q \
-    pandoc
-
 # Copy over source files
 COPY client /build/client
 COPY libsplinter /build/libsplinter

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 # Copy over source files
 

--- a/examples/gameroom/tests/Dockerfile
+++ b/examples/gameroom/tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1
+FROM splintercommunity/splinter-dev:v2
 
 RUN apt-get update \
  && apt-get install -y \

--- a/examples/private_counter/cli/Dockerfile-installed-bionic
+++ b/examples/private_counter/cli/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 # Copy over source files
 COPY examples/private_counter/cli/ /build/examples/private_counter/cli

--- a/examples/private_counter/service/Dockerfile-installed-bionic
+++ b/examples/private_counter/service/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 # Copy over source files
 COPY examples/private_counter/protos /build/examples/private_counter/protos

--- a/examples/private_xo/Dockerfile-installed-bionic
+++ b/examples/private_xo/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 COPY libsplinter /build/libsplinter
 COPY examples/private_xo /build/examples/private_xo

--- a/services/scabbard/Dockerfile-installed-bionic
+++ b/services/scabbard/Dockerfile-installed-bionic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 # Copy over source files
 COPY Cargo.toml /build/Cargo.toml

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -18,10 +18,6 @@ FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
 
-RUN apt-get update \
- && apt-get install -y -q \
-    pandoc
-
 COPY cli /build/cli
 COPY libsplinter /build/libsplinter
 COPY services/health /build/services/health

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -14,7 +14,7 @@
 
 # -------------=== splinterd docker build ===-------------
 
-FROM splintercommunity/splinter-dev:v1 as BUILDER
+FROM splintercommunity/splinter-dev:v2 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v1
+FROM splintercommunity/splinter-dev:v2
 
 RUN apt-get update \
  && apt-get install -y \


### PR DESCRIPTION
Depends on https://github.com/Cargill/splinter/pull/588 being merged and successfully built.