### PR TITLE
Key management store updates

### DIFF
--- a/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
@@ -42,7 +42,7 @@ impl PostgresKeyStore {
     }
 }
 
-impl KeyStore<Key> for PostgresKeyStore {
+impl KeyStore for PostgresKeyStore {
     fn add_key(&self, key: Key) -> Result<(), KeyStoreError> {
         KeyStoreOperations::new(&*self.connection_pool.get()?).insert_key(key)
     }

--- a/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
+++ b/libsplinter/src/biome/key_management/store/diesel/postgres/mod.rs
@@ -26,23 +26,23 @@ use crate::biome::key_management::Key;
 use crate::database::ConnectionPool;
 
 /// Manages creating, updating and fetching keys from a PostgreSQL database.
-pub struct PostgresKeyStore {
+pub struct DieselKeyStore {
     pub connection_pool: ConnectionPool,
 }
 
-impl PostgresKeyStore {
-    /// Creates a new PostgresKeyStore
+impl DieselKeyStore {
+    /// Creates a new DieselKeyStore
     ///
     /// # Arguments
     ///
     ///  * `connection_pool`: connection pool to the PostgreSQL database
     ///
     pub fn new(connection_pool: ConnectionPool) -> Self {
-        PostgresKeyStore { connection_pool }
+        DieselKeyStore { connection_pool }
     }
 }
 
-impl KeyStore for PostgresKeyStore {
+impl KeyStore for DieselKeyStore {
     fn add_key(&self, key: Key) -> Result<(), KeyStoreError> {
         KeyStoreOperations::new(&*self.connection_pool.get()?).insert_key(key)
     }

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -16,6 +16,8 @@
 pub(in crate::biome) mod diesel;
 pub mod error;
 
+use super::Key;
+
 #[cfg(feature = "postgres")]
 pub use self::diesel::postgres::PostgresKeyStore;
 
@@ -23,13 +25,13 @@ pub use error::KeyStoreError;
 
 /// Defines methods for CRUD operations and fetching and listing keys
 /// without defining a storage strategy
-pub trait KeyStore<T>: Sync + Send {
+pub trait KeyStore: Sync + Send {
     /// Adds a key to the underlying storage
     ///
     /// # Arguments
     ///
     ///  * `key` - The key to be added
-    fn add_key(&self, key: T) -> Result<(), KeyStoreError>;
+    fn add_key(&self, key: Key) -> Result<(), KeyStoreError>;
 
     /// Updates a key information in the underling storage
     ///
@@ -51,7 +53,7 @@ pub trait KeyStore<T>: Sync + Send {
     ///
     /// * `public_key`: The public key of the key record to be removed.
     /// * `user_id`: The ID owner of the key record to be removed.
-    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<T, KeyStoreError>;
+    fn remove_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError>;
 
     /// Fetches a key from the underlying storage
     ///
@@ -59,14 +61,14 @@ pub trait KeyStore<T>: Sync + Send {
     ///
     /// * `public_key`: The public key of the key record to be fetched.
     /// * `user_id`: The ID owner of the key record to be fetched.
-    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<T, KeyStoreError>;
+    fn fetch_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError>;
 
     /// List all keys from the underlying storage
     ///
     /// # Arguments
     ///
     /// * `user_id`: The ID owner of the key records to list.
-    fn list_keys(&self, user_id: Option<&str>) -> Result<Vec<T>, KeyStoreError>;
+    fn list_keys(&self, user_id: Option<&str>) -> Result<Vec<Key>, KeyStoreError>;
 
     #[cfg(feature = "biome-credentials")]
     /// Updates keys and the associated user's password in the underlying storage
@@ -81,6 +83,6 @@ pub trait KeyStore<T>: Sync + Send {
         &self,
         user_id: &str,
         updated_password: &str,
-        keys: &[T],
+        keys: &[Key],
     ) -> Result<(), KeyStoreError>;
 }

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -19,7 +19,7 @@ pub mod error;
 use super::Key;
 
 #[cfg(feature = "postgres")]
-pub use self::diesel::postgres::PostgresKeyStore;
+pub use self::diesel::postgres::DieselKeyStore;
 
 pub use error::KeyStoreError;
 

--- a/libsplinter/src/biome/rest_api/actix/key_management.rs
+++ b/libsplinter/src/biome/rest_api/actix/key_management.rs
@@ -33,7 +33,7 @@ use crate::rest_api::{secrets::SecretManager, sessions::default_validation};
 /// Defines a REST endpoint for managing keys including inserting, listing and updating keys
 pub fn make_key_management_route(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
     Resource::build("/biome/keys")
@@ -66,7 +66,7 @@ pub fn make_key_management_route(
 /// Defines a REST endpoint for adding a key to the underlying storage
 fn handle_post(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
@@ -138,7 +138,7 @@ fn handle_post(
 /// Defines a REST endpoint for retrieving keys from the underlying storage
 fn handle_get(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> HandlerFunction {
     Box::new(move |request, _| {
@@ -190,7 +190,7 @@ fn handle_get(
 /// Defines a REST endpoint for updating a key in the underlying storage
 fn handle_patch(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
@@ -256,7 +256,7 @@ fn handle_patch(
 /// Defines a REST endpoint for managing keys including fetching and deleting a user's key
 pub fn make_key_management_route_with_public_key(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
     Resource::build("/biome/keys/{public_key}")
@@ -281,7 +281,7 @@ pub fn make_key_management_route_with_public_key(
 /// Defines a REST endpoint method to fetch a key from the underlying storage
 fn handle_fetch(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> HandlerFunction {
     Box::new(move |request, _| {
@@ -351,7 +351,7 @@ fn handle_fetch(
 /// Defines a REST endpoint method to delete a key from the underlying storage
 fn handle_delete(
     rest_config: Arc<BiomeRestConfig>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> HandlerFunction {
     Box::new(move |request, _| {

--- a/libsplinter/src/biome/rest_api/actix/user.rs
+++ b/libsplinter/src/biome/rest_api/actix/user.rs
@@ -67,7 +67,7 @@ pub fn make_user_routes(
     secret_manager: Arc<dyn SecretManager>,
     credentials_store: Arc<DieselCredentialsStore>,
     user_store: DieselUserStore,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
 ) -> Resource {
     Resource::build("/biome/users/{id}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
@@ -148,7 +148,7 @@ fn add_modify_user_method(
     credentials_store: Arc<DieselCredentialsStore>,
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
-    key_store: Arc<dyn KeyStore<Key>>,
+    key_store: Arc<dyn KeyStore>,
 ) -> HandlerFunction {
     Box::new(move |request, payload| {
         let credentials_store = credentials_store.clone();

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -60,7 +60,7 @@ use self::actix::key_management::{
 };
 
 #[cfg(feature = "biome-key-management")]
-use super::key_management::store::PostgresKeyStore;
+use super::key_management::store::DieselKeyStore;
 use super::user::store::diesel::DieselUserStore;
 
 #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
@@ -120,7 +120,7 @@ pub struct BiomeRestResourceManager {
     #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
     user_store: DieselUserStore,
     #[cfg(feature = "biome-key-management")]
-    key_store: Arc<PostgresKeyStore>,
+    key_store: Arc<DieselKeyStore>,
     #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
     rest_config: Arc<BiomeRestConfig>,
     #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
@@ -235,7 +235,7 @@ impl RestResourceProvider for BiomeRestResourceManager {
 pub struct BiomeRestResourceManagerBuilder {
     user_store: Option<DieselUserStore>,
     #[cfg(feature = "biome-key-management")]
-    key_store: Option<PostgresKeyStore>,
+    key_store: Option<DieselKeyStore>,
     rest_config: Option<BiomeRestConfig>,
     token_secret_manager: Option<Arc<dyn SecretManager>>,
     #[cfg(feature = "biome-refresh-tokens")]
@@ -264,7 +264,7 @@ impl BiomeRestResourceManagerBuilder {
     /// * `pool`: ConnectionPool to database that will serve as backend for KeyStore
     #[cfg(feature = "biome-key-management")]
     pub fn with_key_store(mut self, pool: ConnectionPool) -> BiomeRestResourceManagerBuilder {
-        self.key_store = Some(PostgresKeyStore::new(pool));
+        self.key_store = Some(DieselKeyStore::new(pool));
         self
     }
 


### PR DESCRIPTION
PR to update the KeyStore so it's consistent with the patterns followed by the other stores.

1. Remove generic form KeyStore trait signature
2. Rename PostgresKeyStore to DieselKeyStore