### PR TITLE
Implement NetworkMessageSender and NetworkMessagSendQueue

### DIFF
--- a/examples/private_counter/docker-compose.yaml
+++ b/examples/private_counter/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
                 --registry-file /node_registry/nodes.yaml
       "
     environment:
-      SPLINTER_STATE_DIR: /splinter_state
+      SPLINTER_STATE_DIR: /splinter_state/
 
   splinter-node-1:
     image: splinterd:latest
@@ -66,7 +66,7 @@ services:
                 --registry-file /node_registry/nodes.yaml
       "
     environment:
-      SPLINTER_STATE_DIR: /splinter_state
+      SPLINTER_STATE_DIR: /splinter_state/
 
   splinter-node-2:
     image: splinterd:latest
@@ -92,7 +92,7 @@ services:
                 --registry-file /node_registry/nodes.yaml
       "
     environment:
-      SPLINTER_STATE_DIR: /splinter_state
+      SPLINTER_STATE_DIR: /splinter_state/
 
   private-counter-service-a:
     image: private-counter:latest

--- a/examples/private_counter/node_registry/nodes.yaml
+++ b/examples/private_counter/node_registry/nodes.yaml
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 - identity: "012"
+  endpoint: "tcp://splinter-node-0:8044"
+  display_name: "Node 1"
   metadata: {}
 - identity: "345"
+  endpoint: "tcp://splinter-node-1:8046"
+  display_name: "Node 2"
   metadata: {}
 - identity: "678"
+  endpoint: "tcp://splinter-node-2:8048"
+  display_name: "Node 3"
   metadata: {}

--- a/examples/private_counter/service/src/consensus.rs
+++ b/examples/private_counter/service/src/consensus.rs
@@ -23,7 +23,6 @@ use splinter::consensus::{
     ConsensusMessage, ConsensusNetworkSender, PeerId, Proposal, ProposalId, ProposalManager,
     ProposalUpdate,
 };
