### PR TITLE
Update PUT /biome/users/{user_id} route

### DIFF
--- a/libsplinter/src/biome/credentials/store/diesel/mod.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/mod.rs
@@ -14,7 +14,7 @@
 
 pub(in crate::biome) mod models;
 mod operations;
-mod schema;
+pub(in crate::biome) mod schema;
 
 use super::{CredentialsStore, CredentialsStoreError, UserCredentials, UsernameId};
 use crate::database::ConnectionPool;

--- a/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/mod.rs
@@ -17,6 +17,8 @@ pub(super) mod insert_key;
 pub(super) mod list_keys;
 pub(super) mod remove_key;
 pub(super) mod update_key;
+#[cfg(feature = "biome-credentials")]
+pub(super) mod update_keys_and_password;
 
 pub(super) struct KeyStoreOperations<'a, C> {
     conn: &'a C,

--- a/libsplinter/src/biome/key_management/store/diesel/operations/update_keys_and_password.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/operations/update_keys_and_password.rs
@@ -1,0 +1,109 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::KeyStoreOperations;
+use crate::biome::credentials::store::diesel::schema::user_credentials;
+use crate::biome::key_management::store::diesel::models::KeyModel;
+use crate::biome::key_management::store::diesel::schema::keys;
+use crate::biome::key_management::{store::KeyStoreError, Key};
+
+use diesel::{
+    dsl::{delete, insert_into},
+    prelude::*,
+    result::{DatabaseErrorKind, Error as QueryError},
+};
+
+pub(in crate::biome::key_management) trait KeyStoreUpdateKeysAndPasswordOperation {
+    fn update_keys_and_password(
+        &self,
+        user_id: &str,
+        updated_password: &str,
+        keys: &[Key],
+    ) -> Result<(), KeyStoreError>;
+}
+
+impl<'a, C> KeyStoreUpdateKeysAndPasswordOperation for KeyStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    <C as diesel::Connection>::Backend: diesel::backend::SupportsDefaultKeyword,
+    <C as diesel::Connection>::Backend: 'static,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn update_keys_and_password(
+        &self,
+        user_id: &str,
+        updated_password: &str,
+        keys: &[Key],
+    ) -> Result<(), KeyStoreError> {
+        let replacement_keys = keys
+            .iter()
+            .map(|key| key.clone().into())
+            .collect::<Vec<KeyModel>>();
+
+        self.conn
+            .transaction::<(), _, _>(|| {
+                if let Err(err) =
+                    delete(keys::table.filter(keys::user_id.eq(user_id))).execute(self.conn)
+                {
+                    return Err(err);
+                }
+                if let Err(err) = insert_into(keys::table)
+                    .values(replacement_keys)
+                    .execute(self.conn)
+                {
+                    return Err(err);
+                }
+                if let Err(err) = diesel::update(
+                    user_credentials::table.filter(user_credentials::user_id.eq(&user_id)),
+                )
+                .set(user_credentials::password.eq(&updated_password))
+                .execute(self.conn)
+                {
+                    return Err(err);
+                }
+
+                Ok(())
+            })
+            .map_err(|err| {
+                if let QueryError::DatabaseError(db_err, _) = err {
+                    match db_err {
+                        DatabaseErrorKind::UniqueViolation => {
+                            return KeyStoreError::DuplicateKeyError(format!(
+                                "Public key for user {} is already in database",
+                                user_id
+                            ));
+                        }
+                        DatabaseErrorKind::ForeignKeyViolation => {
+                            return KeyStoreError::UserDoesNotExistError(format!(
+                                "User with ID {} does not exist in database",
+                                user_id
+                            ));
+                        }
+                        _ => {
+                            return KeyStoreError::OperationError {
+                                context: "Failed to add key".to_string(),
+                                source: Box::new(err),
+                            }
+                        }
+                    }
+                }
+                KeyStoreError::OperationError {
+                    context: "Failed to add key".to_string(),
+                    source: Box::new(err),
+                }
+            })?;
+
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "biome-credentials")]
+use super::operations::update_keys_and_password::KeyStoreUpdateKeysAndPasswordOperation as _;
 use super::operations::{
     fetch_key::KeyStoreFetchKeyOperation as _, insert_key::KeyStoreInsertKeyOperation as _,
     list_keys::KeyStoreListKeysOperation as _, list_keys::KeyStoreListKeysWithUserIDOperation as _,
@@ -72,5 +74,19 @@ impl KeyStore<Key> for PostgresKeyStore {
                 .list_keys_with_user_id(user_id),
             None => KeyStoreOperations::new(&*self.connection_pool.get()?).list_keys(),
         }
+    }
+
+    #[cfg(feature = "biome-credentials")]
+    fn update_keys_and_password(
+        &self,
+        user_id: &str,
+        updated_password: &str,
+        keys: &[Key],
+    ) -> Result<(), KeyStoreError> {
+        KeyStoreOperations::new(&*self.connection_pool.get()?).update_keys_and_password(
+            user_id,
+            updated_password,
+            keys,
+        )
     }
 }

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -67,4 +67,20 @@ pub trait KeyStore<T>: Sync + Send {
     ///
     /// * `user_id`: The ID owner of the key records to list.
     fn list_keys(&self, user_id: Option<&str>) -> Result<Vec<T>, KeyStoreError>;
+
+    #[cfg(feature = "biome-credentials")]
+    /// Updates keys and the associated user's password in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id`: The ID owner of the key records to list.
+    ///  * `updated_password` - The updated password for the user
+    ///  * `keys` - The keys to be replaced
+    ///
+    fn update_keys_and_password(
+        &self,
+        user_id: &str,
+        updated_password: &str,
+        keys: &[T],
+    ) -> Result<(), KeyStoreError>;
 }

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use super::authorize::authorize_user;
-use crate::actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
+use crate::actix_web::HttpResponse;
 use crate::biome::credentials::store::{
     diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
 };
