### PR TITLE
Add tests for the circuit CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -45,6 +45,10 @@ serde_yaml = "0.8"
 splinter = { path = "../libsplinter" }
 whoami = { version = "0.7.0", optional = true }
 
+[dev-dependencies]
+gag = "0.1"
+serial_test = "0.3"
+
 [features]
 default = []
 

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -297,7 +297,7 @@ impl fmt::Display for CircuitSlice {
             for service in self.roster.iter() {
                 if service.allowed_nodes.contains(member) {
                     display_string += &format!(
-                        "        Service ({}): {}\n ",
+                        "        Service ({}): {}\n",
                         service.service_type, service.service_id
                     );
 

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -22,6 +22,8 @@ use splinter::protocol::ADMIN_PROTOCOL_VERSION;
 
 use crate::error::CliError;
 
+const PAGING_LIMIT: &str = "1000";
+
 /// A wrapper around the Splinter REST API.
 pub struct SplinterRestClient<'a> {
     url: &'a str,
@@ -105,9 +107,9 @@ impl<'a> SplinterRestClient<'a> {
     }
 
     pub fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, CliError> {
-        let mut request = format!("{}/admin/circuits", self.url);
+        let mut request = format!("{}/admin/circuits?limit={}", self.url, PAGING_LIMIT);
         if let Some(filter) = filter {
-            request = format!("{}?filter={}", &request, &filter);
+            request = format!("{}&filter={}", &request, &filter);
         }
 
         Client::new()
@@ -192,9 +194,9 @@ impl<'a> SplinterRestClient<'a> {
             filters.push(format!("member={}", member));
         }
 
-        let mut request = format!("{}/admin/proposals", self.url);
+        let mut request = format!("{}/admin/proposals?limit={}", self.url, PAGING_LIMIT);
         if !filters.is_empty() {
-            request.push_str(&format!("?{}", filters.join("&")));
+            request.push_str(&format!("&{}", filters.join("&")));
         }
 
         Client::new()

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -11,13 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use std::error::Error;
 use std::fmt;
+
+use clap::Error as ClapError;
 
 #[derive(Debug)]
 pub enum CliError {
     RequiresArgs,
     InvalidSubcommand,
+    ClapError(ClapError),
     ActionError(String),
     EnvironmentError(String),
     #[cfg(feature = "database")]
@@ -31,6 +35,7 @@ impl fmt::Display for CliError {
         match self {
             CliError::RequiresArgs => write!(f, "action requires arguments"),
             CliError::InvalidSubcommand => write!(f, "received invalid subcommand"),
+            CliError::ClapError(err) => f.write_str(&err.message),
             CliError::ActionError(msg) => write!(f, "action encountered an error: {}", msg),
             CliError::EnvironmentError(msg) => {
                 write!(f, "action encountered an environment error: {}", msg)
@@ -38,5 +43,11 @@ impl fmt::Display for CliError {
             #[cfg(feature = "database")]
             CliError::DatabaseError(msg) => write!(f, "database error: {}", msg),
         }
+    }
+}
+
+impl From<ClapError> for CliError {
+    fn from(err: ClapError) -> Self {
+        Self::ClapError(err)
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -475,6 +475,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                     .arg(
                         Arg::with_name("circuit")
                             .help("ID of the circuit to be shown")
+                            .required(true)
                             .takes_value(true),
                     )
                     .arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,8 @@ extern crate diesel;
 
 mod action;
 mod error;
+#[cfg(test)]
+mod tests;
 
 #[cfg(feature = "circuit-template")]
 mod template;

--- a/cli/src/tests/circuit/list.rs
+++ b/cli/src/tests/circuit/list.rs
@@ -1,0 +1,245 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `splinter circuit list` subcommand.
+
+use serial_test::serial;
+
+use crate::CliError;
+
+use super::{
+    get_circuit_id_from_propose_output, get_key, run_with_captured_output,
+    wait_until_circuits_created, wait_until_proposals_committed,
+};
+
+/// Test that a basic `splinter circuit list` is successful.
+///
+/// 1. Make sure at least two circuits exist by proposing and voting on two new circuits and
+///    waiting for them to be created.
+/// 2. Run the `splinter circuit list` command without any special arguments and verify that the
+///    two new circuits appear in the output along with the correct circuit management types and
+///    members.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn list_successful() {
+    // Make sure at least two circuits exist
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit1");
+    let circuit_id1 = get_circuit_id_from_propose_output(&output);
+
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit2");
+    let circuit_id2 = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id1, &circuit_id2]);
+
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id1,
+    ))
+    .expect("Failed to vote on circuit1");
+
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id2,
+    ))
+    .expect("Failed to vote on circuit2");
+
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id1, &circuit_id2]);
+
+    // List circuits and verify the new circuits are in the list
+    let output = run_with_captured_output("splinter circuit list --url http://localhost:8088")
+        .expect("Failed to get circuits");
+
+    let circuit1 = output
+        .split('\n')
+        .find(|line| line.contains(&circuit_id1))
+        .expect("Circuit1 not found")
+        .to_string();
+    let circuit2 = output
+        .split('\n')
+        .find(|line| line.contains(&circuit_id2))
+        .expect("Circuit2 not found")
+        .to_string();
+
+    // Management
+    assert!(circuit1.contains("custom"));
+    assert!(circuit2.contains("custom"));
+    // Members
+    assert!(circuit1.contains("acme-node-000"));
+    assert!(circuit1.contains("bubba-node-000"));
+    assert!(circuit2.contains("acme-node-000"));
+    assert!(circuit2.contains("bubba-node-000"));
+}
+
+/// Test that the human-readable format of `splinter circuit list` is correct and that it is the
+/// default.
+///
+/// 1. Make sure at least one circuits exists by proposing and voting on a new circuit and waiting
+///    for it to be created.
+/// 2. Run the `splinter circuit list` command without any special arguments and verify that the
+///    appropriate headers appear in the output separated by whitespace, and that each entry has
+///    the correct number of fields separated by whitespace.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn list_format_human() {
+    // Make sure at least one circuit exists
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+
+    // List circuits and verify the output
+    let output = run_with_captured_output("splinter circuit list --url http://localhost:8088")
+        .expect("Failed to get circuits");
+    let mut lines = output.split('\n');
+    let mut headers = lines.next().expect("No list output").split_whitespace();
+    assert_eq!(headers.next(), Some("ID"));
+    assert_eq!(headers.next(), Some("MANAGEMENT"));
+    assert_eq!(headers.next(), Some("MEMBERS"));
+
+    for line in lines {
+        if !line.is_empty() {
+            assert!(line.split_whitespace().count() == 3);
+        }
+    }
+}
+
+/// Test that the `csv` format of `splinter circuit list` is correct.
+///
+/// 1. Make sure at least one circuits exists by proposing and voting on a new circuit and waiting
+///    for it to be created.
+/// 2. Run the `splinter circuit list` command with the `--format csv` argument and verify that the
+///    appropriate headers appear in the output separated by commas, and that each entry has the
+///    correct number of fields separated by commas.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn list_format_csv() {
+    // Make sure at least one circuit exists
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+
+    // List circuits and verify the output
+    let output =
+        run_with_captured_output("splinter circuit list --url http://localhost:8088 --format csv")
+            .expect("Failed to get circuits");
+    let mut lines = output.split('\n');
+    let mut headers = lines.next().expect("No list output").split(',');
+    assert_eq!(headers.next(), Some("ID"));
+    assert_eq!(headers.next(), Some("MANAGEMENT"));
+    assert_eq!(headers.next(), Some("MEMBERS"));
+
+    for line in lines {
+        if !line.is_empty() {
+            assert!(line.split(',').count() == 3);
+        }
+    }
+}
+
+/// Test that a `splinter circuit list` command with an invalid format argument (`--format invalid`)
+/// fails with a `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_invalid_format() {
+    match run_with_captured_output(
+        "splinter circuit list --url http://localhost:8088 --format invalid",
+    ) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}

