### PR TITLE
Rename key routes /biome/users/keys to /biome/keys

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -36,7 +36,7 @@ pub fn make_key_management_route(
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
-    Resource::build("/biome/users/keys")
+    Resource::build("/biome/keys")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_KEYS_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,
@@ -259,7 +259,7 @@ pub fn make_key_management_route_with_public_key(
     key_store: Arc<dyn KeyStore<Key>>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
-    Resource::build("/biome/users/keys/{public_key}")
+    Resource::build("/biome/keys/{public_key}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::BIOME_KEYS_PROTOCOL_MIN,
             protocol::BIOME_PROTOCOL_VERSION,

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1284,7 +1284,7 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
-  /biome/users/keys:
+  /biome/keys:
     get:
       tags:
       - Biome
@@ -1419,7 +1419,7 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
-  /biome/users/keys/{public_key}:
+  /biome/keys/{public_key}:
     get:
       tags:
       - Biome


### PR DESCRIPTION
/biome/users/keys conflicted with /biome/user/{id} causing attempts to
create new keys to return a 404.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>