### PR TITLE
 Allow specifying URL for CLI with env variable

### DIFF
--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -30,7 +30,7 @@ use crate::error::CliError;
 #[cfg(feature = "circuit-template")]
 use crate::template::CircuitTemplate;
 
-use super::{Action, DEFAULT_ENDPOINT, SPLINTER_REST_API_URL_ENV};
+use super::{Action, DEFAULT_SPLINTER_REST_API_URL, SPLINTER_REST_API_URL_ENV};
 
 use builder::CreateCircuitMessageBuilder;
 
@@ -43,7 +43,7 @@ impl Action for CircuitCreateAction {
             .value_of("url")
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
         let key = args.value_of("key").unwrap_or("./splinter.priv");
 
         let mut builder = CreateCircuitMessageBuilder::new();
@@ -391,7 +391,7 @@ impl Action for CircuitVoteAction {
             .value_of("url")
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
         let key = args.value_of("private_key_file").unwrap_or("splinter");
         let circuit_id = match args.value_of("circuit_id") {
             Some(circuit_id) => circuit_id,
@@ -450,7 +450,7 @@ impl Action for CircuitListAction {
             .and_then(|args| args.value_of("url"))
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
 
         let filter = arg_matches.and_then(|args| args.value_of("member"));
 
@@ -501,7 +501,7 @@ impl Action for CircuitShowAction {
             .value_of("url")
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
         let circuit_id = args
             .value_of("circuit")
             .ok_or_else(|| CliError::ActionError("Circuit name must be provided".to_string()))?;
@@ -580,7 +580,7 @@ impl Action for CircuitProposalsAction {
             .and_then(|args| args.value_of("url"))
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
 
         let management_type_filter = arg_matches.and_then(|args| args.value_of("management_type"));
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -30,8 +30,8 @@ use crate::error::CliError;
 #[cfg(feature = "circuit-template")]
 use crate::template::CircuitTemplate;
 
-use super::Action;
-use crate::action::DEFAULT_ENDPOINT;
+use super::{Action, DEFAULT_ENDPOINT, SPLINTER_REST_API_URL_ENV};
+
 use builder::CreateCircuitMessageBuilder;
 
 pub struct CircuitCreateAction;
@@ -39,7 +39,11 @@ pub struct CircuitCreateAction;
 impl Action for CircuitCreateAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-        let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
         let key = args.value_of("key").unwrap_or("./splinter.priv");
 
         let mut builder = CreateCircuitMessageBuilder::new();
@@ -172,7 +176,7 @@ impl Action for CircuitCreateAction {
 
         let circuit_id = create_circuit.circuit_id.clone();
 
-        let client = api::SplinterRestClient::new(url);
+        let client = api::SplinterRestClient::new(&url);
         let requester_node = client.fetch_node_id()?;
         let private_key_hex = read_private_key(key)?;
 
@@ -383,7 +387,11 @@ pub struct CircuitVoteAction;
 impl Action for CircuitVoteAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-        let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
         let key = args.value_of("private_key_file").unwrap_or("splinter");
         let circuit_id = match args.value_of("circuit_id") {
             Some(circuit_id) => circuit_id,
@@ -399,7 +407,7 @@ impl Action for CircuitVoteAction {
             }
         };
 
-        vote_on_circuit_proposal(url, key, circuit_id, vote)
+        vote_on_circuit_proposal(&url, key, circuit_id, vote)
     }
 }
 
@@ -440,13 +448,17 @@ impl Action for CircuitListAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
-        let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
 
         let filter = args.value_of("member");
 
         let format = args.value_of("format").unwrap_or("human");
 
-        list_circuits(url, filter, format)
+        list_circuits(&url, filter, format)
     }
 }
 
@@ -485,7 +497,11 @@ impl Action for CircuitShowAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
-        let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
         let circuit_id = args
             .value_of("circuit")
             .ok_or_else(|| CliError::ActionError("Circuit name must be provided".to_string()))?;
@@ -493,7 +509,7 @@ impl Action for CircuitShowAction {
         // A value should always be passed because a default is defined
         let format = args.value_of("format").unwrap_or("human");
 
-        show_circuit(url, circuit_id, format)
+        show_circuit(&url, circuit_id, format)
     }
 }
 
@@ -562,7 +578,11 @@ impl Action for CircuitProposalsAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
 
-        let url = args.value_of("url").unwrap_or(DEFAULT_ENDPOINT);
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
 
         let management_type_filter = args.value_of("management_type");
 
@@ -570,7 +590,7 @@ impl Action for CircuitProposalsAction {
 
         let format = args.value_of("format").unwrap_or("human");
 
-        list_proposals(url, management_type_filter, member_filter, format)
+        list_proposals(&url, management_type_filter, member_filter, format)
     }
 }
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -446,17 +446,17 @@ pub struct CircuitListAction;
 
 impl Action for CircuitListAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        let url = args
-            .value_of("url")
+        let url = arg_matches
+            .and_then(|args| args.value_of("url"))
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
             .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
 
-        let filter = args.value_of("member");
+        let filter = arg_matches.and_then(|args| args.value_of("member"));
 
-        let format = args.value_of("format").unwrap_or("human");
+        let format = arg_matches
+            .and_then(|args| args.value_of("format"))
+            .unwrap_or("human");
 
         list_circuits(&url, filter, format)
     }