--- a/cli/src/tests/circuit/mod.rs
+++ b/cli/src/tests/circuit/mod.rs
@@ -1,0 +1,129 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides integration tests for the `splinter circuit` subcommands.
+//!
+//! These tests are currently disabled because they are unreliable and/or they require special
+//! environment setup like modifying local files, running docker containers, and not capturing
+//! output.
+//!
+//! The tests in this module are run serially using the `serial_test` crate with the
+//! `#[serial(stdout)]` annotation added to the individual tests. This is required because stdout
+//! cannot be capture more than once at a time and stdout output from one test could show up in
+//! another if run in parallel.
+
+mod list;
+mod proposals;
+mod propose;
+mod show;
+mod vote;
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Read;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use gag::BufferRedirect;
+use serde::{Deserialize, Serialize};
+
+use crate::{run, CliError};
+
+/// Call the `run` function with the given command and return any error that occurs. Return stdout
+/// on success.
+fn run_with_captured_output(command: &str) -> Result<String, CliError> {
+    let mut stdout = BufferRedirect::stdout().expect("Failed to capture stdout");
+    run(command.split_whitespace())?;
+    let mut stdout_output = String::new();
+    stdout
+        .read_to_string(&mut stdout_output)
+        .expect("Failed to read stdout");
+    Ok(stdout_output)
+}
+
+/// Get the ciricuit ID from the output of a successful `splinter circuit propose`.
+fn get_circuit_id_from_propose_output(output: &str) -> String {
+    output
+        .split_whitespace()
+        .skip_while(|item| item != &"Circuit:")
+        .skip(1)
+        .next()
+        .expect("Circuit ID not found in output")
+        .to_string()
+}
+
+/// Polls the splinter REST API at the given URL until all of the given circuit IDs show up in the
+/// node's list of proposals. The poll occurs every second up to 60 seconds before timing out.
+fn wait_until_proposals_committed(url: &str, circuit_ids: &[&str]) {
+    repeat_until_true(|| {
+        let output = run_with_captured_output(&format!("splinter circuit proposals --url {}", url))
+            .expect("Failed to get proposals");
+        circuit_ids
+            .iter()
+            .all(|id| output.split('\n').find(|line| line.contains(id)).is_some())
+    })
+}
+
+/// Polls the splinter REST API at the given URL until all of the given circuit IDs show up in the
+/// node's list of circuits. The poll occurs every second up to 60 seconds before timing out.
+fn wait_until_circuits_created(url: &str, circuit_ids: &[&str]) {
+    repeat_until_true(|| {
+        let output = run_with_captured_output(&format!("splinter circuit list --url {}", url))
+            .expect("Failed to get circuits");
+        circuit_ids
+            .iter()
+            .all(|id| output.split('\n').find(|line| line.contains(id)).is_some())
+    })
+}
+
+/// Call the given function every second until it returns `true`. If the function does not return
+/// `true` after 60 seconds, the function will timeout and panic.
+fn repeat_until_true<F: Fn() -> bool>(func: F) {
+    let timeout = Instant::now() + Duration::from_secs(60);
+    loop {
+        if func() {
+            return;
+        } else if Instant::now() >= timeout {
+            panic!("Timed out");
+        } else {
+            sleep(Duration::from_millis(1000))
+        }
+    }
+}
+
+/// Load the key from the key file at the given path.
+fn get_key(path: &str) -> String {
+    let mut key = String::new();
+    let mut file = File::open(path).expect("Failed to open key file");
+    file.read_to_string(&mut key).expect("Failed to read key");
+    key = key.trim().into();
+    key
+}
+
+/// Local representation of the `splinter circuit show` response
+#[derive(Serialize, Deserialize)]
+struct Circuit {
+    pub id: String,
+    pub members: Vec<String>,
+    pub roster: Vec<Service>,
+    pub management_type: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Service {
+    pub service_id: String,
+    pub service_type: String,
+    pub allowed_nodes: Vec<String>,
+    pub arguments: BTreeMap<String, String>,
+}

--- a/cli/src/tests/circuit/proposals.rs
+++ b/cli/src/tests/circuit/proposals.rs
@@ -1,0 +1,260 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `splinter circuit proposals` subcommand.
+
+use serial_test::serial;
+
+use crate::CliError;
+
+use super::{
+    get_circuit_id_from_propose_output, get_key, run_with_captured_output,
+    wait_until_proposals_committed,
+};
+
+/// Test that a basic `splinter circuit proposals` command is successful.
+///
+/// 1. Make sure at least one proposal exists by proposing a new circuit and waiting for the
+///    proposal to be committed.
+/// 2. Run the `splinter circuit proposals` command without any special arguments and verify that
+///    the proposal appears in the output along with the correct circuit management type, members,
+///    and proposal comment.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_successful_basic() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+
+    // List the proposals and verify the new proposal is in the list
+    let output = run_with_captured_output("splinter circuit proposals --url http://localhost:8088")
+        .expect("Failed to get proposals");
+    let proposal = output
+        .split('\n')
+        .find(|line| line.contains(&circuit_id))
+        .expect("Proposal not found")
+        .to_string();
+
+    // Management
+    assert!(proposal.contains("custom"));
+    // Members
+    assert!(proposal.contains("acme-node-000"));
+    assert!(proposal.contains("bubba-node-000"));
+    // Comments
+    assert!(proposal.contains("test_comment"));
+}
+
+/// Test that a `splinter circuit proposals` command with `--management-type` filter works properly.
+///
+/// 1. Propose two new circuits with different management types and wait for the proposals to be
+///    committed.
+/// 2. Run the `splinter circuit proposals` command with the `--management-type` option and verify
+///    that the proposal with the matching management type appears in the output, but not the other
+///    proposal.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_successful_with_management_type() {
+    // Submit two new proposals with different management types, get the circuit IDs, and wait for
+    // the proposals to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management test1 \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit1");
+    let circuit_id1 = get_circuit_id_from_propose_output(&output);
+
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management test2 \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit2");
+    let circuit_id2 = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id1, &circuit_id2]);
+
+    // List the proposals with `--management-type test2` and verify that only the second proposal
+    // shows up
+    let output = run_with_captured_output(
+        "splinter circuit proposals --url http://localhost:8088 --management-type test2",
+    )
+    .expect("Failed to get proposals");
+    let proposal = output
+        .split('\n')
+        .find(|line| line.contains(&circuit_id2))
+        .expect("Proposal not found")
+        .to_string();
+
+    assert!(proposal.contains("test2"));
+    assert!(!output.contains(&circuit_id1));
+}
+
+/// Test that the human-readable output of the `splinter circuit proposals` command is correct and
+/// that it is the default.
+///
+/// 1. Make sure at least one proposal exists by proposing a new circuit and waiting for the
+///    proposal to be committed.
+/// 2. Run the `splinter circuit list` command without any special arguments and verify that the
+///    appropriate headers appear in the output separated by whitespace, and that each entry has
+///    the correct number of fields separated by whitespace.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_format_human() {
+    // Make sure at least one proposal exists
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+
+    // Verify the human-readable output
+    let output = run_with_captured_output("splinter circuit proposals --url http://localhost:8088")
+        .expect("Failed to get proposals");
+    let mut lines = output.split('\n');
+    let mut headers = lines
+        .next()
+        .expect("No proposals output")
+        .split_whitespace();
+    assert_eq!(headers.next(), Some("ID"));
+    assert_eq!(headers.next(), Some("MANAGEMENT"));
+    assert_eq!(headers.next(), Some("MEMBERS"));
+    assert_eq!(headers.next(), Some("COMMENTS"));
+
+    for line in lines {
+        if !line.is_empty() {
+            // If a proposal doesn't have a comment, there will only be three entries
+            let num_entries = line.split_whitespace().count();
+            assert!(num_entries == 3 || num_entries == 4);
+        }
+    }
+}
+
+/// Test that the csv output of the `splinter circuit proposals` command is correct.
+///
+/// 1. Make sure at least one proposal exists by proposing a new circuit and waiting for the
+///    proposal to be committed.
+/// 2. Run the `splinter circuit list` command with the `--format csv` argument and verify that the
+///    appropriate headers appear in the output separated by commas, and that each entry has the
+///    correct number of fields separated by commas.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_format_csv() {
+    // Make sure at least one proposal exists
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+
+    // Verify the csv output
+    let output = run_with_captured_output(
+        "splinter circuit proposals --url http://localhost:8088 --format csv",
+    )
+    .expect("Failed to get proposals");
+    let mut lines = output.split('\n');
+    let mut headers = lines.next().expect("No proposals output").split(',');
+    assert_eq!(headers.next(), Some("ID"));
+    assert_eq!(headers.next(), Some("MANAGEMENT"));
+    assert_eq!(headers.next(), Some("MEMBERS"));
+    assert_eq!(headers.next(), Some("COMMENTS"));
+
+    for line in lines {
+        if !line.is_empty() {
+            // If a proposal doesn't have a comment, there will only be three entries
+            let num_entries = line.split(',').count();
+            assert!(num_entries == 3 || num_entries == 4);
+        }
+    }
+}
+
+/// Test that a `splinter circuit proposals` command with an invalid format argument
+/// (`--format invalid`) fails with a `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn proposals_invalid_format() {
+    match run_with_captured_output(
+        "splinter circuit proposals --url http://localhost:8088 --format invalid",
+    ) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}

