### PR TITLE
Update unified node registry for stabilization

### DIFF
--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -17,8 +17,6 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum NodeRegistryError {
-    /// This error is returned when a node is not found.
-    NotFoundError(String),
     InvalidNode(InvalidNodeError),
     /// This error is returned when an internal error occurred
     InternalError(Box<dyn Error + Send>),
@@ -29,7 +27,6 @@ pub enum NodeRegistryError {
 impl Error for NodeRegistryError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            NodeRegistryError::NotFoundError(_) => None,
             NodeRegistryError::InvalidNode(err) => Some(err),
             NodeRegistryError::InternalError(err) => Some(err.as_ref()),
             // Unfortunately, have to match on both arms to return the expected result
@@ -42,7 +39,6 @@ impl Error for NodeRegistryError {
 impl fmt::Display for NodeRegistryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            NodeRegistryError::NotFoundError(e) => write!(f, "Node not found: {}", e),
             NodeRegistryError::InvalidNode(e) => write!(f, "Invalid node: {}", e),
             NodeRegistryError::InternalError(e) => write!(f, "Internal error: {}", e),
             NodeRegistryError::UnableToAddNode(msg, err) => write!(

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -141,14 +141,10 @@ pub trait NodeRegistryReader: Send + Sync {
     ///
     ///  * `identity` - The Splinter identity of the node.
     ///
-    fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError>;
+    fn fetch_node(&self, identity: &str) -> Result<Option<Node>, NodeRegistryError>;
 
     fn has_node(&self, identity: &str) -> Result<bool, NodeRegistryError> {
-        match self.fetch_node(identity) {
-            Ok(_) => Ok(true),
-            Err(NodeRegistryError::NotFoundError(_)) => Ok(false),
-            Err(err) => Err(err),
-        }
+        self.fetch_node(identity).map(|opt| opt.is_some())
     }
 }
 
@@ -168,7 +164,7 @@ pub trait NodeRegistryWriter: Send + Sync {
     ///
     ///  * `identity` - The Splinter identity of the node.
     ///
-    fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError>;
+    fn delete_node(&self, identity: &str) -> Result<Option<Node>, NodeRegistryError>;
 }
 
 /// Provides a marker trait for a clonable, readable and writable Node Registry.
@@ -204,7 +200,7 @@ where
         (**self).count_nodes(predicates)
     }
 
-    fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
+    fn fetch_node(&self, identity: &str) -> Result<Option<Node>, NodeRegistryError> {
         (**self).fetch_node(identity)
     }
 
@@ -221,7 +217,7 @@ where
         (**self).insert_node(node)
     }
 
-    fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {
+    fn delete_node(&self, identity: &str) -> Result<Option<Node>, NodeRegistryError> {
         (**self).delete_node(identity)
     }
 }

--- a/libsplinter/src/node_registry/noop.rs
+++ b/libsplinter/src/node_registry/noop.rs
@@ -33,8 +33,8 @@ impl NodeRegistryReader for NoOpNodeRegistry {
         Ok(Box::new(std::iter::empty()))
     }
 
-    fn fetch_node(&self, identity: &str) -> Result<Node, NodeRegistryError> {
-        Err(NodeRegistryError::NotFoundError(identity.to_string()))
+    fn fetch_node(&self, _identity: &str) -> Result<Option<Node>, NodeRegistryError> {
+        Ok(None)
     }
 
     fn count_nodes(&self, _predicates: &[MetadataPredicate]) -> Result<u32, NodeRegistryError> {
@@ -50,8 +50,8 @@ impl NodeRegistryWriter for NoOpNodeRegistry {
         ))
     }
 
-    fn delete_node(&self, identity: &str) -> Result<(), NodeRegistryError> {
-        Err(NodeRegistryError::NotFoundError(identity.to_string()))
+    fn delete_node(&self, _identity: &str) -> Result<Option<Node>, NodeRegistryError> {
+        Ok(None)
     }
 }
 

--- a/libsplinter/src/node_registry/rest_api.rs
+++ b/libsplinter/src/node_registry/rest_api.rs
@@ -89,14 +89,9 @@ where
         .to_string();
     Box::new(
         web::block(move || registry.fetch_node(&identity)).then(|res| match res {
-            Ok(node) => Ok(HttpResponse::Ok().json(node)),
-            Err(err) => match err {
-                BlockingError::Error(err) => match err {
-                    NodeRegistryError::NotFoundError(err) => Ok(HttpResponse::NotFound().json(err)),
-                    _ => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
-                },
-                _ => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
-            },
+            Ok(Some(node)) => Ok(HttpResponse::Ok().json(node)),
+            Ok(None) => Ok(HttpResponse::NotFound().json("node not found")),
+            Err(err) => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
         }),
     )
 }
@@ -178,14 +173,9 @@ where
         .to_string();
     Box::new(
         web::block(move || registry.delete_node(&identity)).then(|res| match res {
-            Ok(_) => Ok(HttpResponse::Ok().finish()),
-            Err(err) => match err {
-                BlockingError::Error(err) => match err {
-                    NodeRegistryError::NotFoundError(err) => Ok(HttpResponse::NotFound().json(err)),
-                    _ => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
-                },
-                _ => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
-            },
+            Ok(Some(_)) => Ok(HttpResponse::Ok().finish()),
+            Ok(None) => Ok(HttpResponse::NotFound().json("node not found")),
+            Err(err) => Ok(HttpResponse::InternalServerError().json(format!("{}", err))),
         }),
     )
 }

