### PR TITLE
Proto conversion traits

### DIFF
--- a/libsplinter/src/protos/mod.rs
+++ b/libsplinter/src/protos/mod.rs
@@ -81,20 +81,28 @@ where
     }
 }
 
-pub trait IntoNative<T>: Sized
+pub trait IntoNative<T>: Sized {
+    fn into_native(self) -> Result<T, ProtoConversionError>;
+}
+
+impl<N, P> IntoNative<N> for P
 where
-    T: FromProto<Self>,
+    N: FromProto<P>,
 {
-    fn into_native(self) -> Result<T, ProtoConversionError> {
+    fn into_native(self) -> Result<N, ProtoConversionError> {
         FromProto::from_proto(self)
     }
 }
 
-pub trait IntoProto<T>: Sized
+pub trait IntoProto<T>: Sized {
+    fn into_proto(self) -> Result<T, ProtoConversionError>;
+}
+
+impl<N, P> IntoProto<P> for N
 where
-    T: FromNative<Self>,
+    P: FromNative<N>,
 {
-    fn into_proto(self) -> Result<T, ProtoConversionError> {
+    fn into_proto(self) -> Result<P, ProtoConversionError> {
         FromNative::from_native(self)
     }
 }

--- a/libsplinter/src/protos/mod.rs
+++ b/libsplinter/src/protos/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018 Bitwise IO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,5 +12,66 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#[derive(Debug)]
+pub enum ProtoConversionError {
+    DeserializationError(String),
+    SerializationError(String),
+    InvalidTypeError(String),
+}
+
+impl std::error::Error for ProtoConversionError {}
+
+impl std::fmt::Display for ProtoConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ProtoConversionError::DeserializationError(ref s) => {
+                write!(f, "unable to deserialize during protobuf conversion: {}", s)
+            }
+            ProtoConversionError::SerializationError(ref s) => {
+                write!(f, "unable to serialize during protobuf conversion: {}", s)
+            }
+            ProtoConversionError::InvalidTypeError(ref s) => write!(
+                f,
+                "invalid type encountered during protobuf conversion: {}",
+                s
+            ),
+        }
+    }
+}
+
+pub trait FromProto<P>: Sized {
+    fn from_proto(other: P) -> Result<Self, ProtoConversionError>;
+}
+
+pub trait FromNative<N>: Sized {
+    fn from_native(other: N) -> Result<Self, ProtoConversionError>;
+}
+
+pub trait FromBytes<N>: Sized {
+    fn from_bytes(bytes: &[u8]) -> Result<N, ProtoConversionError>;
+}
+
+pub trait IntoBytes: Sized {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError>;
+}
+
+pub trait IntoNative<T>: Sized
+where
+    T: FromProto<Self>,
+{
+    fn into_native(self) -> Result<T, ProtoConversionError> {
+        FromProto::from_proto(self)
+    }
+}
+
+pub trait IntoProto<T>: Sized
+where
+    T: FromNative<Self>,
+{
+    fn into_proto(self) -> Result<T, ProtoConversionError> {
+        FromNative::from_native(self)
+    }
+}
 
 include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));

--- a/libsplinter/src/protos/mod.rs
+++ b/libsplinter/src/protos/mod.rs
@@ -107,4 +107,20 @@ where
     }
 }
 
+pub mod prelude {
+    //! Allows for the convenient requirement of the proto conversion traits and errors.
+    //!
+    //! ```
+    //! use splinter::protos::prelude::*;
+    //! ```
+
+    pub use super::FromBytes;
+    pub use super::FromNative;
+    pub use super::FromProto;
+    pub use super::IntoBytes;
+    pub use super::IntoNative;
+    pub use super::IntoProto;
+    pub use super::ProtoConversionError;
+}
+
 include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));


### PR DESCRIPTION
This PR takes the various proto<->native traits from transact, updates the code based on the latest Rust (1.42 as of this PR), as well as makes some modifications to support more auto trait implementations. 

The largest change is `To-/FromBytes` which adds a generic parameter, `ViaProtocol`.  This allows for the auto-trait implementation for traits where the `ViaProtocol` is a `protobuf::Message`.

Additionally, `IntoNative/-Proto` have also been turned into auto trait implementations, vs default function implementations.

With these updates, consumers of the api only need to implement `FromNative` and `FromProto` for their structs.

A simplification for users of these traits is to also re-export the traits and error via a prelude module.  Use can now do:

```
use splinter::protos::prelude::*;
```

and gain all the benefits of the traits.