--- a/cli/src/tests/circuit/propose.rs
+++ b/cli/src/tests/circuit/propose.rs
@@ -1,0 +1,354 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `splinter circuit propose` subcommand.
+
+use serial_test::serial;
+
+use crate::CliError;
+
+use super::{
+    get_circuit_id_from_propose_output, get_key, run_with_captured_output,
+    wait_until_proposals_committed,
+};
+
+/// Test that a basic circuit proposal with two nodes (specified with `--node`) and two services is
+/// submitted successfully.
+///
+/// 1. Submit a proposal using the `splinter circuit propose` command and verify that the command
+///    is successfully run.
+/// 2. Verify that the proposal summary is output correctly by inspecting the output for the node
+///    IDs, service IDs, service types, and `admin_keys` service argument.
+/// 3. Verify that the proposal is committed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_successful_basic() {
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a valid circuit proposal using the `--node-file` argument is submitted successfully.
+///
+/// 1. Submit a proposal using the `splinter circuit propose` command with the `--node-file`
+///    argument and verify that the command is successfully run.
+/// 2. Verify that the proposal summary is output correctly by inspecting the output for the node
+///    IDs, service IDs, service types, and `admin_keys` service argument.
+/// 3. Verify that the proposal is committed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_successful_with_node_file() {
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node-file {}/../examples/gameroom/node_registry/nodes.yaml \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        env!("CARGO_MANIFEST_DIR"),
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a valid circuit proposal using individual service types (rather than a wildcard for
+/// service IDs) is submitted successfully.
+///
+/// 1. Submit a proposal using the `splinter circuit propose` command with individually specified
+///    service types and verify that the command is successfully run.
+/// 2. Verify that the proposal summary is output correctly by inspecting the output for the node
+///    IDs, service IDs, service types, and `admin_keys` service argument.
+/// 3. Verify that the proposal is committed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_successful_with_individual_service_types() {
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type sc00::scabbard \
+         --service-type sc01::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a valid circuit proposal using individual service args (rather than a wildcard for
+/// service IDs) is submitted successfully.
+///
+/// 1. Submit a proposal using the `splinter circuit propose` command with individually specified
+///    service arguments and verify that the command is successfully run.
+/// 2. Verify that the proposal summary is output correctly by inspecting the output for the node
+///    IDs, service IDs, service types, and `admin_keys` service argument.
+/// 3. Verify that the proposal is committed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_successful_with_individual_service_args() {
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg sc00::admin_keys={} \
+         --service-arg sc01::admin_keys={} \
+         --service-peer-group sc00,sc01",
+        get_key("/tmp/alice.pub"),
+        get_key("/tmp/bob.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a valid circuit proposal with JSON metadata is submitted successfully.
+///
+/// 1. Submit a proposal using the `splinter circuit propose` command with two key/value metadata
+///    entries and the `--metadata-encoding json` argument; verify that the command is successfully
+///    run.
+/// 2. Verify that the proposal summary is output correctly by inspecting the output for the node
+///    IDs, service IDs, service types, and `admin_keys` service argument.
+/// 3. Verify that the proposal is committed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_successful_with_json_metadata() {
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata key1=value1 \
+         --metadata key2=value2 \
+         --metadata-encoding json",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a circuit proposal without either the `--node` or `--node-file` arguments fails with
+/// a `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_without_nodes() {
+    match run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    )) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a circuit proposal with fewer than 2 services fails with a
+/// `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_too_few_services() {
+    // 0 services
+    match run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    )) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+
+    // 1 service
+    match run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    )) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a circuit proposal with multiple string metadata entries fails with a
+/// `Err(CliError::ActionError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_multiple_string_metadata() {
+    match run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata1 \
+         --metadata test_metadata2 \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    )) {
+        Err(CliError::ActionError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a circuit proposal with `--metadata-encoding` set but not `--metadata` fails with a
+/// `Err(CliError::ActionError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn propose_metadata_encoding_without_metadata() {
+    match run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata-encoding json \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    )) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}

