### PR TITLE
Compartmentalize actix, pt 1

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -34,7 +34,7 @@ pub fn make_list_circuits_resource<T: CircuitStore + 'static>(store: T) -> Resou
             protocol::ADMIN_LIST_CIRCUITS_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |r, _| {
+        .add_method(Method::Get, move |r| {
             list_circuits(r, web::Data::new(store.clone()))
         })
 }

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -31,7 +31,7 @@ pub fn make_fetch_circuit_resource<T: CircuitStore + 'static>(store: T) -> Resou
             protocol::ADMIN_FETCH_CIRCUIT_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |r, _| {
+        .add_method(Method::Get, move |r| {
             fetch_circuit(r, web::Data::new(store.clone()))
         })
 }

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -15,12 +15,12 @@
 //! This module provides the `GET /admin/circuits/{circuit_id} endpoint for fetching the
 //! definition of a circuit in Splinter's state by its circuit ID.
 
-use actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
+use actix_web::{error::BlockingError, web, Error, HttpResponse};
 use futures::Future;
 
 use crate::circuit::store::CircuitStore;
 use crate::protocol;
-use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Request, Resource};
 
 use super::super::error::CircuitFetchError;
 use super::super::resources::circuits_circuit_id::CircuitResponse;
@@ -37,12 +37,11 @@ pub fn make_fetch_circuit_resource<T: CircuitStore + 'static>(store: T) -> Resou
 }
 
 fn fetch_circuit<T: CircuitStore + 'static>(
-    request: HttpRequest,
+    request: Request,
     store: web::Data<T>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let circuit_id = request
-        .match_info()
-        .get("circuit_id")
+        .path_parameter("circuit_id")
         .unwrap_or("")
         .to_string();
     Box::new(

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -30,7 +30,7 @@ pub fn make_list_proposals_resource<PS: ProposalStore + 'static>(proposal_store:
             protocol::ADMIN_LIST_PROPOSALS_PROTOCOL_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |r, _| {
+        .add_method(Method::Get, move |r| {
             list_proposals(r, web::Data::new(proposal_store.clone()))
         })
 }

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -15,13 +15,13 @@
 //! Provides the `GET /admin/proposals/{circuit_id} endpoint for fetching circuit proposals by
 //! circuit ID.
 
-use actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
+use actix_web::{error::BlockingError, web, Error, HttpResponse};
 use futures::Future;
 
 use crate::admin::rest_api::error::ProposalFetchError;
 use crate::admin::service::proposal_store::ProposalStore;
 use crate::protocol;
-use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Request, Resource};
 
 use super::super::resources::proposals_circuit_id::ProposalResponse;
 
@@ -37,12 +37,11 @@ pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store:
 }
 
 fn fetch_proposal<PS: ProposalStore + 'static>(
-    request: HttpRequest,
+    request: Request,
     proposal_store: web::Data<PS>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let circuit_id = request
