### PR TITLE
Add DispatchLoopBuilder and implement shutdown 

### DIFF
--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -11,15 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::channel::Sender;
-use crate::network::dispatch::{DispatchError, DispatchMessage, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, DispatchMessageSender, Handler, MessageContext};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{CircuitMessage, CircuitMessageType};
 use crate::protos::network::NetworkMessageType;
 
 // Implements a handler that pass messages to another dispatcher loop
 pub struct CircuitMessageHandler {
-    sender: Box<dyn Sender<DispatchMessage<CircuitMessageType>>>,
+    sender: DispatchMessageSender<CircuitMessageType>,
 }
 
 impl Handler<NetworkMessageType, CircuitMessage> for CircuitMessageHandler {
@@ -40,20 +39,22 @@ impl Handler<NetworkMessageType, CircuitMessage> for CircuitMessageHandler {
                 "s"
             }
         );
-        let dispatch_msg = DispatchMessage::new(
-            msg.get_message_type(),
-            msg.get_payload().to_vec(),
-            context.source_peer_id().to_string(),
-        );
-        self.sender.send(dispatch_msg).map_err(|_| {
-            DispatchError::NetworkSendError((context.source_peer_id().to_string(), msg.payload))
-        })?;
+
+        self.sender
+            .send(
+                msg.get_message_type(),
+                msg.get_payload().to_vec(),
+                context.source_peer_id().to_string(),
+            )
+            .map_err(|_| {
+                DispatchError::NetworkSendError((context.source_peer_id().to_string(), msg.payload))
+            })?;
         Ok(())
     }
 }
 
 impl CircuitMessageHandler {
-    pub fn new(sender: Box<dyn Sender<DispatchMessage<CircuitMessageType>>>) -> Self {
+    pub fn new(sender: DispatchMessageSender<CircuitMessageType>) -> Self {
         CircuitMessageHandler { sender }
     }
 }
@@ -61,13 +62,15 @@ impl CircuitMessageHandler {
 #[cfg(test)]
 mod tests {
 
+    use std::sync::{Arc, RwLock};
+    use std::{thread, time};
+
     use super::*;
-    use crate::channel::mock::MockSender;
-    use crate::channel::Sender;
     use crate::mesh::Mesh;
-    use crate::network::dispatch::Dispatcher;
+    use crate::network::dispatch::{DispatchLoopBuilder, Dispatcher};
     use crate::network::sender;
     use crate::network::Network;
+    use crate::protos::circuit::ServiceConnectRequest;
     use crate::protos::network::NetworkMessageType;
 
     use protobuf::Message;
@@ -85,16 +88,33 @@ mod tests {
             .expect("Unable to create queue");
         let network_sender = network_message_queue.new_network_sender();
 
-        let circuit_sender = Box::new(MockSender::default());
-        let mut network_dispatcher = Dispatcher::new(network_sender);
+        let mut network_dispatcher = Dispatcher::new(network_sender.clone());
 
-        let handler = CircuitMessageHandler::new(circuit_sender.box_clone());
+        let mut circuit_dispatcher = Dispatcher::new(network_sender);
+        let handler = ServiceConnectedTestHandler::default();
+        let echos = handler.echos.clone();
+        circuit_dispatcher.set_handler(
+            CircuitMessageType::SERVICE_CONNECT_REQUEST,
+            Box::new(handler),
+        );
+
+        let circuit_dispatcher_loop = DispatchLoopBuilder::new()
+            .with_dispatcher(circuit_dispatcher)
+            .build()
+            .unwrap();
+        let circuit_dispatcher_message_sender = circuit_dispatcher_loop.new_dispatcher_sender();
+
+        let handler = CircuitMessageHandler::new(circuit_dispatcher_message_sender);
         network_dispatcher.set_handler(NetworkMessageType::CIRCUIT, Box::new(handler));
 
+        // Create ServiceConnectRequest
+        let mut service_request = ServiceConnectRequest::new();
+        service_request.set_service_id("TEST_SERVICE".to_string());
+        let service_msg_bytes = service_request.write_to_bytes().unwrap();
         // Create a CircuitMessage
         let mut circuit_msg = CircuitMessage::new();
         circuit_msg.set_message_type(CircuitMessageType::SERVICE_CONNECT_REQUEST);
-        circuit_msg.set_payload(b"test".to_vec());
+        circuit_msg.set_payload(service_msg_bytes);
         let circuit_bytes = circuit_msg.write_to_bytes().unwrap();
 
         // Dispatch network message
@@ -102,15 +122,37 @@ mod tests {
             .dispatch("PEER", &NetworkMessageType::CIRCUIT, circuit_bytes.clone())
             .unwrap();
 
-        // Check that the CircuitMessage is put in the DispatchMessage and send over the sender
-        let dispatched_messages = circuit_sender.sent();
-        let message = dispatched_messages.get(0).unwrap();
+        let mut count = 0;
+        let ten_millis = time::Duration::from_millis(10);
+        // give the dispatcher a chance to pass the message to the circuit dispatcher
+        while echos.read().unwrap().is_empty() && count < 10 {
+            thread::sleep(ten_millis);
+            count += 1;
+        }
 
-        assert_eq!(message.source_peer_id(), "PEER");
-        assert_eq!(b"test".to_vec(), message.message_bytes());
         assert_eq!(
-            message.message_type(),
-            &CircuitMessageType::SERVICE_CONNECT_REQUEST
+            vec!["TEST_SERVICE".to_string()],
+            echos.read().unwrap().clone()
         );
+    }
+
+    #[derive(Default)]
+    struct ServiceConnectedTestHandler {
+        echos: Arc<RwLock<Vec<String>>>,
+    }
+
+    impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectedTestHandler {
+        fn handle(
+            &self,
+            message: ServiceConnectRequest,
+            _message_context: &MessageContext<CircuitMessageType>,
+            _: &NetworkMessageSender,
+        ) -> Result<(), DispatchError> {
+            self.echos
+                .write()
+                .unwrap()
+                .push(message.get_service_id().to_string());
+            Ok(())
+        }
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -180,7 +180,12 @@ impl SplinterDaemon {
         let network_message_queue = sender::Builder::new()
             .with_network(network)
             .build()
-            .expect("Unable to create queue");
+            .map_err(|err| {
+                StartError::NetworkError(format!(
+                    "Unable to create network message sender: {}",
+                    err
+                ))
+            })?;
         let network_sender = network_message_queue.new_network_sender();
         let sender_shutdown_signaler = network_message_queue.shutdown_signaler();
 


### PR DESCRIPTION
Before a DispatchLoop would need to be run in a separate thread
that splinterd would need to create. The loop would take an
Arc<AtomicBool> to signal shutdown and a recv to get messages from.

Now a DispatchLoopBuilder will take the dispatcher and start up its
own channel and thread on build. The DispatchLoop provides methods
to get a sender and a shutdown_signaler. This change also
required that the DispatchMessage got changed into a enum with
Message and Shutdown.