### PR TITLE
Add initial network test for splinter

### DIFF
--- a/tests/configs/key_registry_spec.yaml
+++ b/tests/configs/key_registry_spec.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+alpha:
+  node_id: alpha
+  metadata:
+    gameroom/first-name: alice
+    gameroom/organization: Acme
+beta:
+  node_id: beta
+  metadata:
+    gameroom/first-name: bob
+    gameroom/organization: Bubba Bakery

--- a/tests/network-test.dockerfile
+++ b/tests/network-test.dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM splintercommunity/splinter-cli:experimental
+
+RUN apt-get install -yq \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+
+RUN add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable"
+
+RUN apt-get update \
+ && apt-get install -yq \
+    containerd.io \
+    docker-ce \
+    docker-ce-cli
+
+RUN curl -L \
+    "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" \
+    -o /usr/local/bin/docker-compose \
+ && chmod +x /usr/local/bin/docker-compose
+
+WORKDIR /project

--- a/tests/pumba.yaml
+++ b/tests/pumba.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.7"
+
+services:
+
+  pumba-loss:
+    image: gaiaadm/pumba
+    container_name: pumba-loss
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: |
+      --log-level info netem --tc-image gaiadocker/iproute2 --duration 30s loss --percent 100 splinterd-alpha

--- a/tests/test-network
+++ b/tests/test-network
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info() {
+    printf '%s %s\n' \
+        "$(date '+%b %d %T')" \
+     "$1"
+}
+
+circuit_propose(){
+    info "--== sending circuit proposal from $1 ==--"
+
+    proposed_circuit=$(splinter circuit propose \
+    --key /key_registry_shared/$1.priv \
+    --url http://splinterd-$1:8085  \
+    --node alpha::tls://splinterd-alpha:8044 \
+    --node beta::tls://splinterd-beta:8044 \
+    --service gsAA::alpha \
+    --service gsBB::beta \
+    --service-type *::scabbard \
+    --management $2 \
+    --service-arg *::admin_keys=$(cat /key_registry_shared/$1.pub) \
+    --service-peer-group gsAA,gsBB | grep "Circuit:" |awk '{print $2}')
+
+    info "--== proposed circuit $proposed_circuit ==--"
+}
+
+circuit_accept(){
+    info "--== accepting circuit proposal from $1 ==--"
+
+    splinter circuit vote \
+    --key /key_registry_shared/$1.priv \
+    --url http://splinterd-$1:8085 \
+    $proposed_circuit \
+    --accept
+}
+
+circuit_list(){
+    info "--== circuit list from $1 ==--"
+
+    splinter circuit list \
+    --url http://splinterd-$1:8085
+    echo
+}
+
+proposal_list(){
+    info "--== proposal list from $1 ==--"
+
+    splinter circuit proposals \
+    --url http://splinterd-$1:8085
+    echo
+}
+
+circuit_wait(){
+    end=$((SECONDS+10))
+    while [ $SECONDS -lt $end ]; do
+        splinter circuit list --url http://splinterd-$1:8085 | grep -q $2
+        if [ $? -eq 0 ]; then
+            info "$1 - Found circuit $2"
+            return 0
+        else
+            sleep 1
+        fi
+    done
+    info "Unable to find circuit after 10 seconds"
+    exit 1
+}
+
+proposal_wait(){
+    end=$((SECONDS+10))
+    while [ $SECONDS -lt $end ]; do
+        splinter circuit proposals --url http://splinterd-$1:8085 | grep -q $2
+        if [ $? -eq 0 ]; then
+            info "$1 - Found proposal $2"
+            return 0
+        else
+            sleep 1
+        fi
+    done
+    info "Unable to find proposal after 10 seconds"
+    exit 1
+}
+
+circuit_propose alpha test1
+
+proposal_wait beta $proposed_circuit
+
+circuit_accept beta
+
+circuit_wait alpha $proposed_circuit
+circuit_wait beta $proposed_circuit
+
+unset proposed_circuit
+
+info "--== network down on alpha ==--"
+docker-compose -f pumba.yaml up -d
+
+while $(docker ps |grep -q pumba-loss); [ $? -ne 1 ]; do
+    info "waiting for pumba to exit"
+    sleep 5
+done
+
+info "--== networking has been restored to alpha ==--"
+
+curl http://splinterd-alpha:8085
+
+circuit_propose beta test2
+
+proposal_wait alpha $proposed_circuit
+
+circuit_accept alpha
+
+circuit_wait alpha $proposed_circuit
+circuit_wait beta $proposed_circuit
+
+info "--== cleaning up ==--"
+docker rm $(docker ps -a | grep iproute2 | awk {'print $1'})

