### PR TITLE
Dispatcher Refactors

### DIFF
--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -34,6 +34,10 @@ impl Handler for AdminDirectMessageHandler {
     type MessageType = CircuitMessageType;
     type Message = AdminDirectMessage;
 
+    fn match_type(&self) -> Self::MessageType {
+        CircuitMessageType::ADMIN_DIRECT_MESSAGE
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -215,7 +219,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
 
                 let handler = AdminDirectMessageHandler::new("1234".into(), state);
-                dispatcher.set_handler(CircuitMessageType::ADMIN_DIRECT_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 let mut direct_message = AdminDirectMessage::new();
                 direct_message.set_circuit("admin".into());
@@ -276,7 +280,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
 
                 let handler = AdminDirectMessageHandler::new("1234".into(), state);
-                dispatcher.set_handler(CircuitMessageType::ADMIN_DIRECT_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 let mut direct_message = AdminDirectMessage::new();
                 direct_message.set_circuit("admin".into());
@@ -337,7 +341,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
 
                 let handler = AdminDirectMessageHandler::new("1234".into(), state);
-                dispatcher.set_handler(CircuitMessageType::ADMIN_DIRECT_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 let mut direct_message = AdminDirectMessage::new();
                 direct_message.set_circuit("alpha".into());
@@ -383,7 +387,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
 
                 let handler = AdminDirectMessageHandler::new("1234".into(), state);
-                dispatcher.set_handler(CircuitMessageType::ADMIN_DIRECT_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 let mut direct_message = AdminDirectMessage::new();
                 direct_message.set_circuit("admin".into());
@@ -429,7 +433,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
 
                 let handler = AdminDirectMessageHandler::new("1234".into(), state);
-                dispatcher.set_handler(CircuitMessageType::ADMIN_DIRECT_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 let mut direct_message = AdminDirectMessage::new();
                 direct_message.set_circuit("admin".into());

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -32,6 +32,10 @@ impl Handler for CircuitErrorHandler {
     type MessageType = CircuitMessageType;
     type Message = CircuitError;
 
+    fn match_type(&self) -> Self::MessageType {
+        CircuitMessageType::CIRCUIT_ERROR_MESSAGE
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -163,8 +167,7 @@ mod tests {
 
                 // Add circuit error handler to the the dispatcher
                 let handler = CircuitErrorHandler::new("123".to_string(), state);
-                dispatcher
-                    .set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 // Create the error message
                 let mut circuit_error = CircuitError::new();
@@ -246,8 +249,7 @@ mod tests {
 
                 // Add circuit error handler to the the dispatcher
                 let handler = CircuitErrorHandler::new("123".to_string(), state);
-                dispatcher
-                    .set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+                dispatcher.set_handler(Box::new(handler));
 
                 // Create the error message
                 let mut circuit_error = CircuitError::new();
@@ -315,7 +317,7 @@ mod tests {
 
             // Add circuit error handler to the the dispatcher
             let handler = CircuitErrorHandler::new("123".to_string(), state);
-            dispatcher.set_handler(CircuitMessageType::CIRCUIT_ERROR_MESSAGE, Box::new(handler));
+            dispatcher.set_handler(Box::new(handler));
 
             // Create the circuit error message
             let mut circuit_error = CircuitError::new();

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::network::dispatch::{
-    DispatchError, DispatchMessageSender, Handler, MessageContext, PeerId,
+    DispatchError, DispatchMessageSender, Handler, MessageContext, MessageSender, PeerId,
 };
-use crate::network::sender::NetworkMessageSender;
 use crate::protos::circuit::{CircuitMessage, CircuitMessageType};
 use crate::protos::network::NetworkMessageType;
 
@@ -36,7 +35,7 @@ impl Handler for CircuitMessageHandler {
         &self,
         msg: Self::Message,
         context: &MessageContext<Self::Source, Self::MessageType>,
-        _: &NetworkMessageSender,
+        _: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
         debug!(
             "Handle CircuitMessage {:?} from {} [{} byte{}]",
@@ -165,7 +164,7 @@ mod tests {
             &self,
             message: Self::Message,
             _message_context: &MessageContext<Self::Source, Self::MessageType>,
-            _: &NetworkMessageSender,
+            _: &dyn MessageSender<Self::Source>,
         ) -> Result<(), DispatchError> {
             self.echos
                 .write()

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -28,6 +28,10 @@ impl Handler for CircuitMessageHandler {
     type MessageType = NetworkMessageType;
     type Message = CircuitMessage;
 
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::CIRCUIT
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -99,10 +103,7 @@ mod tests {
         let mut circuit_dispatcher = Dispatcher::new(network_sender);
         let handler = ServiceConnectedTestHandler::default();
         let echos = handler.echos.clone();
-        circuit_dispatcher.set_handler(
-            CircuitMessageType::SERVICE_CONNECT_REQUEST,
-            Box::new(handler),
-        );
+        circuit_dispatcher.set_handler(Box::new(handler));
 
         let circuit_dispatcher_loop = DispatchLoopBuilder::new()
             .with_dispatcher(circuit_dispatcher)
@@ -111,7 +112,7 @@ mod tests {
         let circuit_dispatcher_message_sender = circuit_dispatcher_loop.new_dispatcher_sender();
 
         let handler = CircuitMessageHandler::new(circuit_dispatcher_message_sender);
-        network_dispatcher.set_handler(NetworkMessageType::CIRCUIT, Box::new(handler));
+        network_dispatcher.set_handler(Box::new(handler));
 
         // Create ServiceConnectRequest
         let mut service_request = ServiceConnectRequest::new();
@@ -155,6 +156,10 @@ mod tests {
         type Source = PeerId;
         type MessageType = CircuitMessageType;
         type Message = ServiceConnectRequest;
+
+        fn match_type(&self) -> Self::MessageType {
+            CircuitMessageType::SERVICE_CONNECT_REQUEST
+        }
 
         fn handle(
             &self,

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -33,6 +33,10 @@ impl Handler for CircuitDirectMessageHandler {
     type MessageType = CircuitMessageType;
     type Message = CircuitDirectMessage;
 
+    fn match_type(&self) -> Self::MessageType {
+        CircuitMessageType::CIRCUIT_DIRECT_MESSAGE
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -270,10 +274,7 @@ mod tests {
 
                 // Add direct message handler to the the dispatcher
                 let handler = CircuitDirectMessageHandler::new("123".to_string(), state);
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // Create the direct message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -351,10 +352,7 @@ mod tests {
                 // Add direct message handler to dispatcher
                 let handler = CircuitDirectMessageHandler::new("345".to_string(), state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create dispatch message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -426,10 +424,7 @@ mod tests {
                 // add direct message handler to the dispatcher
                 let handler = CircuitDirectMessageHandler::new("123".to_string(), state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create direct message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -501,10 +496,7 @@ mod tests {
                 // add direct message handler to the dispatcher
                 let handler = CircuitDirectMessageHandler::new("123".to_string(), state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create direct message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -574,10 +566,7 @@ mod tests {
 
                 // add handler to dispatcher
                 let handler = CircuitDirectMessageHandler::new("345".to_string(), state);
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create direct message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -647,10 +636,7 @@ mod tests {
 
                 // add direct message handler
                 let handler = CircuitDirectMessageHandler::new("345".to_string(), state);
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create direct message
                 let mut direct_message = CircuitDirectMessage::new();
@@ -700,10 +686,7 @@ mod tests {
 
                 // add direct message handler to the dispatcher
                 let handler = CircuitDirectMessageHandler::new("345".to_string(), state);
-                dispatcher.set_handler(
-                    CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
 
                 // create direct message
                 let mut direct_message = CircuitDirectMessage::new();

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -37,6 +37,10 @@ impl Handler for ServiceConnectRequestHandler {
     type MessageType = CircuitMessageType;
     type Message = ServiceConnectRequest;
 
+    fn match_type(&self) -> Self::MessageType {
+        CircuitMessageType::SERVICE_CONNECT_REQUEST
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -169,6 +173,10 @@ impl Handler for ServiceDisconnectRequestHandler {
     type MessageType = CircuitMessageType;
     type Message = ServiceDisconnectRequest;
 
+    fn match_type(&self) -> Self::MessageType {
+        CircuitMessageType::SERVICE_DISCONNECT_REQUEST
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -296,10 +304,7 @@ mod tests {
                     state,
                 );
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut connect_request = ServiceConnectRequest::new();
                 connect_request.set_circuit("alpha".into());
                 connect_request.set_service_id("abc".into());
@@ -349,10 +354,7 @@ mod tests {
                     state,
                 );
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut connect_request = ServiceConnectRequest::new();
                 connect_request.set_circuit("alpha".into());
                 connect_request.set_service_id("BAD".into());
@@ -402,10 +404,7 @@ mod tests {
                     state.clone(),
                 );
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut connect_request = ServiceConnectRequest::new();
                 connect_request.set_circuit("alpha".into());
                 connect_request.set_service_id("abc".into());
@@ -461,10 +460,7 @@ mod tests {
                     state,
                 );
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_CONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut connect_request = ServiceConnectRequest::new();
                 connect_request.set_circuit("alpha".into());
                 connect_request.set_service_id("abc".into());
@@ -507,10 +503,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
                 let handler = ServiceDisconnectRequestHandler::new(state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut disconnect_request = ServiceDisconnectRequest::new();
                 disconnect_request.set_circuit("alpha".into());
                 disconnect_request.set_service_id("abc".into());
@@ -556,10 +549,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
                 let handler = ServiceDisconnectRequestHandler::new(state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut disconnect_request = ServiceDisconnectRequest::new();
                 disconnect_request.set_circuit("alpha".into());
                 disconnect_request.set_service_id("BAD".into());
@@ -612,10 +602,7 @@ mod tests {
 
                 let handler = ServiceDisconnectRequestHandler::new(state.clone());
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut disconnect_request = ServiceDisconnectRequest::new();
                 disconnect_request.set_circuit("alpha".into());
                 disconnect_request.set_service_id("abc".into());
@@ -659,10 +646,7 @@ mod tests {
 
                 let handler = ServiceDisconnectRequestHandler::new(state);
 
-                dispatcher.set_handler(
-                    CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-                    Box::new(handler),
-                );
+                dispatcher.set_handler(Box::new(handler));
                 let mut disconnect_request = ServiceDisconnectRequest::new();
                 disconnect_request.set_circuit("alpha".into());
                 disconnect_request.set_service_id("abc".into());

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -42,30 +42,15 @@ pub fn create_authorization_dispatcher(
 ) -> Dispatcher<AuthorizationMessageType> {
     let mut auth_dispatcher = Dispatcher::new(network_sender);
 
-    auth_dispatcher.set_handler(
-        AuthorizationMessageType::CONNECT_REQUEST,
-        Box::new(ConnectRequestHandler::new(auth_manager.clone())),
-    );
+    auth_dispatcher.set_handler(Box::new(ConnectRequestHandler::new(auth_manager.clone())));
 
-    auth_dispatcher.set_handler(
-        AuthorizationMessageType::CONNECT_RESPONSE,
-        Box::new(ConnectResponseHandler::new(auth_manager.clone())),
-    );
+    auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(auth_manager.clone())));
 
-    auth_dispatcher.set_handler(
-        AuthorizationMessageType::TRUST_REQUEST,
-        Box::new(TrustRequestHandler::new(auth_manager.clone())),
-    );
+    auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
 
-    auth_dispatcher.set_handler(
-        AuthorizationMessageType::AUTHORIZE,
-        Box::new(AuthorizedHandler),
-    );
+    auth_dispatcher.set_handler(Box::new(AuthorizedHandler));
 
-    auth_dispatcher.set_handler(
-        AuthorizationMessageType::AUTHORIZATION_ERROR,
-        Box::new(AuthorizationErrorHandler::new(auth_manager)),
-    );
+    auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
 
     auth_dispatcher
 }
@@ -93,6 +78,10 @@ impl Handler for AuthorizationMessageHandler {
     type MessageType = NetworkMessageType;
     type Message = AuthorizationMessage;
 
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::AUTHORIZATION
+    }
+
     fn handle(
         &self,
         mut msg: Self::Message,
@@ -118,6 +107,10 @@ impl Handler for AuthorizedHandler {
     type Source = PeerId;
     type MessageType = AuthorizationMessageType;
     type Message = AuthorizedMessage;
+
+    fn match_type(&self) -> Self::MessageType {
+        AuthorizationMessageType::AUTHORIZE
+    }
 
     fn handle(
         &self,
@@ -163,6 +156,10 @@ impl<M: FromMessageBytes> Handler for NetworkAuthGuardHandler<M> {
     type MessageType = NetworkMessageType;
     type Message = M;
 
+    fn match_type(&self) -> Self::MessageType {
+        self.handler.match_type()
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -197,6 +194,10 @@ impl Handler for ConnectRequestHandler {
     type Source = PeerId;
     type MessageType = AuthorizationMessageType;
     type Message = ConnectRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        AuthorizationMessageType::CONNECT_REQUEST
+    }
 
     fn handle(
         &self,
@@ -297,6 +298,10 @@ impl Handler for ConnectResponseHandler {
     type MessageType = AuthorizationMessageType;
     type Message = ConnectResponse;
 
+    fn match_type(&self) -> Self::MessageType {
+        AuthorizationMessageType::CONNECT_RESPONSE
+    }
+
     fn handle(
         &self,
         msg: Self::Message,
@@ -346,6 +351,10 @@ impl Handler for TrustRequestHandler {
     type Source = PeerId;
     type MessageType = AuthorizationMessageType;
     type Message = TrustRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        AuthorizationMessageType::TRUST_REQUEST
+    }
 
     fn handle(
         &self,
@@ -404,6 +413,10 @@ impl Handler for AuthorizationErrorHandler {
     type Source = PeerId;
     type MessageType = AuthorizationMessageType;
     type Message = AuthorizationError;
+
+    fn match_type(&self) -> Self::MessageType {
+        AuthorizationMessageType::AUTHORIZATION_ERROR
+    }
 
     fn handle(
         &self,

--- a/libsplinter/src/network/dispatch_peer.rs
+++ b/libsplinter/src/network/dispatch_peer.rs
@@ -1,0 +1,30 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::network::sender::NetworkMessageSender;
+
+use super::dispatch::{MessageSender, PeerId};
+
+impl MessageSender<PeerId> for NetworkMessageSender {
+    fn send(&self, recipient: PeerId, message: Vec<u8>) -> Result<(), (PeerId, Vec<u8>)> {
+        NetworkMessageSender::send(self, recipient.into(), message)
+            .map_err(|(id, msg)| (id.into(), msg))
+    }
+}
+
+impl Into<Box<dyn MessageSender<PeerId>>> for NetworkMessageSender {
+    fn into(self) -> Box<dyn MessageSender<PeerId>> {
+        Box::new(self)
+    }
+}

--- a/libsplinter/src/network/dispatch_proto.rs
+++ b/libsplinter/src/network/dispatch_proto.rs
@@ -15,6 +15,7 @@
 use protobuf::Message;
 
 use crate::network::dispatch::{DispatchError, FromMessageBytes};
+use crate::protos::prelude::*;
 
 // Implements FromMessageBytes for all protobuf Message values.
 impl<M> FromMessageBytes for M
@@ -24,5 +25,16 @@ where
     fn from_message_bytes(message_bytes: &[u8]) -> Result<Self, DispatchError> {
         protobuf::parse_from_bytes(message_bytes)
             .map_err(|err| DispatchError::DeserializationError(err.to_string()))
+    }
+}
+
+impl From<ProtoConversionError> for DispatchError {
+    fn from(err: ProtoConversionError) -> DispatchError {
+        match err {
+            ProtoConversionError::DeserializationError(s) => DispatchError::DeserializationError(s),
+            ProtoConversionError::SerializationError(s) => DispatchError::SerializationError(s),
+            // This is detected due to a protobuf that does not properly have fields set correctly.
+            ProtoConversionError::InvalidTypeError(s) => DispatchError::DeserializationError(s),
+        }
     }
 }

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -28,6 +28,10 @@ impl Handler for NetworkEchoHandler {
     type MessageType = NetworkMessageType;
     type Message = NetworkEcho;
 
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::NETWORK_ECHO
+    }
+
     fn handle(
         &self,
         mut msg: Self::Message,
@@ -81,6 +85,10 @@ impl Handler for NetworkHeartbeatHandler {
     type Source = PeerId;
     type MessageType = NetworkMessageType;
     type Message = NetworkHeartbeat;
+
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::NETWORK_HEARTBEAT
+    }
 
     fn handle(
         &self,
@@ -136,7 +144,7 @@ mod tests {
 
             let handler = NetworkEchoHandler::new("TestPeer".to_string());
 
-            dispatcher.set_handler(NetworkMessageType::NETWORK_ECHO, Box::new(handler));
+            dispatcher.set_handler(Box::new(handler));
 
             let msg = {
                 let mut echo = NetworkEcho::new();

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -15,6 +15,7 @@ pub mod auth;
 #[cfg(feature = "connection-manager")]
 pub mod connection_manager;
 pub mod dispatch;
+mod dispatch_peer;
 mod dispatch_proto;
 pub mod handlers;
 pub mod peer;

--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -431,8 +431,7 @@ pub mod tests {
 
     use crate::mesh::{Envelope, Mesh};
     use crate::network::connection_manager::ConnectionManager;
-    use crate::network::dispatch::PeerId;
-    use crate::network::dispatch::{DispatchError, Handler, MessageContext};
+    use crate::network::dispatch::{DispatchError, Handler, MessageContext, MessageSender, PeerId};
     use crate::network::peer_manager::PeerManager;
     use crate::protos::network::NetworkEcho;
     use crate::transport::{inproc::InprocTransport, Transport};
@@ -618,7 +617,7 @@ pub mod tests {
             &self,
             message: NetworkEcho,
             message_context: &MessageContext<Self::Source, NetworkMessageType>,
-            network_sender: &NetworkMessageSender,
+            network_sender: &dyn MessageSender<Self::Source>,
         ) -> Result<(), DispatchError> {
             let echo_string = String::from_utf8(message.get_payload().to_vec()).unwrap();
             if &echo_string == "shutdown_string" {
@@ -635,10 +634,7 @@ pub mod tests {
                 let network_msg_bytes = network_msg.write_to_bytes().unwrap();
 
                 network_sender
-                    .send(
-                        message_context.source_peer_id().to_string(),
-                        network_msg_bytes,
-                    )
+                    .send(message_context.source_id().clone(), network_msg_bytes)
                     .expect("Cannot send message");
             }
 

--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -540,7 +540,7 @@ pub mod tests {
 
         let mut dispatcher = Dispatcher::default();
         let handler = NetworkTestHandler::new(send);
-        dispatcher.set_handler(NetworkMessageType::NETWORK_ECHO, Box::new(handler));
+        dispatcher.set_handler(Box::new(handler));
         let interconnect = PeerInterconnectBuilder::new()
             .with_peer_connector(peer_connector)
             .with_message_receiver(mesh1.get_receiver())
@@ -609,6 +609,10 @@ pub mod tests {
         type Source = PeerId;
         type MessageType = NetworkMessageType;
         type Message = NetworkEcho;
+
+        fn match_type(&self) -> Self::MessageType {
+            NetworkMessageType::NETWORK_ECHO
+        }
 
         fn handle(
             &self,

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -878,35 +878,23 @@ fn set_up_network_dispatcher(
     let mut dispatcher = Dispatcher::<NetworkMessageType>::new(network_sender);
 
     let network_echo_handler = NetworkEchoHandler::new(node_id.to_string());
-    dispatcher.set_handler(
-        NetworkMessageType::NETWORK_ECHO,
-        Box::new(NetworkAuthGuardHandler::new(
-            auth_manager.clone(),
-            Box::new(network_echo_handler),
-        )),
-    );
+    dispatcher.set_handler(Box::new(NetworkAuthGuardHandler::new(
+        auth_manager.clone(),
+        Box::new(network_echo_handler),
+    )));
 
     let network_heartbeat_handler = NetworkHeartbeatHandler::new();
     // do not add auth guard
-    dispatcher.set_handler(
-        NetworkMessageType::NETWORK_HEARTBEAT,
-        Box::new(network_heartbeat_handler),
-    );
+    dispatcher.set_handler(Box::new(network_heartbeat_handler));
 
     let circuit_message_handler = CircuitMessageHandler::new(circuit_sender);
-    dispatcher.set_handler(
-        NetworkMessageType::CIRCUIT,
-        Box::new(NetworkAuthGuardHandler::new(
-            auth_manager,
-            Box::new(circuit_message_handler),
-        )),
-    );
+    dispatcher.set_handler(Box::new(NetworkAuthGuardHandler::new(
+        auth_manager,
+        Box::new(circuit_message_handler),
+    )));
 
     let auth_message_handler = AuthorizationMessageHandler::new(auth_sender);
-    dispatcher.set_handler(
-        NetworkMessageType::AUTHORIZATION,
-        Box::new(auth_message_handler),
-    );
+    dispatcher.set_handler(Box::new(auth_message_handler));
 
     dispatcher
 }
@@ -921,36 +909,21 @@ fn set_up_circuit_dispatcher(
 
     let service_connect_request_handler =
         ServiceConnectRequestHandler::new(node_id.to_string(), endpoint.to_string(), state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::SERVICE_CONNECT_REQUEST,
-        Box::new(service_connect_request_handler),
-    );
+    dispatcher.set_handler(Box::new(service_connect_request_handler));
 
     let service_disconnect_request_handler = ServiceDisconnectRequestHandler::new(state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
-        Box::new(service_disconnect_request_handler),
-    );
+    dispatcher.set_handler(Box::new(service_disconnect_request_handler));
 
     let direct_message_handler =
         CircuitDirectMessageHandler::new(node_id.to_string(), state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
-        Box::new(direct_message_handler),
-    );
+    dispatcher.set_handler(Box::new(direct_message_handler));
 
     let circuit_error_handler = CircuitErrorHandler::new(node_id.to_string(), state.clone());
-    dispatcher.set_handler(
-        CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
-        Box::new(circuit_error_handler),
-    );
+    dispatcher.set_handler(Box::new(circuit_error_handler));
 
     // Circuit Admin handlers
     let admin_direct_message_handler = AdminDirectMessageHandler::new(node_id.to_string(), state);
-    dispatcher.set_handler(
-        CircuitMessageType::ADMIN_DIRECT_MESSAGE,
-        Box::new(admin_direct_message_handler),
-    );
+    dispatcher.set_handler(Box::new(admin_direct_message_handler));
 
     dispatcher
 }


### PR DESCRIPTION
Modifies the Dispatcher code in the following ways:

- Adds `From` implementation for `ProtoConversionError` in the `dispatch_proto` module.  This will allow for uses of the various proto conversion traits to be used with the `?` operator in handlers.
- Adds a function to the `Handler` trait for `match_type`, which more tightly couples the message type to the handler.  This change greatly reduces the possibility that the handler and the type it is registered to could get out of sync. 
- Adds a trait for message sending, that can be coupled to the Source via generics.  A new module, `dispatch_peer`, implements this new trait specifically on `PeerId` for `NetworkMessageSender`, which supports the existing usages.