### PR TITLE
Make experimental feature depend upon stable

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,9 @@ default = []
 stable = ["default"]
 
 experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
     "circuit",
     "circuit-template",
     "health",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -36,4 +36,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -61,7 +61,11 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]
 
 # These are test-only features, so they will not be in `default`, `stable`,
 # or `experimental`

--- a/examples/gameroom/database/Cargo.toml
+++ b/examples/gameroom/database/Cargo.toml
@@ -34,4 +34,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/examples/private_counter/cli/Cargo.toml
+++ b/examples/private_counter/cli/Cargo.toml
@@ -37,4 +37,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/examples/private_counter/service/Cargo.toml
+++ b/examples/private_counter/service/Cargo.toml
@@ -51,4 +51,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/examples/private_xo/Cargo.toml
+++ b/examples/private_xo/Cargo.toml
@@ -56,4 +56,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -86,6 +86,9 @@ stable = [
 ]
 
 experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
     "biome",
     "biome-credentials",
     "biome-key-management",

--- a/services/health/Cargo.toml
+++ b/services/health/Cargo.toml
@@ -33,4 +33,8 @@ default = []
 
 stable = ["default"]
 
-experimental = []
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -55,6 +55,9 @@ default = [
 stable = ["default"]
 
 experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
     "biome",
     "biome-credentials",
     "biome-key-management",


### PR DESCRIPTION
This conceptually makes experimental an extension of stable features,
instead of an extension of default features. This is useful primarily
to make sure that experimental and stable remain compatible.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>