### PR TITLE
Save circuit ID to circuit store

### DIFF
--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -34,7 +34,7 @@ use crate::storage::get_storage;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Circuit {
-    #[serde(skip)]
+    #[serde(default)]
     id: String,
     auth: AuthorizationType,
     members: Vec<String>,


### PR DESCRIPTION
Updates the circuit store to save the circuit's ID. By changing the `id`
field's annotation from `#[serde(skip)]` to `#[serde(default)]`, we save
the ID for new circuits while maintaining backwards compatibility; if we
attempt to load a circuit that was saved before this change, it won't
have an ID field and the resulting Rust struct will just use the empty
string as a default.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

To test:
1. Startup gameroom (be sure to build at least the splinterd image)
2. Create a new gameroom/circuit
3. Restart both `gameroomd-acme` and `splinterd-node-acme` using `docker restart`.
4. Start a new splinter CLI session: `docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash`
5. Verify that the ID of the circuit shows up when running `splinter circuit list --url http://splinterd-node-acme:8085`