@@ -27,8 +27,8 @@ use crate::futures::{Future, IntoFuture};
 use crate::protocol;
 use crate::rest_api::secrets::SecretManager;
 use crate::rest_api::{
-    into_bytes, sessions::default_validation, ErrorResponse, Method, ProtocolVersionRangeGuard,
-    Resource,
+    into_bytes, sessions::default_validation, ErrorResponse, HandlerFunction, Method,
+    ProtocolVersionRangeGuard, Resource,
 };
 
 /// Defines a REST endpoint to list users from the db
@@ -59,69 +59,55 @@ pub fn make_user_routes(
     credentials_store: Arc<SplinterCredentialsStore>,
     user_store: DieselUserStore,
 ) -> Resource {
-    let credentials_store_modify = credentials_store.clone();
-    let credentials_store_fetch = credentials_store;
-    let user_store_modify = user_store.clone();
-    let user_store_delete = user_store;
     Resource::build("/biome/users/{id}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_USER_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Put, move |request, payload| {
-            add_modify_user_method(
-                request,
-                payload,
-                credentials_store_modify.clone(),
-                user_store_modify.clone(),
-            )
-        })
-        .add_method(Method::Get, move |request, _| {
-            add_fetch_user_method(request, credentials_store_fetch.clone())
-        })
-        .add_method(Method::Delete, move |request, _| {
-            add_delete_user_method(
-                request,
-                rest_config.clone(),
-                secret_manager.clone(),
-                user_store_delete.clone(),
-            )
-        })
+        .add_method(
+            Method::Put,
+            add_modify_user_method(credentials_store.clone(), user_store.clone()),
+        )
+        .add_method(Method::Get, add_fetch_user_method(credentials_store))
+        .add_method(
+            Method::Delete,
+            add_delete_user_method(rest_config, secret_manager, user_store),
+        )
 }
 
 /// Defines a REST endpoint to fetch a user from the database
 /// returns the user's ID and username
