### PR TITLE
Add splinter-circuit-template man pages

### DIFF
--- a/cli/man/splinter-circuit-template-arguments.1.md
+++ b/cli/man/splinter-circuit-template-arguments.1.md
@@ -1,0 +1,70 @@
+% SPLINTER-CIRCUIT-TEMPLATE-ARGUMENTS(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-arguments** — Displays the arguments defined in a
+circuit template
+
+SYNOPSIS
+========
+**splinter circuit template arguments** \[**FLAGS**\] TEMPLATE-NAME
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. Circuit template arguments are required when
+building a circuit from the template. This command lists the arguments that are
+defined in the specified circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+ARGUMENTS
+=========
+`TEMPLATE-NAME`
+: Circuit template that contains the arguments of interest.
+
+EXAMPLES
+========
+The following command shows the arguments for the `scabbard` circuit template,
+which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template arguments scabbard
+
+name: admin_keys
+required: false
+default_value: $(a:SIGNER_PUB_KEY)
+description: Public keys used to verify transactions in the scabbard service
+
+name: nodes
+required: true
+default_value: Not set
+description: List of node IDs
+
+name: signer_pub_key
+required: false
+default_value: Not set
+description: Public key of the signer
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-list(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/cli/man/splinter-circuit-template-list.1.md
+++ b/cli/man/splinter-circuit-template-list.1.md
@@ -1,0 +1,56 @@
+% SPLINTER-CIRCUIT-TEMPLATE-LIST(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-list** — Displays all available circuit templates
+
+SYNOPSIS
+========
+**splinter circuit template list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. This command lists all available circuit
+templates.
+
+A Scabbard circuit template is available by default (this template is packaged
+with the Splinter CLI).
+
+Tip: Use the `splinter circuit template arguments` command to see the required
+arguments for a specific circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+EXAMPLES
+========
+The following example lists the circuit templates on a system that has only the
+`scabbard` template, which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template list
+Available templates:
+scabbard
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/cli/man/splinter-circuit-template-show.1.md
+++ b/cli/man/splinter-circuit-template-show.1.md
@@ -1,0 +1,79 @@
+% SPLINTER-CIRCUIT-TEMPLATE-SHOW(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-show** — Displays the details of a circuit template
+
+SYNOPSIS
+========
+**splinter circuit template show** \[**FLAGS**\] TEMPLATE-NAME
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. This command displays the entire template
+definition, including the arguments and rules, for the specified template.
+
+Tip: Use the `splinter circuit template arguments` command to show only the
+required arguments for a specific circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+ARGUMENTS
+=========
+`TEMPLATE-NAME`
+: Circuit template to be displayed.
+
+EXAMPLES
+========
+The following command shows the details of the `scabbard` circuit template,
+which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template show scabbard
+---
+version: v1
+args:
+  - name: “$(a:ADMIN_KEYS)”
+    required: false
+    default: “$(a:SIGNER_PUB_KEY)”
+    description: Public keys used to verify transactions in the scabbard service
+  - name: “$(a:NODES)”
+    required: true
+    description: List of node IDs
+  - name: “$(a:SIGNER_PUB_KEY)”
+    required: false
+    description: Public key of the signer
+rules:
+  create-services:
+    service-type: scabbard
+    service-args:
+      - key: admin_keys
+        value:
+          - "$(a:ADMIN_KEYS)"
+      - key: peer_services
+        value: "$(r:ALL_OTHER_SERVICES)"
+    first-service: a000
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-list(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/cli/man/splinter-circuit-template.1.md
+++ b/cli/man/splinter-circuit-template.1.md
@@ -1,0 +1,59 @@
+% SPLINTER-CIRCUIT-TEMPLATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template** — Manage circuit templates
+
+SYNOPSIS
+========
+**splinter circuit template** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command provides subcommands to list the available circuit templates, display
+template details, and show the required arguments for a specific template.
+
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. A circuit template specifies the required
+arguments and rules for the circuit. Each template on the system must have a unique
+name.
+
+A Scabbard circuit template, named `scabbard`, is available by default (packaged
+with the Splinter CLI). This template can be used as a model for other circuit
+templates.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`arguments`
+: List arguments of a template.
+
+`list`
+: List available templates.
+
+`show`
+: Display a specific available template.
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-list(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md


### PR DESCRIPTION
Adds man pages for the following commands:

- `splinter circuit template`
- `splinter circuit template arguments` 
- `splinter circuit template list`
- `splinter circuit template show`