### PR TITLE
Remove User prefix from Credential structs

### DIFF
--- a/libsplinter/src/biome/credentials/store/diesel/mod.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/mod.rs
@@ -16,9 +16,9 @@ pub(in crate::biome) mod models;
 mod operations;
 pub(in crate::biome) mod schema;
 
-use super::{CredentialsStore, CredentialsStoreError, UserCredentials, UsernameId};
+use super::{Credentials, CredentialsStore, CredentialsStoreError, UsernameId};
 use crate::database::ConnectionPool;
-use models::UserCredentialsModel;
+use models::CredentialsModel;
 use operations::add_credentials::CredentialsStoreAddCredentialsOperation as _;
 use operations::fetch_credential_by_id::CredentialsStoreFetchCredentialByIdOperation as _;
 use operations::fetch_credential_by_username::CredentialsStoreFetchCredentialByUsernameOperation as _;
@@ -46,7 +46,7 @@ impl DieselCredentialsStore {
 }
 
 impl CredentialsStore for DieselCredentialsStore {
-    fn add_credentials(&self, credentials: UserCredentials) -> Result<(), CredentialsStoreError> {
+    fn add_credentials(&self, credentials: Credentials) -> Result<(), CredentialsStoreError> {
         CredentialsStoreOperations::new(&*self.connection_pool.get()?).add_credentials(credentials)
     }
 
@@ -67,7 +67,7 @@ impl CredentialsStore for DieselCredentialsStore {
     fn fetch_credential_by_user_id(
         &self,
         user_id: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError> {
+    ) -> Result<Credentials, CredentialsStoreError> {
         CredentialsStoreOperations::new(&*self.connection_pool.get()?)
             .fetch_credential_by_id(user_id)
     }
@@ -75,7 +75,7 @@ impl CredentialsStore for DieselCredentialsStore {
     fn fetch_credential_by_username(
         &self,
         username: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError> {
+    ) -> Result<Credentials, CredentialsStoreError> {
         CredentialsStoreOperations::new(&*self.connection_pool.get()?)
             .fetch_credential_by_username(username)
     }
@@ -89,8 +89,8 @@ impl CredentialsStore for DieselCredentialsStore {
     }
 }
 
-impl From<UserCredentialsModel> for UsernameId {
-    fn from(user_credentials: UserCredentialsModel) -> Self {
+impl From<CredentialsModel> for UsernameId {
+    fn from(user_credentials: CredentialsModel) -> Self {
         Self {
             user_id: user_credentials.user_id,
             username: user_credentials.username,
@@ -98,8 +98,8 @@ impl From<UserCredentialsModel> for UsernameId {
     }
 }
 
-impl From<UserCredentialsModel> for UserCredentials {
-    fn from(user_credentials: UserCredentialsModel) -> Self {
+impl From<CredentialsModel> for Credentials {
+    fn from(user_credentials: CredentialsModel) -> Self {
         Self {
             user_id: user_credentials.user_id,
             username: user_credentials.username,

--- a/libsplinter/src/biome/credentials/store/diesel/models.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/models.rs
@@ -18,7 +18,7 @@ use crate::biome::user::store::diesel::models::UserModel;
 #[derive(Queryable, Identifiable, Associations, PartialEq, Debug)]
 #[table_name = "user_credentials"]
 #[belongs_to(UserModel, foreign_key = "user_id")]
-pub struct UserCredentialsModel {
+pub struct CredentialsModel {
     pub id: i64,
     pub user_id: String,
     pub username: String,
@@ -27,7 +27,7 @@ pub struct UserCredentialsModel {
 
 #[derive(Insertable, PartialEq, Debug)]
 #[table_name = "user_credentials"]
-pub struct NewUserCredentialsModel {
+pub struct NewCredentialsModel {
     pub user_id: String,
     pub username: String,
     pub password: String,

--- a/libsplinter/src/biome/credentials/store/diesel/operations/fetch_credential_by_id.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/fetch_credential_by_id.rs
@@ -15,14 +15,11 @@
 use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::schema::user_credentials;
 use crate::biome::credentials::store::error::CredentialsStoreError;
-use crate::biome::credentials::store::{UserCredentials, UserCredentialsModel};
+use crate::biome::credentials::store::{Credentials, CredentialsModel};
 use diesel::{prelude::*, result::Error::NotFound};
 
 pub(in crate::biome::credentials) trait CredentialsStoreFetchCredentialByIdOperation {
-    fn fetch_credential_by_id(
-        &self,
-        user_id: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError>;
+    fn fetch_credential_by_id(&self, user_id: &str) -> Result<Credentials, CredentialsStoreError>;
 }
 
 impl<'a, C> CredentialsStoreFetchCredentialByIdOperation for CredentialsStoreOperations<'a, C>
@@ -33,13 +30,10 @@ where
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
-    fn fetch_credential_by_id(
-        &self,
-        user_id: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError> {
+    fn fetch_credential_by_id(&self, user_id: &str) -> Result<Credentials, CredentialsStoreError> {
         let credentials = user_credentials::table
             .filter(user_credentials::user_id.eq(user_id))
-            .first::<UserCredentialsModel>(self.conn)
+            .first::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
             .map_err(|err| CredentialsStoreError::QueryError {
@@ -52,6 +46,6 @@ where
                     user_id
                 ))
             })?;
-        Ok(UserCredentials::from(credentials))
+        Ok(Credentials::from(credentials))
     }
 }

--- a/libsplinter/src/biome/credentials/store/diesel/operations/fetch_credential_by_username.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/fetch_credential_by_username.rs
@@ -15,14 +15,14 @@
 use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::schema::user_credentials;
 use crate::biome::credentials::store::error::CredentialsStoreError;
-use crate::biome::credentials::store::{UserCredentials, UserCredentialsModel};
+use crate::biome::credentials::store::{Credentials, CredentialsModel};
 use diesel::{prelude::*, result::Error::NotFound};
 
 pub(in crate::biome::credentials) trait CredentialsStoreFetchCredentialByUsernameOperation {
     fn fetch_credential_by_username(
         &self,
         username: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError>;
+    ) -> Result<Credentials, CredentialsStoreError>;
 }
 
 impl<'a, C> CredentialsStoreFetchCredentialByUsernameOperation for CredentialsStoreOperations<'a, C>
@@ -36,10 +36,10 @@ where
     fn fetch_credential_by_username(
         &self,
         username: &str,
-    ) -> Result<UserCredentials, CredentialsStoreError> {
+    ) -> Result<Credentials, CredentialsStoreError> {
         let credentials = user_credentials::table
             .filter(user_credentials::username.eq(username))
-            .first::<UserCredentialsModel>(self.conn)
+            .first::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
             .map_err(|err| CredentialsStoreError::QueryError {
@@ -52,6 +52,6 @@ where
                     username
                 ))
             })?;
-        Ok(UserCredentials::from(credentials))
+        Ok(Credentials::from(credentials))
     }
 }

--- a/libsplinter/src/biome/credentials/store/diesel/operations/fetch_username.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/fetch_username.rs
@@ -15,7 +15,7 @@
 use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::schema::user_credentials;
 use crate::biome::credentials::store::error::CredentialsStoreError;
-use crate::biome::credentials::store::{UserCredentialsModel, UsernameId};
+use crate::biome::credentials::store::{CredentialsModel, UsernameId};
 use diesel::{prelude::*, result::Error::NotFound};
 
 pub(in crate::biome::credentials) trait CredentialsStoreFetchUsernameOperation {
@@ -33,7 +33,7 @@ where
     fn fetch_username_by_id(&self, user_id: &str) -> Result<UsernameId, CredentialsStoreError> {
         let username = user_credentials::table
             .filter(user_credentials::user_id.eq(user_id))
-            .first::<UserCredentialsModel>(self.conn)
+            .first::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
             .map_err(|err| CredentialsStoreError::QueryError {

--- a/libsplinter/src/biome/credentials/store/diesel/operations/get_usernames.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/get_usernames.rs
@@ -16,7 +16,7 @@ use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::{
     schema::user_credentials, CredentialsStoreError, UsernameId,
 };
-use crate::biome::credentials::store::UserCredentialsModel;
+use crate::biome::credentials::store::CredentialsModel;
 use diesel::prelude::*;
 
 pub(in crate::biome::credentials) trait CredentialsStoreGetUsernamesOperation {
@@ -34,7 +34,7 @@ where
     fn get_usernames(&self) -> Result<Vec<UsernameId>, CredentialsStoreError> {
         let usernames = user_credentials::table
             .select(user_credentials::all_columns)
-            .load::<UserCredentialsModel>(self.conn)
+            .load::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(Err)
             .map_err(|err| CredentialsStoreError::QueryError {

--- a/libsplinter/src/biome/credentials/store/diesel/operations/remove_credentials.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/remove_credentials.rs
@@ -14,7 +14,7 @@
 
 use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::{schema::user_credentials, CredentialsStoreError};
-use crate::biome::credentials::store::UserCredentialsModel;
+use crate::biome::credentials::store::CredentialsModel;
 use diesel::{dsl::delete, prelude::*, result::Error::NotFound};
 
 pub(in crate::biome::credentials) trait CredentialsStoreRemoveCredentialsOperation {
@@ -32,7 +32,7 @@ where
     fn remove_credentials(&self, user_id: &str) -> Result<(), CredentialsStoreError> {
         let credentials = user_credentials::table
             .filter(user_credentials::user_id.eq(user_id))
-            .first::<UserCredentialsModel>(self.conn)
+            .first::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
             .map_err(|err| CredentialsStoreError::QueryError {

--- a/libsplinter/src/biome/credentials/store/diesel/operations/update_credentials.rs
+++ b/libsplinter/src/biome/credentials/store/diesel/operations/update_credentials.rs
@@ -15,7 +15,7 @@
 use super::CredentialsStoreOperations;
 use crate::biome::credentials::store::diesel::schema::user_credentials;
 use crate::biome::credentials::store::error::CredentialsStoreError;
-use crate::biome::credentials::store::{UserCredentialsBuilder, UserCredentialsModel};
+use crate::biome::credentials::store::{CredentialsBuilder, CredentialsModel};
 use diesel::{dsl::update, prelude::*, result::Error::NotFound};
 
 pub(in crate::biome::credentials) trait CredentialsStoreUpdateCredentialsOperation {
@@ -41,7 +41,7 @@ where
         username: &str,
         password: &str,
     ) -> Result<(), CredentialsStoreError> {
-        let credentials_builder: UserCredentialsBuilder = Default::default();
+        let credentials_builder: CredentialsBuilder = Default::default();
         let credentials = credentials_builder
             .with_user_id(user_id)
             .with_username(username)
@@ -53,7 +53,7 @@ where
             })?;
         let credential_exists = user_credentials::table
             .filter(user_credentials::user_id.eq(&credentials.user_id))
-            .first::<UserCredentialsModel>(self.conn)
+            .first::<CredentialsModel>(self.conn)
             .map(Some)
             .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
             .map_err(|err| CredentialsStoreError::QueryError {

--- a/libsplinter/src/biome/credentials/store/error.rs
+++ b/libsplinter/src/biome/credentials/store/error.rs
@@ -97,9 +97,9 @@ impl From<DatabaseError> for CredentialsStoreError {
     }
 }
 
-/// Represents UserCredentialsBuilder errors
+/// Represents CredentialsBuilder errors
 #[derive(Debug)]
-pub enum UserCredentialsBuilderError {
+pub enum CredentialsBuilderError {
     /// Returned when a required field was not set
     MissingRequiredField(String),
     /// Returned when an error occurs building the credentials
@@ -108,65 +108,65 @@ pub enum UserCredentialsBuilderError {
     EncryptionError(Box<dyn Error>),
 }
 
-impl Error for UserCredentialsBuilderError {
+impl Error for CredentialsBuilderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            UserCredentialsBuilderError::MissingRequiredField(_) => None,
-            UserCredentialsBuilderError::BuildError(err) => Some(&**err),
-            UserCredentialsBuilderError::EncryptionError(err) => Some(&**err),
+            CredentialsBuilderError::MissingRequiredField(_) => None,
+            CredentialsBuilderError::BuildError(err) => Some(&**err),
+            CredentialsBuilderError::EncryptionError(err) => Some(&**err),
         }
     }
 }
 
-impl fmt::Display for UserCredentialsBuilderError {
+impl fmt::Display for CredentialsBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            UserCredentialsBuilderError::MissingRequiredField(ref s) => {
+            CredentialsBuilderError::MissingRequiredField(ref s) => {
                 write!(f, "failed to build user credentials: {}", s)
             }
-            UserCredentialsBuilderError::BuildError(ref s) => {
+            CredentialsBuilderError::BuildError(ref s) => {
                 write!(f, "failed to build credentials: {}", s)
             }
-            UserCredentialsBuilderError::EncryptionError(ref s) => {
+            CredentialsBuilderError::EncryptionError(ref s) => {
                 write!(f, "failed encrypt password: {}", s)
             }
         }
     }
 }
 
-impl From<BcryptError> for UserCredentialsBuilderError {
-    fn from(err: BcryptError) -> UserCredentialsBuilderError {
-        UserCredentialsBuilderError::EncryptionError(Box::new(err))
+impl From<BcryptError> for CredentialsBuilderError {
+    fn from(err: BcryptError) -> CredentialsBuilderError {
+        CredentialsBuilderError::EncryptionError(Box::new(err))
     }
 }
 
-/// Represents UserCredentials errors
+/// Represents Credentials errors
 #[derive(Debug)]
-pub enum UserCredentialsError {
+pub enum CredentialsError {
     /// Returned when an error occurs while attempting to verify the password
     VerificationError(Box<dyn Error>),
 }
 
-impl Error for UserCredentialsError {
+impl Error for CredentialsError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            UserCredentialsError::VerificationError(err) => Some(&**err),
+            CredentialsError::VerificationError(err) => Some(&**err),
         }
     }
 }
 
-impl fmt::Display for UserCredentialsError {
+impl fmt::Display for CredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            UserCredentialsError::VerificationError(ref s) => {
+            CredentialsError::VerificationError(ref s) => {
                 write!(f, "failed to build verify password: {}", s)
             }
         }
     }
 }
 
-impl From<BcryptError> for UserCredentialsError {
-    fn from(err: BcryptError) -> UserCredentialsError {
-        UserCredentialsError::VerificationError(Box::new(err))
+impl From<BcryptError> for CredentialsError {
+    fn from(err: BcryptError) -> CredentialsError {
+        CredentialsError::VerificationError(Box::new(err))
     }
 }

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::actix_web::HttpResponse;
 use crate::biome::credentials::store::{
-    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError, UserCredentialsBuilder,
+    diesel::DieselCredentialsStore, CredentialsBuilder, CredentialsStore, CredentialsStoreError,
 };
 use crate::biome::rest_api::resources::credentials::{NewUser, UsernamePassword};
 use crate::biome::rest_api::BiomeRestConfig;
@@ -64,7 +64,7 @@ pub fn make_register_route(
                 let splinter_user = User::new(&user_id);
                 match user_store.add_user(splinter_user) {
                     Ok(()) => {
-                        let credentials_builder: UserCredentialsBuilder = Default::default();
+                        let credentials_builder = CredentialsBuilder::default();
                         let credentials = match credentials_builder
                             .with_user_id(&user_id)
                             .with_username(&username_password.username)


### PR DESCRIPTION
Remove the prefix "User" from the following objects. User is redundant
since credentials automatically imply users.

UserCredentialsModel -> CedentialsModel
NewUserCredentialsModel -> NewCredentialsModel
UserCredentials -> Credentials
UserCredentialsBuilder -> CredentialsBuilder
UserCredentialsBuilderError -> CredentialsBuilderError
UserCredentialsError -> CredentialsError

Signed-off-by: Ryan Banks <rbanks@bitwise.io>