--- a/libsplinter/src/node_registry/unified.rs
+++ b/libsplinter/src/node_registry/unified.rs
@@ -21,6 +21,7 @@
 //!
 //! This module is behind the `"node-registry-unified"` feature, and is considered experimental.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::{
@@ -50,6 +51,26 @@ impl UnifiedNodeRegistry {
             readable_sources: readable_sources.into_iter().map(Arc::from).collect(),
         }
     }
+
+    /// Gets all nodes from all sources (in ascending order of precedence) without deduplication.
+    fn all_nodes<'a>(&'a self) -> Result<NodeIter<'a>, NodeRegistryError> {
+        // Get node iterators from all read-only sources
+        self.readable_sources
+            .iter()
+            .map(|registry| registry.list_nodes(&[]))
+            // Reverse the sources, so lowest precedence is first
+            .rev()
+            // Add the local source's node iterator to the end, since it has highest precedence
+            .chain(std::iter::once(self.local_source.list_nodes(&[])))
+            // Flatten into a single iterator, returning any errors from the `list_nodes` calls
+            .try_fold(
+                Box::new(std::iter::empty()) as NodeIter<'a>,
+                |chain, nodes_res| {
+                    let v = nodes_res?.collect::<Vec<_>>();
+                    Ok(Box::new(chain.chain(v.into_iter())) as NodeIter<'a>)
+                },
+            )
+    }
 }
 
 // Some type conveniences to cleanup some of the type requirements in the list_nodes implementation
@@ -60,55 +81,60 @@ impl NodeRegistryReader for UnifiedNodeRegistry {
         &'b self,
         predicates: &'a [MetadataPredicate],
     ) -> Result<NodeIter<'a>, NodeRegistryError> {
-        self.readable_sources
-            .iter()
-            .map(|registry| registry.list_nodes(predicates))
-            .fold(self.local_source.list_nodes(predicates), |acc, iter| {
-                let local_source = self.local_source.clone();
-                acc.and_then(|chained| {
-                    let res: NodeIter<'a> = Box::new(chained.chain(iter?.filter(move |node| {
-                        match local_source.has_node(&node.identity) {
-                            Ok(exists) => !exists,
-                            Err(err) => {
-                                error!(
-                                    "unable to load local entry for {}; using read-only copy: {}",
-                                    node.identity, err
-                                );
-                                false
-                            }
-                        }
-                    })));
-                    Ok(res)
+        Ok(Box::new(
+            // Get all nodes from all sources
+            self.all_nodes()?
+                // Deduplicate and merge metadata
+                .fold(HashMap::<String, Node>::new(), |mut acc, mut node| {
+                    // If the node is already present, merge metadata
+                    if let Some(existing) = acc.remove(&node.identity) {
+                        // Overwrite the existing node's metadata with the new node's if they share
+                        // the same metadata keys
+                        let mut merged_metadata = existing.metadata;
+                        merged_metadata.extend(node.metadata);
+                        node.metadata = merged_metadata;
+                    }
+                    acc.insert(node.identity.clone(), node);
+                    acc
                 })
-            })
+                // Convert to iterator of just the nodes
+                .into_iter()
+                .map(|(_, node)| node)
+                // Apply predicate filters
+                .filter(move |node| predicates.iter().all(|predicate| predicate.apply(node))),
+        ))
     }
 
