### PR TITLE
Refactor DatabaseError into ConnectionError

### DIFF
--- a/libsplinter/src/biome/credentials/store/error.rs
+++ b/libsplinter/src/biome/credentials/store/error.rs
@@ -18,7 +18,7 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "diesel")]
-use crate::database::error::DatabaseError;
+use crate::database::error;
 
 /// Represents CredentialsStore errors
 #[derive(Debug)]
@@ -87,13 +87,9 @@ impl fmt::Display for CredentialsStoreError {
 }
 
 #[cfg(feature = "diesel")]
-impl From<DatabaseError> for CredentialsStoreError {
-    fn from(err: DatabaseError) -> CredentialsStoreError {
-        match err {
-            DatabaseError::ConnectionError(_) => {
-                CredentialsStoreError::ConnectionError(Box::new(err))
-            }
-        }
+impl From<error::ConnectionError> for CredentialsStoreError {
+    fn from(err: error::ConnectionError) -> CredentialsStoreError {
+        CredentialsStoreError::ConnectionError(Box::new(err))
     }
 }
 

--- a/libsplinter/src/biome/key_management/store/error.rs
+++ b/libsplinter/src/biome/key_management/store/error.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "diesel")]
-use crate::database::error::DatabaseError;
+use crate::database::error;
 
 /// Represents KeyStore errors
 #[derive(Debug)]
@@ -87,10 +87,8 @@ impl fmt::Display for KeyStoreError {
 }
 
 #[cfg(feature = "diesel")]
-impl From<DatabaseError> for KeyStoreError {
-    fn from(err: DatabaseError) -> KeyStoreError {
-        match err {
-            DatabaseError::ConnectionError(_) => KeyStoreError::ConnectionError(Box::new(err)),
-        }
+impl From<error::ConnectionError> for KeyStoreError {
+    fn from(err: error::ConnectionError) -> KeyStoreError {
+        KeyStoreError::ConnectionError(Box::new(err))
     }
 }

--- a/libsplinter/src/biome/migrations/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/migrations/diesel/postgres/mod.rs
@@ -18,7 +18,7 @@ embed_migrations!("./src/biome/migrations/diesel/postgres/migrations");
 
 use diesel::pg::PgConnection;
 
-use crate::database::error::DatabaseError;
+use crate::database::error::ConnectionError;
 
 /// Run database migrations to create tables defined in the user module
 ///
@@ -26,8 +26,11 @@ use crate::database::error::DatabaseError;
 ///
 /// * `conn` - Connection to database
 ///
-pub fn run_migrations(conn: &PgConnection) -> Result<(), DatabaseError> {
-    embedded_migrations::run(conn).map_err(|err| DatabaseError::ConnectionError(Box::new(err)))?;
+pub fn run_migrations(conn: &PgConnection) -> Result<(), ConnectionError> {
+    embedded_migrations::run(conn).map_err(|err| ConnectionError {
+        context: "Failed to embed migrations".to_string(),
+        source: Box::new(err),
+    })?;
 
     info!("Successfully applied biome credentials migrations");
 

--- a/libsplinter/src/biome/refresh_tokens/store/error.rs
+++ b/libsplinter/src/biome/refresh_tokens/store/error.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "diesel")]
-use crate::database::error::DatabaseError;
+use crate::database::error;
 
 #[derive(Debug)]
 pub enum RefreshTokenError {
@@ -76,10 +76,8 @@ impl fmt::Display for RefreshTokenError {
 }
 
 #[cfg(feature = "diesel")]
-impl From<DatabaseError> for RefreshTokenError {
-    fn from(err: DatabaseError) -> RefreshTokenError {
-        match err {
-            DatabaseError::ConnectionError(_) => RefreshTokenError::ConnectionError(Box::new(err)),
-        }
+impl From<error::ConnectionError> for RefreshTokenError {
+    fn from(err: error::ConnectionError) -> RefreshTokenError {
+        RefreshTokenError::ConnectionError(Box::new(err))
     }
 }

--- a/libsplinter/src/biome/user/store/error.rs
+++ b/libsplinter/src/biome/user/store/error.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "diesel")]
-use crate::database::error::DatabaseError;
+use crate::database::error;
 
 /// Represents UserStore errors
 #[derive(Debug)]
@@ -76,10 +76,8 @@ impl fmt::Display for UserStoreError {
 }
 
 #[cfg(feature = "diesel")]
-impl From<DatabaseError> for UserStoreError {
-    fn from(err: DatabaseError) -> UserStoreError {
-        match err {
-            DatabaseError::ConnectionError(_) => UserStoreError::ConnectionError(Box::new(err)),
-        }
+impl From<error::ConnectionError> for UserStoreError {
+    fn from(err: error::ConnectionError) -> UserStoreError {
+        UserStoreError::ConnectionError(Box::new(err))
     }
 }

--- a/libsplinter/src/database/error.rs
+++ b/libsplinter/src/database/error.rs
@@ -16,22 +16,19 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
-pub enum DatabaseError {
-    ConnectionError(Box<dyn Error>),
+pub struct ConnectionError {
+    pub context: String,
+    pub source: Box<dyn Error>,
 }
 
-impl Error for DatabaseError {
+impl Error for ConnectionError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            DatabaseError::ConnectionError(e) => Some(&**e),
-        }
+        Some(&*self.source)
     }
 }
 
-impl fmt::Display for DatabaseError {
+impl fmt::Display for ConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            DatabaseError::ConnectionError(e) => write!(f, "Unable to connect to database: {}", e),
-        }
+        write!(f, "Unable to connect to database: {}", self.context)
     }
 }


### PR DESCRIPTION
The enum DatabaseError is now the struct ConnectionError, this is
because to only variant of DatabaseError that was being used was
ConnectionError.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>