@@ -576,19 +576,19 @@ pub struct CircuitProposalsAction;
 
 impl Action for CircuitProposalsAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
-        let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
-
-        let url = args
-            .value_of("url")
+        let url = arg_matches
+            .and_then(|args| args.value_of("url"))
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
             .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
 
-        let management_type_filter = args.value_of("management_type");
+        let management_type_filter = arg_matches.and_then(|args| args.value_of("management_type"));
 
-        let member_filter = args.value_of("member");
+        let member_filter = arg_matches.and_then(|args| args.value_of("member"));
 
-        let format = args.value_of("format").unwrap_or("human");
+        let format = arg_matches
+            .and_then(|args| args.value_of("format"))
+            .unwrap_or("human");
 
         list_proposals(&url, management_type_filter, member_filter, format)
     }

--- a/cli/src/action/health.rs
+++ b/cli/src/action/health.rs
@@ -16,7 +16,7 @@ use clap::ArgMatches;
 use reqwest;
 use serde_json::Value;
 
-use super::{Action, DEFAULT_ENDPOINT, SPLINTER_REST_API_URL_ENV};
+use super::{Action, DEFAULT_SPLINTER_REST_API_URL, SPLINTER_REST_API_URL_ENV};
 
 use crate::error::CliError;
 
@@ -28,7 +28,7 @@ impl Action for StatusAction {
             .and_then(|args| args.value_of("url"))
             .map(ToOwned::to_owned)
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
-            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
 
         let status: Value = reqwest::blocking::get(&format!("{}/health/status", url))
             .and_then(|res| res.json())

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -36,6 +36,8 @@ use super::error::CliError;
 
 #[cfg(any(feature = "health", feature = "circuit"))]
 const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:8085";
+#[cfg(any(feature = "health", feature = "circuit"))]
+const SPLINTER_REST_API_URL_ENV: &str = "SPLINTER_REST_API_URL";
 
 /// A CLI Command Action.
 ///

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -35,7 +35,7 @@ use libc;
 use super::error::CliError;
 
 #[cfg(any(feature = "health", feature = "circuit"))]
-const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:8085";
+const DEFAULT_SPLINTER_REST_API_URL: &str = "http://127.0.0.1:8085";
 #[cfg(any(feature = "health", feature = "circuit"))]
 const SPLINTER_REST_API_URL_ENV: &str = "SPLINTER_REST_API_URL";
 


### PR DESCRIPTION
Splinter CLI commands that take the URL of a splinter daemon as an
argument now check the `SPLINTERD_URL` environment variable if the
`-U`/`--url` argument is not specified.

Signed-off-by: Logan Seeley <seeley@bitwise.io>