### PR TITLE
Add long name to url for `splinter health status`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -531,8 +531,9 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .arg(
                             Arg::with_name("url")
                                 .short("U")
-                                .takes_value(true)
-                                .help("URL of node"),
+                                .long("url")
+                                .help("URL of the Splinter daemon REST API")
+                                .takes_value(true),
                         ),
                 ),
         );


### PR DESCRIPTION
Adds long option for url to `splinter health status` the url can now be
specified with either `--url` or `-U`. This to make it consistent with
other commands that use `--url`

Signed-off-by: Ryan Banks <rbanks@bitwise.io>