### PR TITLE
Use From conversion for transport IoError errors

### DIFF
--- a/libsplinter/src/transport/socket/tcp.rs
+++ b/libsplinter/src/transport/socket/tcp.rs
@@ -55,7 +55,7 @@ impl Transport for TcpTransport {
                 FrameError::UnsupportedVersion => ConnectError::ProtocolError(
                     "Unable to connect; remote version is not with in range".into(),
                 ),
-                FrameError::IoError(err) => ConnectError::IoError(err),
+                FrameError::IoError(err) => ConnectError::from(err),
                 e => ConnectError::ProtocolError(format!("Unexpected protocol error: {}", e)),
             })?;
 
@@ -100,7 +100,7 @@ impl Listener for TcpListener {
                 FrameError::UnsupportedVersion => AcceptError::ProtocolError(
                     "Unable to connect; local version not supported by remote".into(),
                 ),
-                FrameError::IoError(err) => AcceptError::IoError(err),
+                FrameError::IoError(err) => AcceptError::from(err),
                 err => AcceptError::ProtocolError(format!("Unexpected protocol error: {}", err)),
             })?;
 
@@ -124,7 +124,7 @@ struct TcpConnection {
 impl Connection for TcpConnection {
     fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
         match FrameRef::new(self.frame_version, message).write(&mut self.stream) {
-            Err(FrameError::IoError(e)) => Err(SendError::IoError(e)),
+            Err(FrameError::IoError(e)) => Err(SendError::from(e)),
             Err(err) => Err(SendError::ProtocolError(err.to_string())),
             Ok(_) => Ok(()),
         }
@@ -132,7 +132,7 @@ impl Connection for TcpConnection {
 
     fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
         match Frame::read(&mut self.stream) {
-            Err(FrameError::IoError(e)) => Err(RecvError::IoError(e)),
+            Err(FrameError::IoError(e)) => Err(RecvError::from(e)),
             Err(err) => Err(RecvError::ProtocolError(err.to_string())),
             Ok(frame) => Ok(frame.into_inner()),
         }

--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -134,7 +134,7 @@ impl Transport for TlsTransport {
                 FrameError::UnsupportedVersion => ConnectError::ProtocolError(
                     "Unable to connect; remote version is not with in range".into(),
                 ),
-                FrameError::IoError(err) => ConnectError::IoError(err),
+                FrameError::IoError(err) => ConnectError::from(err),
                 e => ConnectError::ProtocolError(format!("Unexpected protocol error: {}", e)),
             })?;
 
@@ -183,7 +183,7 @@ impl Listener for TlsListener {
                 FrameError::UnsupportedVersion => AcceptError::ProtocolError(
                     "Unable to connect; local version not supported by remote".into(),
                 ),
-                FrameError::IoError(err) => AcceptError::IoError(err),
+                FrameError::IoError(err) => AcceptError::from(err),
                 err => AcceptError::ProtocolError(format!("Unexpected protocol error: {}", err)),
             })?;
 
@@ -208,7 +208,7 @@ pub struct TlsConnection {
 impl Connection for TlsConnection {
     fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
         match FrameRef::new(self.frame_version, message).write(&mut self.stream) {
-            Err(FrameError::IoError(e)) => Err(SendError::IoError(e)),
+            Err(FrameError::IoError(e)) => Err(SendError::from(e)),
             Err(err) => Err(SendError::ProtocolError(err.to_string())),
             Ok(_) => Ok(()),
         }
@@ -216,7 +216,7 @@ impl Connection for TlsConnection {
 
     fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
         match Frame::read(&mut self.stream) {
-            Err(FrameError::IoError(e)) => Err(RecvError::IoError(e)),
+            Err(FrameError::IoError(e)) => Err(RecvError::from(e)),
             Err(err) => Err(RecvError::ProtocolError(err.to_string())),
             Ok(frame) => Ok(frame.into_inner()),
         }


### PR DESCRIPTION
The From<io::Error> impl for SendError and RecvError translates
io::ErrorKind::UnexpectedEof to Send/RecvError::Disconnected and
io::ErrorKine::WouldBlock to Send/RecvError::WouldBlock.

However, socket::tcp and socket::tls were not using from but instead
directly creating the errors via Send/RecvError::IoError(err).
Potentially, there are some bugs created because Mesh uses
Send/RecvError::Disconnected/WouldBlock in its logic.

Universally changed all transport code involving IoError to use ::from.
Although other errors don't currenlty differentiate (and thus it isn't
a functional changer for them), it seems best to do it the same way
throughout.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>