### PR TITLE
Adds justfile for simple cross-repo build, lint, test

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,76 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+crates := '\
+    libsplinter \
+    splinterd \
+    cli \
+    client \
+    services/scabbard \
+    services/health \
+    examples/gameroom/database \
+    examples/gameroom/daemon \
+    examples/gameroom/cli \
+    examples/private_counter/cli \
+    examples/private_counter/service \
+    examples/private_xo \
+    '
+
+features := '\
+    --features=experimental \
+    --features=stable \
+    --features=default \
+    --no-default-features \
+    '
+
+build:
+    #!/usr/bin/env sh
+    set -e
+    for feature in $(echo {{features}})
+    do
+        for crate in $(echo {{crates}})
+        do
+            cmd="cargo build --tests --manifest-path=$crate/Cargo.toml $feature"
+            echo "\033[1m$cmd\033[0m"
+            $cmd
+        done
+    done
+    echo "\n\033[92mBuild Success\033[0m\n"
+
+lint: build
+    #!/usr/bin/env sh
+    set -e
+    echo "\033[1mcargo fmt -- --check\033[0m"
+    cargo fmt -- --check
+    for feature in $(echo {{features}})
+    do
+        cmd="cargo clippy --manifest-path=libsplinter/Cargo.toml $feature"
+        echo "\033[1m$cmd\033[0m"
+        $cmd
+    done
+    echo "\n\033[92mLint Success\033[0m\n"
+
+test: build
+    #!/usr/bin/env sh
+    set -e
+    for feature in $(echo {{features}})
+    do
+        for crate in $(echo {{crates}})
+        do
+            cmd="cargo test --manifest-path=$crate/Cargo.toml $feature"
+            echo "\033[1m$cmd\033[0m"
+            $cmd
+        done
+    done
+    echo "\n\033[92mTest Success\033[0m\n"


### PR DESCRIPTION
Just is a tool for running commands. See:

    https://github.com/casey/just

In this case, the justfile allows you to use the command to run:

  just build
  just lint
  just test

These will operate across the entire repository.

The intent is to use Just outside of docker during development, while
providing reasonable coverage of the commands normally run inside docker
during the PR checks. The behavior of the justfile and docker CI are not
guaranteed to be equivalent.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>