### PR TITLE
Small fix ups for the splinter man pages

### DIFF
--- a/cli/man/TEMPLATE.1.md.example
+++ b/cli/man/TEMPLATE.1.md.example
@@ -47,7 +47,7 @@ what arguments it takes, and the default value/behavior. If appropriate, explain
 how/when it's used, with tips, gotchas, and very short examples.
 -->
 
-`-e`, `--example <example>`
+`-e`, `--example EXAMPLE`
 : Description about example options
 
 

--- a/cli/man/splinter-cert-generate.1.md
+++ b/cli/man/splinter-cert-generate.1.md
@@ -52,12 +52,12 @@ flag is not provided and the file exists, an error is returned.
 
 OPTIONS
 =======
-`-d`, `--cert-dir <cert_dir>`
+`-d`, `--cert-dir CERT-DIR`
 : Path to the directory certificates are created in. Defaults to
   /etc/splinter/certs/. This location can also be changed with the
   SPLINTER_CERT_DIR environment variable. This directory must exist.
 
-`--common-name <common_name>`
+`--common-name COMMON-NAME`
 : String that specifies a common name for the generated certificate (defaults to
   localhost). Use this option if the splinterd URL uses a DNS address instead
   of a numerical IP address.
@@ -74,7 +74,7 @@ that are missing.
 
   `$ splinter cert generate --skip`
 
-To recreate the certificates and keys from scratch, use the  `--force` flag to
+To recreate the certificates and keys from scratch, use the `--force` flag to
 overwrite all existing files.
 
   `$ splinter cert generate --force`
@@ -87,7 +87,7 @@ generate:
 **SPLINTER_CERT_DIR**
 
 : The certificates and keys will be generated at the location specified by the
-  environment variable.  (See `--cert-dir`)
+  environment variable. (See `--cert-dir`)
 
 SEE ALSO
 ========

--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -37,7 +37,7 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` <format>
+`-f`, `--format` FORMAT
 : Specifies the output format of the circuit. (default `human`). Possible values
   for formatting are `human` and `csv`.
 
@@ -45,9 +45,9 @@ OPTIONS
 : Filter the circuits list by a node ID that is present in the circuits’ members
   list.
 
-`-U`, `--url` <url>
+`-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
-  `$SPLINTER_REST_API_URL_ENV` is set.
+  `$SPLINTER_REST_API_URL` is set.
 
 EXAMPLES
 ========
@@ -59,7 +59,7 @@ The following command does not specify any filters, therefore all circuits
 the local node, `alpha-node-000` is a member of are displayed.
 ```
 $ splinter circuit list \
-  --url <URL-of-alpha-node-000-splinterd-REST-API>
+  --url URL-of-alpha-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
@@ -72,20 +72,20 @@ ID will be listed.
 ```
 $ splinter circuit list \
   member gamma-node-000 \
-  --url <URL-of-alpha-node-000-splinterd-REST-API>
+  --url URL-of-alpha-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
 56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
 ```
 
-Since all of the circuits listed have been accepted by each member, the same c
-ircuit information will be displayed for member nodes.
+Since all of the circuits listed have been accepted by each member, the same
+circuit information will be displayed for member nodes.
 
 From the perspective of the `gamma-node-000` node, this command will display the
 following with no filters:
 ```
 $ splinter circuit list \
-  --url <URL-of-gamma-node-000-splinterd-REST-API>
+  --url URL-of-gamma-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
 56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
@@ -95,14 +95,14 @@ From the perspective of the `beta-node-000` node, this command will display the
 following with no filters:
 ```
 $ splinter circuit list \
-  --url <URL-of-gamma-node-000-splinterd-REST-API>
+  --url URL-of-gamma-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
 ```
 
 ENVIRONMENT VARIABLES
 =====================
-**SPLINTER_REST_API_URL_ENV**
+**SPLINTER_REST_API_URL**
 : URL for the `splinterd` REST API. (See `-U`, `--url`.)
 
 SEE ALSO

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -36,22 +36,22 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` <format>
+`-f`, `--format` FORMAT
 : Specifies the output format of the circuit proposal. (default `human`).
   Possible values for formatting are `human` and `csv`. The `human` option
   displays the circuit proposals information in a formatted table, while `csv`
   prints the circuit proposals information via comma-separated values.
 
-`--management-type` <management_type>
+`--management-type` MANAGEMENT-TYPE
 : Filter the circuit proposals by their circuit management type.
 
-`-m`, `--member` <member>
+`-m`, `--member` MEMBER
 : Filter the circuits list by a node ID that is present in the circuit proposal’s
   members list.
 
-`-U`, `--url` <url>
+`-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
-  `$SPLINTER_REST_API_URL_ENV` is set.
+  `$SPLINTER_REST_API_URL` is set.
 
 EXAMPLES
 ========