--- a/cli/src/tests/circuit/show.rs
+++ b/cli/src/tests/circuit/show.rs
@@ -1,0 +1,274 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `splinter circuit show` subcommand.
+
+use std::collections::BTreeMap;
+
+use serial_test::serial;
+
+use crate::CliError;
+
+use super::{
+    get_circuit_id_from_propose_output, get_key, run_with_captured_output,
+    wait_until_circuits_created, wait_until_proposals_committed, Circuit,
+};
+
+/// Test that a basic `splinter circuit show` command is successful.
+///
+/// 1. Create a new circuit by proposing and voting on it and waiting for it to be created.
+/// 2. Run the `splinter circuit show` command with the new circuit's ID and no special arguments;
+///    verify that the circuit is shown by inspecting the output for the member node IDs, service
+///    IDs, service types, and admin keys.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn show_successful() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    // Vote on the circuit and wait for it to be created
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+
+    // Verify `show` output
+    let output = run_with_captured_output(&format!(
+        "splinter circuit show --url http://localhost:8088 {}",
+        circuit_id,
+    ))
+    .expect("Failed to show circuit");
+
+    assert!(output.contains("acme-node-000"));
+    assert!(output.contains("bubba-node-000"));
+    assert!(output.contains("sc00"));
+    assert!(output.contains("sc01"));
+    assert!(output.contains("scabbard"));
+    assert!(output.contains(&get_key("/tmp/alice.pub")));
+}
+
+/// Test that a `splinter circuit show --format json` is successful.
+///
+/// 1. Create a new circuit by proposing and voting on it and waiting for it to be created.
+/// 2. Run the `splinter circuit show` command with the new circuit's ID and the `--format json`
+///    argument; verify that the circuit is in correct JSON format by deserializing the output and
+///    checking the values of all fields on the parsed circuit.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn show_format_json() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    // Vote on the circuit and wait for it to be created
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+
+    // Verify `show` output
+    let output = run_with_captured_output(&format!(
+        "splinter circuit show --url http://localhost:8088 {} --format json",
+        circuit_id,
+    ))
+    .expect("Failed to show circuit");
+
+    let circuit: Circuit = serde_json::from_str(&output).expect("Failed to parse JSON");
+    assert_eq!(circuit.id, circuit_id);
+    assert_eq!(
+        circuit.members,
+        vec!["acme-node-000".to_string(), "bubba-node-000".to_string()]
+    );
+    assert_eq!(&circuit.management_type, "custom");
+    assert_eq!(circuit.roster.len(), 2);
+
+    let mut expected_service_args = BTreeMap::new();
+    expected_service_args.insert(
+        "admin_keys".into(),
+        format!("[\"{}\"]", get_key("/tmp/alice.pub")),
+    );
+
+    let service1 = &circuit.roster[0];
+    assert_eq!(&service1.service_id, "sc00");
+    assert_eq!(&service1.service_type, "scabbard");
+    assert_eq!(service1.allowed_nodes, vec!["acme-node-000".to_string()]);
+    let mut expected_service_args_service1 = expected_service_args.clone();
+    expected_service_args_service1.insert("peer_services".into(), "[\"sc01\"]".into());
+    assert_eq!(service1.arguments, expected_service_args_service1);
+
+    let service2 = &circuit.roster[1];
+    assert_eq!(&service2.service_id, "sc01");
+    assert_eq!(&service2.service_type, "scabbard");
+    assert_eq!(service2.allowed_nodes, vec!["bubba-node-000".to_string()]);
+    let mut expected_service_args_service2 = expected_service_args;
+    expected_service_args_service2.insert("peer_services".into(), "[\"sc00\"]".into());
+    assert_eq!(service2.arguments, expected_service_args_service2);
+}
+
+/// Test that a `splinter circuit show --format yaml` is successful.
+///
+/// 1. Create a new circuit by proposing and voting on it and waiting for it to be created.
+/// 2. Run the `splinter circuit show` command with the new circuit's ID and the `--format yaml`
+///    argument; verify that the circuit is in correct YAML format by deserializing the output and
+///    checking the values of all fields on the parsed circuit.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn show_format_yaml() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    // Vote on the circuit and wait for it to be created
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+
+    // Verify `show` output
+    let output = run_with_captured_output(&format!(
+        "splinter circuit show --url http://localhost:8088 {} --format yaml",
+        circuit_id,
+    ))
+    .expect("Failed to show circuit");
+
+    let circuit: Circuit = serde_yaml::from_str(&output).expect("Failed to parse YAML");
+    assert_eq!(circuit.id, circuit_id);
+    assert_eq!(
+        circuit.members,
+        vec!["acme-node-000".to_string(), "bubba-node-000".to_string()]
+    );
+    assert_eq!(&circuit.management_type, "custom");
+    assert_eq!(circuit.roster.len(), 2);
+
+    let mut expected_service_args = BTreeMap::new();
+    expected_service_args.insert(
+        "admin_keys".into(),
+        format!("[\"{}\"]", get_key("/tmp/alice.pub")),
+    );
+
+    let service1 = &circuit.roster[0];
+    assert_eq!(&service1.service_id, "sc00");
+    assert_eq!(&service1.service_type, "scabbard");
+    assert_eq!(service1.allowed_nodes, vec!["acme-node-000".to_string()]);
+    let mut expected_service_args_service1 = expected_service_args.clone();
+    expected_service_args_service1.insert("peer_services".into(), "[\"sc01\"]".into());
+    assert_eq!(service1.arguments, expected_service_args_service1);
+
+    let service2 = &circuit.roster[1];
+    assert_eq!(&service2.service_id, "sc01");
+    assert_eq!(&service2.service_type, "scabbard");
+    assert_eq!(service2.allowed_nodes, vec!["bubba-node-000".to_string()]);
+    let mut expected_service_args_service2 = expected_service_args;
+    expected_service_args_service2.insert("peer_services".into(), "[\"sc00\"]".into());
+    assert_eq!(service2.arguments, expected_service_args_service2);
+}
+
+/// Test that a `splinter circuit show` command with an invalid format argument (`--format invalid`)
+/// fails with a `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn show_invalid_format() {
+    match run_with_captured_output(
+        "splinter circuit show circuit_id --url http://localhost:8088 --format invalid",
+    ) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a `splinter circuit show` command without a circuit ID fails with a
+/// `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn show_without_circuit_id() {
+    match run_with_captured_output("splinter circuit show --url http://localhost:8088") {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}

