### PR TITLE
Shutdown REST API on test completion

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     /// Tests a GET /admin/circuits request with no filters returns the expected circuits.
     fn test_list_circuits_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_circuits_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!("http://{}/admin/circuits", bind_url))
@@ -202,13 +202,18 @@ mod tests {
                 "/admin/circuits?",
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/circuits request with filter returns the expected circuit.
     fn test_list_circuit_with_filters_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_circuits_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!("http://{}/admin/circuits?filter=node_1", bind_url))
@@ -239,13 +244,18 @@ mod tests {
                 &format!("/admin/circuits?filter=node_1&"),
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/circuits?limit=1 request returns the expected circuit.
     fn test_list_circuit_with_limit() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_circuits_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!("http://{}/admin/circuits?limit=1", bind_url))
@@ -276,13 +286,18 @@ mod tests {
                 "/admin/circuits?",
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/circuits?offset=1 request returns the expected circuit.
     fn test_list_circuit_with_offset() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_circuits_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!("http://{}/admin/circuits?offset=1", bind_url))
@@ -313,7 +328,12 @@ mod tests {
                 "/admin/circuits?"
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     fn create_test_paging_response(

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     /// Tests a GET /admin/circuit/{circuit_id} request returns the expected circuit.
     fn test_fetch_circuit_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_fetch_circuit_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!(
@@ -113,13 +113,18 @@ mod tests {
             to_value(CircuitResponse::from(&get_circuit_1()))
                 .expect("failed to convert expected circuit"),
         );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/circuits/{circuit_id} request returns NotFound when an invalid
     /// circuit_id is passed.
     fn test_fetch_circuit_not_found() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_fetch_circuit_resource(filled_splinter_state())]);
 
         let url = Url::parse(&format!(
@@ -133,6 +138,11 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     fn get_circuit_1() -> Circuit {

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     /// Tests a GET /admin/proposals request with no filters returns the expected proposals.
     fn test_list_proposals_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!("http://{}/admin/proposals", bind_url))
@@ -218,14 +218,19 @@ mod tests {
                 "/admin/proposals?"
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals request with the `management_type` filter returns the expected
     /// proposal.
     fn test_list_proposals_with_management_type_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!(
@@ -261,14 +266,19 @@ mod tests {
                 &format!("/admin/proposals?management_type=mgmt_type_1&")
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals request with the `member` filter returns the expected
     /// proposals.
     fn test_list_proposals_with_member_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!(
@@ -307,14 +317,19 @@ mod tests {
                 &format!("/admin/proposals?member=node_id&")
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals request with both the `management_type` and `member` filters returns
     /// the expected proposal.
     fn test_list_proposals_with_management_type_and_member_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!(
@@ -350,13 +365,18 @@ mod tests {
                 &format!("/admin/proposals?management_type=mgmt_type_2&member=node_id&")
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals?limit=1 request returns the expected proposal.
     fn test_list_proposal_with_limit() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!("http://{}/admin/proposals?limit=1", bind_url))
@@ -389,13 +409,18 @@ mod tests {
                 "/admin/proposals?"
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals?offset=1 request returns the expected proposals.
     fn test_list_proposal_with_offset() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_list_proposals_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!("http://{}/admin/proposals?offset=1", bind_url))
@@ -431,7 +456,12 @@ mod tests {
                 "/admin/proposals?"
             ))
             .expect("failed to convert expected paging")
-        )
+        );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     fn create_test_paging_response(

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     /// Tests a GET /admin/proposals/{circuit_id} request returns the expected proposal.
     fn test_fetch_proposal_ok() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_fetch_proposal_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!(
@@ -117,13 +117,18 @@ mod tests {
             to_value(ProposalResponse::from(&get_proposal()))
                 .expect("failed to convert expected data")
         );
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[test]
     /// Tests a GET /admin/proposals/{circuit_id} request returns NotFound when an invalid
     /// circuit_id is passed.
     fn test_fetch_proposal_not_found() {
-        let (_shutdown_handle, _join_handle, bind_url) =
+        let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_fetch_proposal_resource(MockProposalStore)]);
 
         let url = Url::parse(&format!(
@@ -137,6 +142,11 @@ mod tests {
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        shutdown_handle
+            .shutdown()
+            .expect("unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
When testing REST API endpoints, it is necessary to shutdown the REST API server, so that the all the in-use sockets are closed.  Without this change, tests will fail due to "Too many open files", particularly on MacOS, but may begin to occur on linux, etc, with the addition of more
REST API tests.