### PR TITLE
Fix error message in UserCredentialsBuilder when missing username

### DIFF
--- a/libsplinter/src/biome/credentials/store/mod.rs
+++ b/libsplinter/src/biome/credentials/store/mod.rs
@@ -112,7 +112,7 @@ impl UserCredentialsBuilder {
             UserCredentialsBuilderError::MissingRequiredField("Missing user_id".to_string())
         })?;
         let username = self.username.ok_or_else(|| {
-            UserCredentialsBuilderError::MissingRequiredField("Missing user_id".to_string())
+            UserCredentialsBuilderError::MissingRequiredField("Missing username".to_string())
         })?;
 
         let cost = self


### PR DESCRIPTION
Before it said user_id but should have said username.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>