-fn add_fetch_user_method(
-    request: HttpRequest,
-    credentials_store: Arc<SplinterCredentialsStore>,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let user_id = if let Some(t) = request.match_info().get("id") {
-        t.to_string()
-    } else {
-        return Box::new(
-            HttpResponse::BadRequest()
-                .json(ErrorResponse::bad_request(
-                    &"Failed to process request: no user id".to_string(),
-                ))
-                .into_future(),
-        );
-    };
-    Box::new(match credentials_store.fetch_username_by_id(&user_id) {
-        Ok(user) => HttpResponse::Ok().json(user).into_future(),
-        Err(err) => {
-            debug!("Failed to get user from the database {}", err);
-            match err {
-                CredentialsStoreError::NotFoundError(_) => HttpResponse::NotFound()
-                    .json(ErrorResponse::not_found(&format!(
-                        "User ID not found: {}",
-                        &user_id
-                    )))
+fn add_fetch_user_method(credentials_store: Arc<SplinterCredentialsStore>) -> HandlerFunction {
+    Box::new(move |request, _| {
+        let credentials_store = credentials_store.clone();
+        let user_id = if let Some(t) = request.match_info().get("id") {
+            t.to_string()
+        } else {
+            return Box::new(
+                HttpResponse::BadRequest()
+                    .json(ErrorResponse::bad_request(
+                        &"Failed to process request: no user id".to_string(),
+                    ))
                     .into_future(),
-                _ => HttpResponse::InternalServerError()
-                    .json(ErrorResponse::internal_error())
-                    .into_future(),
+            );
+        };
+        Box::new(match credentials_store.fetch_username_by_id(&user_id) {
+            Ok(user) => HttpResponse::Ok().json(user).into_future(),
+            Err(err) => {
+                debug!("Failed to get user from the database {}", err);
+                match err {
+                    CredentialsStoreError::NotFoundError(_) => HttpResponse::NotFound()
+                        .json(ErrorResponse::not_found(&format!(
+                            "User ID not found: {}",
+                            &user_id
+                        )))
+                        .into_future(),
+                    _ => HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                }
             }
-        }
+        })
     })
 }
 
@@ -134,193 +120,183 @@ fn add_fetch_user_method(
 ///       "new_password": OPTIONAL <hash of the user's updated password>
 ///   }
 fn add_modify_user_method(
-    request: HttpRequest,
-    payload: Payload,
     credentials_store: Arc<SplinterCredentialsStore>,
-    mut user_store: DieselUserStore,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let user_id = if let Some(t) = request.match_info().get("id") {
-        t.to_string()
-    } else {
-        return Box::new(
-            HttpResponse::BadRequest()
-                .json(ErrorResponse::bad_request(
-                    &"Failed to parse payload: no user id".to_string(),
-                ))
-                .into_future(),
-        );
-    };
-    Box::new(into_bytes(payload).and_then(move |bytes| {
-        let body = match serde_json::from_slice::<serde_json::Value>(&bytes) {
-            Ok(val) => val,
-            Err(err) => {
-                debug!("Error parsing request body {}", err);
-                return HttpResponse::BadRequest()
-                    .json(ErrorResponse::bad_request(&format!(
-                        "Failed to parse payload body: {}",
-                        err
-                    )))
-                    .into_future();
-            }
+    user_store: DieselUserStore,
+) -> HandlerFunction {
+    Box::new(move |request, payload| {
+        let credentials_store = credentials_store.clone();
+        let mut user_store = user_store.clone();
+        let user_id = if let Some(t) = request.match_info().get("id") {
+            t.to_string()
+        } else {
+            return Box::new(
+                HttpResponse::BadRequest()
+                    .json(ErrorResponse::bad_request(
+                        &"Failed to parse payload: no user id".to_string(),
+                    ))
+                    .into_future(),
+            );
         };
-        let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
-            Ok(val) => val,
-            Err(err) => {
-                debug!("Error parsing payload {}", err);
-                return HttpResponse::BadRequest()
-                    .json(ErrorResponse::bad_request(&format!(
-                        "Failed to parse payload: {}",
-                        err
-                    )))
-                    .into_future();
-            }
-        };
-
-        let credentials =
-            match credentials_store.fetch_credential_by_username(&username_password.username) {
-                Ok(credentials) => credentials,
+        Box::new(into_bytes(payload).and_then(move |bytes| {
+            let body = match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Ok(val) => val,
                 Err(err) => {
-                    debug!("Failed to fetch credentials {}", err);
-                    match err {
-                        CredentialsStoreError::NotFoundError(_) => {
-                            return HttpResponse::NotFound()
-                                .json(ErrorResponse::not_found(&format!(
-                                    "Username not found: {}",
-                                    username_password.username
-                                )))
-                                .into_future();
-                        }
-                        _ => {
-                            return HttpResponse::InternalServerError()
-                                .json(ErrorResponse::internal_error())
-                                .into_future()
-                        }
-                    }
+                    debug!("Error parsing request body {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload body: {}",
+                            err
+                        )))
+                        .into_future();
                 }
             };
-        let splinter_user = User::new(&user_id);
-        match credentials.verify_password(&username_password.hashed_password) {
-            Ok(is_valid) => {
-                if is_valid {
-                    let new_password = match body.get("new_password") {
-                        Some(val) => match val.as_str() {
-                            Some(val) => val,
-                            None => &username_password.hashed_password,
-                        },
-                        None => &username_password.hashed_password,
-                    };
+            let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload: {}",
+                            err
+                        )))
+                        .into_future();
+                }
+            };
 
-                    match user_store.update_user(splinter_user) {
-                        Ok(()) => {
-                            match credentials_store.update_credentials(
-                                &user_id,
-                                &username_password.username,
-                                &new_password,
-                            ) {
-                                Ok(()) => HttpResponse::Ok()
-                                    .json(json!({ "message": "User updated successfully" }))
-                                    .into_future(),
-                                Err(err) => {
-                                    debug!("Failed to update credentials in database {}", err);
-                                    match err {
-                                        CredentialsStoreError::DuplicateError(err) => {
-                                            HttpResponse::BadRequest()
-                                                .json(ErrorResponse::bad_request(&format!(
-                                                    "Failed to update user: {}",
-                                                    err
-                                                )))
-                                                .into_future()
+            let credentials =
+                match credentials_store.fetch_credential_by_username(&username_password.username) {
+                    Ok(credentials) => credentials,
+                    Err(err) => {
+                        debug!("Failed to fetch credentials {}", err);
+                        match err {
+                            CredentialsStoreError::NotFoundError(_) => {
+                                return HttpResponse::NotFound()
+                                    .json(ErrorResponse::not_found(&format!(
+                                        "Username not found: {}",
+                                        username_password.username
+                                    )))
+                                    .into_future();
+                            }
+                            _ => {
+                                return HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future()
+                            }
+                        }
+                    }
+                };
+            let splinter_user = User::new(&user_id);
+            match credentials.verify_password(&username_password.hashed_password) {
+                Ok(is_valid) => {
+                    if is_valid {
+                        let new_password = match body.get("new_password") {
+                            Some(val) => match val.as_str() {
+                                Some(val) => val,
+                                None => &username_password.hashed_password,
+                            },
+                            None => &username_password.hashed_password,
+                        };
+
+                        match user_store.update_user(splinter_user) {
+                            Ok(()) => {
+                                match credentials_store.update_credentials(
+                                    &user_id,
+                                    &username_password.username,
+                                    &new_password,
+                                ) {
+                                    Ok(()) => HttpResponse::Ok()
+                                        .json(json!({ "message": "User updated successfully" }))
+                                        .into_future(),
+                                    Err(err) => {
+                                        debug!("Failed to update credentials in database {}", err);
+                                        match err {
+                                            CredentialsStoreError::DuplicateError(err) => {
+                                                HttpResponse::BadRequest()
+                                                    .json(ErrorResponse::bad_request(&format!(
+                                                        "Failed to update user: {}",
+                                                        err
+                                                    )))
+                                                    .into_future()
+                                            }
+                                            _ => HttpResponse::InternalServerError()
+                                                .json(ErrorResponse::internal_error())
+                                                .into_future(),
                                         }
-                                        _ => HttpResponse::InternalServerError()
-                                            .json(ErrorResponse::internal_error())
-                                            .into_future(),
                                     }
                                 }
                             }
+                            Err(err) => {
+                                debug!("Failed to update user in database {}", err);
+                                HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future()
+                            }
                         }
-                        Err(err) => {
-                            debug!("Failed to update user in database {}", err);
-                            HttpResponse::InternalServerError()
-                                .json(ErrorResponse::internal_error())
-                                .into_future()
-                        }
+                    } else {
+                        HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request("Invalid password"))
+                            .into_future()
                     }
-                } else {
-                    HttpResponse::BadRequest()
-                        .json(ErrorResponse::bad_request("Invalid password"))
+                }
+                Err(err) => {
+                    debug!("Failed to verify password {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
                         .into_future()
                 }
             }
-            Err(err) => {
-                debug!("Failed to verify password {}", err);
-                HttpResponse::InternalServerError()
-                    .json(ErrorResponse::internal_error())
-                    .into_future()
-            }
-        }
-    }))
+        }))
+    })
 }
 
 /// Defines a REST endpoint to delete a user from the database
 fn add_delete_user_method(
-    request: HttpRequest,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
-    mut user_store: DieselUserStore,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let validation = default_validation(&rest_config.issuer());
-    let user_id = if let Some(t) = request.match_info().get("id") {
-        t.to_string()
-    } else {
-        return Box::new(
-            HttpResponse::BadRequest()
-                .json(ErrorResponse::bad_request(
-                    &"Failed to parse payload: no user id".to_string(),
-                ))
+    user_store: DieselUserStore,
+) -> HandlerFunction {
+    Box::new(move |request, _| {
+        let mut user_store = user_store.clone();
+        let validation = default_validation(&rest_config.issuer());
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
+            AuthorizationResult::Unauthorized(msg) => {
+                return Box::new(
+                    HttpResponse::Unauthorized()
+                        .json(ErrorResponse::unauthorized(&msg))
+                        .into_future(),
+                )
+            }
+            AuthorizationResult::Failed => {
+                return Box::new(
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                );
+            }
+        };
+
+        Box::new(match user_store.remove_user(&user_id) {
+            Ok(()) => HttpResponse::Ok()
+                .json(json!({ "message": "User deleted sucessfully" }))
                 .into_future(),
-        );
-    };
-    match authorize_user(&request, &secret_manager, &validation) {
-        AuthorizationResult::Authorized(_) => match user_store.remove_user(&user_id) {
-            Ok(()) => Box::new(
-                HttpResponse::Ok()
-                    .json(json!({ "message": "User deleted sucessfully" }))
-                    .into_future(),
-            ),
             Err(err) => match err {
                 UserStoreError::NotFoundError(msg) => {
                     debug!("User not found: {}", msg);
-                    Box::new(
-                        HttpResponse::NotFound()
-                            .json(ErrorResponse::not_found(&format!(
-                                "User ID not found: {}",
-                                &user_id
-                            )))
-                            .into_future(),
-                    )
+                    HttpResponse::NotFound()
+                        .json(ErrorResponse::not_found(&format!(
+                            "User ID not found: {}",
+                            &user_id
+                        )))
+                        .into_future()
                 }
                 _ => {
                     error!("Failed to delete user in database {}", err);
-                    Box::new(
-                        HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error())
-                            .into_future(),
-                    )
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
                 }
             },
-        },
-        AuthorizationResult::Unauthorized(msg) => Box::new(
-            HttpResponse::Unauthorized()
-                .json(ErrorResponse::unauthorized(&msg))
-                .into_future(),
-        ),
-        AuthorizationResult::Failed => {
-            error!("Failed to authorize user");
-            Box::new(
-                HttpResponse::InternalServerError()
-                    .json(ErrorResponse::internal_error())
-                    .into_future(),
-            )
-        }
-    }
+        })
+    })
 }

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -83,14 +83,17 @@ use self::actix::register::make_register_route;
 use self::actix::token::make_token_route;
 #[cfg(all(
     feature = "biome-credentials",
+    feature = "biome-key-management",
     feature = "rest-api-actix",
     feature = "json-web-tokens"
 ))]
-use self::actix::{
-    login::make_login_route,
-    user::{make_list_route, make_user_routes},
-    verify::make_verify_route,
-};
+use self::actix::user::make_user_routes;
+#[cfg(all(
+    feature = "biome-credentials",
+    feature = "rest-api-actix",
+    feature = "json-web-tokens"
+))]
+use self::actix::{login::make_login_route, user::make_list_route, verify::make_verify_route};
 #[cfg(feature = "biome-credentials")]
 use super::credentials::store::diesel::SplinterCredentialsStore;
 
