### PR TITLE
Add MeshShutdownSignaler and update Mesh to shutdown

### DIFF
--- a/libsplinter/src/matrix.rs
+++ b/libsplinter/src/matrix.rs
@@ -162,6 +162,7 @@ pub enum MatrixRecvError {
         context: String,
         source: Option<Box<dyn Error + Send>>,
     },
+    Shutdown,
 }
 
 impl MatrixRecvError {
@@ -181,6 +182,7 @@ impl Error for MatrixRecvError {
                     None
                 }
             }
+            MatrixRecvError::Shutdown => None,
         }
     }
 }
@@ -198,6 +200,7 @@ impl fmt::Display for MatrixRecvError {
                     f.write_str(&context)
                 }
             }
+            MatrixRecvError::Shutdown => f.write_str("Unable to receive: matrix has shutdown"),
         }
     }
 }
@@ -210,6 +213,7 @@ pub enum MatrixRecvTimeoutError {
         context: String,
         source: Option<Box<dyn Error + Send>>,
     },
+    Shutdown,
 }
 
 impl MatrixRecvTimeoutError {
@@ -230,6 +234,7 @@ impl Error for MatrixRecvTimeoutError {
                     None
                 }
             }
+            MatrixRecvTimeoutError::Shutdown => None,
         }
     }
 }
@@ -247,6 +252,9 @@ impl std::fmt::Display for MatrixRecvTimeoutError {
                 } else {
                     f.write_str(&context)
                 }
+            }
+            MatrixRecvTimeoutError::Shutdown => {
+                f.write_str("Unable to receive: matrix has shutdown")
             }
         }
     }

--- a/libsplinter/src/mesh/control.rs
+++ b/libsplinter/src/mesh/control.rs
@@ -56,11 +56,18 @@ impl Control {
             Err(_err) => Err(RemoveError::ReceiverDisconnected),
         }
     }
+
+    pub fn shutdown(&self) {
+        if self.tx.send(ControlRequest::Shutdown).is_err() {
+            error!("Mesh has already shutdown")
+        }
+    }
 }
 
 pub(super) enum ControlRequest {
     Add(AddRequest),
     Remove(RemoveRequest),
+    Shutdown,
 }
 
 pub(super) struct AddRequest {

--- a/libsplinter/src/mesh/incoming.rs
+++ b/libsplinter/src/mesh/incoming.rs
@@ -20,7 +20,7 @@ use super::InternalEnvelope;
 
 /// Handle for receiving envelopes from the mesh
 #[derive(Clone)]
-pub struct Incoming {
+pub(super) struct Incoming {
     rx: crossbeam_channel::Receiver<InternalEnvelope>,
 }
 

--- a/libsplinter/src/mesh/matrix.rs
+++ b/libsplinter/src/mesh/matrix.rs
@@ -90,6 +90,7 @@ impl MatrixReceiver for MeshMatrixReceiver {
                     "Internal state poisoned".to_string(),
                     Some(Box::new(err)),
                 )),
+                RecvError::Shutdown => Err(MatrixRecvError::Shutdown),
             },
         }
     }
@@ -104,6 +105,7 @@ impl MatrixReceiver for MeshMatrixReceiver {
                     "Internal state poisoned".to_string(),
                     Some(Box::new(err)),
                 )),
+                RecvTimeoutError::Shutdown => Err(MatrixRecvTimeoutError::Shutdown),
             },
         }
     }

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -76,28 +76,10 @@ use crate::mesh::reactor::Reactor;
 use crate::transport::Connection;
 
 /// Wrapper around payload to include connection id
-#[derive(Debug, Default, PartialEq)]
-pub struct InternalEnvelope {
-    id: usize,
-    payload: Vec<u8>,
-}
-
-impl InternalEnvelope {
-    pub fn new(id: usize, payload: Vec<u8>) -> Self {
-        InternalEnvelope { id, payload }
-    }
-
-    pub fn id(&self) -> usize {
-        self.id
-    }
-
-    pub fn payload(&self) -> &[u8] {
-        &self.payload
-    }
-
-    pub fn take_payload(self) -> Vec<u8> {
-        self.payload
-    }
+#[derive(Debug, PartialEq)]
+pub enum InternalEnvelope {
+    Message { id: usize, payload: Vec<u8> },
+    Shutdown,
 }
 
 #[cfg(not(feature = "matrix"))]
@@ -141,6 +123,16 @@ impl MeshState {
     }
 }
 
