### PR TITLE
Remove DatabaseError::QueryError variant which was unused

### DIFF
--- a/libsplinter/src/biome/credentials/store/error.rs
+++ b/libsplinter/src/biome/credentials/store/error.rs
@@ -91,10 +91,6 @@ impl From<DatabaseError> for CredentialsStoreError {
             DatabaseError::ConnectionError(_) => {
                 CredentialsStoreError::ConnectionError(Box::new(err))
             }
-            _ => CredentialsStoreError::StorageError {
-                context: "The database returned an error".to_string(),
-                source: Box::new(err),
-            },
         }
     }
 }

--- a/libsplinter/src/biome/key_management/store/error.rs
+++ b/libsplinter/src/biome/key_management/store/error.rs
@@ -89,10 +89,6 @@ impl From<DatabaseError> for KeyStoreError {
     fn from(err: DatabaseError) -> KeyStoreError {
         match err {
             DatabaseError::ConnectionError(_) => KeyStoreError::ConnectionError(Box::new(err)),
-            _ => KeyStoreError::StorageError {
-                context: "The database returned an error".to_string(),
-                source: Box::new(err),
-            },
         }
     }
 }

--- a/libsplinter/src/biome/refresh_tokens/store/error.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/error.rs
@@ -78,10 +78,6 @@ impl From<DatabaseError> for RefreshTokenError {
     fn from(err: DatabaseError) -> RefreshTokenError {
         match err {
             DatabaseError::ConnectionError(_) => RefreshTokenError::ConnectionError(Box::new(err)),
-            _ => RefreshTokenError::StorageError {
-                context: "The database returned an error".to_string(),
-                source: Box::new(err),
-            },
         }
     }
 }

--- a/libsplinter/src/biome/user/store/error.rs
+++ b/libsplinter/src/biome/user/store/error.rs
@@ -78,10 +78,6 @@ impl From<DatabaseError> for UserStoreError {
     fn from(err: DatabaseError) -> UserStoreError {
         match err {
             DatabaseError::ConnectionError(_) => UserStoreError::ConnectionError(Box::new(err)),
-            _ => UserStoreError::StorageError {
-                context: "The database returned an error".to_string(),
-                source: Box::new(err),
-            },
         }
     }
 }

--- a/libsplinter/src/database/error.rs
+++ b/libsplinter/src/database/error.rs
@@ -18,14 +18,12 @@ use std::fmt;
 #[derive(Debug)]
 pub enum DatabaseError {
     ConnectionError(Box<dyn Error>),
-    QueryError(Box<dyn Error>),
 }
 
 impl Error for DatabaseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             DatabaseError::ConnectionError(e) => Some(&**e),
-            DatabaseError::QueryError(e) => Some(&**e),
         }
     }
 }
@@ -34,13 +32,6 @@ impl fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             DatabaseError::ConnectionError(e) => write!(f, "Unable to connect to database: {}", e),
-            DatabaseError::QueryError(e) => write!(f, "Database query failed: {}", e),
         }
-    }
-}
-
-impl From<diesel::result::Error> for DatabaseError {
-    fn from(err: diesel::result::Error) -> Self {
-        DatabaseError::QueryError(Box::new(err))
     }
 }


### PR DESCRIPTION
The QueryError variant wasn't used by any of the existing code, and
Store-specific errors are preferred currently, so removed.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>