### PR TITLE
Refactor ConnectionPool and modify constructor call

### DIFF
--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -22,7 +22,7 @@
 //! use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
 //! use splinter::database::{self, ConnectionPool};
 //!
-//! let connection_pool: ConnectionPool = database::create_connection_pool(
+//! let connection_pool: ConnectionPool = database::ConnectionPool::new_pg(
 //!            "postgres://db_admin:db_password@0.0.0.0:5432/db",
 //!        )
 //!        .unwrap();

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -638,7 +638,7 @@ fn start_health_service(
 fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartError> {
     info!("Adding biome routes");
     let connection_pool: ConnectionPool =
-        database::create_connection_pool(db_url).map_err(|err| {
+        database::ConnectionPool::new_pg(db_url).map_err(|err| {
             StartError::RestApiError(format!(
                 "Unable to connect to the Splinter database: {}",
                 err


### PR DESCRIPTION
This refactors ConnectionPool and Connection such that it could support
additional databases beyond PostgreSQL. It also moves the constructor to
ConnectionPool::new_pg().

This not a complete solution as the Dref and migrations still need solutions.