### PR TITLE
Make user module private in biome

### DIFF
--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -34,4 +34,4 @@ pub mod notifications;
 
 #[cfg(feature = "rest-api")]
 pub mod rest_api;
-pub mod user;
+mod user;

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -33,6 +33,7 @@ impl SplinterUser {
     ///
     /// * `user_id`: unique identifier for the user being created
     ///
+    #[cfg(feature = "rest-api")]
     pub fn new(user_id: &str) -> Self {
         SplinterUser {
             id: user_id.to_string(),


### PR DESCRIPTION
Make crate::biome::user non public

Signed-off-by: Ryan Banks <rbanks@bitwise.io>