### PR TITLE
Fix typo in doc commment in transport module

### DIFF
--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -83,7 +83,7 @@ impl Incoming for dyn Listener {
 
 /// Factory-pattern based type for creating connections
 pub trait Transport: Send {
-    /// Indicates whether or not a given address can be used to create a conneciton or listener.
+    /// Indicates whether or not a given address can be used to create a connection or listener.
     fn accepts(&self, address: &str) -> bool;
     fn connect(&mut self, endpoint: &str) -> Result<Box<dyn Connection>, ConnectError>;
     fn listen(&mut self, bind: &str) -> Result<Box<dyn Listener>, ListenError>;


### PR DESCRIPTION
Fixes a typo of the word 'connection'.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>