### PR TITLE
Remove nightly publishing of experimental docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,11 +79,6 @@ jobs:
           on:
             branch: master
         - provider: script
-          script: bash ci/publish-docker experimental
-          on:
-            branch: master
-            condition: $TRAVIS_EVENT_TYPE == cron
-        - provider: script
           script: bash ci/publish-docker
           on:
             tags: true


### PR DESCRIPTION
This has been relocated to https://build.sawtooth.me so experimental images can
be tested and published on every master merge without negatively impacting
master build times in Travis.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>