-        .match_info()
-        .get("circuit_id")
+        .path_parameter("circuit_id")
         .unwrap_or("")
         .to_string();
     Box::new(

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -31,7 +31,7 @@ pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store:
             protocol::ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |r, _| {
+        .add_method(Method::Get, move |r| {
             fetch_proposal(r, web::Data::new(proposal_store.clone()))
         })
 }

--- a/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
+++ b/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
@@ -31,7 +31,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
             protocol::ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |request, payload| {
+        .add_method(Method::Get, move |request| {
             let circuit_management_type = if let Some(t) = request.path_parameter("type") {
                 t.to_string()
             } else {
@@ -74,8 +74,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                 }
             };
 
-            match new_websocket_event_sender(&request, payload, Box::new(initial_events.skip(skip)))
-            {
+            match new_websocket_event_sender(&request, Box::new(initial_events.skip(skip))) {
                 Ok((sender, res)) => {
                     if let Err(err) = admin_commands.add_event_subscriber(
                         &circuit_management_type,

--- a/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
+++ b/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
@@ -21,7 +21,7 @@ use crate::admin::messages::AdminServiceEvent;
 use crate::admin::service::{AdminCommands, AdminServiceEventSubscriber, AdminSubscriberError};
 use crate::protocol;
 use crate::rest_api::{
-    new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Request, Resource,
+    new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Resource,
 };
 
 pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 'static>(
@@ -75,8 +75,8 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                 }
             };
 
-            let request = Request::from((request, payload));
-            match new_websocket_event_sender(request, Box::new(initial_events.skip(skip))) {
+            match new_websocket_event_sender(request, payload, Box::new(initial_events.skip(skip)))
+            {
                 Ok((sender, res)) => {
                     if let Err(err) = admin_commands.add_event_subscriber(
                         &circuit_management_type,

--- a/libsplinter/src/biome/rest_api/actix/authorize.rs
+++ b/libsplinter/src/biome/rest_api/actix/authorize.rs
@@ -14,37 +14,29 @@
 
 use std::sync::Arc;
 
-use crate::actix_web::HttpRequest;
 use crate::biome::rest_api::BiomeRestConfig;
 use crate::rest_api::{
     secrets::SecretManager,
     sessions::{validate_token, TokenValidationError},
+    Request,
 };
 
 use super::super::resources::authorize::AuthorizationResult;
 
 /// Verifies the user has the correct permissions
 pub(crate) fn authorize_user(
-    request: &HttpRequest,
+    request: &Request,
     user_id: &str,
     secret_manager: &Arc<dyn SecretManager>,
     rest_config: &BiomeRestConfig,
 ) -> AuthorizationResult {
-    let auth_token = match request.headers().get("Authorization") {
-        Some(header_value) => match header_value.to_str() {
-            Ok(header_string) => match header_string.split_whitespace().last() {
-                Some(auth_token) => auth_token.to_string(),
-                None => {
-                    return AuthorizationResult::Unauthorized(
-                        "Authorization token not included in request".into(),
-                    )
-                }
-            },
-            Err(err) => {
-                return AuthorizationResult::Unauthorized(format!(
-                    "Invalid value for 'Authorization' header: {}",
-                    err
-                ))
+    let auth_token = match request.header("Authorization") {
+        Some(header_value) => match header_value.split_whitespace().last() {
+            Some(auth_token) => auth_token.to_string(),
+            None => {
+                return AuthorizationResult::Unauthorized(
+                    "Authorization token not included in request".into(),
+                )
             }
         },
         None => {

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -73,7 +73,7 @@ fn handle_post(
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
+        let user_id = match request.path_parameter("user_id") {
             Some(id) => id.to_owned(),
             None => {
                 error!("User ID is not in path request");
@@ -155,7 +155,7 @@ fn handle_get(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
+        let user_id = match request.path_parameter("user_id") {
             Some(id) => id.to_owned(),
             None => {
                 error!("User ID is not in path request");
@@ -211,7 +211,7 @@ fn handle_patch(
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
+        let user_id = match request.path_parameter("user_id") {
             Some(id) => id.to_owned(),
             None => {
                 error!("User ID is not in path request");
@@ -312,7 +312,7 @@ fn handle_fetch(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
+        let user_id = match request.path_parameter("user_id") {
             Some(id) => id.to_owned(),
             None => {
                 error!("User ID is not in path request");
@@ -326,7 +326,7 @@ fn handle_fetch(
             }
         };
 
-        let public_key = match request.match_info().get("public_key") {
+        let public_key = match request.path_parameter("public_key") {
             Some(id) => id.to_owned(),
             None => {
                 error!("Public key is not in path request");
@@ -394,7 +394,7 @@ fn handle_delete(
 ) -> HandlerFunction {
     Box::new(move |request, _| {
         let key_store = key_store.clone();
-        let user_id = match request.match_info().get("user_id") {
+        let user_id = match request.path_parameter("user_id") {
             Some(id) => id.to_owned(),
             None => {
                 error!("User ID is not in path request");
@@ -408,7 +408,7 @@ fn handle_delete(
             }
         };
 
-        let public_key = match request.match_info().get("public_key") {
+        let public_key = match request.path_parameter("public_key") {
             Some(id) => id.to_owned(),
             None => {
                 error!("Public key is not in path request");

--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -15,9 +15,9 @@
 use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
-use crate::futures::{Future, IntoFuture};
+use crate::futures::IntoFuture;
 use crate::protocol;
-use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
 use crate::biome::credentials::store::{
     diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
@@ -44,73 +44,94 @@ pub fn make_login_route(
             protocol::BIOME_LOGIN_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Post, move |_, payload| {
+        .add_method(Method::Post, move |request| {
             let credentials_store = credentials_store.clone();
             let rest_config = rest_config.clone();
             let token_issuer = token_issuer.clone();
-            Box::new(into_bytes(payload).and_then(move |bytes| {
-                let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        debug!("Error parsing payload {}", err);
-                        return HttpResponse::BadRequest()
+
+            let username_password = match serde_json::from_slice::<UsernamePassword>(request.body())
+            {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return Box::new(
+                        HttpResponse::BadRequest()
                             .json(ErrorResponse::bad_request(&format!(
                                 "Failed to parse payload: {}",
                                 err
                             )))
-                            .into_future();
-                    }
-                };
+                            .into_future(),
+                    );
+                }
+            };
 
-                let credentials =
-                    match credentials_store.fetch_credential_by_username(&username_password.username) {
-                        Ok(credentials) => credentials,
-                        Err(err) => {
-                            debug!("Failed to fetch credentials {}", err);
-                            match err {
-                                CredentialsStoreError::NotFoundError(_) => {
-                                    return HttpResponse::BadRequest()
+            let credentials =
+                match credentials_store.fetch_credential_by_username(&username_password.username) {
+                    Ok(credentials) => credentials,
+                    Err(err) => {
+                        debug!("Failed to fetch credentials {}", err);
+                        match err {
+                            CredentialsStoreError::NotFoundError(_) => {
+                                return Box::new(
+                                    HttpResponse::BadRequest()
                                         .json(ErrorResponse::bad_request(&format!(
                                             "Username not found: {}",
                                             username_password.username
                                         )))
-                                        .into_future();
-                                }
-                                _ => {
-                                    return HttpResponse::InternalServerError()
+                                        .into_future(),
+                                );
+                            }
+                            _ => {
+                                return Box::new(
+                                    HttpResponse::InternalServerError()
                                         .json(ErrorResponse::internal_error())
-                                        .into_future()
-                                }
+                                        .into_future(),
+                                )
                             }
                         }
-                    };
+                    }
+                };
 
+            Box::new(
                 match credentials.verify_password(&username_password.hashed_password) {
                     Ok(is_valid) => {
                         if is_valid {
                             let claim_builder: ClaimsBuilder = Default::default();
-                            let claim = match claim_builder.with_user_id(&credentials.user_id)
+                            let claim = match claim_builder
+                                .with_user_id(&credentials.user_id)
                                 .with_issuer(&rest_config.issuer())
                                 .with_duration(rest_config.access_token_duration())
-                                .build() {
-                                    Ok(claim) => claim,
-                                    Err(err) => {
-                                        debug!("Failed to build claim {}", err);
-                                        return HttpResponse::InternalServerError()
+                                .build()
+                            {
+                                Ok(claim) => claim,
+                                Err(err) => {
+                                    debug!("Failed to build claim {}", err);
+                                    return Box::new(
+                                        HttpResponse::InternalServerError()
                                             .json(ErrorResponse::internal_error())
-                                            .into_future()}
-                                    };
+                                            .into_future(),
+                                    );
+                                }
+                            };
 
                             let token = match token_issuer.issue_token_with_claims(claim) {
-                                    Ok(token) => token,
-                                    Err(err) => {
-                                        debug!("Failed to issue token {}", err);
-                                        return HttpResponse::InternalServerError()
+                                Ok(token) => token,
+                                Err(err) => {
+                                    debug!("Failed to issue token {}", err);
+                                    return Box::new(
+                                        HttpResponse::InternalServerError()
                                             .json(ErrorResponse::internal_error())
-                                            .into_future()}
-                                    };
+                                            .into_future(),
+                                    );
+                                }
+                            };
+
                             HttpResponse::Ok()
-                                .json(json!({ "message": "Successful login", "user_id": credentials.user_id ,"token": token  }))
+                                .json(json!({
+                                    "message": "Successful login",
+                                    "user_id": credentials.user_id,
+                                    "token": token
+                                }))
                                 .into_future()
                         } else {
                             HttpResponse::BadRequest()
@@ -124,7 +145,7 @@ pub fn make_login_route(
                             .json(ErrorResponse::internal_error())
                             .into_future()
                     }
-                }
-            }))
+                },
+            )
         })
 }

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -16,9 +16,9 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::actix_web::HttpResponse;
-use crate::futures::{Future, IntoFuture};
+use crate::futures::IntoFuture;
 use crate::protocol;
-use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
 use crate::biome::credentials::store::{
     diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
@@ -46,82 +46,88 @@ pub fn make_register_route(
             protocol::BIOME_REGISTER_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Post, move |_, payload| {
+        .add_method(Method::Post, move |request| {
             let credentials_store = credentials_store.clone();
             let mut user_store = user_store.clone();
             let rest_config = rest_config.clone();
-            Box::new(into_bytes(payload).and_then(move |bytes| {
-                let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        debug!("Error parsing payload {}", err);
-                        return HttpResponse::BadRequest()
+
+            let username_password = match serde_json::from_slice::<UsernamePassword>(request.body())
+            {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return Box::new(
+                        HttpResponse::BadRequest()
                             .json(ErrorResponse::bad_request(&format!(
                                 "Failed to parse payload: {}",
                                 err
                             )))
-                            .into_future();
-                    }
-                };
-                let user_id = Uuid::new_v4().to_string();
-                let splinter_user = SplinterUser::new(&user_id);
-                match user_store.add_user(splinter_user) {
-                    Ok(()) => {
-                        let credentials_builder: UserCredentialsBuilder = Default::default();
-                        let credentials = match credentials_builder
-                            .with_user_id(&user_id)
-                            .with_username(&username_password.username)
-                            .with_password(&username_password.hashed_password)
-                            .with_password_encryption_cost(rest_config.password_encryption_cost())
-                            .build()
-                        {
-                            Ok(credential) => credential,
-                            Err(err) => {
-                                debug!("Failed to create credentials {}", err);
-                                return HttpResponse::InternalServerError()
-                                    .json(ErrorResponse::internal_error())
-                                    .into_future();
-                            }
-                        };
+                            .into_future(),
+                    );
+                }
+            };
 
-                        match credentials_store.add_credentials(credentials) {
-                            Ok(()) => {
-                                let new_user = NewUser {
-                                    user_id: &user_id,
-                                    username: &username_password.username,
-                                };
-                                HttpResponse::Ok()
-                                    .json(json!({
-                                        "message": "User created successfully",
-                                        "data": new_user,
-                                    }))
-                                    .into_future()
-                            }
-                            Err(err) => {
-                                debug!("Failed to add new credentials to database {}", err);
-                                match err {
-                                    CredentialsStoreError::DuplicateError(err) => {
-                                        HttpResponse::BadRequest()
-                                            .json(ErrorResponse::bad_request(&format!(
-                                                "Failed to create user: {}",
-                                                err
-                                            )))
-                                            .into_future()
-                                    }
-                                    _ => HttpResponse::InternalServerError()
-                                        .json(ErrorResponse::internal_error())
-                                        .into_future(),
+            let user_id = Uuid::new_v4().to_string();
+            let splinter_user = SplinterUser::new(&user_id);
+
+            Box::new(match user_store.add_user(splinter_user) {
+                Ok(()) => {
+                    let credentials_builder: UserCredentialsBuilder = Default::default();
+                    let credentials = match credentials_builder
+                        .with_user_id(&user_id)
+                        .with_username(&username_password.username)
+                        .with_password(&username_password.hashed_password)
+                        .with_password_encryption_cost(rest_config.password_encryption_cost())
+                        .build()
+                    {
+                        Ok(credential) => credential,
+                        Err(err) => {
+                            debug!("Failed to create credentials {}", err);
+                            return Box::new(
+                                HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future(),
+                            );
+                        }
+                    };
+
+                    match credentials_store.add_credentials(credentials) {
+                        Ok(()) => {
+                            let new_user = NewUser {
+                                user_id: &user_id,
+                                username: &username_password.username,
+                            };
+                            HttpResponse::Ok()
+                                .json(json!({
+                                    "message": "User created successfully",
+                                    "data": new_user,
+                                }))
+                                .into_future()
+                        }
+                        Err(err) => {
+                            debug!("Failed to add new credentials to database {}", err);
+                            match err {
+                                CredentialsStoreError::DuplicateError(err) => {
+                                    HttpResponse::BadRequest()
+                                        .json(ErrorResponse::bad_request(&format!(
+                                            "Failed to create user: {}",
+                                            err
+                                        )))
+                                        .into_future()
                                 }
+                                _ => HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future(),
                             }
                         }
                     }
-                    Err(err) => {
-                        debug!("Failed to add new user to database {}", err);
-                        HttpResponse::InternalServerError()
-                            .json(ErrorResponse::internal_error())
-                            .into_future()
-                    }
                 }
-            }))
+                Err(err) => {
+                    debug!("Failed to add new user to database {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            })
         })
 }

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -14,10 +14,12 @@
 
 use std::sync::Arc;
 
-use crate::actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
+use crate::actix_web::{web::Payload, Error, HttpResponse};
 use crate::futures::{Future, IntoFuture};
 use crate::protocol;
-use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{
+    into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Request, Resource,
+};
 
 use crate::biome::credentials::store::{
     diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
@@ -93,10 +95,10 @@ pub fn make_user_routes(
 /// Defines a REST endpoint to fetch a user from the database
 /// returns the user's ID and username
 fn add_fetch_user_method(
-    request: HttpRequest,
+    request: Request,
     credentials_store: Arc<SplinterCredentialsStore>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let user_id = if let Some(t) = request.match_info().get("id") {
+    let user_id = if let Some(t) = request.path_parameter("id") {
         t.to_string()
     } else {
         return Box::new(
@@ -135,12 +137,12 @@ fn add_fetch_user_method(
 ///       "new_password": OPTIONAL <hash of the user's updated password>
 ///   }
 fn add_modify_user_method(
-    request: HttpRequest,
+    request: Request,
     payload: Payload,
     credentials_store: Arc<SplinterCredentialsStore>,
     mut user_store: SplinterUserStore,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let user_id = if let Some(t) = request.match_info().get("id") {
+    let user_id = if let Some(t) = request.path_parameter("id") {
         t.to_string()
     } else {
         return Box::new(
@@ -264,12 +266,12 @@ fn add_modify_user_method(
 
 /// Defines a REST endpoint to delete a user from the database
 fn add_delete_user_method(
-    request: HttpRequest,
+    request: Request,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
     mut user_store: SplinterUserStore,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
-    let user_id = if let Some(t) = request.match_info().get("id") {
+    let user_id = if let Some(t) = request.path_parameter("id") {
         t.to_string()
     } else {
         return Box::new(

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -148,7 +148,7 @@ fn add_modify_user_method(
         return Box::new(
             HttpResponse::BadRequest()
                 .json(ErrorResponse::bad_request(
-                    &"Failed to parse payload: no user id".to_string(),
+                    &"Failed to parse request: no user id".to_string(),
                 ))
                 .into_future(),
         );
@@ -277,7 +277,7 @@ fn add_delete_user_method(
         return Box::new(
             HttpResponse::BadRequest()
                 .json(ErrorResponse::bad_request(
-                    &"Failed to parse payload: no user id".to_string(),
+                    &"Failed to parse request: no user id".to_string(),
                 ))
                 .into_future(),
         );

--- a/libsplinter/src/biome/rest_api/actix/verify.rs
+++ b/libsplinter/src/biome/rest_api/actix/verify.rs
@@ -15,10 +15,10 @@
 use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
-use crate::futures::{Future, IntoFuture};
+use crate::futures::IntoFuture;
 use crate::protocol;
 use crate::rest_api::secrets::SecretManager;
-use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
 use crate::biome::credentials::store::{
     diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
@@ -46,61 +46,73 @@ pub fn make_verify_route(
             protocol::BIOME_VERIFY_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Post, move |request, payload| {
+        .add_method(Method::Post, move |request| {
             let credentials_store = credentials_store.clone();
             let rest_config = rest_config.clone();
             let secret_manager = secret_manager.clone();
-            Box::new(into_bytes(payload).and_then(move |bytes| {
-                let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
-                    Ok(val) => val,
-                    Err(err) => {
-                        debug!("Error parsing payload: {}", err);
-                        return HttpResponse::BadRequest()
+
+            let username_password = match serde_json::from_slice::<UsernamePassword>(request.body())
+            {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload: {}", err);
+                    return Box::new(
+                        HttpResponse::BadRequest()
                             .json(ErrorResponse::bad_request(&format!(
                                 "Failed to parse payload: {}",
                                 err
                             )))
-                            .into_future();
-                    }
-                };
+                            .into_future(),
+                    );
+                }
+            };
 
-                let credentials =
-                    match credentials_store.fetch_credential_by_username(&username_password.username) {
-                        Ok(credentials) => credentials,
-                        Err(err) => {
-                            debug!("Failed to fetch credentials: {}", err);
-                            match err {
-                                CredentialsStoreError::NotFoundError(_) => {
-                                    return HttpResponse::BadRequest()
+            let credentials =
+                match credentials_store.fetch_credential_by_username(&username_password.username) {
+                    Ok(credentials) => credentials,
+                    Err(err) => {
+                        debug!("Failed to fetch credentials: {}", err);
+                        match err {
+                            CredentialsStoreError::NotFoundError(_) => {
+                                return Box::new(
+                                    HttpResponse::BadRequest()
                                         .json(ErrorResponse::bad_request(&format!(
                                             "Username not found: {}",
                                             username_password.username
                                         )))
-                                        .into_future()
-                                }
-                                _ => {
-                                    error!("Failed to fetch credentials: {}", err);
-                                    return HttpResponse::InternalServerError()
+                                        .into_future(),
+                                )
+                            }
+                            _ => {
+                                error!("Failed to fetch credentials: {}", err);
+                                return Box::new(
+                                    HttpResponse::InternalServerError()
                                         .json(ErrorResponse::internal_error())
-                                        .into_future()
-                                }
+                                        .into_future(),
+                                );
                             }
                         }
-                    };
+                    }
+                };
 
-                match authorize_user(&request, &credentials.user_id, &secret_manager, &rest_config) {
+            Box::new(
+                match authorize_user(
+                    &request,
+                    &credentials.user_id,
+                    &secret_manager,
+                    &rest_config,
+                ) {
                     AuthorizationResult::Authorized => {
                         match credentials.verify_password(&username_password.hashed_password) {
-                            Ok(true) => {
-                                    HttpResponse::Ok()
-                                        .json(json!({ "message": "Successful verification", "user_id": credentials.user_id }))
-                                        .into_future()
-                                    }
-                            Ok(false) => {
-                                HttpResponse::BadRequest()
-                                    .json(ErrorResponse::bad_request("Invalid password"))
-                                    .into_future()
-                            }
+                            Ok(true) => HttpResponse::Ok()
+                                .json(json!({
+                                    "message": "Successful verification",
+                                    "user_id": credentials.user_id
+                                }))
+                                .into_future(),
+                            Ok(false) => HttpResponse::BadRequest()
+                                .json(ErrorResponse::bad_request("Invalid password"))
+                                .into_future(),
                             Err(err) => {
                                 error!("Failed to verify password: {}", err);
                                 HttpResponse::InternalServerError()
@@ -109,18 +121,16 @@ pub fn make_verify_route(
                             }
                         }
                     }
-                    AuthorizationResult::Unauthorized(msg) => {
-                        HttpResponse::Unauthorized()
-                                .json(ErrorResponse::unauthorized(&msg))
-                                .into_future()
-                    }
+                    AuthorizationResult::Unauthorized(msg) => HttpResponse::Unauthorized()
+                        .json(ErrorResponse::unauthorized(&msg))
+                        .into_future(),
                     AuthorizationResult::Failed => {
                         error!("Failed to authorize user");
-                            HttpResponse::InternalServerError()
-                                .json(ErrorResponse::internal_error())
-                                .into_future()
+                        HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future()
                     }
-                }
-            }))
+                },
+            )
         })
 }

--- a/libsplinter/src/keys/rest_api.rs
+++ b/libsplinter/src/keys/rest_api.rs
@@ -83,7 +83,7 @@ fn make_fetch_key_resource(key_registry: Box<dyn KeyRegistry>) -> Resource {
             protocol::ADMIN_FETCH_KEY_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |req, _| {
+        .add_method(Method::Get, move |req| {
             let public_key = match parse_hex(req.path_parameter("public_key").unwrap_or("")) {
                 Ok(public_key) => public_key,
                 Err(err_msg) => {
@@ -118,7 +118,7 @@ fn make_list_key_resources(key_registry: Box<dyn KeyRegistry>) -> Resource {
             protocol::ADMIN_LIST_KEYS_MIN,
             protocol::ADMIN_PROTOCOL_VERSION,
         ))
-        .add_method(Method::Get, move |req, _| {
+        .add_method(Method::Get, move |req| {
             let offset = match req.query_parameter("offset") {
                 Some(value) => match value.parse::<usize>() {
                     Ok(val) => val,

--- a/libsplinter/src/orchestrator/rest_api.rs
+++ b/libsplinter/src/orchestrator/rest_api.rs
@@ -44,14 +44,10 @@ impl RestResourceProvider for ServiceOrchestrator {
                         let service_type = endpoint.service_type;
                         let handler = endpoint.handler;
                         resource_builder.add_method(endpoint.method, move |request, payload| {
-                            let circuit = request
-                                .match_info()
-                                .get("circuit")
-                                .unwrap_or("")
-                                .to_string();
+                            let circuit =
+                                request.path_parameter("circuit").unwrap_or("").to_string();
                             let service_id = request
-                                .match_info()
-                                .get("service_id")
+                                .path_parameter("service_id")
                                 .unwrap_or("")
                                 .to_string();
 

--- a/libsplinter/src/orchestrator/rest_api.rs
+++ b/libsplinter/src/orchestrator/rest_api.rs
@@ -43,7 +43,7 @@ impl RestResourceProvider for ServiceOrchestrator {
 
                         let service_type = endpoint.service_type;
                         let handler = endpoint.handler;
-                        resource_builder.add_method(endpoint.method, move |request, payload| {
+                        resource_builder.add_method(endpoint.method, move |request| {
                             let circuit =
                                 request.path_parameter("circuit").unwrap_or("").to_string();
                             let service_id = request
@@ -94,7 +94,7 @@ impl RestResourceProvider for ServiceOrchestrator {
                                     }
                                 };
 
-                            handler(request, payload, service)
+                            handler(request, service)
                         })
                     })
                     .collect::<Vec<_>>();

--- a/libsplinter/src/rest_api/actix_impl.rs
+++ b/libsplinter/src/rest_api/actix_impl.rs
@@ -1,0 +1,112 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Actix implemenation of the splinter REST API.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use actix_http::Payload;
+use actix_web::{web::Query, FromRequest, HttpRequest, ResponseError};
+
+use super::{Request, RequestBuilder};
+
+impl FromRequest for Request {
+    type Error = RequestConversionError;
+    type Future = Result<Self, Self::Error>;
+    type Config = ();
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let path = req.path().to_string();
+
+        let headers = req
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                let header_name = name.as_str().to_string();
+                let header_value = value
+                    .to_str()
+                    .map_err(|err| {
+                        RequestConversionError::new_with_source(
+                            &format!("Value of header '{}' is not valid", header_name),
+                            err.into(),
+                        )
+                    })?
+                    .to_string();
+                Ok((header_name, header_value))
+            })
+            .collect::<Result<_, _>>()?;
+
+        let path_parameters = req
+            .match_info()
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect();
+
+        let query_parameters = Query::<BTreeMap<String, String>>::from_query(req.query_string())
+            .map(Query::into_inner)
+            .map_err(|err| RequestConversionError::new(&format!("Query is invalid: {}", err)))?;
+
+        RequestBuilder::new()
+            .with_path(path)
+            .with_headers(headers)
+            .with_path_parameters(path_parameters)
+            .with_query_parameters(query_parameters)
+            .with_actix_request(req.clone())
+            .build()
+            .map_err(|err| {
+                RequestConversionError::new_with_source("Failed to convert request", err.into())
+            })
+    }
+}
+
+#[derive(Debug)]
+pub struct RequestConversionError {
+    context: String,
+    source: Option<Box<dyn Error>>,
+}
+
+impl RequestConversionError {
+    pub fn new(context: &str) -> Self {
+        Self {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn new_with_source(context: &str, err: Box<dyn Error>) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(err),
+        }
+    }
+}
+
+impl Error for RequestConversionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(|err| &**err)
+    }
+}
+
+impl fmt::Display for RequestConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.source {
+            Some(ref err) => write!(f, "{}: {}", self.context, err),
+            None => f.write_str(&self.context),
+        }
+    }
+}
+
+impl ResponseError for RequestConversionError {}

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -89,20 +89,3 @@ impl From<ActixError> for ResponseError {
         ResponseError::ActixError(err)
     }
 }
-
-#[derive(Debug)]
-pub enum RequestError {
-    MissingHeader(String),
-    InvalidHeaderValue(String),
-}
-
-impl Error for RequestError {}
-
-impl fmt::Display for RequestError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            RequestError::MissingHeader(msg) => f.write_str(&msg),
-            RequestError::InvalidHeaderValue(msg) => f.write_str(&msg),
-        }
-    }
-}

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -89,3 +89,20 @@ impl From<ActixError> for ResponseError {
         ResponseError::ActixError(err)
     }
 }
+
+#[derive(Debug)]
+pub(super) enum RequestBuilderError {
+    MissingRequiredField(String),
+}
+
+impl Error for RequestBuilderError {}
+
+impl fmt::Display for RequestBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RequestBuilderError::MissingRequiredField(field) => {
+                write!(f, "Required field is missing: {}", field)
+            }
+        }
+    }
+}

--- a/libsplinter/src/rest_api/events.rs
+++ b/libsplinter/src/rest_api/events.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use actix::prelude::*;
-use actix_web::{web::Payload, HttpRequest, HttpResponse};
+use actix_web::{web::Payload, HttpResponse};
 use actix_web_actors::ws::{self, CloseCode, CloseReason};
 use futures::{
     stream::{iter_ok, Stream},
@@ -25,13 +25,13 @@ use futures::{
 use serde::ser::Serialize;
 use serde_json;
 
-use crate::rest_api::errors::ResponseError;
+use super::{errors::ResponseError, Request};
 
 /// Wait time in seconds between ping messages being sent by the ws server to the ws client
 const PING_INTERVAL: u64 = 30;
 
 pub fn new_websocket_event_sender<T: Serialize + Debug>(
-    request: HttpRequest,
+    request: &Request,
     payload: Payload,
     initial_events: Box<dyn Iterator<Item = T> + Send>,
 ) -> Result<(EventSender<T>, HttpResponse), ResponseError> {
@@ -41,7 +41,7 @@ pub fn new_websocket_event_sender<T: Serialize + Debug>(
 
     let res = ws::start(
         EventSenderWebSocket::new(Box::new(stream)),
-        &request,
+        request.actix_request(),
         payload,
     )
     .map_err(ResponseError::from)?;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -66,7 +66,7 @@ use actix_web::{
     error::ErrorBadRequest, http::header, middleware, web, App, Error as ActixError, HttpRequest,
     HttpResponse, HttpServer,
 };
-use futures::{future::FutureResult, stream::Stream, Future, IntoFuture};
+use futures::{stream::Stream, Future, IntoFuture};
 use percent_encoding::{AsciiSet, CONTROLS};
 use protobuf::{self, Message};
 use std::boxed::Box;
@@ -115,44 +115,6 @@ pub struct RestApiShutdownHandle {
 impl RestApiShutdownHandle {
     pub fn shutdown(&self) -> Result<(), RestApiServerError> {
         (*self.do_shutdown)()
-    }
-}
-
-pub struct Request(HttpRequest, web::Payload);
-
-impl From<(HttpRequest, web::Payload)> for Request {
-    fn from((http_request, payload): (HttpRequest, web::Payload)) -> Self {
-        Self(http_request, payload)
-    }
-}
-
-impl Into<(HttpRequest, web::Payload)> for Request {
-    fn into(self) -> (HttpRequest, web::Payload) {
-        (self.0, self.1)
-    }
-}
-
-pub struct Response(HttpResponse);
-
-impl From<HttpResponse> for Response {
-    fn from(res: HttpResponse) -> Self {
-        Self(res)
-    }
-}
-
-impl IntoFuture for Response {
-    type Item = HttpResponse;
-    type Error = ActixError;
-    type Future = FutureResult<HttpResponse, ActixError>;
-
-    fn into_future(self) -> Self::Future {
-        self.0.into_future()
-    }
-}
-
-impl std::fmt::Debug for Response {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
     }
 }
 

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -64,7 +64,10 @@ pub mod secrets;
 #[cfg(feature = "json-web-tokens")]
 pub mod sessions;
 
+use std::boxed::Box;
 use std::collections::BTreeMap;
+use std::sync::{mpsc, Arc};
+use std::thread;
 
 #[cfg(feature = "rest-api-actix")]
 use actix_web::HttpRequest as ActixRequest;
@@ -73,9 +76,6 @@ use actix_web::{
 };
 use futures::{Future, IntoFuture};
 use percent_encoding::{AsciiSet, CONTROLS};
-use std::boxed::Box;
-use std::sync::{mpsc, Arc};
-use std::thread;
 
 use errors::RequestBuilderError;
 pub use errors::{RestApiServerError, WebSocketError};

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -78,10 +78,8 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 
 use errors::RequestBuilderError;
-pub use errors::{ResponseError, RestApiServerError};
-
+pub use errors::{RestApiServerError, WebSocketError};
 pub use events::{new_websocket_event_sender, EventSender};
-
 pub use response_models::ErrorResponse;
 
 const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -73,7 +73,7 @@ use std::boxed::Box;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-pub use errors::{RequestError, ResponseError, RestApiServerError};
+pub use errors::{ResponseError, RestApiServerError};
 
 pub use events::{new_websocket_event_sender, EventSender};
 
@@ -579,29 +579,6 @@ pub fn into_bytes(payload: web::Payload) -> impl Future<Item = Vec<u8>, Error = 
 
 pub fn percent_encode_filter_query(input: &str) -> String {
     percent_encoding::utf8_percent_encode(input, QUERY_ENCODE_SET).to_string()
-}
-
-pub fn require_header(header_key: &str, request: &HttpRequest) -> Result<String, RequestError> {
-    let header = request.headers().get(header_key).ok_or_else(|| {
-        RequestError::MissingHeader(format!("Header {} not included in Request", header_key))
-    })?;
-    Ok(header
-        .to_str()
-        .map_err(|err| RequestError::InvalidHeaderValue(format!("Invalid header value: {}", err)))?
-        .to_string())
-}
-
-pub fn get_authorization_token(request: &HttpRequest) -> Result<String, RequestError> {
-    let auth_header = require_header("Authorization", &request)?;
-    Ok(auth_header
-        .split_whitespace()
-        .last()
-        .ok_or_else(|| {
-            RequestError::InvalidHeaderValue(
-                "Authorization token not included in request".to_string(),
-            )
-        })?
-        .to_string())
 }
 
 #[cfg(test)]

--- a/libsplinter/src/service/rest_api.rs
+++ b/libsplinter/src/service/rest_api.rs
@@ -14,18 +14,14 @@
 
 use std::sync::Arc;
 
-use crate::actix_web::{web, Error as ActixError, HttpResponse};
+use crate::actix_web::{Error as ActixError, HttpResponse};
 use crate::futures::Future;
 use crate::rest_api::{Continuation, Method, Request, RequestGuard};
 
 use super::Service;
 
 type Handler = Arc<
-    dyn Fn(
-            Request,
-            web::Payload,
-            &dyn Service,
-        ) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
+    dyn Fn(Request, &dyn Service) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
         + Send
         + Sync
         + 'static,

--- a/libsplinter/src/service/rest_api.rs
+++ b/libsplinter/src/service/rest_api.rs
@@ -14,15 +14,15 @@
 
 use std::sync::Arc;
 
-use crate::actix_web::{web, Error as ActixError, HttpRequest, HttpResponse};
+use crate::actix_web::{web, Error as ActixError, HttpResponse};
 use crate::futures::Future;
-use crate::rest_api::{Continuation, Method, RequestGuard};
+use crate::rest_api::{Continuation, Method, Request, RequestGuard};
 
 use super::Service;
 
 type Handler = Arc<
     dyn Fn(
-            HttpRequest,
+            Request,
             web::Payload,
             &dyn Service,
         ) -> Box<dyn Future<Item = HttpResponse, Error = ActixError>>
@@ -62,7 +62,7 @@ impl Clone for Box<dyn ServiceRequestGuard> {
 }
 
 impl RequestGuard for Box<dyn ServiceRequestGuard> {
-    fn evaluate(&self, req: &HttpRequest) -> Continuation {
+    fn evaluate(&self, req: &Request) -> Continuation {
         (**self).evaluate(req)
     }
 }

--- a/libsplinter/src/service/scabbard/rest_api.rs
+++ b/libsplinter/src/service/scabbard/rest_api.rs
@@ -22,9 +22,7 @@ use transact::protos::FromBytes;
 use crate::actix_web::{web, Error as ActixError, HttpResponse};
 use crate::futures::{stream::Stream, Future, IntoFuture};
 use crate::protocol;
-use crate::rest_api::{
-    new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Request,
-};
+use crate::rest_api::{new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard};
 use crate::service::rest_api::ServiceEndpoint;
 
 use super::error::StateSubscriberError;
@@ -111,8 +109,7 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                 }
             };
 
-            let request = Request::from((request, payload));
-            match new_websocket_event_sender(request, Box::new(unseen_events)) {
+            match new_websocket_event_sender(request, payload, Box::new(unseen_events)) {
                 Ok((sender, res)) => {
                     if let Err(err) =
                         scabbard.add_state_subscriber(Box::new(WsStateSubscriber { sender }))

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -89,7 +89,7 @@ impl RestResourceProvider for HealthService {
 }
 
 fn make_status_resource() -> Resource {
-    Resource::build("/health/status").add_method(Method::Get, move |_, _| {
+    Resource::build("/health/status").add_method(Method::Get, move |_| {
         Box::new(HttpResponse::Ok().finish().into_future())
     })
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -396,7 +396,7 @@ impl SplinterDaemon {
                 Resource::build("/openapi.yml").add_method(Method::Get, routes::get_openapi),
             )
             .add_resource(
-                Resource::build("/status").add_method(Method::Get, move |_, _| {
+                Resource::build("/status").add_method(Method::Get, move |_| {
                     routes::get_status(node_id.clone(), service_endpoint.clone())
                 }),
             )

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -36,10 +36,7 @@ pub fn get_status(
     Box::new(HttpResponse::Ok().json(status).into_future())
 }
 
-pub fn get_openapi(
-    _: Request,
-    _: web::Payload,
-) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+pub fn get_openapi(_: Request) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     Box::new(
         HttpResponse::Ok()
             .body(include_str!("../../api/static/openapi.yml"))

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use splinter::actix_web::{web, Error, HttpRequest, HttpResponse};
+use splinter::actix_web::{Error, HttpResponse};
 use splinter::futures::{Future, IntoFuture};
+use splinter::rest_api::Request;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Status {
@@ -36,7 +37,7 @@ pub fn get_status(
 }
 
 pub fn get_openapi(
-    _: HttpRequest,
+    _: Request,
     _: web::Payload,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     Box::new(


### PR DESCRIPTION
Makes a couple major changes to the REST API infrastructure:
- Add a new `Request` struct, which is the input for resource handler methods
- Move the body of the request into the `Request` struct itself

These changes allow us to move Actix-specific code into its own module and further compartmentalize the backend Actix implementation.

This is the first part of this change; future PRs will address generalizing the responses and the REST API server itself.