### PR TITLE
Allow BiHashMap look-ups with Borrow implementations

### DIFF
--- a/libsplinter/src/collections/mod.rs
+++ b/libsplinter/src/collections/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::collections::hash_map::{Iter, Keys, Values};
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -87,19 +88,35 @@ where
         self.vk_hash_map.clear();
     }
 
-    pub fn get_by_key(&self, key: &K) -> Option<&V> {
+    pub fn get_by_key<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         self.kv_hash_map.get(key)
     }
 
-    pub fn get_by_value(&self, value: &V) -> Option<&K> {
+    pub fn get_by_value<VQ: ?Sized>(&self, value: &VQ) -> Option<&K>
+    where
+        V: Borrow<VQ>,
+        VQ: Hash + Eq,
+    {
         self.vk_hash_map.get(value)
     }
 
-    pub fn contains_key(&self, key: &K) -> bool {
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         self.kv_hash_map.contains_key(key)
     }
 
-    pub fn contains_value(&self, value: &V) -> bool {
+    pub fn contains_value<VQ: ?Sized>(&self, value: &VQ) -> bool
+    where
+        V: Borrow<VQ>,
+        VQ: Hash + Eq,
+    {
         self.vk_hash_map.contains_key(value)
     }
 
@@ -111,7 +128,11 @@ where
     }
 
     // If the key is in the map, the removed key and value is returned otherwise None
-    pub fn remove_by_key(&mut self, key: &K) -> Option<(K, V)> {
+    pub fn remove_by_key<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
         let value = self.kv_hash_map.remove(key);
         if let Some(value) = value {
             let key = self.vk_hash_map.remove(&value);
@@ -123,7 +144,11 @@ where
     }
 
     // If the value is in the map, the removed key and value is returned otherwise None
-    pub fn remove_by_value(&mut self, value: &V) -> Option<(K, V)> {
+    pub fn remove_by_value<VQ: ?Sized>(&mut self, value: &VQ) -> Option<(K, V)>
+    where
+        V: Borrow<VQ>,
+        VQ: Hash + Eq,
+    {
         let key = self.vk_hash_map.remove(value);
         if let Some(key) = key {
             let value = self.kv_hash_map.remove(&key);
@@ -253,10 +278,10 @@ pub mod tests {
         map.insert("TWO".to_string(), 2);
         map.insert("THREE".to_string(), 3);
 
-        assert_eq!(map.get_by_key(&"ONE".to_string()), Some(&1));
-        assert_eq!(map.get_by_key(&"TWO".to_string()), Some(&2));
-        assert_eq!(map.get_by_key(&"THREE".to_string()), Some(&3));
-        assert_eq!(map.get_by_key(&"FOUR".to_string()), None);
+        assert_eq!(map.get_by_key("ONE"), Some(&1));
+        assert_eq!(map.get_by_key("TWO"), Some(&2));
+        assert_eq!(map.get_by_key("THREE"), Some(&3));
+        assert_eq!(map.get_by_key("FOUR"), None);
 
         assert_eq!(map.get_by_value(&1), Some(&"ONE".to_string()));
         assert_eq!(map.get_by_value(&2), Some(&"TWO".to_string()));
@@ -269,10 +294,10 @@ pub mod tests {
         let mut map: BiHashMap<String, usize> = BiHashMap::new();
         map.insert("ONE".to_string(), 1);
 
-        assert!(map.contains_key(&"ONE".to_string()));
+        assert!(map.contains_key("ONE"));
         assert!(map.contains_value(&1));
 
-        assert!(!map.contains_key(&"TWO".to_string()));
+        assert!(!map.contains_key("TWO"));
         assert!(!map.contains_value(&2));
     }
 
@@ -283,10 +308,10 @@ pub mod tests {
         map.insert("TWO".to_string(), 2);
         map.insert("THREE".to_string(), 3);
 
-        let removed = map.remove_by_key(&"ONE".to_string());
+        let removed = map.remove_by_key("ONE");
         assert_eq!(removed, Some(("ONE".to_string(), 1)));
 
-        let removed = map.remove_by_key(&"ONE".to_string());
+        let removed = map.remove_by_key("ONE");
         assert_eq!(removed, None);
 
         let removed = map.remove_by_value(&2);

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -205,7 +205,7 @@ impl Mesh {
             match state.outgoings.get(mesh_id) {
                 Some(ref outgoing) => match outgoing.send(envelope.take_payload()) {
                     Ok(()) => Ok(()),
-                    Err(err) => Err(SendError::from_outgoing_send_error(err, id.to_string())),
+                    Err(err) => Err(SendError::from_outgoing_send_error(err, id)),
                 },
                 None => Err(SendError::NotFound),
             }

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -181,7 +181,7 @@ impl Mesh {
     /// Remove an existing connection from the mesh and return it.
     pub fn remove(&self, unique_id: &str) -> Result<Box<dyn Connection>, RemoveError> {
         let mut state = self.state.write().map_err(|_| RemoveError::PoisonedLock)?;
-        if let Some((_, mesh_id)) = state.unique_ids.remove_by_key(&unique_id.to_string()) {
+        if let Some((_, mesh_id)) = state.unique_ids.remove_by_key(unique_id) {
             let connection = self.ctrl.remove(mesh_id)?;
             // The outgoing channel needs to be removed after the control request completes, or else
             // the reactor will detect that the outgoing sender has dropped and clean it up

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -111,12 +111,11 @@ impl PeerMap {
     /// Remove a peer id, its endpoint and all of its redirects
     fn remove(&mut self, peer_id: &str) -> Option<String> {
         info!("Removing peer: {}", peer_id);
-        let peer_id_key = peer_id.to_string();
         self.redirects
             .retain(|_, target_peer_id| target_peer_id != peer_id);
-        self.endpoints.remove_by_key(&peer_id_key);
+        self.endpoints.remove_by_key(peer_id);
         self.peers
-            .remove_by_key(&peer_id_key)
+            .remove_by_key(peer_id)
             .map(|(_, mesh_id)| mesh_id)
     }
 
@@ -155,12 +154,12 @@ impl PeerMap {
         self.redirects
             .get(peer_id)
             .and_then(|target_peer_id| self.peers.get_by_key(target_peer_id))
-            .or_else(|| self.peers.get_by_key(&peer_id.to_string()))
+            .or_else(|| self.peers.get_by_key(peer_id))
     }
 
     /// Returns the direct peer id for the given mesh_id
     fn get_peer_id(&self, mesh_id: &str) -> Option<&String> {
-        self.peers.get_by_value(&mesh_id.to_string())
+        self.peers.get_by_value(mesh_id)
     }
 
     /// Returns the endpoint for the given peer id
@@ -169,13 +168,13 @@ impl PeerMap {
             .redirects
             .get(peer_id)
             .and_then(|target_peer_id| self.endpoints.get_by_key(target_peer_id))
-            .or_else(|| self.endpoints.get_by_key(&peer_id.to_string()));
+            .or_else(|| self.endpoints.get_by_key(peer_id));
 
         endpoint_opt.cloned()
     }
 
     fn get_peer_by_endpoint(&self, endpoint: &str) -> Option<String> {
-        self.endpoints.get_by_value(&endpoint.to_string()).cloned()
+        self.endpoints.get_by_value(endpoint).cloned()
     }
 }
 


### PR DESCRIPTION
Like `HashMap`, allow the `BiHashMap` to support `get_*` via elements that `K` or `V` implement  the `Borrow` trait on.  This removes the need, for example, to clone strings in order to look up a string key.

For example:

```rust
    bi_map.get_by_key(&"some-key".to_string())
```

can now be simplified to

```rust
    bi_map.get_by_key("some-key")
```