### PR TITLE
Stabilize proposal-read

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -105,7 +105,6 @@ experimental = [
     "network-peer-manager",
     "network-ref-map",
     "node-registry-unified",
-    "proposal-read",
     "rest-api-cors",
     "scabbard-client",
     "scabbard-get-state",
@@ -121,7 +120,6 @@ biome-refresh-tokens = []
 biome-rest-api = ["biome", "postgres"]
 biome-user = ["biome"]
 circuit-template = []
-proposal-read = []
 connection-manager = ["matrix"]
 connection-manager-notification-iter-try-next = ["connection-manager"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]

--- a/libsplinter/src/admin/rest_api/actix/mod.rs
+++ b/libsplinter/src/admin/rest_api/actix/mod.rs
@@ -14,9 +14,7 @@
 
 pub(super) mod circuits;
 pub(super) mod circuits_circuit_id;
-#[cfg(feature = "proposal-read")]
 pub(super) mod proposals;
-#[cfg(feature = "proposal-read")]
 pub(super) mod proposals_circuit_id;
 pub(super) mod submit;
 pub(super) mod ws_register_type;

--- a/libsplinter/src/admin/rest_api/error.rs
+++ b/libsplinter/src/admin/rest_api/error.rs
@@ -16,14 +16,12 @@ use std::error::Error;
 
 use crate::circuit::store;
 
-#[cfg(feature = "proposal-read")]
 #[derive(Debug)]
 pub enum ProposalFetchError {
     NotFound(String),
     InternalError(String),
 }
 
-#[cfg(feature = "proposal-read")]
 impl Error for ProposalFetchError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -33,7 +31,6 @@ impl Error for ProposalFetchError {
     }
 }
 
-#[cfg(feature = "proposal-read")]
 impl std::fmt::Display for ProposalFetchError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -43,13 +40,11 @@ impl std::fmt::Display for ProposalFetchError {
     }
 }
 
-#[cfg(feature = "proposal-read")]
 #[derive(Debug)]
 pub enum ProposalListError {
     InternalError(String),
 }
 
-#[cfg(feature = "proposal-read")]
 impl Error for ProposalListError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -58,7 +53,6 @@ impl Error for ProposalListError {
     }
 }
 
-#[cfg(feature = "proposal-read")]
 impl std::fmt::Display for ProposalListError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -27,9 +27,9 @@ use crate::rest_api::{Resource, RestResourceProvider};
 use self::actix::circuits::make_list_circuits_resource;
 #[cfg(feature = "rest-api-actix")]
 use self::actix::circuits_circuit_id::make_fetch_circuit_resource;
-#[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
+#[cfg(feature = "rest-api-actix")]
 use self::actix::proposals::make_list_proposals_resource;
-#[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
+#[cfg(feature = "rest-api-actix")]
 use self::actix::proposals_circuit_id::make_fetch_proposal_resource;
 #[cfg(feature = "rest-api-actix")]
 use self::actix::submit::make_submit_route;
@@ -57,9 +57,9 @@ impl RestResourceProvider for AdminService {
         #[cfg(feature = "rest-api-actix")]
         resources.push(make_submit_route(self.commands()));
 
-        #[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
+        #[cfg(feature = "rest-api-actix")]
         resources.push(make_fetch_proposal_resource(self.proposals()));
-        #[cfg(all(feature = "proposal-read", feature = "rest-api-actix"))]
+        #[cfg(feature = "rest-api-actix")]
         resources.push(make_list_proposals_resource(self.proposals()));
 
         resources

--- a/libsplinter/src/admin/rest_api/resources/mod.rs
+++ b/libsplinter/src/admin/rest_api/resources/mod.rs
@@ -14,7 +14,5 @@
 
 pub(in super::super) mod circuits;
 pub(in super::super) mod circuits_circuit_id;
-#[cfg(feature = "proposal-read")]
 pub(in super::super) mod proposals;
-#[cfg(feature = "proposal-read")]
 pub(in super::super) mod proposals_circuit_id;

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -17,7 +17,6 @@ pub(crate) mod error;
 mod mailbox;
 pub(crate) mod messages;
 pub(super) mod open_proposals;
-#[cfg(feature = "proposal-read")]
 pub(super) mod proposal_store;
 mod shared;
 
@@ -50,7 +49,6 @@ use crate::signing::SignatureVerifier;
 
 use self::consensus::AdminConsensusManager;
 use self::error::{AdminError, Sha256Error};
-#[cfg(feature = "proposal-read")]
 use self::proposal_store::{AdminServiceProposals, ProposalStore};
 use self::shared::AdminServiceShared;
 
@@ -196,7 +194,6 @@ impl AdminService {
         }
     }
 
-    #[cfg(feature = "proposal-read")]
     pub fn proposals(&self) -> impl ProposalStore {
         AdminServiceProposals::new(&self.admin_service_shared)
     }

--- a/libsplinter/src/admin/service/open_proposals.rs
+++ b/libsplinter/src/admin/service/open_proposals.rs
@@ -72,7 +72,6 @@ impl OpenProposals {
         self.proposal_registry.get_proposal(circuit_id)
     }
 
-    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
         self.proposal_registry.get_proposals()
     }
@@ -136,7 +135,6 @@ impl ProposalRegistry {
         }
     }
 
-    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
         self.proposals.clone()
     }

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -895,7 +895,6 @@ impl AdminServiceShared {
         Ok(self.open_proposals.get_proposal(circuit_id)?)
     }
 
-    #[cfg(feature = "proposal-read")]
     pub fn get_proposals(&self) -> BTreeMap<String, messages::CircuitProposal> {
         self.open_proposals.get_proposals()
     }

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -21,10 +21,10 @@ pub(crate) const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
 
-#[cfg(all(feature = "rest-api", feature = "proposal-read"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 
-#[cfg(all(feature = "rest-api", feature = "proposal-read"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "rest-api")]
 pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -64,7 +64,6 @@ experimental = [
     "biome-refresh-tokens",
     "biome-rest-api",
     "health",
-    "proposal-read",
     "rest-api-cors",
     "scabbard-get-state",
     "service-arg-validation"
@@ -75,7 +74,6 @@ biome-credentials = ["splinter/biome-credentials", "biome-refresh-tokens", "json
 biome-key-management = ["splinter/biome-key-management", "biome-refresh-tokens", "json-web-tokens", "biome"]
 biome-refresh-tokens = ["splinter/biome-refresh-tokens"]
 biome-rest-api = ["splinter/biome-rest-api"]
-proposal-read = ["splinter/proposal-read"]
 config-default = []
 config-command-line = []
 config-env-var = []


### PR DESCRIPTION
Stabilizes the `proposal-read` feature by removing the feature from the
libsplinter and splinterd Cargo.toml files and removing the feature
guards in the code.

Signed-off-by: Logan Seeley <seeley@bitwise.io>