-use splinter::network::sender::SendRequest;
 
 use crate::error::ServiceError;
 use crate::protos::private_counter::{
@@ -74,7 +73,7 @@ impl ProposalManager for PrivateCounterProposalManager {
                 for verifier in &state.verifiers {
                     state
                         .service_sender
-                        .send(SendRequest::new(
+                        .send(
                             state.peer_id.clone(),
                             create_circuit_direct_msg(
                                 state.circuit.clone(),
@@ -83,7 +82,7 @@ impl ProposalManager for PrivateCounterProposalManager {
                                 msg.write_to_bytes().map_err(ServiceError::from)?,
                                 Uuid::new_v4().to_string(),
                             )?,
-                        ))
+                        )
                         .map_err(ServiceError::from)?;
                 }
 
@@ -208,7 +207,7 @@ impl ConsensusNetworkSender for PrivateCounterNetworkSender {
 
         state
             .service_sender
-            .send(SendRequest::new(
+            .send(
                 state.peer_id.clone(),
                 create_circuit_direct_msg(
                     state.circuit.clone(),
@@ -220,7 +219,7 @@ impl ConsensusNetworkSender for PrivateCounterNetworkSender {
                     Uuid::new_v4().to_string(),
                 )
                 .map_err(|err| ConsensusSendError::Internal(Box::new(err)))?,
-            ))
+            )
             .map_err(|err| ConsensusSendError::Internal(Box::new(ServiceError::from(err))))?;
 
         Ok(())
@@ -237,7 +236,7 @@ impl ConsensusNetworkSender for PrivateCounterNetworkSender {
         for verifier in &state.verifiers {
             state
                 .service_sender
-                .send(SendRequest::new(
+                .send(
                     state.peer_id.clone(),
                     create_circuit_direct_msg(
                         state.circuit.clone(),
@@ -248,7 +247,7 @@ impl ConsensusNetworkSender for PrivateCounterNetworkSender {
                         Uuid::new_v4().to_string(),
                     )
                     .map_err(|err| ConsensusSendError::Internal(Box::new(err)))?,
-                ))
+                )
                 .map_err(|err| ConsensusSendError::Internal(Box::new(ServiceError::from(err))))?;
         }
 

--- a/examples/private_counter/service/src/error.rs
+++ b/examples/private_counter/service/src/error.rs
@@ -103,6 +103,12 @@ impl<T> From<std::sync::mpsc::SendError<T>> for ServiceError {
     }
 }
 
+impl From<(String, Vec<u8>)> for ServiceError {
+    fn from(err: (String, Vec<u8>)) -> Self {
+        ServiceError(format!("Unable to send to {}", err.0))
+    }
+}
+
 impl From<ServiceError> for ProposalManagerError {
     fn from(err: ServiceError) -> Self {
         ProposalManagerError::Internal(Box::new(err))

--- a/examples/private_xo/docker-compose.yaml
+++ b/examples/private_xo/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
                 --registry-file /node_registry/nodes.yaml
       "
     environment:
-      SPLINTER_STATE_DIR: /splinter_state
+      SPLINTER_STATE_DIR: /splinter_state/
 
   splinter-node-1:
     image: splinterd:latest
@@ -66,7 +66,7 @@ services:
                 --registry-file /node_registry/nodes.yaml
       "
     environment:
-      SPLINTER_STATE_DIR: /splinter_state
+      SPLINTER_STATE_DIR: /splinter_state/
 
   private-xo-service-a:
     image: private-xo:latest

--- a/examples/private_xo/node_registry/nodes.yaml
+++ b/examples/private_xo/node_registry/nodes.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 - identity: "012"
+  endpoint: "tcp://splinter-node-0:8044"
+  display_name: "Node 1"
   metadata: {}
 - identity: "345"
+  endpoint: "tcp://splinter-node-1:8046"
+  display_name: "Node 2"
   metadata: {}

--- a/examples/private_xo/src/service/error.rs
+++ b/examples/private_xo/src/service/error.rs
@@ -41,6 +41,12 @@ impl<T> From<std::sync::mpsc::SendError<T>> for ServiceError {
     }
 }
 
+impl From<(String, Vec<u8>)> for ServiceError {
+    fn from(err: (String, Vec<u8>)) -> Self {
+        ServiceError(format!("Unable to send to {}", err.0))
+    }
+}
+
 impl From<ServiceError> for ProposalManagerError {
     fn from(err: ServiceError) -> Self {
         ProposalManagerError::Internal(Box::new(err))

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::channel::Sender;
 use crate::circuit::handlers::create_message;
 use crate::circuit::{ServiceId, SplinterState};
 use crate::network::dispatch::{DispatchError, Handler, MessageContext};
-use crate::network::sender::SendRequest;
+use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{CircuitError, CircuitMessageType};
 
 // Implements a handler that handles CircuitError messages
@@ -33,7 +32,7 @@ impl Handler<CircuitMessageType, CircuitError> for CircuitErrorHandler {
         &self,
         msg: CircuitError,
         context: &MessageContext<CircuitMessageType>,
-        sender: &dyn Sender<SendRequest>,
+        sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Circuit Error Message {:?}", msg);
         let circuit_name = msg.get_circuit_name();
@@ -81,8 +80,11 @@ impl Handler<CircuitMessageType, CircuitError> for CircuitErrorHandler {
         )?;
 
         // forward error message
-        let send_request = SendRequest::new(recipient, network_msg_bytes);
-        sender.send(send_request)?;
+        sender
+            .send(recipient, network_msg_bytes)
+            .map_err(|(recipient, payload)| {
+                DispatchError::NetworkSendError((recipient, payload))
+            })?;
         Ok(())
     }
 }
@@ -98,100 +100,99 @@ mod tests {
     use protobuf::Message;
 
     use super::*;
-    use crate::channel::mock::MockSender;
-    use crate::channel::Sender;
     use crate::circuit::directory::CircuitDirectory;
     use crate::circuit::service::{Service, SplinterNode};
     use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
+    use crate::mesh::Mesh;
     use crate::network::dispatch::Dispatcher;
+    use crate::network::sender;
+    use crate::network::{Network, NetworkMessageWrapper};
     use crate::protos::circuit::{CircuitError_Error, CircuitMessage};
-    use crate::protos::network::NetworkMessage;
+    use crate::protos::network::{NetworkEcho, NetworkMessage, NetworkMessageType};
+    use crate::transport::inproc::InprocTransport;
+    use crate::transport::{Listener, Transport};
 
     // Test that if an error message received is meant for the service connected to a node,
     // the error message is sent to the service
     #[test]
     fn test_circuit_error_handler_service() {
         // Set up disptacher and mock sender
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc_network".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        // Add circuit and service to splinter state
-        let circuit = Circuit::builder()
-            .with_id("alpha".into())
-            .with_auth(AuthorizationType::Trust)
-            .with_members(vec!["123".into()])
-            .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence(PersistenceType::Any)
-            .with_durability(DurabilityType::NoDurability)
-            .with_routes(RouteType::Any)
-            .with_circuit_management_type("circuit_errors_test_app".into())
-            .build()
-            .expect("Should have built a correct circuit");
+                // Add circuit and service to splinter state
+                let circuit = Circuit::builder()
+                    .with_id("alpha".into())
+                    .with_auth(AuthorizationType::Trust)
+                    .with_members(vec!["123".into()])
+                    .with_roster(vec!["abc".into(), "def".into()])
+                    .with_persistence(PersistenceType::Any)
+                    .with_durability(DurabilityType::NoDurability)
+                    .with_routes(RouteType::Any)
+                    .with_circuit_management_type("circuit_errors_test_app".into())
+                    .build()
+                    .expect("Should have built a correct circuit");
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        let node_123 = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = SplinterNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+                let node_123 =
+                    SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
+                let node_345 =
+                    SplinterNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
 
-        let service_abc =
-            Service::new("abc".to_string(), Some("abc_network".to_string()), node_123);
-        let service_def =
-            Service::new("def".to_string(), Some("def_network".to_string()), node_345);
+                let service_abc =
+                    Service::new("abc".to_string(), Some("abc_network".to_string()), node_123);
+                let service_def =
+                    Service::new("def".to_string(), Some("def_network".to_string()), node_345);
 
-        let abc_id = ServiceId::new("alpha".into(), "abc".into());
-        let def_id = ServiceId::new("alpha".into(), "def".into());
-        state.add_service(abc_id, service_abc).unwrap();
-        state.add_service(def_id, service_def).unwrap();
+                let abc_id = ServiceId::new("alpha".into(), "abc".into());
+                let def_id = ServiceId::new("alpha".into(), "def".into());
+                state.add_service(abc_id, service_abc).unwrap();
+                state.add_service(def_id, service_def).unwrap();
 
-        // Add circuit error handler to the the dispatcher
-        let handler = CircuitErrorHandler::new("123".to_string(), state);
-        dispatcher.set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+                // Add circuit error handler to the the dispatcher
+                let handler = CircuitErrorHandler::new("123".to_string(), state);
+                dispatcher
+                    .set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
 
-        // Create the error message
-        let mut circuit_error = CircuitError::new();
-        circuit_error.set_service_id("abc".into());
-        circuit_error.set_circuit_name("alpha".into());
-        circuit_error.set_correlation_id("1234".into());
-        circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
-        circuit_error.set_error_message("TEST".into());
-        let error_bytes = circuit_error.write_to_bytes().unwrap();
+                // Create the error message
+                let mut circuit_error = CircuitError::new();
+                circuit_error.set_service_id("abc".into());
+                circuit_error.set_circuit_name("alpha".into());
+                circuit_error.set_correlation_id("1234".into());
+                circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
+                circuit_error.set_error_message("TEST".into());
+                let error_bytes = circuit_error.write_to_bytes().unwrap();
 
-        // dispatch the error message
-        dispatcher
-            .dispatch(
-                "345",
-                &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
-                error_bytes.clone(),
-            )
-            .unwrap();
-
-        // verify that the error message was sent to the abc service
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "abc_network");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let circuit_error: CircuitError =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::CIRCUIT_ERROR_MESSAGE
-        );
-
-        assert_eq!(circuit_error.get_service_id(), "abc");
-        assert_eq!(
-            circuit_error.get_error(),
-            CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY
-        );
-        assert_eq!(circuit_error.get_error_message(), "TEST");
-        assert_eq!(circuit_error.get_correlation_id(), "1234");
+                // dispatch the error message
+                dispatcher
+                    .dispatch(
+                        "345",
+                        &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
+                        error_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
+            |msg: CircuitError| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit_name(), "alpha");
+                assert_eq!(
+                    msg.get_error(),
+                    CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY
+                );
+                assert_eq!(msg.get_error_message(), "TEST");
+                assert_eq!(msg.get_correlation_id(), "1234");
+            },
+        )
     }
 
     // Test that if an error message received is meant for the service not connected to this node,
@@ -199,126 +200,234 @@ mod tests {
     #[test]
     fn test_circuit_error_handler_node() {
         // Set up disptacher and mock sender
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("345".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        // Add circuit and service to splinter state
-        let circuit = Circuit::builder()
-            .with_id("alpha".into())
-            .with_auth(AuthorizationType::Trust)
-            .with_members(vec!["123".into()])
-            .with_roster(vec!["abc".into(), "def".into()])
-            .with_persistence(PersistenceType::Any)
-            .with_durability(DurabilityType::NoDurability)
-            .with_routes(RouteType::Any)
-            .with_circuit_management_type("circuit_error_test_app".into())
-            .build()
-            .expect("Should have built a correct circuit");
+                // Add circuit and service to splinter state
+                let circuit = Circuit::builder()
+                    .with_id("alpha".into())
+                    .with_auth(AuthorizationType::Trust)
+                    .with_members(vec!["123".into()])
+                    .with_roster(vec!["abc".into(), "def".into()])
+                    .with_persistence(PersistenceType::Any)
+                    .with_durability(DurabilityType::NoDurability)
+                    .with_routes(RouteType::Any)
+                    .with_circuit_management_type("circuit_error_test_app".into())
+                    .build()
+                    .expect("Should have built a correct circuit");
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        let node_123 = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = SplinterNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+                let node_123 =
+                    SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
+                let node_345 =
+                    SplinterNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
 
-        let service_abc =
-            Service::new("abc".to_string(), Some("abc_network".to_string()), node_123);
-        let service_def =
-            Service::new("def".to_string(), Some("def_network".to_string()), node_345);
+                let service_abc =
+                    Service::new("abc".to_string(), Some("abc_network".to_string()), node_123);
+                let service_def =
+                    Service::new("def".to_string(), Some("def_network".to_string()), node_345);
 
-        let abc_id = ServiceId::new("alpha".into(), "abc".into());
-        let def_id = ServiceId::new("alpha".into(), "def".into());
-        state.add_service(abc_id, service_abc).unwrap();
-        state.add_service(def_id, service_def).unwrap();
+                let abc_id = ServiceId::new("alpha".into(), "abc".into());
+                let def_id = ServiceId::new("alpha".into(), "def".into());
+                state.add_service(abc_id, service_abc).unwrap();
+                state.add_service(def_id, service_def).unwrap();
 
-        // Add circuit error handler to the the dispatcher
-        let handler = CircuitErrorHandler::new("123".to_string(), state);
-        dispatcher.set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+                // Add circuit error handler to the the dispatcher
+                let handler = CircuitErrorHandler::new("123".to_string(), state);
+                dispatcher
+                    .set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
 
-        // Create the error message
-        let mut circuit_error = CircuitError::new();
-        circuit_error.set_service_id("def".into());
-        circuit_error.set_circuit_name("alpha".into());
-        circuit_error.set_correlation_id("1234".into());
-        circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
-        circuit_error.set_error_message("TEST".into());
-        let error_bytes = circuit_error.write_to_bytes().unwrap();
+                // Create the error message
+                let mut circuit_error = CircuitError::new();
+                circuit_error.set_service_id("def".into());
+                circuit_error.set_circuit_name("alpha".into());
+                circuit_error.set_correlation_id("1234".into());
+                circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
+                circuit_error.set_error_message("TEST".into());
+                let error_bytes = circuit_error.write_to_bytes().unwrap();
 
-        // dispatch the error message
-        dispatcher
-            .dispatch(
-                "568",
-                &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
-                error_bytes.clone(),
-            )
-            .unwrap();
-
-        // verify that the error message was sent to the 345 node
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "345");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let circuit_error: CircuitError =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::CIRCUIT_ERROR_MESSAGE
-        );
-
-        assert_eq!(circuit_error.get_service_id(), "def");
-        assert_eq!(
-            circuit_error.get_error(),
-            CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY
-        );
-        assert_eq!(circuit_error.get_error_message(), "TEST");
-        assert_eq!(circuit_error.get_correlation_id(), "1234");
+                // dispatch the error message
+                dispatcher
+                    .dispatch(
+                        "586",
+                        &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
+                        error_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
+            |msg: CircuitError| {
+                assert_eq!(msg.get_service_id(), "def");
+                assert_eq!(
+                    msg.get_error(),
+                    CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY
+                );
+                assert_eq!(msg.get_error_message(), "TEST");
+                assert_eq!(msg.get_correlation_id(), "1234");
+            },
+        )
     }
 
     // Test that if the service the error message is meant for is not connected, the message is
-    // dropped because there is no way to know where to send it
+    // dropped because there is no way to know where to send it. This test sends NetworkEcho
     #[test]
     fn test_circuit_error_handler_no_service() {
         // Set up disptacher and mock sender
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        // Set up dispatcher and mock sender
+        let mesh1 = Mesh::new(1, 1);
+        let network1 = Network::new(mesh1.clone(), 0).unwrap();
 
-        // create empty state
-        let circuit_directory = CircuitDirectory::new();
+        let network_message_queue = sender::Builder::new()
+            .with_network(network1.clone())
+            .build()
+            .expect("Unable to create queue");
+        let network_sender = network_message_queue.new_network_sender();
+        let network_echo_sender = network_message_queue.new_network_sender();
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+        let mut inproc_transport = InprocTransport::default();
+        let mut dispatcher = Dispatcher::new(network_sender);
+        let mut listener = inproc_transport
+            .listen("inproc://circuit_error")
+            .expect("Cannot get listener");
 
-        // Add circuit error handler to the the dispatcher
-        let handler = CircuitErrorHandler::new("123".to_string(), state);
-        dispatcher.set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+        std::thread::spawn(move || {
+            let connection = listener.accept().expect("Cannot accept connection");
+            network1
+                .add_peer("345".to_string(), connection)
+                .expect("Unable to add peer");
+            // create empty state
+            let circuit_directory = CircuitDirectory::new();
 
-        // Create the circuit error message
-        let mut circuit_error = CircuitError::new();
-        circuit_error.set_service_id("abc".into());
-        circuit_error.set_circuit_name("alpha".into());
-        circuit_error.set_correlation_id("1234".into());
-        circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
-        circuit_error.set_error_message("TEST".into());
-        let error_bytes = circuit_error.write_to_bytes().unwrap();
+            let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        // dispatch the error message
-        dispatcher
-            .dispatch(
-                "def",
-                &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
-                error_bytes.clone(),
-            )
-            .unwrap();
+            // Add circuit error handler to the the dispatcher
+            let handler = CircuitErrorHandler::new("123".to_string(), state);
+            dispatcher.set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
 
-        // verify that the direct message was dropped
-        let send_request = sender.sent();
+            // Create the circuit error message
+            let mut circuit_error = CircuitError::new();
+            circuit_error.set_service_id("abc".into());
+            circuit_error.set_circuit_name("alpha".into());
+            circuit_error.set_correlation_id("1234".into());
+            circuit_error.set_error(CircuitError_Error::ERROR_RECIPIENT_NOT_IN_DIRECTORY);
+            circuit_error.set_error_message("TEST".into());
+            let error_bytes = circuit_error.write_to_bytes().unwrap();
 
-        assert_eq!(send_request.len(), 0);
+            // dispatch the error message
+            dispatcher
+                .dispatch(
+                    "def",
+                    &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
+                    error_bytes.clone(),
+                )
+                .unwrap();
+
+            let mut network_echo = NetworkEcho::new();
+            network_echo.set_payload(b"send_echo".to_vec());
+            let mut network_msg = NetworkMessage::new();
+            network_msg.set_payload(network_echo.write_to_bytes().unwrap());
+            network_msg.set_message_type(NetworkMessageType::NETWORK_ECHO);
+            network_echo_sender
+                .send("345".to_string(), network_msg.write_to_bytes().unwrap())
+                .expect("Unable to send network echo");
+        });
+
+        let mesh2 = Mesh::new(1, 1);
+        let network2 = Network::new(mesh2.clone(), 0).unwrap();
+        let connection = inproc_transport
+            .connect("inproc://circuit_error")
+            .expect("Unable to connect to inproc");
+        network2
+            .add_peer("123".to_string(), connection)
+            .expect("Unable to add peer");
+        let network_message = network2
+            .recv()
+            .expect("Unable to receive message over the network");
+
+        // verify that the message returned was an NetworkEcho, not a CircuitError
+        let network_msg: NetworkMessage =
+            protobuf::parse_from_bytes(network_message.payload()).unwrap();
+
+        assert_eq!(
+            network_msg.get_message_type(),
+            NetworkMessageType::NETWORK_ECHO
+        );
+    }
+
+    // Helper function for running the tests. This function starts up two networks, a transport
+    // and a dispatcher. The function is passed the test to run, and the expected message that
+    // will be should be returned.
+    fn run_test<F: 'static, M: protobuf::Message, A>(
+        test: F,
+        expected_sender: &str,
+        expected_circuit_msg_type: CircuitMessageType,
+        detail_assertions: A,
+    ) where
+        F: Fn(Box<dyn Listener>, Dispatcher<CircuitMessageType>, Network) -> () + Send,
+        A: Fn(M),
+    {
+        // Set up dispatcher and mock sender
+        let mesh1 = Mesh::new(1, 1);
+        let network1 = Network::new(mesh1.clone(), 0).unwrap();
+
+        let network_message_queue = sender::Builder::new()
+            .with_network(network1.clone())
+            .build()
+            .expect("Unable to create queue");
+        let network_sender = network_message_queue.new_network_sender();
+
+        let mut inproc_transport = InprocTransport::default();
+        let dispatcher = Dispatcher::new(network_sender);
+        let listener = inproc_transport
+            .listen("inproc://circuit_error")
+            .expect("Cannot get listener");
+
+        std::thread::spawn(move || test(listener, dispatcher, network1));
+
+        let mesh2 = Mesh::new(1, 1);
+        let network2 = Network::new(mesh2.clone(), 0).unwrap();
+        let connection = inproc_transport
+            .connect("inproc://circuit_error")
+            .expect("Unable to connect to inproc");
+        network2
+            .add_peer("123".to_string(), connection)
+            .expect("Unable to add peer");
+        let network_message = network2
+            .recv()
+            .expect("Unable to receive message over the network");
+
+        assert_network_message(
+            network_message,
+            expected_sender,
+            expected_circuit_msg_type,
+            detail_assertions,
+        )
+    }
+
+    fn assert_network_message<M: protobuf::Message, F: Fn(M)>(
+        network_message: NetworkMessageWrapper,
+        expected_sender: &str,
+        expected_circuit_msg_type: CircuitMessageType,
+        detail_assertions: F,
+    ) {
+        assert_eq!(expected_sender, network_message.peer_id());
+
+        let network_msg: NetworkMessage =
+            protobuf::parse_from_bytes(network_message.payload()).unwrap();
+        let circuit_msg: CircuitMessage =
+            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+        assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
+        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+
+        detail_assertions(circuit_msg);
     }
 }

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::channel::Sender;
+
 use crate::circuit::handlers::create_message;
 use crate::circuit::service::{Service, ServiceId, SplinterNode};
 use crate::circuit::{ServiceDefinition, SplinterState};
 use crate::network::dispatch::{DispatchError, Handler, MessageContext};
-use crate::network::sender::SendRequest;
+use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{
     CircuitMessageType, ServiceConnectRequest, ServiceConnectResponse,
     ServiceConnectResponse_Status, ServiceDisconnectRequest, ServiceDisconnectResponse,
@@ -37,7 +37,7 @@ impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectReques
         &self,
         msg: ServiceConnectRequest,
         context: &MessageContext<CircuitMessageType>,
-        sender: &dyn Sender<SendRequest>,
+        sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Connect Request {:?}", msg);
         let circuit_name = msg.get_circuit();
@@ -135,8 +135,12 @@ impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectReques
             create_message(response_bytes, CircuitMessageType::SERVICE_CONNECT_RESPONSE)?;
 
         let recipient = context.source_peer_id().to_string();
-        let send_request = SendRequest::new(recipient, network_msg_bytes);
-        sender.send(send_request)?;
+
+        sender
+            .send(recipient, network_msg_bytes)
+            .map_err(|(recipient, payload)| {
+                DispatchError::NetworkSendError((recipient, payload))
+            })?;
         Ok(())
     }
 }
@@ -161,7 +165,7 @@ impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnect
         &self,
         msg: ServiceDisconnectRequest,
         context: &MessageContext<CircuitMessageType>,
-        sender: &dyn Sender<SendRequest>,
+        sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Disconnect Request {:?}", msg);
         let circuit_name = msg.get_circuit();
@@ -227,8 +231,11 @@ impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnect
         )?;
 
         let recipient = context.source_peer_id().to_string();
-        let send_request = SendRequest::new(recipient, network_msg_bytes);
-        sender.send(send_request)?;
+        sender
+            .send(recipient, network_msg_bytes)
+            .map_err(|(recipient, payload)| {
+                DispatchError::NetworkSendError((recipient, payload))
+            })?;
         Ok(())
     }
 }
