### PR TITLE
Copy splinterd files in gameroomd dockerfile

### DIFF
--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -21,6 +21,7 @@ COPY examples/gameroom/cli /build/examples/gameroom/cli
 COPY examples/gameroom/database /build/examples/gameroom/database
 COPY examples/gameroom/daemon/ /build/examples/gameroom/daemon
 COPY libsplinter /build/libsplinter
+COPY splinterd /build/splinterd
 
 # Build the gameroomd package
 WORKDIR /build/examples/gameroom/daemon


### PR DESCRIPTION
This is a workaround for compiling in the splinter-dev image. During
builds, the workspace Cargo.toml makes all splinter components
recompile. As various features are removed or renamed, splinterd's
Cargo.toml becomes out of date, depending on features that are no longer
available. Copying over the updated files from the PR fixes the broken
dependencies.

Signed-off-by: Logan Seeley <seeley@bitwise.io>