### PR TITLE
Add node-file arg to splinter circuit create cmd

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,6 +34,19 @@ use error::CliError;
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[cfg(feature = "circuit")]
+const CIRCUIT_CREATE_AFTER_HELP: &str = r"DETAILS:
+    One or more nodes must be specified using the --node and/or --node-file arguments. These
+    arguments can be used on their own or together, but at least one of them is required.
+
+    The --node-file argument must be a valid YAML file. A valid YAML file will be a list of nodes,
+    where each node has an 'identity' or 'node_id' field, as well as an 'endpoint' field. Example:
+        ---
+        - identity: 'node-1'
+          endpoint: tls://node-1-endpoint:8044
+        - node_id: 'node-2'
+          endpoint: tls://node-2-endpoint:8045";
+
 // log format for cli that will only show the log message
 pub fn log_format(
     w: &mut dyn std::io::Write,
@@ -238,10 +251,17 @@ fn run() -> Result<(), CliError> {
                     .help("Path to private key file"),
             )
             .arg(
+                Arg::with_name("node_file")
+                    .long("node-file")
+                    .takes_value(true)
+                    .required_unless("node")
+                    .help("File system path or HTTP(S) URL to nodes file"),
+            )
+            .arg(
                 Arg::with_name("node")
                     .long("node")
                     .takes_value(true)
-                    .required(true)
+                    .required_unless("node_file")
                     .multiple(true)
                     .long_help(
                         "Node that is part of the circuit. \
@@ -321,7 +341,8 @@ fn run() -> Result<(), CliError> {
                     .long("dry-run")
                     .short("n")
                     .help("Print the circuit definition without submitting the proposal"),
-            );
+            )
+            .after_help(CIRCUIT_CREATE_AFTER_HELP);
 
         #[cfg(feature = "circuit-auth-type")]
         let create_circuit = create_circuit.arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -244,7 +244,7 @@ fn run() -> Result<(), CliError> {
                     .required(true)
                     .multiple(true)
                     .long_help(
-                        "Node that are part of the circuit. \
+                        "Node that is part of the circuit. \
                          Format: <node_id>::<endpoint>. \
                          Endpoint is optional if node alias has been set.",
                     ),
@@ -257,7 +257,7 @@ fn run() -> Result<(), CliError> {
                     .min_values(2)
                     .required_unless("template")
                     .long_help(
-                        "Service ID and allowed node. \
+                        "Service ID and allowed nodes. \
                          Format <service-id>::<allowed_nodes>",
                     ),
             )


### PR DESCRIPTION
Add the `--node-file` argument to the `splinter circuit create` command.
This argument, which can be used instead of or in conjunction with the
`--node` argument, allows the user to load a list of nodes from a .yaml
file either on the local file system or from a remote server with HTTP.
This argument supports the existing node file types used in splinter,
namely those used by the node registry and the `splinter node alias`
commands.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

To test:
1. Add `- ./node_registry:/node_registry` to the `generate-key-registry` container's volumes in `examples/gameroom/docker-compose.yaml`.
2. Run gameroom with `CARGO_ARGS="-- --features=experimental" docker-compose -f examples/gameroom/docker-compose.yaml up --build`
3. Start a session in the `generate-key-registry` container with `docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash`
4. Create a circuit using a node registry file:
```
splinter circuit create \
  --key /key_registry/alice.priv \
  --url http://splinterd-node-acme:8085  \
  --node-file /node_registry/nodes.yaml \
  --service sc00::acme-node-000 \
  --service sc01::bubba-node-000 \
  --service-type *::scabbard \
  --management custom \
  --service-arg *::admin_keys=$(cat /key_registry/alice.pub) \
  --service-peer-group sc00,sc01
```
5. Create a circuit using a node alias file:
```
splinter node alias add acme acme-node-000 tls://splinterd-node-acme:8044 && \
splinter node alias add bubba bubba-node-000 tls://splinterd-node-bubba:8044 && \
splinter circuit create \
  --key /key_registry/alice.priv \
  --url http://splinterd-node-acme:8085  \
  --node-file ~/.splinter/node_alias.yaml \
  --service sc00::acme-node-000 \
  --service sc01::bubba-node-000 \
  --service-type *::scabbard \
  --management custom \
  --service-arg *::admin_keys=$(cat /key_registry/alice.pub) \
  --service-peer-group sc00,sc01
```
6. Create a circuit using a remote .yaml file:
```
apt-get install -y -q ca-certificates && \
splinter circuit create \
  --key /key_registry/alice.priv \
  --url http://splinterd-node-acme:8085  \
  --node-file http://raw.githubusercontent.com/Cargill/splinter/master/examples/gameroom/node_registry/nodes.yaml \
  --service sc00::acme-node-000 \
  --service sc01::bubba-node-000 \
  --service-type *::scabbard \
  --management custom \
  --service-arg *::admin_keys=$(cat /key_registry/alice.pub) \
  --service-peer-group sc00,sc01
```