### PR TITLE
Add MatrixReceiver trait and Mesh implementation

### DIFF
--- a/libsplinter/src/mesh/matrix.rs
+++ b/libsplinter/src/mesh/matrix.rs
@@ -36,7 +36,7 @@ impl MatrixLifeCycle for MeshLifeCycle {
     fn add(&self, connection: Box<dyn Connection>, id: String) -> Result<usize, MatrixAddError> {
         self.mesh.add(connection, id).map_err(|err| {
             MatrixAddError::new(
-                "Unable to add connection to Matrix.".to_string(),
+                "Unable to add connection to Matrix".to_string(),
                 Some(Box::new(err)),
             )
         })
@@ -45,7 +45,7 @@ impl MatrixLifeCycle for MeshLifeCycle {
     fn remove(&self, id: &str) -> Result<Box<dyn Connection>, MatrixRemoveError> {
         self.mesh.remove(id).map_err(|err| {
             MatrixRemoveError::new(
-                "Unable to remove connection from Matrix.".to_string(),
+                "Unable to remove connection from Matrix".to_string(),
                 Some(Box::new(err)),
             )
         })
@@ -68,7 +68,7 @@ impl MatrixSender for MeshMatrixSender {
         let envelope = Envelope::new(id, message);
         self.mesh.send(envelope).map_err(|err| {
             MatrixSendError::new(
-                "Unable to send message to connection.".to_string(),
+                "Unable to send message to connection".to_string(),
                 Some(Box::new(err)),
             )
         })

--- a/libsplinter/src/mesh/matrix.rs
+++ b/libsplinter/src/mesh/matrix.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use crate::matrix::{
-    MatrixAddError, MatrixLifeCycle, MatrixRemoveError, MatrixSendError, MatrixSender,
+    Envelope, MatrixAddError, MatrixLifeCycle, MatrixRemoveError, MatrixSendError, MatrixSender,
 };
 use crate::transport::Connection;
 
-use super::{Envelope, Mesh};
+use super::Mesh;
 
 #[derive(Clone)]
 pub struct MeshLifeCycle {

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -212,10 +212,8 @@ impl Mesh {
 
     /// Receive a new envelope from the mesh.
     pub fn recv(&self) -> Result<Envelope, RecvError> {
-        let internal_envelope = self
-            .incoming
-            .recv()
-            .map_err(|_| RecvError::InternalError("Cannot receive message".to_string()))?;
+        let internal_envelope = self.incoming.recv().map_err(|_| RecvError::Disconnected)?;
+
         let id = self
             .state
             .read()
@@ -332,7 +330,7 @@ impl SendError {
 
 #[derive(Debug)]
 pub enum RecvError {
-    InternalError(String),
+    Disconnected,
     PoisonedLock,
 }
 
@@ -341,7 +339,7 @@ impl Error for RecvError {}
 impl std::fmt::Display for RecvError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            RecvError::InternalError(msg) => write!(f, "Receive Error: {}", msg),
+            RecvError::Disconnected => write!(f, "Unable to receive: channel has disconnected"),
             RecvError::PoisonedLock => write!(f, "MeshState lock was poisoned"),
         }
     }


### PR DESCRIPTION
This trait will be used to separate out message receiving
from sending, adding and removing connections.

This commit also moves Envelope into matrix when this
feature is enabled. This is where Envelope should
leave once this feature is stable.