### PR TITLE
Add /biome/logout route

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/logout.rs
+++ b/libsplinter/src/biome/rest_api/actix/logout.rs
@@ -1,0 +1,98 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::HttpResponse;
+use crate::biome::refresh_tokens::store::{RefreshTokenError, RefreshTokenStore};
+use crate::biome::rest_api::{
+    actix::authorize::authorize_user, config::BiomeRestConfig,
+    resources::authorize::AuthorizationResult,
+};
+use crate::futures::IntoFuture;
+use crate::protocol;
+use crate::rest_api::{
+    secrets::SecretManager, sessions::default_validation, ErrorResponse, HandlerFunction, Method,
+    ProtocolVersionRangeGuard, Resource,
+};
+
+/// Defines a REST endpoint to remove any refresh tokens belonging to the user.
+///
+pub fn make_logout_route(
+    refresh_token_store: Arc<dyn RefreshTokenStore>,
+    secret_manager: Arc<dyn SecretManager>,
+    rest_config: Arc<BiomeRestConfig>,
+) -> Resource {
+    Resource::build("/biome/logout")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_LOGIN_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ))
+        .add_method(
+            Method::Patch,
+            add_logout_route(refresh_token_store, secret_manager, rest_config),
+        )
+}
+
+pub fn add_logout_route(
+    refresh_token_store: Arc<dyn RefreshTokenStore>,
+    secret_manager: Arc<dyn SecretManager>,
+    rest_config: Arc<BiomeRestConfig>,
+) -> HandlerFunction {
+    Box::new(move |request, _| {
+        let rest_config = rest_config.clone();
+        let secret_manager = secret_manager.clone();
+        let refresh_token_store = refresh_token_store.clone();
+        let validation = default_validation(&rest_config.issuer());
+        let user_id = match authorize_user(&request, &secret_manager, &validation) {
+            AuthorizationResult::Authorized(claims) => claims.user_id(),
+            AuthorizationResult::Unauthorized(msg) => {
+                return Box::new(
+                    HttpResponse::Unauthorized()
+                        .json(ErrorResponse::unauthorized(&msg))
+                        .into_future(),
+                )
+            }
+            AuthorizationResult::Failed => {
+                return Box::new(
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                );
+            }
+        };
+
+        Box::new(match refresh_token_store.remove_token(&user_id) {
+            Ok(()) => HttpResponse::Ok()
+                .json(json!({
+                    "message": "User successfully logged out"
+                }))
+                .into_future(),
+            Err(err) => match err {
+                RefreshTokenError::NotFoundError(_) => HttpResponse::BadRequest()
+                    .json(ErrorResponse::bad_request(&format!(
+                        "User not found: {}",
+                        &user_id
+                    )))
+                    .into_future(),
+                _ => {
+                    error!("Failed to remove refresh token: {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            },
+        })
+    })
+}

--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -21,6 +21,8 @@ pub(crate) mod authorize;
 pub(super) mod key_management;
 #[cfg(all(feature = "biome-credentials", feature = "json-web-tokens"))]
 pub(super) mod login;
+#[cfg(all(feature = "biome-refresh-tokens", feature = "json-web-tokens"))]
+pub(super) mod logout;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod register;
 #[cfg(all(

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -72,6 +72,12 @@ use crate::rest_api::secrets::{AutoSecretManager, SecretManager};
 pub use config::{BiomeRestConfig, BiomeRestConfigBuilder};
 pub use error::BiomeRestResourceManagerBuilderError;
 
+#[cfg(all(
+    feature = "json-web-tokens",
+    feature = "rest-api-actix",
+    feature = "biome-refresh-tokens"
+))]
+use self::actix::logout::make_logout_route;
 #[cfg(all(feature = "biome-credentials", feature = "rest-api-actix"))]
 use self::actix::register::make_register_route;
 #[cfg(all(
@@ -178,6 +184,18 @@ impl RestResourceProvider for BiomeRestResourceManager {
                             self.token_secret_manager.clone(),
                             self.refresh_token_secret_manager.clone(),
                         )),
+                        self.rest_config.clone(),
+                    ));
+                }
+                #[cfg(all(
+                    feature = "biome-refresh-tokens",
+                    feature = "json-web-tokens",
+                    feature = "rest-api-actix",
+                ))]
+                {
+                    resources.push(make_logout_route(
+                        self.refresh_token_store.clone(),
+                        self.token_secret_manager.clone(),
                         self.rest_config.clone(),
                     ));
                 }

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -918,6 +918,44 @@ paths:
             application/json:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
+
+  /biome/logout:
+    patch:
+      tags:
+        - Biome
+      description: Removes access tokens associated with a user
+      parameters:
+        - $ref: "#/components/parameters/protocol_version"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User successfully logged out"
+        400:
+          description: Invalid request
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        401:
+          description: Access token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+
   /biome/token:
     post:
       tags:


### PR DESCRIPTION
Adds a route to enable the removal of refresh tokens for a user, which will simulate logging when out accompanied with the removal of the authorization token by the client.

Signed-off-by: Shannyn Telander <telander@bitwise.io>