### PR TITLE
Remove all Cargo.toml files from splinter-dev image

### DIFF
--- a/ci/splinter-dev
+++ b/ci/splinter-dev
@@ -100,6 +100,10 @@ COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 RUN find . -name 'Cargo.toml' -exec \
     sh -c 'x="{}"; cargo build --release --manifest-path "$x" ' \;
 
+# Remove all Cargo.toml
+RUN find . -name 'Cargo.toml' -exec \
+    sh -c 'x="{}"; rm "$x" ' \;
+
 # Clean up built files
 RUN rm \
     target/release/gameroom-database* \

--- a/ci/splinter-dev.yaml
+++ b/ci/splinter-dev.yaml
@@ -17,7 +17,7 @@ version: '3.7'
 
 services:
   splinter-dev:
-    image: splintercommunity/splinter-dev:v2
+    image: splintercommunity/splinter-dev:v3
     build:
       context: ..
       dockerfile: ci/splinter-dev


### PR DESCRIPTION
Not removing these files prior to publishing to dockerhub was causing some
transient problems when features were moved from experimenal to stable.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>