### PR TITLE
Stabilize circuit-read

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -96,7 +96,6 @@ experimental = [
     "biome-refresh-tokens",
     "biome-rest-api",
     "biome-user",
-    "circuit-read",
     "circuit-template",
     "connection-manager",
     "connection-manager-notification-iter-try-next",
@@ -121,7 +120,6 @@ biome-notifications = ["biome"]
 biome-refresh-tokens = []
 biome-rest-api = ["biome", "postgres"]
 biome-user = ["biome"]
-circuit-read = []
 circuit-template = []
 proposal-read = []
 connection-manager = ["matrix"]

--- a/libsplinter/src/admin/rest_api/actix/mod.rs
+++ b/libsplinter/src/admin/rest_api/actix/mod.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "circuit-read")]
 pub(super) mod circuits;
-#[cfg(feature = "circuit-read")]
 pub(super) mod circuits_circuit_id;
 #[cfg(feature = "proposal-read")]
 pub(super) mod proposals;

--- a/libsplinter/src/admin/rest_api/error.rs
+++ b/libsplinter/src/admin/rest_api/error.rs
@@ -14,7 +14,6 @@
 
 use std::error::Error;
 
-#[cfg(feature = "circuit-read")]
 use crate::circuit::store;
 
 #[cfg(feature = "proposal-read")]
@@ -68,14 +67,12 @@ impl std::fmt::Display for ProposalListError {
     }
 }
 
-#[cfg(feature = "circuit-read")]
 #[derive(Debug)]
 pub enum CircuitFetchError {
     NotFound(String),
     CircuitStoreError(store::CircuitStoreError),
 }
 
-#[cfg(feature = "circuit-read")]
 impl Error for CircuitFetchError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -85,7 +82,6 @@ impl Error for CircuitFetchError {
     }
 }
 
-#[cfg(feature = "circuit-read")]
 impl std::fmt::Display for CircuitFetchError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -95,20 +91,17 @@ impl std::fmt::Display for CircuitFetchError {
     }
 }
 
-#[cfg(feature = "circuit-read")]
 impl From<store::CircuitStoreError> for CircuitFetchError {
     fn from(err: store::CircuitStoreError) -> Self {
         CircuitFetchError::CircuitStoreError(err)
     }
 }
 
-#[cfg(feature = "circuit-read")]
 #[derive(Debug)]
 pub enum CircuitListError {
     CircuitStoreError(store::CircuitStoreError),
 }
 
-#[cfg(feature = "circuit-read")]
 impl Error for CircuitListError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -117,7 +110,6 @@ impl Error for CircuitListError {
     }
 }
 
-#[cfg(feature = "circuit-read")]
 impl std::fmt::Display for CircuitListError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -126,7 +118,6 @@ impl std::fmt::Display for CircuitListError {
     }
 }
 
-#[cfg(feature = "circuit-read")]
 impl From<store::CircuitStoreError> for CircuitListError {
     fn from(err: store::CircuitStoreError) -> Self {
         CircuitListError::CircuitStoreError(err)

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -16,7 +16,6 @@
 
 #[cfg(feature = "rest-api-actix")]
 mod actix;
-#[cfg(any(feature = "circuit-read", feature = "proposal-read"))]
 mod error;
 mod resources;
 
@@ -24,9 +23,9 @@ use crate::admin::service::AdminService;
 use crate::circuit::store;
 use crate::rest_api::{Resource, RestResourceProvider};
 
-#[cfg(all(feature = "circuit-read", feature = "rest-api-actix"))]
+#[cfg(feature = "rest-api-actix")]
 use self::actix::circuits::make_list_circuits_resource;
-#[cfg(all(feature = "circuit-read", feature = "rest-api-actix"))]
+#[cfg(feature = "rest-api-actix")]
 use self::actix::circuits_circuit_id::make_fetch_circuit_resource;
 #[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
 use self::actix::proposals::make_list_proposals_resource;
@@ -102,10 +101,11 @@ impl<T: store::CircuitStore + 'static> CircuitResourceProvider<T> {
 /// * `rest-api-actix`
 impl<T: store::CircuitStore + 'static> RestResourceProvider for CircuitResourceProvider<T> {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature circuit-read is enabled
+        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
+        // enabled
         #[allow(unused_mut)]
         let mut resources = Vec::new();
-        #[cfg(all(feature = "circuit-read", feature = "rest-api-actix"))]
+        #[cfg(feature = "rest-api-actix")]
         {
             resources.append(&mut vec![
                 make_fetch_circuit_resource(self.store.clone()),

--- a/libsplinter/src/admin/rest_api/resources/mod.rs
+++ b/libsplinter/src/admin/rest_api/resources/mod.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "circuit-read")]
 pub(in super::super) mod circuits;
-#[cfg(feature = "circuit-read")]
 pub(in super::super) mod circuits_circuit_id;
 #[cfg(feature = "proposal-read")]
 pub(in super::super) mod proposals;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -26,9 +26,9 @@ pub(crate) const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(all(feature = "rest-api", feature = "proposal-read"))]
 pub(crate) const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "circuit-read", feature = "rest-api"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
-#[cfg(all(feature = "circuit-read", feature = "rest-api"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
 #[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_LIST_NODES_MIN: u32 = 1;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -62,7 +62,6 @@ experimental = [
     "biome-credentials",
     "biome-key-management",
     "biome-rest-api",
-    "circuit-read",
     "health",
     "proposal-read",
     "rest-api-cors",
@@ -75,7 +74,6 @@ biome-credentials = ["splinter/biome-credentials", "biome-refresh-tokens", "json
 biome-key-management = ["splinter/biome-key-management", "biome-refresh-tokens", "json-web-tokens", "biome"]
 biome-refresh-tokens = ["splinter/biome-refresh-tokens"]
 biome-rest-api = ["splinter/biome-rest-api"]
-circuit-read = ["splinter/circuit-read"]
 proposal-read = ["splinter/proposal-read"]
 config-default = []
 config-command-line = []


### PR DESCRIPTION
Stabilizes the `circuit-read` feature by removing the feature from the
libsplinter and splinterd Cargo.toml files and removing the feature
guards in the code.

Signed-off-by: Logan Seeley <seeley@bitwise.io>