-    /// This implementation of count_nodes does not take into account the replaced nodes in the
-    /// node registry, in order to keep the overall operation more efficient.
     fn count_nodes(&self, predicates: &[MetadataPredicate]) -> Result<u32, NodeRegistryError> {
-        let local_source_count = self.local_source.count_nodes(predicates)?;
-
-        self.readable_sources
-            .iter()
-            .map(|source| source.count_nodes(predicates))
-            .fold(Ok(local_source_count), |acc, count| {
-                acc.and_then(|total| Ok(total + count?))
-            })
+        self.list_nodes(predicates).map(|iter| iter.count() as u32)
     }
 
     fn fetch_node(&self, identity: &str) -> Result<Option<Node>, NodeRegistryError> {
-        if let Some(node) = self.local_source.fetch_node(identity)? {
-            return Ok(Some(node));
-        }
-
-        Ok(self
-            .readable_sources
+        // Get node from all read-only sources
+        self.readable_sources
             .iter()
-            .map(|source| source.fetch_node(identity))
-            .find_map(|res| match res {
-                Ok(opt) => opt,
-                _ => None,
-            }))
+            .map(|registry| registry.fetch_node(identity))
+            // Reverse the sources, so lowest precedence is first
+            .rev()
+            // Get node from the local source and add it to the end, since it has highest precedence
+            .chain(std::iter::once(self.local_source.fetch_node(identity)))
+            // Merge metadata and get the highest-precedence definition of the node if it exists
+            .try_fold(None, |final_opt: Option<Node>, fetch_res| {
+                fetch_res.map(|fetch_opt| match fetch_opt {
+                    Some(mut node) => {
+                        // If the node was already found at a lower precedence, merge metadata
+                        if let Some(existing) = final_opt {
+                            // Overwrite the existing node's metadata with the new node's if they
+                            // share the same metadata keys
+                            let mut merged_metadata = existing.metadata;
+                            merged_metadata.extend(node.metadata);
+                            node.metadata = merged_metadata;
+                        }
+                        Some(node)
+                    }
+                    None => final_opt,
+                })
+            })
     }
 }
 
