### PR TITLE
Add biome-rest-api feature to libsplinter

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -90,6 +90,7 @@ experimental = [
     "biome-credentials",
     "biome-key-management",
     "biome-notifications",
+    "biome-rest-api",
     "biome-user",
     "circuit-read",
     "circuit-template",
@@ -114,6 +115,7 @@ biome = ["database"]
 biome-credentials = ["biome", "biome-user", "database", "bcrypt"]
 biome-key-management = ["biome", "database"]
 biome-notifications = ["biome", "database"]
+biome-rest-api = ["biome"]
 biome-user = ["biome", "database"]
 circuit-read = []
 circuit-template = []

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -36,6 +36,6 @@ pub mod key_management;
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;
 
-#[cfg(feature = "rest-api")]
+#[cfg(all(feature = "rest-api", feature = "biome-rest-api"))]
 pub mod rest_api;
 mod user;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -58,6 +58,7 @@ experimental = [
     "biome",
     "biome-credentials",
     "biome-key-management",
+    "biome-rest-api",
     "circuit-read",
     "health",
     "proposal-read",
@@ -69,6 +70,7 @@ experimental = [
 biome = ["splinter/biome", "database"]
 biome-credentials = ["splinter/biome-credentials", "json-web-tokens", "biome"]
 biome-key-management = ["splinter/biome-key-management", "json-web-tokens", "biome"]
+biome-rest-api = ["splinter/biome-rest-api"]
 circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-default = []


### PR DESCRIPTION
Adds new feature guard biome-rest-api as a feature guard for the biome
rest-api module. This is so we can stabilize the high level biome feature
before separately stabilizing the rest api module.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>