### PR TITLE
Reject dup node IDs/endpoints in circuit propose

### DIFF
--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -182,6 +182,22 @@ impl CreateCircuitMessageBuilder {
 
     pub fn add_node(&mut self, node_id: &str, node_endpoint: &str) -> Result<(), CliError> {
         let node = make_splinter_node(node_id, node_endpoint)?;
+
+        for node in &self.nodes {
+            if node.node_id == node_id {
+                return Err(CliError::ActionError(format!(
+                    "Duplicate node ID detected: {}",
+                    node_id
+                )));
+            }
+            if node.endpoint == node_endpoint {
+                return Err(CliError::ActionError(format!(
+                    "Duplicate node endpoint detected: {}",
+                    node_endpoint
+                )));
+            }
+        }
+
         self.nodes.push(node);
         Ok(())
     }

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -177,9 +177,7 @@ impl CreateCircuitMessageBuilder {
             }
         };
 
-        let node = make_splinter_node(&node_id, &endpoint)?;
-        self.nodes.push(node);
-        Ok(())
+        self.add_node(&node_id, &endpoint)
     }
 
     pub fn add_node(&mut self, node_id: &str, node_endpoint: &str) -> Result<(), CliError> {


### PR DESCRIPTION
Updates the `CreateCircuitMessageBuilder::add_node` method used by the
`splinter circuit propose` CLI command to check for duplicate node IDs
and endpoints. If a duplicate is detected, an error is returned to the
user.

Signed-off-by: Logan Seeley <seeley@bitwise.io>