@@ -131,157 +157,415 @@ impl RwNodeRegistry for UnifiedNodeRegistry {
 #[cfg(test)]
 mod test {
     use std::collections::BTreeMap;
+    use std::iter::FromIterator;
     use std::sync::{Arc, Mutex};
 
     use super::*;
 
-    /// Simple macro for creating nodes
-    macro_rules! node {
-        ($identity:expr, $($key:expr => $val:expr),*) => {
-            {
-                let mut node = Node::new($identity, "test://example.com");
-
-                $(
-                    node.metadata.insert($key.into(), $val.into());
-                )*
-
-                node
-            }
-        };
+    fn new_node(id: &str, endpoint: &str, metadata: &[(&str, &str)]) -> Node {
+        let mut node = Node::new(id, endpoint);
+        for (key, val) in metadata {
+            node.metadata.insert(key.to_string(), val.to_string());
+        }
+        node
     }
 
-    /// This test ensures that the resulting fetched node is returned from a read-only source, if
-    /// it only exists there.
+    /// Verify that the number of nodes is correctly reported when all registries are empty.
     #[test]
-    fn test_unified_fetch_node_readable() {
+    fn node_count_empty() {
+        let unified = UnifiedNodeRegistry::new(
+            Box::new(MemRegistry::default()),
+            vec![Box::new(MemRegistry::default())],
+        );
+        assert_eq!(0, unified.count_nodes(&[]).expect("Unable to get count"));
+    }
+
+    /// Verify that the number of nodes is correctly reported when the same node exists across
+    /// registries.
+    #[test]
+    fn node_count_multiple() {
+        let node1 = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+        let node2 = new_node("node2", "endpoint2", &[("meta_b", "val_b")]);
+        let node3 = new_node("node1", "endpoint3", &[("meta_c", "val_c")]);
+
+        let writeable = MemRegistry::default();
+        writeable
+            .insert_node(node1)
+            .expect("Unable to insert node1");
+        writeable
+            .insert_node(node2)
+            .expect("Unable to insert node2");
+
+        let readable = MemRegistry::default();
+        writeable
+            .insert_node(node3)
+            .expect("Unable to insert node3");
+
+        let unified = UnifiedNodeRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
+
+        assert_eq!(2, unified.count_nodes(&[]).expect("Unable to get count"));
+    }
+
+    /// Verify that the number of nodes is correctly reported when metadata predicate are provided.
+    #[test]
+    fn node_count_with_predicates() {
+        let node1 = new_node(
+            "node1",
+            "endpoint1",
+            &[("meta_a", "val_a"), ("meta_b", "val_b")],
+        );
+        let node2 = new_node(
+            "node2",
+            "endpoint2",
+            &[("meta_a", "val_c"), ("meta_b", "val_b")],
+        );
+        let node3 = new_node(
+            "node1",
+            "endpoint3",
+            &[("meta_a", "val_a"), ("meta_b", "val_c")],
+        );
+
+        let writeable = MemRegistry::default();
+        writeable
+            .insert_node(node1)
+            .expect("Unable to insert node1");
+        writeable
+            .insert_node(node2)
+            .expect("Unable to insert node2");
+
+        let readable = MemRegistry::default();
+        readable.insert_node(node3).expect("Unable to insert node3");
+
+        let unified = UnifiedNodeRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
+
+        assert_eq!(
+            1,
+            unified
+                .count_nodes(&[
+                    MetadataPredicate::eq("meta_a", "val_a"),
+                    MetadataPredicate::ne("meta_b", "val_c")
+                ])
+                .expect("Unable to get count")
+        );
+    }
+
+    /// Verify that a node is fetched from a read-only source if it only exists there.
+    #[test]
+    fn fetch_node_read_only() {
+        let node = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+
         let readable = MemRegistry::default();
         readable
-            .insert_node(node!("node1", "meta_a" => "a value"))
+            .insert_node(node.clone())
             .expect("Unable to insert node");
 
-        let writable = MemRegistry::default();
-
-        let unified = UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(readable)]);
+        let unified =
+            UnifiedNodeRegistry::new(Box::new(MemRegistry::default()), vec![Box::new(readable)]);
 
         let retreived_node = unified
             .fetch_node("node1")
             .expect("Unable to fetch node")
             .expect("Node not found");
 
-        assert_eq!(node!("node1", "meta_a" => "a value"), retreived_node);
+        assert_eq!(node, retreived_node);
     }
 
-    /// This test ensures that the resulting fetched node is returned from the local source, if it
-    /// only exists there.
+    /// Verify that a node is fetched from the local source if it only exists there.
     #[test]
-    fn test_unified_fetch_node_local() {
-        let readable = MemRegistry::default();
+    fn fetch_node_local() {
+        let node = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(node!("node1", "meta_b" => "b value"))
+            .insert_node(node.clone())
             .expect("Unable to insert node");
 
-        let unified = UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(readable)]);
+        let unified =
+            UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(MemRegistry::default())]);
 
         let retreived_node = unified
             .fetch_node("node1")
             .expect("Unable to fetch node")
             .expect("Node not found");
 
-        assert_eq!(node!("node1", "meta_b" => "b value"), retreived_node);
+        assert_eq!(node, retreived_node);
     }
 