@@ -63,7 +63,7 @@ The following command does not specify any filters, therefore all circuit propos
 the local node, `alpha-node-000` is a part of are displayed.
 ```
 $ splinter circuit proposals \
-  --url <URL-of-alpha-node-000-splinterd-REST-API>
+  --url URL-of-alpha-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
@@ -76,7 +76,7 @@ of `mgmt001` will be listed.
 ```
 $ splinter circuit proposals \
   --management-type mgmt001 \
-  --url <URL-of-alpha-node-000-splinterd-REST-API>
+  --url URL-of-alpha-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
@@ -88,7 +88,7 @@ ID will be listed.
 ```
 $ splinter circuit proposals \
   member gamma-node-000 \
-  --url <URL-of-alpha-node-000-splinterd-REST-API>
+  --url URL-of-alpha-node-splinterd-REST-API
 ID            MANAGEMENT    MEMBERS
 43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
 56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
@@ -96,7 +96,7 @@ ID            MANAGEMENT    MEMBERS
 
 ENVIRONMENT VARIABLES
 =====================
-**SPLINTER_REST_API_URL_ENV**
+**SPLINTER_REST_API_URL**
 : URL for the `splinterd` REST API. (See `-U`, `--url`.)
 
 SEE ALSO

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -45,77 +45,77 @@ FLAGS
 
 OPTIONS
 =======
-`--comments <comments>`
+`--comments COMMENTS`
 : Adds human-readable comments to the circuit proposal.
 
-`-k, --key <private-key-file>`
+`-k, --key PRIVATE-KEY-FILE`
 : Specifies the full path to the private key file.
 
-`--management <management_type>`
+`--management MANAGEMENT-TYPE`
 : Specifies the circuit management type. Circuit management type indicates the
   application authorization handler which handles the circuit’s change proposals.
 
-`--metadata <application_metadata>` ...
+`--metadata APPLICATION-METADATA` ...
 : Provides application-specific metadata for the circuit proposal. Repeat this
   option to provide multiple entries for the application metadata.
 
-`--metadata-encoding <metadata_encoding>`
+`--metadata-encoding METADATA-ENCODING`
 : Sets the encoding type for the application metadata (default: `string`).
   Accepted values: `json`, `string`.
 
-`--node <node_string>` ...
+`--node NODE-STRING` ...
 : Specifies a node that should be part of the circuit, using the format
-  `<node_id>::<endpoint>`. This node ID must match the node ID and endpoint entry
+  `NODE-ID::ENDPOINT`. This node ID must match the node ID and endpoint entry
   in the node registry. The proposer must also specify its own node, if it is to
   be included on the circuit proposal. Repeat this option to specify multiple
   nodes.
 
-`--service <service_string>` ...
+`--service SERVICE-STRING` ...
 : Specifies the service ID and allowed nodes, using the format
-  `<service_id>::<allowed_nodes>`. Service IDs are comprised of 4 ASCII alphanumeric
-  characters. The <allowed_nodes> specifies the node which the service will run
+  `SERVICE-ID::ALLOWED-NODES`. Service IDs are comprised of 4 ASCII alphanumeric
+  characters. The ALLOWED-NODES specifies the node which the service will run
   on, currently only one node ID is allowed.
 
-`--service-arg <service_argument>` ...
+`--service-arg SERVICE-ARGUMENTS` ...
 : Passes key/value arguments to the specified service (as defined by
-  `--service`), using the format `<service_id>::<key>=<value>`. Service arguments
+  `--service`), using the format `SERVICE-ID::KEY=VALUE`. Service arguments
   provided must match those required to create the service. The glob operator,
-  `*`, may be used in place of the <service_id> to match all or certain parts
-  of the 4 character <service_id>. For instance, `AA*::<key>=<value>` to match
+  `*`, may be used in place of the SERVICE-ID to match all or certain parts
+  of the 4 character SERVICE-ID. For instance, `AA*::KEY=VALUE` to match
   all service IDs that begin with `AA`. Repeat this option to specify multiple
   key/value arguments.
 
-`--service-peer-group <service_peer_group>` ...
+`--service-peer-group SERVICE-PEER-GROUP` ...
 : Specifies the service peer group (a list of peer services). Peer services are
   services used by peer nodes within a circuit. This is the group of services
   that must come to consensus amongst the node peers. Repeat this option to
   specify multiple service peer groups.
 
-`--service-type <service_type>` ...
+`--service-type SERVICE-TYPE` ...
 : Provides a service type for the specified service (as defined by
-  `--service`), using the format `<service_id>::<service_type>`. The glob operator,
-  `*`, may be used in place of the <service_id> to match all or certain parts
-  of the 4 character <service_id>. For instance, `AA*::<service_type>` to match
+  `--service`), using the format `SERVICE-ID::SERVICE-TYPE`. The glob operator,
+  `*`, may be used in place of the SERVICE-ID to match all or certain parts
+  of the 4 character SERVICE-ID. For instance, `AA*::SERVICE-TYPE` to match
   all service IDs that begin with `AA`. Scabbard is a  Splinter service currently
-  implemented to be used, that can be specified with `service_type` of `scabbard`.
+  implemented to be used, that can be specified with `service-type` of `scabbard`.
   Repeat this option to specify multiple service types.
 
-`--template <template>`
+`--template TEMPLATE`
 : Specifies a template to use for defining the circuit. Additional information
   on circuit templates can be found in the splinter-circuit-template(1) man page.
 
-`--template-arg <template_arg>` ...
+`--template-arg TEMPLATE-ARG` ...
 : Provides a key/value argument for the circuit template (as specified by
-  `--template``), using the format `<key>=<value>`. Repeat this option to
+  `--template``), using the format `KEY=VALUE`. Repeat this option to
   specify multiple template arguments.
 
-`-U`, `--url <url>`
+`-U`, `--url URL`
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
-  `$SPLINTER_REST_API_URL_ENV` is set.
+  `$SPLINTER_REST_API_URL` is set.
 
 ENVIRONMENT VARIABLES
 =====================
-**SPLINTER_REST_API_URL_ENV**
+**SPLINTER_REST_API_URL**
 : URL for the `splinterd` REST API. (See `-U`, `--url`.)
 
 EXAMPLES
@@ -132,14 +132,14 @@ $ splinter circuit propose \
   --node alpha001::tls://splinterd-node-alpha001:8044 \
   --node beta001::tls://splinterd-node-beta001:8044 \
   --service AA01::alpha001 \
-  --key <private-key-file>
-  --url <URL-of-your-splinterd-REST-API>
+  --key PRIVATE-KEY-FILE
+  --url URL-of-splinterd-REST-API
 ```
 
 The next command proposes a circuit with one other node, with multiple services
 and multiple service-args.
 
