### PR TITLE
Remove the use of concrete stores from Biome RestApi

### DIFF
--- a/libsplinter/src/biome/credentials/store/mod.rs
+++ b/libsplinter/src/biome/credentials/store/mod.rs
@@ -140,7 +140,7 @@ impl CredentialsBuilder {
 
 /// Defines methods for CRUD operations and fetching a user’s
 /// credentials without defining a storage strategy
-pub trait CredentialsStore {
+pub trait CredentialsStore: Send + Sync {
     /// Adds a credential to the underlying storage
     ///
     /// # Arguments

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -42,3 +42,12 @@ pub mod refresh_tokens;
 #[cfg(feature = "rest-api")]
 pub mod rest_api;
 mod user;
+
+#[cfg(all(feature = "biome-credentials", feature = "diesel"))]
+pub use credentials::store::diesel::DieselCredentialsStore;
+#[cfg(all(feature = "biome-key-management", feature = "diesel"))]
+pub use key_management::store::diesel::postgres::DieselKeyStore;
+#[cfg(all(feature = "biome-refresh-tokens", feature = "diesel"))]
+pub use refresh_tokens::store::diesel::DieselRefreshTokenStore;
+#[cfg(feature = "diesel")]
+pub use user::store::diesel::DieselUserStore;

--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -21,9 +21,7 @@ use crate::futures::{Future, IntoFuture};
 use crate::protocol;
 use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
-use crate::biome::credentials::store::{
-    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError,
-};
+use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use crate::biome::rest_api::resources::credentials::UsernamePassword;
 use crate::biome::rest_api::BiomeRestConfig;
 use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
@@ -36,7 +34,7 @@ use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
 ///       "hashed_password": <hash of the user's existing password>
 ///   }
 pub fn make_login_route(
-    credentials_store: Arc<DieselCredentialsStore>,
+    credentials_store: Arc<dyn CredentialsStore>,
     #[cfg(feature = "biome-refresh-tokens")] refresh_token_store: Arc<dyn RefreshTokenStore>,
     rest_config: Arc<BiomeRestConfig>,
     token_issuer: Arc<AccessTokenIssuer>,

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -17,11 +17,11 @@ use uuid::Uuid;
 
 use crate::actix_web::HttpResponse;
 use crate::biome::credentials::store::{
-    diesel::DieselCredentialsStore, CredentialsBuilder, CredentialsStore, CredentialsStoreError,
+    CredentialsBuilder, CredentialsStore, CredentialsStoreError,
 };
 use crate::biome::rest_api::resources::credentials::{NewUser, UsernamePassword};
 use crate::biome::rest_api::BiomeRestConfig;
-use crate::biome::user::store::{diesel::DieselUserStore, User, UserStore};
+use crate::biome::user::store::{User, UserStore};
 use crate::futures::{Future, IntoFuture};
 use crate::protocol;
 use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
@@ -34,8 +34,8 @@ use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGua
 ///       "hashed_password": <hash of the password the user will use to log in>
 ///   }
 pub fn make_register_route(
-    credentials_store: Arc<DieselCredentialsStore>,
-    user_store: DieselUserStore,
+    credentials_store: Arc<dyn CredentialsStore>,
+    user_store: Arc<dyn UserStore>,
     rest_config: Arc<BiomeRestConfig>,
 ) -> Resource {
     Resource::build("/biome/register")
@@ -45,7 +45,7 @@ pub fn make_register_route(
         ))
         .add_method(Method::Post, move |_, payload| {
             let credentials_store = credentials_store.clone();
-            let mut user_store = user_store.clone();
+            let user_store = user_store.clone();
             let rest_config = rest_config.clone();
             Box::new(into_bytes(payload).and_then(move |bytes| {
                 let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {

--- a/libsplinter/src/biome/rest_api/actix/verify.rs
+++ b/libsplinter/src/biome/rest_api/actix/verify.rs
@@ -22,9 +22,7 @@ use crate::rest_api::{
     ProtocolVersionRangeGuard, Resource,
 };
 
-use crate::biome::credentials::store::{
-    diesel::DieselCredentialsStore, CredentialsStore, CredentialsStoreError,
-};
+use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use crate::biome::rest_api::config::BiomeRestConfig;
 
 use super::super::resources::authorize::AuthorizationResult;
@@ -39,7 +37,7 @@ use super::authorize::authorize_user;
 ///       "hashed_password": <hash of the user's existing password>
 ///   }
 pub fn make_verify_route(
-    credentials_store: Arc<DieselCredentialsStore>,
+    credentials_store: Arc<dyn CredentialsStore>,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {

--- a/libsplinter/src/biome/user/store/diesel/mod.rs
+++ b/libsplinter/src/biome/user/store/diesel/mod.rs
@@ -45,15 +45,15 @@ impl DieselUserStore {
 }
 
 impl UserStore for DieselUserStore {
-    fn add_user(&mut self, user: User) -> Result<(), UserStoreError> {
+    fn add_user(&self, user: User) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).add_user(user.into())
     }
 
-    fn update_user(&mut self, updated_user: User) -> Result<(), UserStoreError> {
+    fn update_user(&self, updated_user: User) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).update_user(updated_user)
     }
 
-    fn remove_user(&mut self, id: &str) -> Result<(), UserStoreError> {
+    fn remove_user(&self, id: &str) -> Result<(), UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).delete_user(id)
     }
 

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -53,21 +53,21 @@ pub trait UserStore: Send + Sync {
     /// # Arguments
     ///
     ///  * `user` - The user to be added
-    fn add_user(&mut self, user: User) -> Result<(), UserStoreError>;
+    fn add_user(&self, user: User) -> Result<(), UserStoreError>;
 
     /// Updates a user information in the underling storage
     ///
     /// # Arguments
     ///
     ///  * `user` - The user with the updated information
-    fn update_user(&mut self, updated_user: User) -> Result<(), UserStoreError>;
+    fn update_user(&self, updated_user: User) -> Result<(), UserStoreError>;
 
     /// Removes a user from the underlying storage
     ///
     /// # Arguments
     ///
     ///  * `id` - The unique id of the user to be removed
-    fn remove_user(&mut self, id: &str) -> Result<(), UserStoreError>;
+    fn remove_user(&self, id: &str) -> Result<(), UserStoreError>;
 
     /// Fetches a user from the underlying storage
     ///

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -28,6 +28,14 @@ use splinter::admin::rest_api::CircuitResourceProvider;
 use splinter::admin::service::{admin_service_id, AdminService};
 #[cfg(feature = "biome")]
 use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
+#[cfg(feature = "biome-credentials")]
+use splinter::biome::DieselCredentialsStore;
+#[cfg(feature = "biome-key-management")]
+use splinter::biome::DieselKeyStore;
+#[cfg(feature = "biome-refresh-tokens")]
+use splinter::biome::DieselRefreshTokenStore;
+#[cfg(feature = "biome")]
+use splinter::biome::DieselUserStore;
 use splinter::circuit::directory::CircuitDirectory;
 use splinter::circuit::handlers::{
     AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
@@ -660,21 +668,21 @@ fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartErr
         })?;
     let mut biome_rest_provider_builder: BiomeRestResourceManagerBuilder = Default::default();
     biome_rest_provider_builder =
-        biome_rest_provider_builder.with_user_store(connection_pool.clone());
+        biome_rest_provider_builder.with_user_store(DieselUserStore::new(connection_pool.clone()));
     #[cfg(feature = "biome-credentials")]
     {
-        biome_rest_provider_builder =
-            biome_rest_provider_builder.with_credentials_store(connection_pool.clone());
+        biome_rest_provider_builder = biome_rest_provider_builder
+            .with_credentials_store(DieselCredentialsStore::new(connection_pool.clone()));
     }
     #[cfg(feature = "biome-key-management")]
     {
         biome_rest_provider_builder =
-            biome_rest_provider_builder.with_key_store(connection_pool.clone())
+            biome_rest_provider_builder.with_key_store(DieselKeyStore::new(connection_pool.clone()))
     }
     #[cfg(feature = "biome-refresh-tokens")]
     {
-        biome_rest_provider_builder =
-            biome_rest_provider_builder.with_refresh_token_store(connection_pool);
+        biome_rest_provider_builder = biome_rest_provider_builder
+            .with_refresh_token_store(DieselRefreshTokenStore::new(connection_pool));
     }
     let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
         StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))


### PR DESCRIPTION
Replaces uses of `DieselUserStore`, `DieselCredentialStore`, and
`PostgresKeyStore` in BiomeRestResourceManager with
`Arc<dyn UserStore>`, `Arc<dyn CredentialsStore>`, and `Arc<dyn
KeyStore<Key>>`. This makes BiomeRestResourceManager testable since it
can now be backed by mock versions of the stores or versions of the
stores that store objects in memory.

Additionally, the signatures of `with_user_store`, `with_credentials_store`,
`with_key_store` and `with_refresh_token_store` have been changed to take
trait objects of their respective stores as arguments instead of
`ConnectionsPool`s to account for store implementations that are not
backed by `ConnectionPool`.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>