-    /// This test ensures that the resulting fetched node is from the local store, even if a node
-    /// is in a read-only source.
-    #[test]
-    fn test_unified_fetch_node_local_selected() {
-        let readable = MemRegistry::default();
-        readable
-            .insert_node(node!("node1", "meta_a" => "a value"))
-            .expect("Unable to insert node");
-
-        let writable = MemRegistry::default();
-        writable
-            .insert_node(node!("node1", "meta_b" => "b value"))
-            .expect("Unable to insert node");
-
-        let unified = UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(readable)]);
-
-        let retreived_node = unified
-            .fetch_node("node1")
-            .expect("Unable to fetch node")
-            .expect("Node not found");
-
-        assert_eq!(node!("node1", "meta_b" => "b value"), retreived_node);
-    }
-
-    /// This test ensures that the results are unified into a single iterator and nodes are
-    /// replaced with the values from the local store, if the exist.
-    #[test]
-    fn test_unified_iteration_local_selected() {
-        let readable = MemRegistry::default();
-        readable
-            .insert_node(node!("node1", "meta_a" => "a value"))
-            .expect("Unable to insert node");
-        readable
-            .insert_node(node!("node2", "meta_c" => "c value"))
-            .expect("Unable to insert node");
-
-        let writable = MemRegistry::default();
-        writable
-            .insert_node(node!("node1", "meta_b" => "b value"))
-            .expect("Unable to insert node");
-
-        let unified = UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(readable)]);
-
-        let mut iterator = unified.list_nodes(&[]).expect("Unable to list nodes");
-
-        assert_eq!(Some(node!("node1", "meta_b" => "b value")), iterator.next());
-        assert_eq!(Some(node!("node2", "meta_c" => "c value")), iterator.next());
-
-        assert_eq!(None, iterator.next());
-    }
-
-    /// This test ensures that a node which is selected by MetadataPredicates is returned
-    /// regardless of source.
+    /// Verify that a node is fetched from the highest-precedence read-only source if it does not
+    /// exist in the local registry, and that the metadata is properly merged.
     ///
-    /// Likewise, nodes that should be filtered out based on properties in one source should not be
-    /// returned in the final iteration.
+    /// 1. Add the same node to three read-only registries with different endpoints and metadata.
+    /// 2. Add the read-only registries to a unified registry, along with an empty writable
+    ///    registry.
+    /// 3. Fetch the node and verify that it has the correct data (endpoint from highest-precedence
+    ///    registry, metadata merged from all registries).
     #[test]