@@ -249,467 +256,429 @@ impl From<protobuf::error::ProtobufError> for DispatchError {
 mod tests {
 
     use super::*;
-    use crate::channel::mock::MockSender;
-    use crate::channel::Sender;
     use crate::circuit::directory::CircuitDirectory;
     use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
+    use crate::mesh::Mesh;
     use crate::network::dispatch::Dispatcher;
+    use crate::network::sender;
+    use crate::network::{Network, NetworkMessageWrapper};
     use crate::protos::circuit::CircuitMessage;
     use crate::protos::network::NetworkMessage;
     use crate::storage::get_storage;
+    use crate::transport::inproc::InprocTransport;
+    use crate::transport::{Listener, Transport};
 
     #[test]
     // Test that if the circuit does not exist, a ServiceConnectResponse is returned with
     // a ERROR_CIRCUIT_DOES_NOT_EXIST
     fn test_service_connect_request_handler_no_circuit() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let storage = get_storage("memory", CircuitDirectory::new).unwrap();
-        let circuit_directory = storage.read().clone();
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
-        let handler =
-            ServiceConnectRequestHandler::new("123".to_string(), "127.0.0.1:0".to_string(), state);
+                let storage = get_storage("memory", CircuitDirectory::new).unwrap();
+                let circuit_directory = storage.read().clone();
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let handler = ServiceConnectRequestHandler::new(
+                    "123".to_string(),
+                    "127.0.0.1:0".to_string(),
+                    state,
+                );
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectRequest::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut connect_request = ServiceConnectRequest::new();
+                connect_request.set_circuit("alpha".into());
+                connect_request.set_service_id("abc".into());
+                let connect_bytes = connect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "abc",
-                &CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "abc");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let connect_response: ServiceConnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_RESPONSE
-        );
-        assert_eq!(connect_response.get_circuit(), "alpha");
-        assert_eq!(connect_response.get_service_id(), "abc");
-        assert_eq!(
-            connect_response.get_status(),
-            ServiceConnectResponse_Status::ERROR_CIRCUIT_DOES_NOT_EXIST
-        );
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                        connect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_CONNECT_RESPONSE,
+            |msg: ServiceConnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceConnectResponse_Status::ERROR_CIRCUIT_DOES_NOT_EXIST
+                );
+            },
+        )
     }
 
     #[test]
     // Test that if the service is not in circuit, a ServiceConnectResponse is returned with
     // a ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
     fn test_service_connect_request_handler_not_in_circuit() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("BAD".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
-        let handler =
-            ServiceConnectRequestHandler::new("123".to_string(), "127.0.0.1:0".to_string(), state);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let handler = ServiceConnectRequestHandler::new(
+                    "123".to_string(),
+                    "127.0.0.1:0".to_string(),
+                    state,
+                );
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectRequest::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("BAD".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut connect_request = ServiceConnectRequest::new();
+                connect_request.set_circuit("alpha".into());
+                connect_request.set_service_id("BAD".into());
+                let connect_bytes = connect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "BAD",
-                &CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "BAD");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let connect_response: ServiceConnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_RESPONSE
-        );
-        assert_eq!(connect_response.get_circuit(), "alpha");
-        assert_eq!(connect_response.get_service_id(), "BAD");
-        assert_eq!(
-            connect_response.get_status(),
-            ServiceConnectResponse_Status::ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
-        );
+                dispatcher
+                    .dispatch(
+                        "BAD",
+                        &CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                        connect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_CONNECT_RESPONSE,
+            |msg: ServiceConnectResponse| {
+                assert_eq!(msg.get_service_id(), "BAD");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceConnectResponse_Status::ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
+                );
+            },
+        )
     }
 
     #[test]
     // Test that if the service is in a circuit and not connected, a ServiceConnectResponse is
     // returned with an OK
     fn test_service_connect_request_handler() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
