### PR TITLE
Credentials store cleanup

### DIFF
--- a/libsplinter/src/biome/credentials/store/diesel/mod.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/mod.rs
@@ -45,7 +45,7 @@ impl SplinterCredentialsStore {
     }
 }
 
-impl CredentialsStore<UserCredentials> for SplinterCredentialsStore {
+impl CredentialsStore for SplinterCredentialsStore {
     fn add_credentials(&self, credentials: UserCredentials) -> Result<(), CredentialsStoreError> {
         CredentialsStoreOperations::new(&*self.connection_pool.get()?).add_credentials(credentials)
     }

--- a/libsplinter/src/biome/credentials/store/diesel/mod.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/mod.rs
@@ -29,23 +29,23 @@ use operations::update_credentials::CredentialsStoreUpdateCredentialsOperation a
 use operations::CredentialsStoreOperations;
 
 /// Manages creating, updating and fetching SplinterCredentials from the database
-pub struct SplinterCredentialsStore {
+pub struct DieselCredentialsStore {
     connection_pool: ConnectionPool,
 }
 
-impl SplinterCredentialsStore {
-    /// Creates a new SplinterCredentialsStore
+impl DieselCredentialsStore {
+    /// Creates a new DieselCredentialsStore
     ///
     /// # Arguments
     ///
     ///  * `connection_pool`: connection pool to the database
     #[cfg(feature = "biome-rest-api")]
-    pub fn new(connection_pool: ConnectionPool) -> SplinterCredentialsStore {
-        SplinterCredentialsStore { connection_pool }
+    pub fn new(connection_pool: ConnectionPool) -> DieselCredentialsStore {
+        DieselCredentialsStore { connection_pool }
     }
 }
 
-impl CredentialsStore for SplinterCredentialsStore {
+impl CredentialsStore for DieselCredentialsStore {
     fn add_credentials(&self, credentials: UserCredentials) -> Result<(), CredentialsStoreError> {
         CredentialsStoreOperations::new(&*self.connection_pool.get()?).add_credentials(credentials)
     }

--- a/libsplinter/src/biome/credentials/store/mod.rs
+++ b/libsplinter/src/biome/credentials/store/mod.rs
@@ -132,7 +132,7 @@ impl UserCredentialsBuilder {
 
 /// Defines methods for CRUD operations and fetching a user’s
 /// credentials without defining a storage strategy
-pub trait CredentialsStore<T> {
+pub trait CredentialsStore {
     /// Adds a credential to the underlying storage
     ///
     /// # Arguments
@@ -143,11 +143,10 @@ pub trait CredentialsStore<T> {
     ///
     /// Returns a CredentialsStoreError if the implementation cannot add a new
     /// credential
-    fn add_credentials(&self, credentials: T) -> Result<(), CredentialsStoreError>;
+    fn add_credentials(&self, credentials: UserCredentials) -> Result<(), CredentialsStoreError>;
 
-    /// Replaces a credential of a certain type for a user in the underlying storage with new
-    /// credentials. This assumes that the user has only one credential of a certain type in
-    /// storage
+    /// Replaces a credential for a user in the underlying storage with new credentials. This
+    /// assumes that the user has only one credential in storage
     ///
     /// # Arguments
     ///
@@ -188,7 +187,10 @@ pub trait CredentialsStore<T> {
     ///
     /// Returns a CredentialsStoreError if implementation cannot fetch the credential or
     /// if the credential cannot be found
-    fn fetch_credential_by_user_id(&self, user_id: &str) -> Result<T, CredentialsStoreError>;
+    fn fetch_credential_by_user_id(
+        &self,
+        user_id: &str,
+    ) -> Result<UserCredentials, CredentialsStoreError>;
 
     /// Fetches a credential for a user
     ///
@@ -200,7 +202,10 @@ pub trait CredentialsStore<T> {
     ///
     /// Returns a CredentialsStoreError if implementation cannot fetch the credential or
     /// if the credential cannot be found
-    fn fetch_credential_by_username(&self, username: &str) -> Result<T, CredentialsStoreError>;
+    fn fetch_credential_by_username(
+        &self,
+        username: &str,
+    ) -> Result<UserCredentials, CredentialsStoreError>;
 
     /// Fetches the username for a user by user_id
     ///

--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -22,7 +22,7 @@ use crate::protocol;
 use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
 use crate::biome::credentials::store::{
-    diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
+    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError,
 };
 use crate::biome::rest_api::resources::credentials::UsernamePassword;
 use crate::biome::rest_api::BiomeRestConfig;
@@ -36,7 +36,7 @@ use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
 ///       "hashed_password": <hash of the user's existing password>
 ///   }
 pub fn make_login_route(
-    credentials_store: Arc<SplinterCredentialsStore>,
+    credentials_store: Arc<DieselCredentialsStore>,
     #[cfg(feature = "biome-refresh-tokens")] refresh_token_store: Arc<dyn RefreshTokenStore>,
     rest_config: Arc<BiomeRestConfig>,
     token_issuer: Arc<AccessTokenIssuer>,

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -17,8 +17,7 @@ use uuid::Uuid;
 
 use crate::actix_web::HttpResponse;
 use crate::biome::credentials::store::{
-    diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
-    UserCredentialsBuilder,
+    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError, UserCredentialsBuilder,
 };
 use crate::biome::rest_api::resources::credentials::{NewUser, UsernamePassword};
 use crate::biome::rest_api::BiomeRestConfig;
@@ -35,7 +34,7 @@ use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGua
 ///       "hashed_password": <hash of the password the user will use to log in>
 ///   }
 pub fn make_register_route(
-    credentials_store: Arc<SplinterCredentialsStore>,
+    credentials_store: Arc<DieselCredentialsStore>,
     user_store: DieselUserStore,
     rest_config: Arc<BiomeRestConfig>,
 ) -> Resource {

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
 use crate::biome::credentials::store::{
-    diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
+    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError,
 };
 use crate::biome::rest_api::resources::authorize::AuthorizationResult;
 use crate::biome::rest_api::resources::credentials::UsernamePassword;
@@ -41,7 +41,7 @@ use crate::biome::rest_api::actix::authorize::authorize_user;
 use crate::biome::rest_api::resources::key_management::{NewKey, ResponseKey};
 
 /// Defines a REST endpoint to list users from the db
-pub fn make_list_route(credentials_store: Arc<SplinterCredentialsStore>) -> Resource {
+pub fn make_list_route(credentials_store: Arc<DieselCredentialsStore>) -> Resource {
     Resource::build("/biome/users")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_LIST_USERS_PROTOCOL_MIN,
@@ -66,7 +66,7 @@ pub fn make_list_route(credentials_store: Arc<SplinterCredentialsStore>) -> Reso
 pub fn make_user_routes(
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
-    credentials_store: Arc<SplinterCredentialsStore>,
+    credentials_store: Arc<DieselCredentialsStore>,
     user_store: DieselUserStore,
     key_store: Arc<dyn KeyStore<Key>>,
 ) -> Resource {
@@ -93,7 +93,7 @@ pub fn make_user_routes(
 
 /// Defines a REST endpoint to fetch a user from the database
 /// returns the user's ID and username
-fn add_fetch_user_method(credentials_store: Arc<SplinterCredentialsStore>) -> HandlerFunction {
+fn add_fetch_user_method(credentials_store: Arc<DieselCredentialsStore>) -> HandlerFunction {
     Box::new(move |request, _| {
         let credentials_store = credentials_store.clone();
         let user_id = if let Some(t) = request.match_info().get("id") {
@@ -146,7 +146,7 @@ fn add_fetch_user_method(credentials_store: Arc<SplinterCredentialsStore>) -> Ha
 ///       ]
 ///   }
 fn add_modify_user_method(
-    credentials_store: Arc<SplinterCredentialsStore>,
+    credentials_store: Arc<DieselCredentialsStore>,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
     key_store: Arc<dyn KeyStore<Key>>,

--- a/libsplinter/src/biome/rest_api/actix/verify.rs
+++ b/libsplinter/src/biome/rest_api/actix/verify.rs
@@ -23,7 +23,7 @@ use crate::rest_api::{
 };
 
 use crate::biome::credentials::store::{
-    diesel::SplinterCredentialsStore, CredentialsStore, CredentialsStoreError,
+    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError,
 };
 use crate::biome::rest_api::config::BiomeRestConfig;
 
@@ -39,7 +39,7 @@ use super::authorize::authorize_user;
 ///       "hashed_password": <hash of the user's existing password>
 ///   }
 pub fn make_verify_route(
-    credentials_store: Arc<SplinterCredentialsStore>,
+    credentials_store: Arc<DieselCredentialsStore>,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -101,7 +101,7 @@ use self::actix::user::make_user_routes;
 ))]
 use self::actix::{login::make_login_route, user::make_list_route, verify::make_verify_route};
 #[cfg(feature = "biome-credentials")]
-use super::credentials::store::diesel::SplinterCredentialsStore;
+use super::credentials::store::diesel::DieselCredentialsStore;
 
 #[allow(unused_imports)]
 #[cfg(feature = "json-web-tokens")]
@@ -125,7 +125,7 @@ pub struct BiomeRestResourceManager {
     #[cfg(feature = "biome-refresh-tokens")]
     refresh_token_store: Arc<dyn RefreshTokenStore>,
     #[cfg(feature = "biome-credentials")]
-    credentials_store: Option<Arc<SplinterCredentialsStore>>,
+    credentials_store: Option<Arc<DieselCredentialsStore>>,
 }
 
 impl RestResourceProvider for BiomeRestResourceManager {
@@ -263,7 +263,7 @@ pub struct BiomeRestResourceManagerBuilder {
     #[cfg(feature = "biome-refresh-tokens")]
     refresh_token_store: Option<Arc<dyn RefreshTokenStore>>,
     #[cfg(feature = "biome-credentials")]
-    credentials_store: Option<SplinterCredentialsStore>,
+    credentials_store: Option<DieselCredentialsStore>,
 }
 
 impl BiomeRestResourceManagerBuilder {
@@ -308,7 +308,7 @@ impl BiomeRestResourceManagerBuilder {
         mut self,
         pool: ConnectionPool,
     ) -> BiomeRestResourceManagerBuilder {
-        self.credentials_store = Some(SplinterCredentialsStore::new(pool));
+        self.credentials_store = Some(DieselCredentialsStore::new(pool));
         self
     }
 


### PR DESCRIPTION
Removes generics from UserCredentialsStore and renames SplinterUserCredentialsStore to DieselUserCredentialsStore.