+pub struct MeshShutdownSignaler {
+    ctrl: Control,
+}
+
+impl MeshShutdownSignaler {
+    pub fn shutdown(&self) {
+        self.ctrl.shutdown();
+    }
+}
+
 /// A Connection reactor
 #[derive(Clone)]
 pub struct Mesh {
@@ -158,6 +150,12 @@ impl Mesh {
             state: Arc::new(RwLock::new(MeshState::new())),
             incoming,
             ctrl,
+        }
+    }
+
+    pub fn shutdown_signaler(&self) -> MeshShutdownSignaler {
+        MeshShutdownSignaler {
+            ctrl: self.ctrl.clone(),
         }
     }
 
@@ -217,17 +215,24 @@ impl Mesh {
     /// Receive a new envelope from the mesh.
     pub fn recv(&self) -> Result<Envelope, RecvError> {
         let internal_envelope = self.incoming.recv().map_err(|_| RecvError::Disconnected)?;
+        match internal_envelope {
+            InternalEnvelope::Shutdown => Err(RecvError::Shutdown),
+            InternalEnvelope::Message {
+                id: connection_id,
+                payload,
+            } => {
+                let id = self
+                    .state
+                    .read()
+                    .map_err(|_| RecvError::PoisonedLock)?
+                    .unique_ids
+                    .get_by_value(&connection_id)
+                    .cloned()
+                    .unwrap_or_default();
 
-        let id = self
-            .state
-            .read()
-            .map_err(|_| RecvError::PoisonedLock)?
-            .unique_ids
-            .get_by_value(&internal_envelope.id)
-            .cloned()
-            .unwrap_or_default();
-
-        Ok(Envelope::new(id, internal_envelope.take_payload()))
+                Ok(Envelope::new(id, payload))
+            }
+        }
     }
 
     /// Receive a new envelope from the mesh.
@@ -236,17 +241,24 @@ impl Mesh {
             .incoming
             .recv_timeout(timeout)
             .map_err(RecvTimeoutError::from)?;
+        match internal_envelope {
+            InternalEnvelope::Shutdown => Err(RecvTimeoutError::Shutdown),
+            InternalEnvelope::Message {
+                id: connection_id,
+                payload,
+            } => {
+                let id = self
+                    .state
+                    .read()
+                    .map_err(|_| RecvTimeoutError::PoisonedLock)?
+                    .unique_ids
+                    .get_by_value(&connection_id)
+                    .cloned()
+                    .unwrap_or_default();
 
-        let id = self
-            .state
-            .read()
-            .map_err(|_| RecvTimeoutError::PoisonedLock)?
-            .unique_ids
-            .get_by_value(&internal_envelope.id)
-            .cloned()
-            .unwrap_or_default();
-
-        Ok(Envelope::new(id, internal_envelope.take_payload()))
+                Ok(Envelope::new(id, payload))
+            }
+        }
     }
 
     /// Create a new handle for sending to the existing connection with the given id.
@@ -330,6 +342,7 @@ impl SendError {
 pub enum RecvError {
     Disconnected,
     PoisonedLock,
+    Shutdown,
 }
 
 impl Error for RecvError {}
@@ -339,6 +352,7 @@ impl std::fmt::Display for RecvError {
         match self {
             RecvError::Disconnected => write!(f, "Unable to receive: channel has disconnected"),
             RecvError::PoisonedLock => write!(f, "MeshState lock was poisoned"),
+            RecvError::Shutdown => write!(f, "Mesh has shutdown"),
         }
     }
 }
@@ -348,6 +362,7 @@ pub enum RecvTimeoutError {
     Timeout,
     Disconnected,
     PoisonedLock,
+    Shutdown,
 }
 
 impl Error for RecvTimeoutError {}
@@ -360,6 +375,7 @@ impl std::fmt::Display for RecvTimeoutError {
                 f.write_str("Unable to receive: channel has disconnected")
             }
             RecvTimeoutError::PoisonedLock => write!(f, "MeshState lock was poisoned"),
+            RecvTimeoutError::Shutdown => write!(f, "Mesh has shutdown"),
         }
     }
 }
