### PR TITLE
Log to stdout

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -627,6 +627,7 @@ fn run() -> Result<(), CliError> {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
         .start()
         .expect("Failed to create logger");
 

--- a/examples/gameroom/cli/src/main.rs
+++ b/examples/gameroom/cli/src/main.rs
@@ -68,6 +68,7 @@ fn setup_logging(log_level: log::LevelFilter) {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
         .start()
         .expect("Failed to create logger");
 }

--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -87,6 +87,7 @@ fn run() -> Result<(), GameroomDaemonError> {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
         .start()?;
 
     let config = GameroomConfigBuilder::default()

--- a/services/scabbard/src/cli/main.rs
+++ b/services/scabbard/src/cli/main.rs
@@ -1381,6 +1381,7 @@ fn setup_logging(log_level: log::LevelFilter) -> Result<(), CliError> {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
         .start()?;
 
     Ok(())

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -198,6 +198,7 @@ fn main() {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
         .start()
         .expect("Failed to create logger");
 


### PR DESCRIPTION
Flexi Logger's default output is stderr.  This commit changes all the ouput targets to stdout.