-        let handler = ServiceConnectRequestHandler::new(
-            "123".to_string(),
-            "127.0.0.1:0".to_string(),
-            state.clone(),
-        );
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let handler = ServiceConnectRequestHandler::new(
+                    "123".to_string(),
+                    "127.0.0.1:0".to_string(),
+                    state.clone(),
+                );
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectRequest::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut connect_request = ServiceConnectRequest::new();
+                connect_request.set_circuit("alpha".into());
+                connect_request.set_service_id("abc".into());
+                let connect_bytes = connect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-        let send_requests = sender.sent();
-        assert_eq!(send_requests.len(), 1);
-        let send_request = send_requests.get(0).unwrap().clone();
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                        connect_bytes.clone(),
+                    )
+                    .unwrap();
 
-        assert_eq!(send_request.recipient(), "PEER");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let connect_response: ServiceConnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_RESPONSE
-        );
-        assert_eq!(connect_response.get_circuit(), "alpha");
-        assert_eq!(connect_response.get_service_id(), "abc");
-        assert_eq!(
-            connect_response.get_status(),
-            ServiceConnectResponse_Status::OK
-        );
-
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        assert!(state.get_service(&id).unwrap().is_some());
+                let id = ServiceId::new("alpha".into(), "abc".into());
+                assert!(state.get_service(&id).unwrap().is_some());
+            },
+            "123",
+            CircuitMessageType::SERVICE_CONNECT_RESPONSE,
+            |msg: ServiceConnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(msg.get_status(), ServiceConnectResponse_Status::OK);
+            },
+        )
     }
 
     #[test]
     // Test that if the service is in a circuit and already connected, a ServiceConnectResponse is
     // returned with an ERROR_SERVICE_ALREADY_REGISTERED
     fn test_service_connect_request_handler_already_connected() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        let node = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let service = Service::new("abc".to_string(), Some("abc_network".to_string()), node);
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        state.add_service(id.clone(), service).unwrap();
-        let handler =
-            ServiceConnectRequestHandler::new("123".to_string(), "127.0.0.1:0".to_string(), state);
+                let node = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
+                let service =
+                    Service::new("abc".to_string(), Some("abc_network".to_string()), node);
+                let id = ServiceId::new("alpha".into(), "abc".into());
+                state.add_service(id.clone(), service).unwrap();
+                let handler = ServiceConnectRequestHandler::new(
+                    "123".to_string(),
+                    "127.0.0.1:0".to_string(),
+                    state,
+                );
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut connect_request = ServiceConnectRequest::new();
-        connect_request.set_circuit("alpha".into());
-        connect_request.set_service_id("abc".into());
-        let connect_bytes = connect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut connect_request = ServiceConnectRequest::new();
+                connect_request.set_circuit("alpha".into());
+                connect_request.set_service_id("abc".into());
+                let connect_bytes = connect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                connect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "PEER");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let connect_response: ServiceConnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_CONNECT_RESPONSE
-        );
-        assert_eq!(connect_response.get_circuit(), "alpha");
-        assert_eq!(connect_response.get_service_id(), "abc");
-        assert_eq!(
-            connect_response.get_status(),
-            ServiceConnectResponse_Status::ERROR_SERVICE_ALREADY_REGISTERED
-        );
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_CONNECT_REQUEST,
+                        connect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_CONNECT_RESPONSE,
+            |msg: ServiceConnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceConnectResponse_Status::ERROR_SERVICE_ALREADY_REGISTERED
+                );
+            },
+        )
     }
 
     #[test]
     // Test that if the circuit does not exist, a ServiceDisconnectResponse is returned with
     // a ERROR_CIRCUIT_DOES_NOT_EXIST
     fn test_service_disconnect_request_handler_no_circuit() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let storage = get_storage("memory", CircuitDirectory::new).unwrap();
