### PR TITLE
Rename `circuit create` to `circuit propose`

### DIFF
--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -34,9 +34,9 @@ use super::{Action, DEFAULT_SPLINTER_REST_API_URL, SPLINTER_REST_API_URL_ENV};
 
 use builder::CreateCircuitMessageBuilder;
 
-pub struct CircuitCreateAction;
+pub struct CircuitProposeAction;
 
-impl Action for CircuitCreateAction {
+impl Action for CircuitProposeAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or_else(|| CliError::RequiresArgs)?;
         let url = args

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -220,7 +220,7 @@ fn run() -> Result<(), CliError> {
 
     #[cfg(feature = "circuit")]
     {
-        let create_circuit = SubCommand::with_name("create")
+        let propose_circuit = SubCommand::with_name("propose")
             .about("Propose that a new circuit is created")
             .arg(
                 Arg::with_name("url")
@@ -324,7 +324,7 @@ fn run() -> Result<(), CliError> {
             );
 
         #[cfg(feature = "circuit-auth-type")]
-        let create_circuit = create_circuit.arg(
+        let propose_circuit = propose_circuit.arg(
             Arg::with_name("authorization_type")
                 .long("auth-type")
                 .possible_values(&["trust"])
@@ -334,7 +334,7 @@ fn run() -> Result<(), CliError> {
         );
 
         #[cfg(feature = "circuit-template")]
-        let create_circuit = create_circuit
+        let propose_circuit = propose_circuit
             .arg(
                 Arg::with_name("template")
                     .long("template")
@@ -353,7 +353,7 @@ fn run() -> Result<(), CliError> {
         let circuit_command = SubCommand::with_name("circuit")
             .about("Provides circuit management functionality")
             .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(create_circuit)
+            .subcommand(propose_circuit)
             .subcommand(
                 SubCommand::with_name("vote")
                     .about("Vote on a new circuit proposal")
@@ -685,7 +685,7 @@ fn run() -> Result<(), CliError> {
     {
         use action::circuit;
         let circuit_command = SubcommandActions::new()
-            .with_command("create", circuit::CircuitCreateAction)
+            .with_command("propose", circuit::CircuitProposeAction)
             .with_command("vote", circuit::CircuitVoteAction)
             .with_command("list", circuit::CircuitListAction)
             .with_command("show", circuit::CircuitShowAction)


### PR DESCRIPTION
Renames the `circuit create` command to `circuit propose` to make the
command more clear about what it does; it doesn't create a circuit, it
proposes a circuit that needs to be voted on before being created.

Signed-off-by: Logan Seeley <seeley@bitwise.io>