@@ -515,7 +531,10 @@ mod tests {
         let incoming = mesh.incoming();
         for _ in 0..CONNECTIONS {
             let envelope = assert_ok(incoming.recv());
-            assert_eq!(b"world", envelope.payload());
+            match envelope {
+                InternalEnvelope::Message { payload, .. } => assert_eq!(b"world".to_vec(), payload),
+                InternalEnvelope::Shutdown => panic!("Should not have received shutdown"),
+            }
         }
 
         handle.join().unwrap();
@@ -557,5 +576,79 @@ mod tests {
     fn test_add_remove_connections_tls() {
         let tls = create_test_tls_transport(true);
         test_add_remove_connections(tls, "127.0.0.1:0");
+    }
+
+    #[test]
+    // Test that mesh can be shutdown after sending and receiving a message.
+    //
+    // 1. Start up Mesh and pass a clone to a thread. Also get a mesh shutdown signaler.
+    // 2. Add two connections to mesh, one for main and on for the thread.
+    // 3. From the main thread, send a message "hello"
+    // 4. From the other thread recv the message "hello", and respond with "world"
+    // 5. In the main thread, verify that "world" is received
+    // 6. Call shutdown on the shutdown signaler
+    // 7. Verify that an InternalEnvelope::Shutdown was received
+    //
+    // This verifies that that mesh's reactor has been shutdown because InternalEnvelope::Shutdown
+    // is only ever sent from within the reactor when it has received a shutdown request. Other
+    // scenarios can cause the reactor to shutdown, but they will send this signal and result in a
+    // disconnection error.
+    fn test_shutdown() {
+        let mut transport = TcpTransport::default();
+        let mut listener = assert_ok(transport.listen("127.0.0.1:0"));
+        let endpoint = listener.endpoint();
+
+        let mesh = Mesh::new(1, 1);
+
+        let (client_ready_tx, client_ready_rx) = channel();
+        let (server_ready_tx, server_ready_rx) = channel();
+
+        let mesh_clone = mesh.clone();
+        let handle = thread::spawn(move || {
+            let mesh = mesh_clone;
+            assert_ok(mesh.add(
+                assert_ok(transport.connect(&endpoint)),
+                "thread_1".to_string(),
+            ));
+
+            // Block waiting for other thread to send a message
+            client_ready_rx.recv().unwrap();
+
+            let envelope = assert_ok(mesh.recv());
+            assert_eq!(b"hello", envelope.payload());
+
+            // Signal to other thread we are done receiving
+            server_ready_tx.send(()).unwrap();
+
+            assert_ok(mesh.send(Envelope::new("thread_1".to_string(), b"world".to_vec())));
+        });
+
+        let conn = assert_ok(listener.accept());
+        assert_ok(mesh.add(conn, "main".to_string()));
+        assert_ok(mesh.send(Envelope::new("main".to_string(), b"hello".to_vec())));
+
+        // Signal done sending to background thread
+        client_ready_tx.send(()).unwrap();
+        // Wait for other thread to drain the queue so we don't accidentally receive messages sent
+        // to that thread
+        server_ready_rx.recv().unwrap();
+
+        let incoming = mesh.incoming();
+        let envelope = assert_ok(incoming.recv());
+        match envelope {
+            InternalEnvelope::Message { payload, .. } => assert_eq!(b"world".to_vec(), payload),
+            InternalEnvelope::Shutdown => panic!("Should not have received shutdown"),
+        }
+
+        let signaler = mesh.shutdown_signaler();
+        signaler.shutdown();
+
+        let envelope = assert_ok(incoming.recv());
+        match envelope {
+            InternalEnvelope::Message { .. } => panic!("Should have received shutdown"),
+            InternalEnvelope::Shutdown => (),
+        };
+
+        handle.join().unwrap();
     }
 }

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -269,7 +269,13 @@ impl Entry {
             Err(TryRecvError::Disconnected) => return Err(TryEventError::OutgoingDisconnected),
         };
 
-        self.try_send_connection_or_cache(envelope.take_payload(), poll)
+        match envelope {
+            InternalEnvelope::Message { payload, .. } => {
+                self.try_send_connection_or_cache(payload, poll)
+            }
+            // won't be sent outgoing
+            InternalEnvelope::Shutdown => unreachable!(),
+        }
     }
 
     // -- Connection --