--- a/cli/src/tests/circuit/vote.rs
+++ b/cli/src/tests/circuit/vote.rs
@@ -1,0 +1,160 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the `splinter circuit vote` subcommand.
+
+use serial_test::serial;
+
+use crate::CliError;
+
+use super::{
+    get_circuit_id_from_propose_output, get_key, repeat_until_true, run_with_captured_output,
+    wait_until_circuits_created, wait_until_proposals_committed,
+};
+
+/// Test that a valid `splinter circuit vote --accept` is successful.
+///
+/// 1. Create a new proposal and wait for it to be committed.
+/// 2. Vote on the circuit and verify that the circuit is created.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn vote_accept_successful() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    // Vote on the circuit and verify that it's created
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+    wait_until_circuits_created("http://localhost:8088", &[&circuit_id]);
+}
+
+/// Test that a valid `splinter circuit vote --reject` is successful.
+///
+/// 1. Create a new proposal and wait for it to be committed.
+/// 2. Vote on the circuit and verify that the proposal is removed.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn vote_reject_successful() {
+    // Submit a new proposal, get the circuit ID, and wait for the proposal to be committed
+    let output = run_with_captured_output(&format!(
+        "splinter circuit propose \
+         --url http://localhost:8088 \
+         --key /tmp/alice.priv \
+         --node acme-node-000::tls://splinterd-node-acme:8044 \
+         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --service sc00::acme-node-000 \
+         --service sc01::bubba-node-000 \
+         --service-type *::scabbard \
+         --management custom \
+         --service-arg *::admin_keys={} \
+         --service-peer-group sc00,sc01 \
+         --metadata test_metadata \
+         --comments test_comment",
+        get_key("/tmp/alice.pub"),
+    ))
+    .expect("Failed to propose circuit");
+    let circuit_id = get_circuit_id_from_propose_output(&output);
+    wait_until_proposals_committed("http://localhost:8089", &[&circuit_id]);
+
+    // Vote on the circuit and verify that the proposal is removed
+    run_with_captured_output(&format!(
+        "splinter circuit vote {} \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --reject",
+        circuit_id,
+    ))
+    .expect("Failed to vote on circuit");
+
+    repeat_until_true(|| {
+        let output =
+            run_with_captured_output("splinter circuit proposals --url http://localhost:8089")
+                .expect("Failed to get proposals");
+        !output.contains(&circuit_id)
+    })
+}
+
+/// Test that a `splinter circuit vote` for a non-existent circuit fails with a
+/// `Err(CliError::ActionError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn vote_non_existent_circuit() {
+    match run_with_captured_output(
+        "splinter circuit vote abcde-01234 \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+    ) {
+        Err(CliError::ActionError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a `splinter circuit vote` without a circuit ID fails with a
+/// `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn vote_without_circuit_id() {
+    match run_with_captured_output(
+        "splinter circuit vote \
+         --url http://localhost:8089 \
+         --key /tmp/bob.priv \
+         --accept",
+    ) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}
+
+/// Test that a `splinter circuit vote` without `--accept` or `--reject` fails with a
+/// `Err(CliError::ClapError(_))` result.
+#[test]
+#[serial(stdout)]
+#[ignore]
+fn vote_without_accept_or_reject() {
+    match run_with_captured_output(
+        "splinter circuit vote circuit_id --url http://localhost:8089 --key /tmp/bob.priv",
+    ) {
+        Err(CliError::ClapError(_)) => {}
+        res => panic!("Got unexpected result: {:?}", res),
+    };
+}

--- a/cli/src/tests/mod.rs
+++ b/cli/src/tests/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides integration tests for the splinter CLI.
+
+#[cfg(feature = "circuit")]
+mod circuit;


### PR DESCRIPTION
Adds a number of tests for the `splinter circuit` CLI subcommands.
These tests verify the behavior of the subcommands, their arguments, and
their outputs.

All of these tests are disabled by default since they require special
setup to work properly, including modifying local files and starting the
Gameroom example application. These tests are considered a work in
progress.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

To run the tests:

1. Startup the gameroom splinterd nodes in a terminal window:
```
$ docker-compose -f examples/gameroom/docker-compose.yaml up generate-key-registry splinterd-node-acme splinterd-node-bubba
```

2. In a new terminal window, copy Alice and Bob’s keys to the temp directory:
```
$ echo $(docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash -c "cat /key_registry/alice.priv") | tee /tmp/alice.priv
$ echo $(docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash -c "cat /key_registry/alice.pub") | tee /tmp/alice.pub
$ echo $(docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash -c "cat /key_registry/bob.priv") | tee /tmp/bob.priv
$ echo $(docker-compose -f examples/gameroom/docker-compose.yaml run generate-key-registry bash -c "cat /key_registry/bob.pub") | tee /tmp/bob.pub
```

3. Run the tests from the CLI root directory:
```
$ cargo test --all-features -- --ignored --nocapture
```

~These tests require the changes in #663 to work properly~