-* The proposing node has ID `alpha001` and endpoint `tls://splinterd-node-acme001:8044`.
+* The proposing node has ID `alpha001` and endpoint `tls://splinterd-node-alpha001:8044`.
 * The other node has ID `beta001` and endpoint `tls://splinterd-node-beta001:8044`.
 * There are two services for each member node with a `service-type` of `scabbard`
   for each. The service ID for the alpha node service is `AA01` and the
@@ -150,33 +150,33 @@ and multiple service-args.
 
 ```
 splinter circuit propose \
-  --key <private-key-file> \
-  --url <URL-of-your-splinterd-REST-API> \
+  --key PRIVATE-KEY-FILE \
+  --url URL-of-splinterd-REST-API \
   --node alpha001::tls://splinterd-node-alpha001:8044 \
   --node beta001::tls://splinterd-node-beta001:8044 \
   --service AA01::alpha-node-001 \
   --service BB01::beta-node-001 \
   --service-type AA01::scabbard \
   --service-type BB01::scabbard \
-  --service-arg AA01::admin_keys=<node-public-key> \
-  --service-arg BB01::admin_keys=<node-public-key> \
+  --service-arg AA01::admin_keys=NODE-PUBLIC-KEY \
+  --service-arg BB01::admin_keys=NODE-PUBLIC-KEY \
   --service-peer-group AA01,BB01
 ```
 
-The glob operator, `*` may be used to match <service_id> for the `--service-type`
+The glob operator, `*` may be used to match SERVICE-ID for the `--service-type`
 and `--service-arg` arguments. Therefore, this part of the command:
 
 ```
 --service-type AA01::scabbard \
 --service-type BB01::scabbard \
---service-arg AA01::admin_keys=<node-public-key> \
---service-arg BB01::admin_keys=<node-public-key> \
+--service-arg AA01::admin_keys=NODE-PUBLIC-KEY \
+--service-arg BB01::admin_keys=NODE-PUBLIC-KEY \
 ```
 
 becomes the following using the glob operator:
 ```
 --service-type *::scabbard \
---service-arg *::admin_keys=<node-public-key> \
+--service-arg *::admin_keys=NODE-PUBLIC-KEY \
 ```
 
 SEE ALSO

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -7,7 +7,7 @@ NAME
 
 SYNOPSIS
 ========