@@ -133,12 +136,6 @@ impl RestResourceProvider for BiomeRestResourceManager {
                     feature = "rest-api-actix",
                 ))]
                 {
-                    resources.push(make_user_routes(
-                        self.rest_config.clone(),
-                        self.token_secret_manager.clone(),
-                        credentials_store.clone(),
-                        self.user_store.clone(),
-                    ));
                     resources.push(make_list_route(credentials_store.clone()));
                     resources.push(make_verify_route(
                         credentials_store.clone(),
@@ -153,6 +150,21 @@ impl RestResourceProvider for BiomeRestResourceManager {
                             Arc::new(AccessTokenIssuer::new(self.token_secret_manager.clone())),
                         ));
                     }
+                }
+                #[cfg(all(
+                    feature = "biome-credentials",
+                    feature = "biome-key-management",
+                    feature = "json-web-tokens",
+                    feature = "rest-api-actix",
+                ))]
+                {
+                    resources.push(make_user_routes(
+                        self.rest_config.clone(),
+                        self.token_secret_manager.clone(),
+                        credentials_store.clone(),
+                        self.user_store.clone(),
+                        self.key_store.clone(),
+                    ));
                 }
                 #[cfg(all(
                     feature = "biome-credentials",

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1144,9 +1144,16 @@ paths:
                 new_password:
                   description: |
                     Hash of the new password to be used for user authentication
