### PR TITLE
Add user_id to refresh token claims builder

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -122,6 +122,7 @@ pub fn make_login_route(
                             #[cfg(feature = "biome-refresh-tokens")]
                             {
                                 let refresh_claims = match ClaimsBuilder::default()
+                                    .with_user_id(&credentials.user_id)
                                     .with_issuer(&rest_config.issuer())
                                     .with_duration(rest_config.refresh_token_duration())
                                     .build()


### PR DESCRIPTION
Fixes a bug that caused the login route to throw an error because it
wasn't able to create claims for the refresh token.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>