### PR TITLE
Update protoc-rust to version 2.14

### DIFF
--- a/examples/private_counter/service/Cargo.toml
+++ b/examples/private_counter/service/Cargo.toml
@@ -44,7 +44,7 @@ uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
 glob = "0.2"
-protoc-rust = "2"
+protoc-rust = "2.14"
 
 [features]
 default = []

--- a/examples/private_counter/service/build.rs
+++ b/examples/private_counter/service/build.rs
@@ -56,16 +56,18 @@ fn main() {
         .write_all(mod_file_content.as_bytes())
         .expect("Unable to write mod file");
 
-    protoc_rust::run(protoc_rust::Args {
-        out_dir: &dest_path.to_str().expect("Invalid proto destination path"),
-        input: &proto_src_files
-            .iter()
-            .map(|a| a.as_ref())
-            .collect::<Vec<&str>>(),
-        includes: &["src", "../protos"],
-        customize: Customize::default(),
-    })
-    .expect("unable to run protoc");
+    protoc_rust::Codegen::new()
+        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .inputs(
+            &proto_src_files
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>(),
+        )
+        .includes(&["src", "../protos"])
+        .customize(Customize::default())
+        .run()
+        .expect("unable to run protoc");
 }
 
 fn glob_simple(pattern: &str) -> Vec<String> {

--- a/examples/private_xo/Cargo.toml
+++ b/examples/private_xo/Cargo.toml
@@ -49,7 +49,7 @@ uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
 glob = "0.2"
-protoc-rust = "2"
+protoc-rust = "2.14"
 
 [features]
 default = []

--- a/examples/private_xo/build.rs
+++ b/examples/private_xo/build.rs
@@ -56,16 +56,18 @@ fn main() {
         .write_all(mod_file_content.as_bytes())
         .expect("Unable to write mod file");
 
-    protoc_rust::run(protoc_rust::Args {
-        out_dir: &dest_path.to_str().expect("Invalid proto destination path"),
-        input: &proto_src_files
-            .iter()
-            .map(|a| a.as_ref())
-            .collect::<Vec<&str>>(),
-        includes: &["src", "./protos"],
-        customize: Customize::default(),
-    })
-    .expect("unable to run protoc");
+    protoc_rust::Codegen::new()
+        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .inputs(
+            &proto_src_files
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>(),
+        )
+        .includes(&["src", "./protos"])
+        .customize(Customize::default())
+        .run()
+        .expect("unable to run protoc");
 }
 
 fn glob_simple(pattern: &str) -> Vec<String> {

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -72,7 +72,7 @@ serial_test = "0.3"
 tempdir = "0.3"
 
 [build-dependencies]
-protoc-rust = "2"
+protoc-rust = "2.14"
 glob = "0.2"
 
 [features]

--- a/libsplinter/build.rs
+++ b/libsplinter/build.rs
@@ -56,16 +56,18 @@ fn main() {
         .write_all(mod_file_content.as_bytes())
         .expect("Unable to write mod file");
 
-    protoc_rust::run(protoc_rust::Args {
-        out_dir: &dest_path.to_str().expect("Invalid proto destination path"),
-        input: &proto_src_files
-            .iter()
-            .map(|a| a.as_ref())
-            .collect::<Vec<&str>>(),
-        includes: &["src", "protos"],
-        customize: Customize::default(),
-    })
-    .expect("unable to run protoc");
+    protoc_rust::Codegen::new()
+        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .inputs(
+            &proto_src_files
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>(),
+        )
+        .includes(&["src", "protos"])
+        .customize(Customize::default())
+        .run()
+        .expect("unable to run protoc");
 }
 
 fn glob_simple(pattern: &str) -> Vec<String> {


### PR DESCRIPTION
protoc-rust::run is deprecated in 2.14. This commit updates
the build.rs files to sue protoc-rust::Codegen instead.

The version requirement for protoc-rust has also been raised
from 2 to 2.14.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>