### PR TITLE
Add Dispatch Source

### DIFF
--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -29,11 +29,14 @@ pub struct AdminDirectMessageHandler {
     state: SplinterState,
 }
 
-impl Handler<CircuitMessageType, AdminDirectMessage> for AdminDirectMessageHandler {
+impl Handler for AdminDirectMessageHandler {
+    type MessageType = CircuitMessageType;
+    type Message = AdminDirectMessage;
+
     fn handle(
         &self,
-        msg: AdminDirectMessage,
-        context: &MessageContext<CircuitMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(

--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -14,7 +14,7 @@
 
 use crate::circuit::handlers::create_message;
 use crate::circuit::SplinterState;
-use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, Handler, MessageContext, PeerId};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{
     AdminDirectMessage, CircuitError, CircuitError_Error, CircuitMessageType,
@@ -30,13 +30,14 @@ pub struct AdminDirectMessageHandler {
 }
 
 impl Handler for AdminDirectMessageHandler {
+    type Source = PeerId;
     type MessageType = CircuitMessageType;
     type Message = AdminDirectMessage;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(
@@ -75,7 +76,7 @@ impl AdminDirectMessageHandler {
     fn create_response(
         &self,
         msg: AdminDirectMessage,
-        context: &MessageContext<CircuitMessageType>,
+        context: &MessageContext<PeerId, CircuitMessageType>,
     ) -> Result<(Vec<u8>, String), DispatchError> {
         let circuit_name = msg.get_circuit();
         let msg_sender = msg.get_sender();
@@ -227,7 +228,7 @@ mod tests {
                 assert_eq!(
                     Ok(()),
                     dispatcher.dispatch(
-                        "5678",
+                        "5678".into(),
                         &CircuitMessageType::ADMIN_DIRECT_MESSAGE,
                         direct_bytes
                     )
@@ -288,7 +289,7 @@ mod tests {
                 assert_eq!(
                     Ok(()),
                     dispatcher.dispatch(
-                        "5678",
+                        "5678".into(),
                         &CircuitMessageType::ADMIN_DIRECT_MESSAGE,
                         direct_bytes
                     )
@@ -349,7 +350,7 @@ mod tests {
                 assert_eq!(
                     Ok(()),
                     dispatcher.dispatch(
-                        "1234",
+                        "1234".into(),
                         &CircuitMessageType::ADMIN_DIRECT_MESSAGE,
                         direct_bytes
                     )
@@ -395,7 +396,7 @@ mod tests {
                 assert_eq!(
                     Ok(()),
                     dispatcher.dispatch(
-                        "1234",
+                        "1234".into(),
                         &CircuitMessageType::ADMIN_DIRECT_MESSAGE,
                         direct_bytes
                     )
@@ -441,7 +442,7 @@ mod tests {
                 assert_eq!(
                     Ok(()),
                     dispatcher.dispatch(
-                        "1234",
+                        "1234".into(),
                         &CircuitMessageType::ADMIN_DIRECT_MESSAGE,
                         direct_bytes
                     )

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -14,7 +14,7 @@
 
 use crate::circuit::handlers::create_message;
 use crate::circuit::{ServiceId, SplinterState};
-use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, Handler, MessageContext, PeerId};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{CircuitError, CircuitMessageType};
 
@@ -28,13 +28,14 @@ pub struct CircuitErrorHandler {
 // where it is returned back to a different node, this node will do its best effort to
 // return it back to the service or node who sent the original message.
 impl Handler for CircuitErrorHandler {
+    type Source = PeerId;
     type MessageType = CircuitMessageType;
     type Message = CircuitError;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Circuit Error Message {:?}", msg);
@@ -177,7 +178,7 @@ mod tests {
                 // dispatch the error message
                 dispatcher
                     .dispatch(
-                        "345",
+                        "345".into(),
                         &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
                         error_bytes.clone(),
                     )
@@ -260,7 +261,7 @@ mod tests {
                 // dispatch the error message
                 dispatcher
                     .dispatch(
-                        "586",
+                        "586".into(),
                         &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
                         error_bytes.clone(),
                     )
@@ -328,7 +329,7 @@ mod tests {
             // dispatch the error message
             dispatcher
                 .dispatch(
-                    "def",
+                    "def".into(),
                     &CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
                     error_bytes.clone(),
                 )

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -27,11 +27,14 @@ pub struct CircuitErrorHandler {
 // In most cases the error message will be returned directly back to service, but in the case
 // where it is returned back to a different node, this node will do its best effort to
 // return it back to the service or node who sent the original message.
-impl Handler<CircuitMessageType, CircuitError> for CircuitErrorHandler {
+impl Handler for CircuitErrorHandler {
+    type MessageType = CircuitMessageType;
+    type Message = CircuitError;
+
     fn handle(
         &self,
-        msg: CircuitError,
-        context: &MessageContext<CircuitMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Circuit Error Message {:?}", msg);

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::network::dispatch::{DispatchError, DispatchMessageSender, Handler, MessageContext};
+use crate::network::dispatch::{
+    DispatchError, DispatchMessageSender, Handler, MessageContext, PeerId,
+};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{CircuitMessage, CircuitMessageType};
 use crate::protos::network::NetworkMessageType;
@@ -22,13 +24,14 @@ pub struct CircuitMessageHandler {
 }
 
 impl Handler for CircuitMessageHandler {
+    type Source = PeerId;
     type MessageType = NetworkMessageType;
     type Message = CircuitMessage;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         _: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(
@@ -47,7 +50,7 @@ impl Handler for CircuitMessageHandler {
             .send(
                 msg.get_message_type(),
                 msg.get_payload().to_vec(),
-                context.source_peer_id().to_string(),
+                context.source_id().clone(),
             )
             .map_err(|_| {
                 DispatchError::NetworkSendError((context.source_peer_id().to_string(), msg.payload))
@@ -122,7 +125,11 @@ mod tests {
 
         // Dispatch network message
         network_dispatcher
-            .dispatch("PEER", &NetworkMessageType::CIRCUIT, circuit_bytes.clone())
+            .dispatch(
+                "PEER".into(),
+                &NetworkMessageType::CIRCUIT,
+                circuit_bytes.clone(),
+            )
             .unwrap();
 
         let mut count = 0;
@@ -145,13 +152,14 @@ mod tests {
     }
 
     impl Handler for ServiceConnectedTestHandler {
+        type Source = PeerId;
         type MessageType = CircuitMessageType;
         type Message = ServiceConnectRequest;
 
         fn handle(
             &self,
             message: Self::Message,
-            _message_context: &MessageContext<Self::MessageType>,
+            _message_context: &MessageContext<Self::Source, Self::MessageType>,
             _: &NetworkMessageSender,
         ) -> Result<(), DispatchError> {
             self.echos

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -21,11 +21,14 @@ pub struct CircuitMessageHandler {
     sender: DispatchMessageSender<CircuitMessageType>,
 }
 
-impl Handler<NetworkMessageType, CircuitMessage> for CircuitMessageHandler {
+impl Handler for CircuitMessageHandler {
+    type MessageType = NetworkMessageType;
+    type Message = CircuitMessage;
+
     fn handle(
         &self,
-        msg: CircuitMessage,
-        context: &MessageContext<NetworkMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         _: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(
@@ -141,11 +144,14 @@ mod tests {
         echos: Arc<RwLock<Vec<String>>>,
     }
 
-    impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectedTestHandler {
+    impl Handler for ServiceConnectedTestHandler {
+        type MessageType = CircuitMessageType;
+        type Message = ServiceConnectRequest;
+
         fn handle(
             &self,
-            message: ServiceConnectRequest,
-            _message_context: &MessageContext<CircuitMessageType>,
+            message: Self::Message,
+            _message_context: &MessageContext<Self::MessageType>,
             _: &NetworkMessageSender,
         ) -> Result<(), DispatchError> {
             self.echos

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -28,11 +28,14 @@ pub struct CircuitDirectMessageHandler {
     state: SplinterState,
 }
 
-impl Handler<CircuitMessageType, CircuitDirectMessage> for CircuitDirectMessageHandler {
+impl Handler for CircuitDirectMessageHandler {
+    type MessageType = CircuitMessageType;
+    type Message = CircuitDirectMessage;
+
     fn handle(
         &self,
-        msg: CircuitDirectMessage,
-        context: &MessageContext<CircuitMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -14,7 +14,7 @@
 
 use crate::circuit::handlers::create_message;
 use crate::circuit::{ServiceId, SplinterState};
-use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, Handler, MessageContext, PeerId};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{
     CircuitDirectMessage, CircuitError, CircuitError_Error, CircuitMessageType,
@@ -29,13 +29,14 @@ pub struct CircuitDirectMessageHandler {
 }
 
 impl Handler for CircuitDirectMessageHandler {
+    type Source = PeerId;
     type MessageType = CircuitMessageType;
     type Message = CircuitDirectMessage;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!(
@@ -286,7 +287,7 @@ mod tests {
                 // dispatch the direct message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -367,7 +368,7 @@ mod tests {
                 // dispatch the message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -442,7 +443,7 @@ mod tests {
                 // dispatcher message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -517,7 +518,7 @@ mod tests {
                 // dispatcher message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -590,7 +591,7 @@ mod tests {
                 // dispatch message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -663,7 +664,7 @@ mod tests {
                 // dispatch message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )
@@ -716,7 +717,7 @@ mod tests {
                 // dispatch message
                 dispatcher
                     .dispatch(
-                        "def",
+                        "def".into(),
                         &CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
                         direct_bytes.clone(),
                     )

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -32,11 +32,14 @@ pub struct ServiceConnectRequestHandler {
     state: SplinterState,
 }
 
-impl Handler<CircuitMessageType, ServiceConnectRequest> for ServiceConnectRequestHandler {
+impl Handler for ServiceConnectRequestHandler {
+    type MessageType = CircuitMessageType;
+    type Message = ServiceConnectRequest;
+
     fn handle(
         &self,
-        msg: ServiceConnectRequest,
-        context: &MessageContext<CircuitMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Connect Request {:?}", msg);
@@ -160,11 +163,14 @@ pub struct ServiceDisconnectRequestHandler {
     state: SplinterState,
 }
 
-impl Handler<CircuitMessageType, ServiceDisconnectRequest> for ServiceDisconnectRequestHandler {
+impl Handler for ServiceDisconnectRequestHandler {
+    type MessageType = CircuitMessageType;
+    type Message = ServiceDisconnectRequest;
+
     fn handle(
         &self,
-        msg: ServiceDisconnectRequest,
-        context: &MessageContext<CircuitMessageType>,
+        msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Disconnect Request {:?}", msg);

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -15,7 +15,7 @@
 use crate::circuit::handlers::create_message;
 use crate::circuit::service::{Service, ServiceId, SplinterNode};
 use crate::circuit::{ServiceDefinition, SplinterState};
-use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, Handler, MessageContext, PeerId};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{
     CircuitMessageType, ServiceConnectRequest, ServiceConnectResponse,
@@ -33,13 +33,14 @@ pub struct ServiceConnectRequestHandler {
 }
 
 impl Handler for ServiceConnectRequestHandler {
+    type Source = PeerId;
     type MessageType = CircuitMessageType;
     type Message = ServiceConnectRequest;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Connect Request {:?}", msg);
@@ -164,13 +165,14 @@ pub struct ServiceDisconnectRequestHandler {
 }
 
 impl Handler for ServiceDisconnectRequestHandler {
+    type Source = PeerId;
     type MessageType = CircuitMessageType;
     type Message = ServiceDisconnectRequest;
 
     fn handle(
         &self,
         msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("Handle Service Disconnect Request {:?}", msg);
@@ -305,7 +307,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                         connect_bytes.clone(),
                     )
@@ -358,7 +360,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "BAD",
+                        "BAD".into(),
                         &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                         connect_bytes.clone(),
                     )
@@ -411,7 +413,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                         connect_bytes.clone(),
                     )
@@ -470,7 +472,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                         connect_bytes.clone(),
                     )
@@ -516,7 +518,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                         disconnect_bytes.clone(),
                     )
@@ -565,7 +567,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "BAD",
+                        "BAD".into(),
                         &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                         disconnect_bytes.clone(),
                     )
@@ -621,7 +623,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                         disconnect_bytes.clone(),
                     )
@@ -668,7 +670,7 @@ mod tests {
 
                 dispatcher
                     .dispatch(
-                        "abc",
+                        "abc".into(),
                         &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                         disconnect_bytes.clone(),
                     )

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+use crate::network::dispatch::{DispatchError, Handler, MessageContext, PeerId};
 use crate::network::sender::NetworkMessageSender;
 use crate::protos::network::{NetworkEcho, NetworkHeartbeat, NetworkMessage, NetworkMessageType};
 
@@ -24,13 +24,14 @@ pub struct NetworkEchoHandler {
 }
 
 impl Handler for NetworkEchoHandler {
+    type Source = PeerId;
     type MessageType = NetworkMessageType;
     type Message = NetworkEcho;
 
     fn handle(
         &self,
         mut msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("ECHO: {:?}", msg);
@@ -77,13 +78,14 @@ impl NetworkEchoHandler {
 pub struct NetworkHeartbeatHandler {}
 
 impl Handler for NetworkHeartbeatHandler {
+    type Source = PeerId;
     type MessageType = NetworkMessageType;
     type Message = NetworkHeartbeat;
 
     fn handle(
         &self,
         _msg: Self::Message,
-        context: &MessageContext<Self::MessageType>,
+        context: &MessageContext<Self::Source, Self::MessageType>,
         _sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         trace!("Received Heartbeat from {}", context.source_peer_id());
@@ -149,7 +151,7 @@ mod tests {
             assert_eq!(
                 Ok(()),
                 dispatcher.dispatch(
-                    "OTHER_PEER",
+                    "OTHER_PEER".into(),
                     &NetworkMessageType::NETWORK_ECHO,
                     outgoing_message_bytes.clone()
                 )

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -23,11 +23,14 @@ pub struct NetworkEchoHandler {
     node_id: String,
 }
 
-impl Handler<NetworkMessageType, NetworkEcho> for NetworkEchoHandler {
+impl Handler for NetworkEchoHandler {
+    type MessageType = NetworkMessageType;
+    type Message = NetworkEcho;
+
     fn handle(
         &self,
-        mut msg: NetworkEcho,
-        context: &MessageContext<NetworkMessageType>,
+        mut msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         debug!("ECHO: {:?}", msg);
@@ -73,11 +76,14 @@ impl NetworkEchoHandler {
 #[derive(Default)]
 pub struct NetworkHeartbeatHandler {}
 
-impl Handler<NetworkMessageType, NetworkHeartbeat> for NetworkHeartbeatHandler {
+impl Handler for NetworkHeartbeatHandler {
+    type MessageType = NetworkMessageType;
+    type Message = NetworkHeartbeat;
+
     fn handle(
         &self,
-        _msg: NetworkHeartbeat,
-        context: &MessageContext<NetworkMessageType>,
+        _msg: Self::Message,
+        context: &MessageContext<Self::MessageType>,
         _sender: &NetworkMessageSender,
     ) -> Result<(), DispatchError> {
         trace!("Received Heartbeat from {}", context.source_peer_id());

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -314,7 +314,7 @@ impl SplinterDaemon {
                             match network_dispatch_send.send(
                                 msg.get_message_type(),
                                 msg.take_payload(),
-                                message.peer_id().to_string(),
+                                message.peer_id().into(),
                             ) {
                                 Ok(()) => (),
                                 Err((message_type, _, _)) => {


### PR DESCRIPTION
Handlers may have varied source information.  That is, the messages might either be on the connection level, where the source is identified by a connection id, or on the peer level, where the source is identified as a peer id (and the connection id is irrelevant).

This change introduces a new generic parameter on dispatcher-related structs, `Source` that specifies this aspect of the context.  It introduces the `Source` associated type to the Handler trait to specify this type on specific handlers.

This type parameter should be one of two kinds of values: `ConnectionId` or `PeerId`.

Source defaults to `PeerId` in the dispatcher-related structs, where possible.

Handlers have also been changed from using generics to using associated types.