### PR TITLE
Revert "Merge pull request #577 from rbuysse/docker-non-root-users"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
           sleep 1
         done
         splinter database migrate -C postgres://splinter_admin:splinter_test@splinter-db:5432/splinter && \
-        sudo splinter cert generate --skip && \
+        splinter cert generate --skip && \
         splinterd \
             -c ./configs/splinterd-node-0-docker.toml \
             --registry-file ./node_registries/nodes.yaml \

--- a/docker/kubernetes/arcade.yaml
+++ b/docker/kubernetes/arcade.yaml
@@ -96,7 +96,7 @@ items:
             args:
               - -c
               - |
-                  sudo splinter cert generate \
+                  splinter cert generate \
                   --common-name acme \
                   --cert-dir /config/certs/ \
                   --force \
@@ -270,7 +270,7 @@ items:
             args:
               - -c
               - |
-                  sudo splinter cert generate \
+                  splinter cert generate \
                   --common-name bubba \
                   --cert-dir /config/certs/ \
                   --force \

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -78,6 +78,4 @@ RUN unzip -oj scar.zip \
  && rm scar.zip xo_*.scar \
  && mv xo-tp-rust.wasm /var/lib/gameroomd/xo-tp-rust.wasm
 
-USER gameroomd
-
 CMD ["gameroomd"]

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -36,8 +36,6 @@ services:
                 -d /key_registry \
                 --force
             fi
-            # group 101 is "splinterd" in the splinterd images
-            chown root:101 /key_registry/*
           "
 
     db-acme:
@@ -117,7 +115,7 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          sudo splinter cert generate --skip && \
+          splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
@@ -203,7 +201,7 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          sudo splinter cert generate --skip && \
+          splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -42,8 +42,6 @@ services:
                 -d /key_registry \
                 --force
             fi
-            # group 101 is "splinterd" in the splinterd images
-            chown root:101 /key_registry/*
           "
 
     db-acme:
@@ -147,7 +145,7 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          sudo splinter cert generate --skip && \
+          splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
@@ -257,7 +255,7 @@ services:
           done && \
           # Copy the generated key registry to its expected location
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
-          sudo splinter cert generate --skip && \
+          splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -100,7 +100,7 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        sudo splinter cert generate --skip && \
+        splinter cert generate --skip && \
         splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
       "
 

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
-        sudo splinter cert generate --skip &&
+        splinter cert generate --skip &&
         splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
       "
 

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -65,12 +65,6 @@ RUN apt-get update \
  && apt-get install -y -q \
     man \
     postgresql-client \
-    sudo \
  && mandb \
  && dpkg --unpack /tmp/splinter-*.deb \
  && apt-get -f -y install
-
-RUN echo "splinterd ALL = (root) NOPASSWD: /usr/bin/splinter cert generate --skip" \
-    >> /etc/sudoers.d/splinterd
-
-USER splinterd


### PR DESCRIPTION
This reverts commit 03e9bfaaba4a4070ad5060628901566ac53b57f3, reversing
changes made to 64365488347ccd206d1b1488ffe0fdbbd2514417.

This change causes problems when using Kubernetes persistent volumes, because the volumes are mounted as root:root. This is not insurmountable, but is enough of a hassle that this change is worth reverting until a good solution can be developed.