### PR TITLE
Add a method to PeerManagerConnector to get connection ids

### DIFF
--- a/libsplinter/src/network/peer_manager/error.rs
+++ b/libsplinter/src/network/peer_manager/error.rs
@@ -121,6 +121,31 @@ impl fmt::Display for PeerListError {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum PeerConnectionIdError {
+    InternalError(String),
+    ReceiveError(String),
+    ListError(String),
+}
+
+impl error::Error for PeerConnectionIdError {}
+
+impl fmt::Display for PeerConnectionIdError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerConnectionIdError::InternalError(msg) => {
+                write!(f, "Received internal error: {}", msg)
+            }
+            PeerConnectionIdError::ReceiveError(msg) => {
+                write!(f, "Unable to receive response from PeerManager: {}", msg)
+            }
+            PeerConnectionIdError::ListError(msg) => {
+                write!(f, "Unable to get connection id map: {}", msg)
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct PeerUpdateError(pub String);
 


### PR DESCRIPTION
Adds a method to PeerManagerConnector to get a BiHashMap for
peer ids to connection ids. This will be used by PeerInterconnect
to get the peers and connection id that can be used for sending
messages.

To support this method, the PeerManager will handle a new message
PeerManagerRequest::ConnectionIds and the PeerMap has a new method
to return the BiHashMap.

This returns a BiHashMap because the PeerInterconnect will need to
go convert the ids to each other, where the direction depends on
if the message is incoming or outgoing.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>