### PR TITLE
Configure RefreshTokenStore with connection pool

### DIFF
--- a/libsplinter/src/biome/refresh_tokens/store/diesel/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/diesel/mod.rs
@@ -29,6 +29,12 @@ pub struct DieselRefreshTokenStore {
     connection_pool: ConnectionPool,
 }
 
+impl DieselRefreshTokenStore {
+    pub fn new(connection_pool: ConnectionPool) -> Self {
+        Self { connection_pool }
+    }
+}
+
 impl RefreshTokenStore for DieselRefreshTokenStore {
     fn add_token(&self, user_id: &str, token: &str) -> Result<(), RefreshTokenError> {
         RefreshTokenStoreOperations::new(&*self.connection_pool.get()?).add_token(user_id, token)

--- a/libsplinter/src/biome/refresh_tokens/store/mod.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod diesel;
+pub(crate) mod diesel;
 mod error;
 
 pub use error::RefreshTokenError;

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -50,7 +50,7 @@ mod resources;
 use std::sync::Arc;
 
 #[cfg(feature = "biome-refresh-tokens")]
-use crate::biome::refresh_tokens::store::RefreshTokenStore;
+use crate::biome::refresh_tokens::store::{diesel::DieselRefreshTokenStore, RefreshTokenStore};
 use crate::database::ConnectionPool;
 use crate::rest_api::{Resource, RestResourceProvider};
 
@@ -340,9 +340,9 @@ impl BiomeRestResourceManagerBuilder {
     #[cfg(feature = "biome-refresh-tokens")]
     pub fn with_refresh_token_store(
         mut self,
-        store: impl RefreshTokenStore + 'static,
+        pool: ConnectionPool,
     ) -> BiomeRestResourceManagerBuilder {
-        self.refresh_token_store = Some(Arc::new(store));
+        self.refresh_token_store = Some(Arc::new(DieselRefreshTokenStore::new(pool)));
         self
     }
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -656,6 +656,11 @@ fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartErr
     {
         biome_rest_provider_builder = biome_rest_provider_builder.with_key_store(connection_pool)
     }
+    #[cfg(features = "biome-refresh-tokens")]
+    {
+        biome_rest_provider_builder =
+            biome_rest_provider_builder.with_refresh_token_store(connection_pool);
+    }
     let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
         StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))
     })?;


### PR DESCRIPTION
Configure the RefreshTokenStore like the other stores in the resource builder: via a connection pool.

Additionally:

- if the "biome-refresh-tokens" feature is enabled, configure it in the   splinter daemon.
- make refresh::store::diesel pub(crate) to support this usage.