-**splinter circuit show** \[**FLAGS**\] \[**OPTIONS**\] <circuit>
+**splinter circuit show** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT
 
 DESCRIPTION
 ===========
@@ -36,24 +36,25 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` <format>
+`-f`, `--format` FORMAT
 : Specifies the output format of the circuit proposal. (default `human`).
   Possible values for formatting are `human` and `csv`.
 
-`-U`, `--url` <url>
+`-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
   `$SPLINTER_REST_API_URL` is set.
 
 
 ARGUMENTS
 =========
-`<circuit>`
+`CIRCUIT`
 : Specify the circuit ID of the circuit to be shown.
 
 EXAMPLES
 ========
 This command displays information about a circuit with the default `human`
-formatting, which intends to use indentation and labels to make the circuit information understandable.
+formatting, which intends to use indentation and labels to make the circuit
+information understandable.
 
 * The proposing node has ID `alpha001` and endpoint
   `tls://splinterd-node-alpha001:8044`, and a service ID of `AA01`.
@@ -70,16 +71,16 @@ the proposal will not be viewable by any nodes.
 
 ```
 $ splinter circuit show 01234-ABCDE \
-  ---url <URL-of-alpha-node-splinterd-REST-API>
+  ---url URL-of-alpha-node-splinterd-REST-API
 Proposal to create: 01234-ABCDE
     Management Type: mgmt001
 
     alpha-001 (tls://splinterd-node-alpha001:8044)
         Vote: ACCEPT (implied as requester):
-            <alpha-public-key>
+            ALPHA-PUBLIC-KEY
         Service: AA01
             admin_keys:
-                <alpha-public-key>
+                ALPHA-PUBLIC-KEY
             peer_services:
                 BB01
 
@@ -87,7 +88,7 @@ Proposal to create: 01234-ABCDE
         Vote: PENDING
         Service: AA01
             admin_keys:
-                <alpha-public-key>
+                ALPHA-PUBLIC-KEY
             peer_services:
                 AA01
 ```

--- a/cli/man/splinter-circuit-vote.1.md
+++ b/cli/man/splinter-circuit-vote.1.md
@@ -7,7 +7,7 @@ NAME
 
 SYNOPSIS
 ========
-**splinter circuit vote** \[**FLAGS**\] \[**OPTIONS**\] <circuit_id> --accept --reject
+**splinter circuit vote** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID --accept --reject
 
 DESCRIPTION
 ===========
@@ -45,16 +45,16 @@ FLAGS
 
 OPTIONS
 =======
-`-k`, `--key` <private-key-file>
+`-k`, `--key` PRIVATE-KEY-FILE
 : Specifies the full path to the private key file.
 
-`-U`, `--url` <url>
+`-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
   `$SPLINTER_REST_API_URL` is set.
 
 ARGUMENTS
 =========
-`<circuit-id>`
+`CIRCUIT-ID`
 : Specify the circuit ID of the circuit to be voted on.
 
 EXAMPLES
@@ -64,8 +64,8 @@ EXAMPLES
 The following command displays a member node voting to accept the circuit proposal:
 ```
 $ splinter circuit vote \
-  --key <proposed-member-node-private-key> \
-  --url <URL-of-proposed-member-node-splinterd-REST-API> \
+  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-proposed-member-node-splinterd-REST-API \
   1234-ABCDE \
   --accept
 ```
@@ -73,8 +73,8 @@ $ splinter circuit vote \
 The following command displays a member node voting to reject the circuit proposal:
 ```
 $ splinter circuit vote \
-  --key <proposed-member-node-private-key> \
-  --url <URL-of-proposed-member-node-splinterd-REST-API> \
+  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-proposed-member-node-splinterd-REST-API \
   1234-ABCDE \
   --reject
 ```


### PR DESCRIPTION
Removes brackets (<>) from the man pages and edits the
values within brackets to all caps, so `<example>` is now
`EXAMPLE`. This also fixes small excess spacing issues as
well.

Signed-off-by: Shannyn Telander <telander@bitwise.io>