@@ -355,7 +361,10 @@ impl Entry {
             };
             match connection.recv() {
                 Ok(payload) => {
-                    match incoming_tx.try_send(InternalEnvelope::new(self.id, payload)) {
+                    match incoming_tx.try_send(InternalEnvelope::Message {
+                        id: self.id,
+                        payload,
+                    }) {
                         Err(TrySendError::Full(_)) => {
                             warn!("Dropped message due to full incoming queue");
                             Ok(())

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -28,7 +28,7 @@ use super::InternalEnvelope;
 
 /// A structure for holding onto many connections and receivers and assigning new connections
 /// unique ids
-pub struct Pool {
+pub(super) struct Pool {
     entries: HashMap<usize, Entry>,
     tokens: HashMap<Token, usize>,
     next_id: usize,

--- a/libsplinter/src/mesh/reactor.rs
+++ b/libsplinter/src/mesh/reactor.rs
@@ -137,6 +137,12 @@ impl Reactor {
                 }
                 Turn::Continue
             }
+            Ok(ControlRequest::Shutdown) => {
+                if self.incoming_tx.send(InternalEnvelope::Shutdown).is_err() {
+                    error!("Unable to send shutdown envelope to Mesh")
+                }
+                Turn::Shutdown
+            }
             Err(TryRecvError::Empty) => Turn::Continue,
             Err(TryRecvError::Disconnected) => Turn::Shutdown,
         }

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -36,8 +36,8 @@ use std::time::Duration;
 
 use crate::collections::BiHashMap;
 use crate::mesh::{
-    AddError, Envelope, Mesh, RecvError as MeshRecvError, RecvTimeoutError as MeshRecvTimeoutError,
-    RemoveError, SendError as MeshSendError,
+    AddError, Envelope, Mesh, MeshShutdownSignaler, RecvError as MeshRecvError,
+    RecvTimeoutError as MeshRecvTimeoutError, RemoveError, SendError as MeshSendError,
 };
 use crate::protos::network::{NetworkHeartbeat, NetworkMessage, NetworkMessageType};
 use crate::transport::Connection;
@@ -362,6 +362,10 @@ impl Network {
 
         Ok(NetworkMessageWrapper::new(peer_id, envelope.take_payload()))
     }
+
+    pub fn shutdown_signaler(&self) -> MeshShutdownSignaler {
+        self.mesh.shutdown_signaler()
+    }
 }
 
 // -------------- Errors --------------
@@ -384,6 +388,7 @@ pub enum RecvTimeoutError {
     Timeout,
     Disconnected,
     PoisonedLock,
+    Shutdown,
 }
 
 impl From<MeshRecvTimeoutError> for RecvTimeoutError {
@@ -392,6 +397,7 @@ impl From<MeshRecvTimeoutError> for RecvTimeoutError {
             MeshRecvTimeoutError::Timeout => RecvTimeoutError::Timeout,
             MeshRecvTimeoutError::Disconnected => RecvTimeoutError::Disconnected,
             MeshRecvTimeoutError::PoisonedLock => RecvTimeoutError::PoisonedLock,
+            MeshRecvTimeoutError::Shutdown => RecvTimeoutError::Shutdown,
         }
     }
 }

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -392,6 +392,10 @@ pub fn run_incoming_loop(
                 error!("Mesh lock was poisoned");
                 break;
             }
+            Err(MeshRecvTimeoutError::Shutdown) => {
+                error!("Mesh has shutdown");
+                break;
+            }
         };
 
         let msg: NetworkMessage = protobuf::parse_from_bytes(&message_bytes)

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -216,6 +216,10 @@ impl ServiceProcessor {
                                 error!("Mesh lock was poisoned");
                                 break;
                             }
+                            Err(MeshRecvTimeoutError::Shutdown) => {
+                                error!("Mesh has shutdown");
+                                break;
+                            }
                         };
 
                         if let Err(err) = process_incoming_msg(&message_bytes, &mut inbound_router)

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -178,6 +178,7 @@ impl SplinterDaemon {
 
         info!("Starting SpinterNode with ID {}", self.node_id);
 
+        let network_shutdown = self.network.shutdown_signaler();
         let network = self.network.clone();
         let network_message_queue = sender::Builder::new()
             .with_network(network)
@@ -310,8 +311,13 @@ impl SplinterDaemon {
                             }
                         }
                         Err(RecvTimeoutError::Disconnected) => {
-                            // if the reciever has disconnected, shutdown
+                            // if the receiver has disconnected, shutdown
                             warn!("Received Disconnected Error from Network");
+                            break;
+                        }
+                        Err(RecvTimeoutError::Shutdown) => {
+                            // if network has shutdown, shutdown
+                            warn!("Received Shutdown from Network");
                             break;
                         }
                         Err(_) => {
@@ -438,8 +444,6 @@ impl SplinterDaemon {
             info!("Received Shutdown");
             r.store(false, Ordering::SeqCst);
 
-            sender_shutdown_signaler.shutdown();
-
             if let Err(err) = admin_shutdown_handle.shutdown() {
                 error!("Unable to cleanly shut down Admin service: {}", err);
             }
@@ -447,6 +451,9 @@ impl SplinterDaemon {
             if let Err(err) = rest_api_shutdown_handle.shutdown() {
                 error!("Unable to cleanly shut down REST API server: {}", err);
             }
+
+            network_shutdown.shutdown();
+            sender_shutdown_signaler.shutdown();
         })
         .expect("Error setting Ctrl-C handler");
 


### PR DESCRIPTION
This commit updates InternalEnvelope to be an Enum with
Message and Shutdown options. Mesh will now has a function
that will return a MeshShutdownSignaler that can be used
to shutdown Mesh. 

A function has also been added to Network to return a
MeshShutdownSignaler as well as Network is just a wrapper
around Mesh.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>