### PR TITLE
Fix use of RefreshTokenStore in splinterd

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -61,6 +61,7 @@ experimental = [
     "biome",
     "biome-credentials",
     "biome-key-management",
+    "biome-refresh-tokens",
     "biome-rest-api",
     "circuit-read",
     "health",

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -654,9 +654,10 @@ fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartErr
     }
     #[cfg(feature = "biome-key-management")]
     {
-        biome_rest_provider_builder = biome_rest_provider_builder.with_key_store(connection_pool)
+        biome_rest_provider_builder =
+            biome_rest_provider_builder.with_key_store(connection_pool.clone())
     }
-    #[cfg(features = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-refresh-tokens")]
     {
         biome_rest_provider_builder =
             biome_rest_provider_builder.with_refresh_token_store(connection_pool);


### PR DESCRIPTION
To test:

```
$ export 'CARGO_ARGS=-- --features experimental'
$ docker-compose up --build
```
Ensure that the splinter daemon starts correctly.