-    fn test_unified_iteration_filtering() {
-        let readable = MemRegistry::default();
-        readable
-            .insert_node(node!("node1", "meta_a" => "a value"))
-            .expect("Unable to insert node");
-        readable
-            .insert_node(node!("node2", "meta_c" => "c value"))
-            .expect("Unable to insert node");
+    fn fetch_node_read_only_precedence() {
+        let high_precedence_node = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+        let med_precedence_node = new_node("node1", "endpoint2", &[("meta_b", "val_b")]);
+        let low_precedence_node = new_node("node1", "endpoint3", &[("meta_a", "val_c")]);
+        let expected_node = new_node(
+            "node1",
+            "endpoint1",
+            &[("meta_a", "val_a"), ("meta_b", "val_b")],
+        );
+
+        let high_precedence_readable = MemRegistry::default();
+        high_precedence_readable
+            .insert_node(high_precedence_node)
+            .expect("Unable to insert high-precedence node");
+
+        let med_precedence_readable = MemRegistry::default();
+        med_precedence_readable
+            .insert_node(med_precedence_node)
+            .expect("Unable to insert medium-precedence node");
+
+        let low_precedence_readable = MemRegistry::default();
+        low_precedence_readable
+            .insert_node(low_precedence_node)
+            .expect("Unable to insert low-precedence node");
+
+        let unified = UnifiedNodeRegistry::new(
+            Box::new(MemRegistry::default()),
+            vec![
+                Box::new(high_precedence_readable),
+                Box::new(med_precedence_readable),
+                Box::new(low_precedence_readable),
+            ],
+        );
+
+        let retreived_node = unified
+            .fetch_node("node1")
+            .expect("Unable to fetch node")
+            .expect("Node not found");
+
+        assert_eq!(expected_node, retreived_node);
+    }
+
+    /// Verify that a node is fetched from the local source even if it exists in one or more
+    /// read-only registries, and that the metadata is properly merged.
+    ///
+    /// 1. Add the same node to the local registry and two read-only registries with different
+    ///    endpoints and metadata.
+    /// 2. Add the registries to a unified registry.
+    /// 3. Fetch the node and verify that it has the correct data (endpoint from local registry,
+    ///    metadata merged from all sources).
+    #[test]
+    fn fetch_node_local_precedence() {
+        let high_precedence_node = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+        let med_precedence_node = new_node("node1", "endpoint2", &[("meta_b", "val_b")]);
+        let low_precedence_node = new_node("node1", "endpoint3", &[("meta_a", "val_c")]);
+        let expected_node = new_node(
+            "node1",
+            "endpoint1",
+            &[("meta_a", "val_a"), ("meta_b", "val_b")],
+        );
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(node!("node1", "meta_b" => "b value"))
-            .expect("Unable to insert node");
+            .insert_node(high_precedence_node)
+            .expect("Unable to insert high-precedence node");
 
-        let unified = UnifiedNodeRegistry::new(Box::new(writable), vec![Box::new(readable)]);
+        let med_precedence_readable = MemRegistry::default();
+        med_precedence_readable
+            .insert_node(med_precedence_node)
+            .expect("Unable to insert medium-precedence node");
 
-        let predicates = vec![MetadataPredicate::eq("meta_b", "b value")];
-        let mut iterator = unified
+        let low_precedence_readable = MemRegistry::default();
+        low_precedence_readable
+            .insert_node(low_precedence_node)
+            .expect("Unable to insert low-precedence node");
+
+        let unified = UnifiedNodeRegistry::new(
+            Box::new(writable),
+            vec![
+                Box::new(med_precedence_readable),
+                Box::new(low_precedence_readable),
+            ],
+        );
+
+        let retreived_node = unified
+            .fetch_node("node1")
+            .expect("Unable to fetch node")
+            .expect("Node not found");
+
+        assert_eq!(expected_node, retreived_node);
+    }
+
+    /// Verify that listed nodes are properly returned based on precedence and that metadata is
+    /// correctly merged.
+    ///
+    /// 1. Add the same node to the local registry and a read-only registry with different data.
+    /// 2. Add the same node to two read-only registries with different data.
+    /// 3. Add all three registries to a unified registry.
+    /// 4. List the nodes and verify that the correct node data is returned.
+    #[test]
+    fn list_nodes_precedence() {
+        let node1_local = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+        let node1_read_only = new_node(
+            "node1",
+            "endpoint3",
+            &[("meta_a", "val_c"), ("meta_b", "val_b")],
+        );
+        let node2_high = new_node("node2", "endpoint2", &[("meta_a", "val_a")]);
+        let node2_low = new_node(
+            "node2",
+            "endpoint3",
+            &[("meta_a", "val_c"), ("meta_b", "val_b")],
+        );
+
+        let expected_nodes = HashMap::from_iter(vec![
+            (
+                "node1".to_string(),
+                new_node(
+                    "node1",
+                    "endpoint1",
+                    &[("meta_a", "val_a"), ("meta_b", "val_b")],
+                ),
+            ),
+            (
+                "node2".to_string(),
+                new_node(
+                    "node2",
+                    "endpoint2",
+                    &[("meta_a", "val_a"), ("meta_b", "val_b")],
+                ),
+            ),
+        ]);
+
+        let writable = MemRegistry::default();
+        writable
+            .insert_node(node1_local)
+            .expect("Unable to insert local node1");
+
+        let readable_high = MemRegistry::default();
+        readable_high
+            .insert_node(node1_read_only)
+            .expect("Unable to insert read-only node1");
+        readable_high
+            .insert_node(node2_high)
+            .expect("Unable to insert high-precedence node2");
+
+        let readable_low = MemRegistry::default();
+        readable_low
+            .insert_node(node2_low)
+            .expect("Unable to insert low-precedence node2");
+
+        let unified = UnifiedNodeRegistry::new(
+            Box::new(writable),
+            vec![Box::new(readable_high), Box::new(readable_low)],
+        );
+
+        let nodes = unified
+            .list_nodes(&[])
+            .expect("Unable to list nodes")
+            .map(|node| (node.identity.clone(), node))
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(expected_nodes, nodes);
+    }
+
+    /// Verify that listed nodes are properly returned when metadata predicates are provided.
+    #[test]
+    fn list_nodes_with_predicates() {
+        let node1 = new_node(
+            "node1",
+            "endpoint1",
+            &[("meta_a", "val_a"), ("meta_b", "val_b")],
+        );
+        let node2 = new_node(
+            "node2",
+            "endpoint2",
+            &[("meta_a", "val_c"), ("meta_b", "val_b")],
+        );
+        let node3 = new_node(
+            "node1",
+            "endpoint3",
+            &[("meta_a", "val_a"), ("meta_b", "val_c")],
+        );
+
+        let writeable = MemRegistry::default();
+        writeable
+            .insert_node(node1.clone())
+            .expect("Unable to insert node1");
+        writeable
+            .insert_node(node2)
+            .expect("Unable to insert node2");
+
+        let readable = MemRegistry::default();
+        readable.insert_node(node3).expect("Unable to insert node3");
+
+        let unified = UnifiedNodeRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
+
+        let predicates = vec![
+            MetadataPredicate::eq("meta_a", "val_a"),
+            MetadataPredicate::ne("meta_b", "val_c"),
+        ];
+        let mut nodes = unified
             .list_nodes(&predicates)
-            .expect("Unable to list nodes");
+            .expect("Unable to get count");
 
-        assert_eq!(Some(node!("node1", "meta_b" => "b value")), iterator.next());
+        assert_eq!(Some(node1), nodes.next());
+        assert_eq!(None, nodes.next());
+    }
 
-        assert_eq!(None, iterator.next());
+    /// Verify that the `NodeRegistryWriter` implementation affects only the local registry.
+    #[test]
+    fn write_nodes() {
+        let node1 = new_node("node1", "endpoint1", &[("meta_a", "val_a")]);
+        let node2 = new_node("node2", "endpoint2", &[("meta_b", "val_b")]);
 
-        let predicates = vec![MetadataPredicate::ne("meta_b", "b value")];
-        let mut iterator = unified
-            .list_nodes(&predicates)
-            .expect("Unable to list nodes");
+        let writeable = MemRegistry::default();
 
-        assert_eq!(Some(node!("node2", "meta_c" => "c value")), iterator.next());
+        let readable = MemRegistry::default();
+        readable
+            .insert_node(node2.clone())
+            .expect("Unable to insert node2 into read-only registry");
 
-        assert_eq!(None, iterator.next());
+        let unified = UnifiedNodeRegistry::new(
+            Box::new(writeable.clone()),
+            vec![Box::new(readable.clone())],
+        );
+
+        // Verify node1 is only added to writeable
+        unified
+            .insert_node(node1.clone())
+            .expect("Unable to add node1");
+        assert!(unified
+            .has_node(&node1.identity)
+            .expect("Unable to check unified for node1"));
+        assert!(writeable
+            .has_node(&node1.identity)
+            .expect("Unable to check writeable for node1"));
+        assert!(!readable
+            .has_node(&node1.identity)
+            .expect("Unable to check readable for node1"));
+
+        // Verify removing node2 is None, node stays in readable
+        assert!(unified
+            .delete_node(&node2.identity)
+            .expect("Unable to remove node2")
+            .is_none());
+        assert!(unified
+            .has_node(&node2.identity)
+            .expect("Unable to check unified for node2"));
+        assert!(readable
+            .has_node(&node2.identity)
+            .expect("Unable to check readable for node2"));
+
+        // Verify removing node1 is Some, node no longer in writeable
+        assert_eq!(
+            Some(node1.clone()),
+            unified
+                .delete_node(&node1.identity)
+                .expect("Unable to remove node1")
+        );
+        assert!(!unified
+            .has_node(&node1.identity)
+            .expect("Unable to check unified for node1"));
+        assert!(!writeable
+            .has_node(&node1.identity)
+            .expect("Unable to check writeable for node1"));
     }
 
     #[derive(Clone, Default)]


### PR DESCRIPTION
This PR includes a planned change to the unified node registry's behavior, as well as updates to its documentation and tests. The goal of this PR is to prepare the `node-registry-unified` feature for stabilization.