+                new_key_pairs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BiomeNewUserKey'
               required:
                 - username
                 - hashed_password
+                - display_name
+                - public_key
+                - encrypted_private_key
               example:
                 username: alice@acme.com
                 hashed_password: |-
@@ -1161,9 +1168,19 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "User updated successfully"
+                    example: "Credentials and key updated successfully"
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BiomeUserKey'
         400:
           description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: Unauthorized request
           content:
             application/json:
                 schema:
@@ -1806,6 +1823,23 @@ components:
           type: string
           description: "Internal unique identifier for the user"
           example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+
+    BiomeNewUserKey:
+      type: object
+      properties:
+        display_name:
+          type: string
+          description: "Display name for key"
+          example: "Biome Admin Key"
+        encrypted_private_key:
+          type: string
+          description: "Encrypted private key"
+          example: "XNzIjoic2VsZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_x\
+            riYX7qryl08ZEp86t5HD_AEVPEUXY70Ehc"
+        public_key:
+          type: string
+          description: "Public key"
+          example: "026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118"
 
     BiomeCredentials:
       type: object


### PR DESCRIPTION
Adds functionality to the existing PUT /biome/users/{user_id} endpoint to update the keys object, as well as the user's password. Also changes the formats to the /biome/users/{user_id} routes so that the closure is handled in the handler function, rather than the function which makes the user routes. 