-        let circuit_directory = storage.read().clone();
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
-        let handler = ServiceDisconnectRequestHandler::new(state);
+                let storage = get_storage("memory", CircuitDirectory::new).unwrap();
+                let circuit_directory = storage.read().clone();
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let handler = ServiceDisconnectRequestHandler::new(state);
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut disconnect_request = ServiceDisconnectRequest::new();
-        disconnect_request.set_circuit("alpha".into());
-        disconnect_request.set_service_id("abc".into());
-        let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut disconnect_request = ServiceDisconnectRequest::new();
+                disconnect_request.set_circuit("alpha".into());
+                disconnect_request.set_service_id("abc".into());
+                let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "abc",
-                &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                disconnect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "abc");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let disconnect_response: ServiceDisconnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE
-        );
-        assert_eq!(disconnect_response.get_circuit(), "alpha");
-        assert_eq!(disconnect_response.get_service_id(), "abc");
-        assert_eq!(
-            disconnect_response.get_status(),
-            ServiceDisconnectResponse_Status::ERROR_CIRCUIT_DOES_NOT_EXIST
-        );
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                        disconnect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
+            |msg: ServiceDisconnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceDisconnectResponse_Status::ERROR_CIRCUIT_DOES_NOT_EXIST
+                );
+            },
+        )
     }
 
     #[test]
     // Test that if the service is not in circuit, a ServiceDisconnectResponse is returned with
     // a ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
     fn test_service_disconnect_request_handler_not_in_circuit() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("BAD".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
-        let handler = ServiceDisconnectRequestHandler::new(state);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let handler = ServiceDisconnectRequestHandler::new(state);
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut disconnect_request = ServiceDisconnectRequest::new();
-        disconnect_request.set_circuit("alpha".into());
-        disconnect_request.set_service_id("BAD".into());
-        let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut disconnect_request = ServiceDisconnectRequest::new();
+                disconnect_request.set_circuit("alpha".into());
+                disconnect_request.set_service_id("BAD".into());
+                let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "BAD",
-                &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                disconnect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "BAD");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let disconnect_response: ServiceDisconnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE
-        );
-        assert_eq!(disconnect_response.get_circuit(), "alpha");
-        assert_eq!(disconnect_response.get_service_id(), "BAD");
-        assert_eq!(
-            disconnect_response.get_status(),
-            ServiceDisconnectResponse_Status::ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
-        );
+                dispatcher
+                    .dispatch(
+                        "BAD",
+                        &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                        disconnect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
+            |msg: ServiceDisconnectResponse| {
+                assert_eq!(msg.get_service_id(), "BAD");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceDisconnectResponse_Status::ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY
+                );
+            },
+        )
     }
 
     #[test]
     // Test that if the service is in a circuit and already connected, a ServiceDisconnectResponse
     // is returned with an OK.
     fn test_service_disconnect_request_handler() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        let node = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let service = Service::new("abc".to_string(), Some("abc_network".to_string()), node);