--- a/tests/test-splinter-network.yaml
+++ b/tests/test-splinter-network.yaml
@@ -1,0 +1,98 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.7"
+
+volumes:
+  key-registry:
+
+services:
+
+  orchestrator:
+    image: splinter-network-tests
+    build:
+      dockerfile: network-test.dockerfile
+      context: .
+    container_name: orchestrator
+    volumes:
+      - key-registry:/key_registry_shared
+      - ./configs:/input
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/project
+    command: |
+      bash -c "
+        if [ ! -f /key_registry_shared/keys.yaml ]
+        then
+          splinter admin keyregistry \
+            -i /input/key_registry_spec.yaml \
+            -d /key_registry_shared \
+            --force
+        fi &&
+        sleep 5
+        /project/test-network
+      "
+
+  splinterd-alpha:
+    image: splintercommunity/splinterd:experimental
+    container_name: splinterd-alpha
+    volumes:
+      - key-registry:/key_registry_shared
+    entrypoint: |
+      bash -c "
+        while [ ! -f /key_registry_shared/keys.yaml ]; do \
+          echo 'waiting for key registry'; \
+          sleep 1; \
+        done && \
+        splinter cert generate --skip && \
+        cp  /key_registry_shared/keys.yaml /var/lib/splinter/keys.yaml && \
+        splinterd \
+            --bind 0.0.0.0:8085 \
+            --insecure \
+            --network-endpoint 0.0.0.0:8044 \
+            --node-id alpha \
+            --service-endpoint 0.0.0.0:8043 \
+            --storage yaml \
+            --transport tls \
+            --heartbeat 10 \
+            -vvv
+      "
+    sysctls:
+      - net.ipv4.tcp_retries2=3
+
+  splinterd-beta:
+    image: splintercommunity/splinterd:experimental
+    container_name: splinterd-beta
+    volumes:
+      - key-registry:/key_registry_shared
+    entrypoint: |
+      bash -c "
+        while [ ! -f /key_registry_shared/keys.yaml ]; do \
+          echo 'waiting for key registry'; \
+          sleep 1; \
+        done && \
+        splinter cert generate --skip && \
+        cp  /key_registry_shared/keys.yaml /var/lib/splinter/keys.yaml && \
+        splinterd \
+            --bind 0.0.0.0:8085 \
+            --insecure \
+            --network-endpoint 0.0.0.0:8044 \
+            --node-id beta \
+            --service-endpoint 0.0.0.0:8043 \
+            --storage yaml \
+            --transport tls \
+            --heartbeat 10 \
+            -vvv
+      "
+    sysctls:
+      - net.ipv4.tcp_retries2=3


### PR DESCRIPTION
This test simulates a brief network interruption between nodes with a created
circuit which causes the splinter nodes to disconnect. When the interruption is
resolved, a second circuit is proposed and created to verify reconnection.

The setting "net.ipv4.tcp_retries2=3" in the Compose file is used to limit the
number of retries before the TCP stack will inform the layers above that the
connection has been broken. tcp_retries2 uses an exponential backoff starting at
approximately 200ms, so a tcp_retries2 value of "3" should cause a timeout
after about 1.4 seconds.

More detailed information about the network settings can be found at
https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>