-        let id = ServiceId::new("alpha".into(), "abc".into());
-        state.add_service(id.clone(), service).unwrap();
+                let node = SplinterNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
+                let service =
+                    Service::new("abc".to_string(), Some("abc_network".to_string()), node);
+                let id = ServiceId::new("alpha".into(), "abc".into());
+                state.add_service(id.clone(), service).unwrap();
 
-        let handler = ServiceDisconnectRequestHandler::new(state.clone());
+                let handler = ServiceDisconnectRequestHandler::new(state.clone());
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut disconnect_request = ServiceDisconnectRequest::new();
-        disconnect_request.set_circuit("alpha".into());
-        disconnect_request.set_service_id("abc".into());
-        let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut disconnect_request = ServiceDisconnectRequest::new();
+                disconnect_request.set_circuit("alpha".into());
+                disconnect_request.set_service_id("abc".into());
+                let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                disconnect_bytes.clone(),
-            )
-            .unwrap();
-        let send_requests = sender.sent();
-        assert_eq!(send_requests.len(), 1);
-        let send_request = send_requests.get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "PEER");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let disconnect_response: ServiceDisconnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE
-        );
-        assert_eq!(disconnect_response.get_circuit(), "alpha");
-        assert_eq!(disconnect_response.get_service_id(), "abc");
-        assert_eq!(
-            disconnect_response.get_status(),
-            ServiceDisconnectResponse_Status::OK
-        );
-
-        assert!(state.get_service(&id).unwrap().is_none());
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                        disconnect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
+            |msg: ServiceDisconnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(msg.get_status(), ServiceDisconnectResponse_Status::OK);
+            },
+        )
     }
 
     #[test]
     // Test that if the service is in a circuit and not connected, a ServiceDisconnectResponse
     // is returned with an ERROR_SERVICE_NOT_REGISTERED
     fn test_service_disconnect_request_handler_not_connected() {
-        let sender = Box::new(MockSender::default());
-        let mut dispatcher = Dispatcher::new(sender.box_clone());
+        run_test(
+            |mut listener, mut dispatcher, network1| {
+                let connection = listener.accept().expect("Cannot accept connection");
+                network1
+                    .add_peer("abc".to_string(), connection)
+                    .expect("Unable to add peer");
 
-        let circuit = build_circuit();
+                let circuit = build_circuit();
 
-        let mut circuit_directory = CircuitDirectory::new();
-        circuit_directory.add_circuit("alpha".to_string(), circuit);
+                let mut circuit_directory = CircuitDirectory::new();
+                circuit_directory.add_circuit("alpha".to_string(), circuit);
 
-        let state = SplinterState::new("memory".to_string(), circuit_directory);
+                let state = SplinterState::new("memory".to_string(), circuit_directory);
 
-        let handler = ServiceDisconnectRequestHandler::new(state);
+                let handler = ServiceDisconnectRequestHandler::new(state);
 
-        dispatcher.set_handler(
-            CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-            Box::new(handler),
-        );
-        let mut disconnect_request = ServiceDisconnectRequest::new();
-        disconnect_request.set_circuit("alpha".into());
-        disconnect_request.set_service_id("abc".into());
-        let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
+                dispatcher.set_handler(
+                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                    Box::new(handler),
+                );
+                let mut disconnect_request = ServiceDisconnectRequest::new();
+                disconnect_request.set_circuit("alpha".into());
+                disconnect_request.set_service_id("abc".into());
+                let disconnect_bytes = disconnect_request.write_to_bytes().unwrap();
 
-        dispatcher
-            .dispatch(
-                "PEER",
-                &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                disconnect_bytes.clone(),
-            )
-            .unwrap();
-        let send_request = sender.sent().get(0).unwrap().clone();
-
-        assert_eq!(send_request.recipient(), "PEER");
-
-        let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(send_request.payload()).unwrap();
-        let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
-        let disconnect_response: ServiceDisconnectResponse =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
-
-        assert_eq!(
-            circuit_msg.get_message_type(),
-            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE
-        );
-        assert_eq!(disconnect_response.get_circuit(), "alpha");
-        assert_eq!(disconnect_response.get_service_id(), "abc");
-        assert_eq!(
-            disconnect_response.get_status(),
-            ServiceDisconnectResponse_Status::ERROR_SERVICE_NOT_REGISTERED
-        );
+                dispatcher
+                    .dispatch(
+                        "abc",
+                        &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
+                        disconnect_bytes.clone(),
+                    )
+                    .unwrap();
+            },
+            "123",
+            CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
+            |msg: ServiceDisconnectResponse| {
+                assert_eq!(msg.get_service_id(), "abc");
+                assert_eq!(msg.get_circuit(), "alpha");
+                assert_eq!(
+                    msg.get_status(),
+                    ServiceDisconnectResponse_Status::ERROR_SERVICE_NOT_REGISTERED
+                );
+            },
+        )
     }
 
     fn build_circuit() -> Circuit {
@@ -734,5 +703,73 @@ mod tests {
             .expect("Should have built a correct circuit");
 
         circuit
+    }
+
+    // Helper function for running the tests. This function starts up two networks, a transport
+    // and a dispatcher. The function is passed the test to run, and the expected message that
+    // will be should be returned.
+    fn run_test<F: 'static, M: protobuf::Message, A>(
+        test: F,
+        expected_sender: &str,
+        expected_circuit_msg_type: CircuitMessageType,
+        detail_assertions: A,
+    ) where
+        F: Fn(Box<dyn Listener>, Dispatcher<CircuitMessageType>, Network) -> () + Send,
+        A: Fn(M),
+    {
+        // Set up dispatcher and mock sender
+        let mesh1 = Mesh::new(1, 1);
+        let network1 = Network::new(mesh1.clone(), 0).unwrap();
+
+        let network_message_queue = sender::Builder::new()
+            .with_network(network1.clone())
+            .build()
+            .expect("Unable to create queue");
+        let network_sender = network_message_queue.new_network_sender();
+
+        let mut inproc_transport = InprocTransport::default();
+        let dispatcher = Dispatcher::new(network_sender);
+        let listener = inproc_transport
+            .listen("inproc://service_handler")
+            .expect("Cannot get listener");
+
+        std::thread::spawn(move || test(listener, dispatcher, network1));
+
+        let mesh2 = Mesh::new(1, 1);
+        let network2 = Network::new(mesh2.clone(), 0).unwrap();
+        let connection = inproc_transport
+            .connect("inproc://service_handler")
+            .expect("Unable to connect to inproc");
+        network2
+            .add_peer("123".to_string(), connection)
+            .expect("Unable to add peer");
+        let network_message = network2
+            .recv()
+            .expect("Unable to receive message over the network");
+
+        assert_network_message(
+            network_message,
+            expected_sender,
+            expected_circuit_msg_type,
+            detail_assertions,
+        )
+    }
+
+    fn assert_network_message<M: protobuf::Message, F: Fn(M)>(
+        network_message: NetworkMessageWrapper,
+        expected_sender: &str,
+        expected_circuit_msg_type: CircuitMessageType,
+        detail_assertions: F,
+    ) {
+        assert_eq!(expected_sender, network_message.peer_id());
+
+        let network_msg: NetworkMessage =
+            protobuf::parse_from_bytes(network_message.payload()).unwrap();
+        let circuit_msg: CircuitMessage =
+            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+        assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
+        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+
+        detail_assertions(circuit_msg);
     }
 }


### PR DESCRIPTION
Instead of having a Sender<SendRequest>, dispatch handlers and
other components that need to send a message over the network
will get a NetworkMessageSender. The sender will hide the
implementation details about sending a message to the network
object. As a result SendRequest is now private.

This change is also in support of removing atomic bools used in
shutdown. The NeworkMessageSendQueue now provides a ShutdownSignaler
that will notify the sending thread to shutdown.

This change required that all handler test were rewritten to use
networks and inproc connections. The authorization handlers required
tcp connections because inproc connections are automatically authorized.


Also fixes private_counter and privater_xo examples

