### PR TITLE
Additional splinterd config

### DIFF
--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -65,8 +65,8 @@ OPTIONS
 
 `--node NODE-STRING` ...
 : Specifies a node that should be part of the circuit, using the format
-  `NODE-ID::ENDPOINT`. This node ID must match the node ID and endpoint entry
-  in the node registry. The proposer must also specify its own node, if it is to
+  `NODE-ID::ENDPOINT1,ENDPOINT2`. All endpoints must be in the node's entry in
+  the node registry. The proposer must also specify its own node, if it is to
   be included on the circuit proposal. Repeat this option to specify multiple
   nodes.
 
@@ -123,14 +123,15 @@ EXAMPLES
 This command proposes a simple circuit with one other node.
 
 * The proposing node has ID `alpha001` and endpoint `tcps://splinterd-node-acme001:8044`.
-* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`.
+* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`
+  and `tcp://splinterd-node-beta001:8045`.
 * There is one service with ID `AA01`. This service has no service
   arguments, service type, or service group.
 
 ```
 $ splinter circuit propose \
   --node alpha001::tcps://splinterd-node-alpha001:8044 \
-  --node beta001::tcps://splinterd-node-beta001:8044 \
+  --node beta001::tcps://splinterd-node-beta001:8044,tcp://splinterd-node-beta001:8045 \
   --service AA01::alpha001 \
   --key PRIVATE-KEY-FILE
   --url URL-of-splinterd-REST-API

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -361,7 +361,7 @@ impl fmt::Display for ProposalSlice {
         );
 
         for member in self.circuit.members.iter() {
-            display_string += &format!("\n    {} ({})\n", member.node_id, member.endpoint);
+            display_string += &format!("\n    {} ({:?})\n", member.node_id, member.endpoints);
             if member.node_id == self.requester_node_id {
                 display_string += &"        Vote: ACCEPT (implied as requester):\n".to_string();
                 display_string += &format!("            {}\n", self.requester);
@@ -420,7 +420,7 @@ pub struct ProposalCircuitSlice {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CircuitMembers {
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -181,7 +181,7 @@ impl CreateCircuitMessageBuilder {
         Ok(())
     }
 
-    pub fn add_node(&mut self, node_id: &str, node_endpoint: &str) -> Result<(), CliError> {
+    pub fn add_node(&mut self, node_id: &str, node_endpoints: &[String]) -> Result<(), CliError> {
         for node in &self.nodes {
             if node.node_id == node_id {
                 return Err(CliError::ActionError(format!(
@@ -189,15 +189,19 @@ impl CreateCircuitMessageBuilder {
                     node_id
                 )));
             }
-            if node.endpoint == node_endpoint {
+            if let Some(endpoint) = node_endpoints
+                .iter()
+                .find(|endpoint| node.endpoints.contains(endpoint))
+            {
                 return Err(CliError::ActionError(format!(
                     "Duplicate node endpoint detected: {}",
-                    node_endpoint
+                    endpoint
                 )));
             }
         }
 
-        self.nodes.push(make_splinter_node(node_id, node_endpoint)?);
+        self.nodes
+            .push(make_splinter_node(node_id, node_endpoints)?);
         Ok(())
     }
 
@@ -328,10 +332,10 @@ fn is_match(service_id_match: &str, service_id: &str) -> bool {
     })
 }
 
-fn make_splinter_node(node_id: &str, endpoint: &str) -> Result<SplinterNode, CliError> {
+fn make_splinter_node(node_id: &str, endpoints: &[String]) -> Result<SplinterNode, CliError> {
     let node = SplinterNodeBuilder::new()
         .with_node_id(&node_id)
-        .with_endpoint(&endpoint)
+        .with_endpoints(endpoints)
         .build()
         .map_err(|err| {
             CliError::ActionError(format!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,12 +44,14 @@ const CIRCUIT_PROPOSE_AFTER_HELP: &str = r"DETAILS:
     arguments can be used on their own or together, but at least one of them is required.
 
     The --node-file argument must be a valid YAML file. A valid YAML file will be a list of nodes,
-    where each node has an 'identity' or 'node_id' field, as well as an 'endpoint' field. Example:
+    where each node has an 'identity' or 'node_id' field, as well as an 'endpoints' field. Example:
         ---
         - identity: 'node-1'
-          endpoint: tcps://node-1-endpoint:8044
+          endpoints:
+            - tcps://node-1-endpoint:8044
         - node_id: 'node-2'
-          endpoint: tcps://node-2-endpoint:8045
+          endpoints:
+            - tcps://node-2-endpoint:8045
 
     For the --service-arg, --service-peer-group, and --service-type options, service IDs can be
     wildcarded with '*' to match multiple services. For example, '--service-type *::scabbard' match
@@ -210,7 +212,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 .multiple(true)
                 .help(
                     "Node that is part of a circuit \
-                     (<node_id>::<endpoint>)",
+                     (<node_id>::<endpoint1>,<endpoint2>)",
                 ),
         )
         .arg(

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -119,13 +119,15 @@ walkthrough. For installation instructions, see the
     ----
     ---
     - identity: "acme"
-      endpoint: "tcps://acme.default.svc.cluster.local:8044"
+      endpoints:
+        - "tcps://acme.default.svc.cluster.local:8044"
       display_name: "Acme"
       metadata:
         organization: "Acme Corporation"
 
     - identity: "bubba"
-      endpoint: "tcps://bubba.default.svc.cluster.local:8044"
+      endpoints:
+        - "tcps://bubba.default.svc.cluster.local:8044"
       display_name: "Bubba Bakery"
       metadata:
         organization: "Bubba Bakery"

--- a/docker/kubernetes/node-registry.yaml
+++ b/docker/kubernetes/node-registry.yaml
@@ -14,13 +14,15 @@
 
 ---
 - identity: "acme"
-  endpoint: "tcps://acme.default.svc.cluster.local:8044"
+  endpoints:
+    - "tcps://acme.default.svc.cluster.local:8044"
   display_name: "Acme"
   metadata:
     organization: "Acme Corporation"
 
 - identity: "bubba"
-  endpoint: "tcps://bubba.default.svc.cluster.local:8044"
+  endpoints:
+    - "tcps://bubba.default.svc.cluster.local:8044"
   display_name: "Bubba Bakery"
   metadata:
     organization: "Bubba Bakery"

--- a/examples/gameroom/daemon/openapi.yml
+++ b/examples/gameroom/daemon/openapi.yml
@@ -904,9 +904,11 @@ components:
         node_id:
           type: string
           example: acme-node-000
-        endpoint:
-          type: string
-          example: tcps://127.0.0.1:8080
+        endpoints:
+          type: array
+          items:
+            type: string
+            example: tcps://127.0.0.1:8080
 
     ApiGameroom:
       type: object
@@ -954,15 +956,18 @@ components:
       properties:
         identity:
           type: string
-        endpoint:
-          type: string
+        endpoints:
+          type: array
+          items:
+            type: string
         display_name:
           type: string
         metadata:
           type: object
       example:
         identity: node-123123-asdf
-        endpoint: tcps://12.0.0.123:8431
+        endpoints:
+          - tcps://12.0.0.123:8431
         display_name: Cargill - Node 1
         metadata:
           company: Cargill

--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -615,7 +615,7 @@ fn parse_splinter_nodes(
         .map(|node| NewGameroomMember {
             circuit_id: circuit_id.to_string(),
             node_id: node.node_id.to_string(),
-            endpoint: node.endpoint.to_string(),
+            endpoints: node.endpoints.to_vec(),
             status: "Pending".to_string(),
             created_time: timestamp,
             updated_time: timestamp,
@@ -755,7 +755,7 @@ mod test {
         let expected_node = get_new_gameroom_member("01234-ABCDE", SystemTime::now());
 
         assert_eq!(node.node_id, expected_node.node_id);
-        assert_eq!(node.endpoint, expected_node.endpoint);
+        assert_eq!(node.endpoints, expected_node.endpoints);
     }
 
     #[test]
@@ -1204,7 +1204,7 @@ mod test {
             }],
             members: vec![SplinterNode {
                 node_id: "Node-123".to_string(),
-                endpoint: "127.0.0.1:8282".to_string(),
+                endpoints: vec!["127.0.0.1:8282".to_string()],
             }],
             authorization_type: AuthorizationType::Trust,
             persistence: PersistenceType::Any,
@@ -1345,7 +1345,7 @@ mod test {
         NewGameroomMember {
             circuit_id: circuit_id.to_string(),
             node_id: "Node-123".to_string(),
-            endpoint: "127.0.0.1:8282".to_string(),
+            endpoints: vec!["127.0.0.1:8282".to_string()],
             status: "Pending".to_string(),
             created_time: timestamp,
             updated_time: timestamp,

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -78,14 +78,14 @@ impl ApiGameroom {
 #[derive(Debug, Serialize)]
 struct ApiGameroomMember {
     node_id: String,
-    endpoint: String,
+    endpoints: Vec<String>,
 }
 
 impl ApiGameroomMember {
     fn from(db_circuit_member: DbGameroomMember) -> Self {
         ApiGameroomMember {
             node_id: db_circuit_member.node_id.to_string(),
-            endpoint: db_circuit_member.endpoint,
+            endpoints: db_circuit_member.endpoints,
         }
     }
 }
@@ -117,13 +117,13 @@ pub async fn propose_gameroom(
         .iter()
         .map(|node| SplinterNode {
             node_id: node.identity.to_string(),
-            endpoint: node.endpoint.to_string(),
+            endpoints: node.endpoints.to_vec(),
         })
         .collect::<Vec<SplinterNode>>();
 
     members.push(SplinterNode {
         node_id: node_info.identity.to_string(),
-        endpoint: node_info.endpoint.to_string(),
+        endpoints: node_info.endpoints.to_vec(),
     });
 
     let scabbard_admin_keys = vec![gameroomd_data.get_ref().public_key.clone()];

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -269,7 +269,7 @@ mod test {
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
         Node {
             identity: "Node-123".to_string(),
-            endpoint: "tcps://127.0.0.1:8080".to_string(),
+            endpoints: vec!["tcps://127.0.0.1:8080".to_string()],
             display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
@@ -280,7 +280,7 @@ mod test {
         metadata.insert("company".to_string(), "Cargill".to_string());
         Node {
             identity: "Node-456".to_string(),
-            endpoint: "tcps://127.0.0.1:8082".to_string(),
+            endpoints: vec!["tcps://127.0.0.1:8082".to_string()],
             display_name: "Cargill - Node 1".to_string(),
             metadata,
         }

--- a/examples/gameroom/daemon/src/rest_api/routes/proposal.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/proposal.rs
@@ -77,14 +77,14 @@ impl ApiGameroomProposal {
 #[derive(Debug, Serialize)]
 struct ApiGameroomMember {
     node_id: String,
-    endpoint: String,
+    endpoints: Vec<String>,
 }
 
 impl ApiGameroomMember {
     fn from(db_circuit_member: GameroomMember) -> Self {
         ApiGameroomMember {
             node_id: db_circuit_member.node_id.to_string(),
-            endpoint: db_circuit_member.endpoint,
+            endpoints: db_circuit_member.endpoints,
         }
     }
 }

--- a/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/down.sql
+++ b/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE gameroom_member ALTER COLUMN endpoints DROP DEFAULT;
+ALTER TABLE gameroom_member ALTER COLUMN endpoints
+  TYPE TEXT USING coalesce(endpoints[1],'');
+ALTER TABLE gameroom_member ALTER COLUMN endpoints SET DEFAULT '';

--- a/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/up.sql
+++ b/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE gameroom_member ALTER COLUMN endpoints DROP DEFAULT;
+ALTER TABLE gameroom_member ALTER COLUMN endpoints
+  TYPE TEXT[] USING array[endpoints];
+ALTER TABLE gameroom_member ALTER COLUMN endpoints SET DEFAULT '{}';

--- a/examples/gameroom/database/src/models.rs
+++ b/examples/gameroom/database/src/models.rs
@@ -100,7 +100,7 @@ pub struct GameroomMember {
     pub id: i64,
     pub circuit_id: String,
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
     pub status: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,
@@ -111,7 +111,7 @@ pub struct GameroomMember {
 pub struct NewGameroomMember {
     pub circuit_id: String,
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
     pub status: String,
     pub created_time: SystemTime,
     pub updated_time: SystemTime,

--- a/examples/gameroom/database/src/schema.rs
+++ b/examples/gameroom/database/src/schema.rs
@@ -69,7 +69,7 @@ table! {
         id -> Int8,
         circuit_id -> Text,
         node_id -> Text,
-        endpoint -> Text,
+        endpoints -> Array<Text>,
         status -> Text,
         created_time -> Timestamp,
         updated_time -> Timestamp,

--- a/examples/gameroom/database/tables/gameroom_tables.sql
+++ b/examples/gameroom/database/tables/gameroom_tables.sql
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS gameroom_member (
   id                        BIGSERIAL   PRIMARY KEY,
   circuit_id               TEXT        NOT NULL,
   node_id                   TEXT        NOT NULL,
-  endpoint                  TEXT        NOT NULL,
+  endpoints                 TEXT[]      NOT NULL,
   status                    TEXT        NOT NULL,
   created_time              TIMESTAMP   NOT NULL,
   updated_time              TIMESTAMP   NOT NULL,

--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -231,7 +231,7 @@ async function getNode(id: string): Promise<Node> {
       console.warn(`Node with ID: ${id} not found. It may have been removed from the registry.`);
       return {
         identity: id,
-        endpoint: 'unknown',
+        endpoints: ['unknown'],
         display_name: 'unknown',
         metadata: {
           organization: id,

--- a/examples/gameroom/gameroom-app/src/store/models.ts
+++ b/examples/gameroom/gameroom-app/src/store/models.ts
@@ -43,7 +43,7 @@ export interface UserAuthResponse {
 
 export interface Node {
   identity: string;
-  endpoint: string;
+  endpoints: string[];
   display_name: string;
   metadata: {
     organization: string;
@@ -58,7 +58,7 @@ export interface NewGameroomProposal {
 export interface Member {
   node_id: string;
   organization: string;
-  endpoint: string;
+  endpoints: string[];
 }
 
 export interface GameroomProposal {

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -166,13 +166,13 @@ export default class Dashboard extends Vue {
   }
 
   getMemberLabel(node: Node) {
-    let endpoint = node.endpoint;
+    let endpoints = node.endpoints;
     if (process.env.VUE_APP_BRAND
-     && node.endpoint.includes(process.env.VUE_APP_BRAND)) {
-      endpoint = 'local';
+     && node.identity.includes(process.env.VUE_APP_BRAND)) {
+      endpoints = ['local'];
     }
 
-    return `${node.metadata.organization} (${endpoint})`;
+    return `${node.metadata.organization} (${endpoints})`;
   }
 
   showNewGameroomModal() {

--- a/examples/gameroom/node_registry/nodes.yaml
+++ b/examples/gameroom/node_registry/nodes.yaml
@@ -14,12 +14,14 @@
 # -----------------------------------------------------------------------------
 
 - identity: 'bubba-node-000'
-  endpoint: 'tcps://splinterd-node-bubba:8044'
+  endpoints:
+    - 'tcps://splinterd-node-bubba:8044'
   display_name: 'Bubba - Node 1'
   metadata:
     organization: 'Bubba Bakery'
 - identity: 'acme-node-000'
-  endpoint: 'tcps://splinterd-node-acme:8044'
+  endpoints:
+    - 'tcps://splinterd-node-acme:8044'
   display_name: 'Acme - Node 1'
   metadata:
     organization: 'ACME Corporation'

--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -18,8 +18,8 @@ node_id = "acme-node-000"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8044"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -18,8 +18,8 @@ node_id = "bubba-node-000"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8044"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/examples/gameroom/tests/sample_node_registry.yaml
+++ b/examples/gameroom/tests/sample_node_registry.yaml
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 - identity: "Node-123"
-  endpoint: "tcps://127.0.0.1:8080"
+  endpoints:
+    - "tcps://127.0.0.1:8080"
   display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
 - identity: "Node-456"
-  endpoint: "tcps://127.0.0.1:8082"
+  endpoints:
+    - "tcps://127.0.0.1:8082"
   display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -18,8 +18,8 @@ node_id = "Node-123"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8044"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/examples/private_counter/node_registry/nodes.yaml
+++ b/examples/private_counter/node_registry/nodes.yaml
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 - identity: "012"
-  endpoint: "tcp://splinter-node-0:8044"
+  endpoints:
+    - "tcp://splinter-node-0:8044"
   display_name: "Node 1"
   metadata: {}
 - identity: "345"
-  endpoint: "tcp://splinter-node-1:8046"
+  endpoints:
+    - "tcp://splinter-node-1:8046"
   display_name: "Node 2"
   metadata: {}
 - identity: "678"
-  endpoint: "tcp://splinter-node-2:8048"
+  endpoints:
+    - "tcp://splinter-node-2:8048"
   display_name: "Node 3"
   metadata: {}

--- a/examples/private_xo/node_registry/nodes.yaml
+++ b/examples/private_xo/node_registry/nodes.yaml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 - identity: "012"
-  endpoint: "tcp://splinter-node-0:8044"
+  endpoints:
+    - "tcp://splinter-node-0:8044"
   display_name: "Node 1"
   metadata: {}
 - identity: "345"
-  endpoint: "tcp://splinter-node-1:8046"
+  endpoints:
+    - "tcp://splinter-node-1:8046"
   display_name: "Node 2"
   metadata: {}

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -19,8 +19,8 @@ message SplinterNode {
     // unique id of a splinter node
     string node_id = 1;
 
-    // The endpoint the splinter node is available on
-    string endpoint = 2;
+    // The endpoints the splinter node is available on
+    repeated string endpoints = 2;
 }
 
 message SplinterService {

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -533,7 +533,7 @@ mod tests {
                 roster: vec![],
                 members: vec![SplinterNode {
                     node_id: "node_id".into(),
-                    endpoint: "".into(),
+                    endpoints: vec!["".into()],
                 }],
                 authorization_type: AuthorizationType::Trust,
                 persistence: PersistenceType::Any,
@@ -582,7 +582,7 @@ mod tests {
                 roster: vec![],
                 members: vec![SplinterNode {
                     node_id: "node_id".into(),
-                    endpoint: "".into(),
+                    endpoints: vec!["".into()],
                 }],
                 authorization_type: AuthorizationType::Trust,
                 persistence: PersistenceType::Any,

--- a/libsplinter/src/admin/rest_api/resources/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/proposals.rs
@@ -108,14 +108,14 @@ impl<'a> From<&'a CreateCircuit> for CircuitResponse<'a> {
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
-    pub endpoint: &'a str,
+    pub endpoints: &'a [String],
 }
 
 impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
     fn from(node: &'a SplinterNode) -> Self {
         Self {
             node_id: &node.node_id,
-            endpoint: &node.endpoint,
+            endpoints: &node.endpoints,
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/proposals_circuit_id.rs
@@ -101,14 +101,14 @@ impl<'a> From<&'a CreateCircuit> for CircuitResponse<'a> {
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
-    pub endpoint: &'a str,
+    pub endpoints: &'a [String],
 }
 
 impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
     fn from(node: &'a SplinterNode) -> Self {
         Self {
             node_id: &node.node_id,
-            endpoint: &node.endpoint,
+            endpoints: &node.endpoints,
         }
     }
 }

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -302,7 +302,7 @@ impl SplinterServiceBuilder {
 #[derive(Default, Clone)]
 pub struct SplinterNodeBuilder {
     node_id: Option<String>,
-    endpoint: Option<String>,
+    endpoints: Option<Vec<String>>,
 }
 
 impl SplinterNodeBuilder {
@@ -314,8 +314,8 @@ impl SplinterNodeBuilder {
         self.node_id.clone()
     }
 
-    pub fn endpoint(&self) -> Option<String> {
-        self.endpoint.clone()
+    pub fn endpoints(&self) -> Option<Vec<String>> {
+        self.endpoints.clone()
     }
 
     pub fn with_node_id(mut self, node_id: &str) -> SplinterNodeBuilder {
@@ -323,8 +323,8 @@ impl SplinterNodeBuilder {
         self
     }
 
-    pub fn with_endpoint(mut self, endpoint: &str) -> SplinterNodeBuilder {
-        self.endpoint = Some(endpoint.into());
+    pub fn with_endpoints(mut self, endpoints: &[String]) -> SplinterNodeBuilder {
+        self.endpoints = Some(endpoints.into());
         self
     }
 
@@ -333,11 +333,11 @@ impl SplinterNodeBuilder {
             .node_id
             .ok_or_else(|| BuilderError::MissingField("node_id".to_string()))?;
 
-        let endpoint = self
-            .endpoint
-            .ok_or_else(|| BuilderError::MissingField("endpoint".to_string()))?;
+        let endpoints = self
+            .endpoints
+            .ok_or_else(|| BuilderError::MissingField("endpoints".to_string()))?;
 
-        let node = SplinterNode { node_id, endpoint };
+        let node = SplinterNode { node_id, endpoints };
 
         Ok(node)
     }
@@ -387,7 +387,7 @@ mod tests {
             .expect("failed to build service");
         let node = SplinterNodeBuilder::new()
             .with_node_id("node_id")
-            .with_endpoint("endpoint")
+            .with_endpoints(&["endpoint".into()])
             .build()
             .expect("failed to build node");
         builder = builder
@@ -437,7 +437,7 @@ mod tests {
             .expect("failed to build service");
         let node = SplinterNodeBuilder::new()
             .with_node_id("node_id")
-            .with_endpoint("endpoint")
+            .with_endpoints(&["endpoint".into()])
             .build()
             .expect("failed to build node");
         let circuit = CreateCircuitBuilder::new()
@@ -477,7 +477,7 @@ mod tests {
             .expect("failed to build service");
         let node = SplinterNodeBuilder::new()
             .with_node_id("node_id")
-            .with_endpoint("endpoint")
+            .with_endpoints(&["endpoint".into()])
             .build()
             .expect("failed to build node");
         let builder = CreateCircuitBuilder::new()
@@ -526,7 +526,7 @@ mod tests {
     fn circuit_builder_unset_roster() {
         let node = SplinterNodeBuilder::new()
             .with_node_id("node_id")
-            .with_endpoint("endpoint")
+            .with_endpoints(&["endpoint".into()])
             .build()
             .expect("failed to build node");
         let builder = CreateCircuitBuilder::new()
@@ -568,7 +568,7 @@ mod tests {
             .expect("failed to build service");
         let node = SplinterNodeBuilder::new()
             .with_node_id("node_id")
-            .with_endpoint("endpoint")
+            .with_endpoints(&["endpoint".into()])
             .build()
             .expect("failed to build node");
         let builder = CreateCircuitBuilder::new()
@@ -699,30 +699,35 @@ mod tests {
     fn node_builder_success() {
         let mut builder = SplinterNodeBuilder::new();
         assert!(builder.node_id().is_none());
-        assert!(builder.endpoint().is_none());
+        assert!(builder.endpoints().is_none());
 
-        builder = builder.with_node_id("node_id").with_endpoint("endpoint");
+        builder = builder
+            .with_node_id("node_id")
+            .with_endpoints(&["endpoint".into()]);
         assert_eq!(builder.node_id(), Some("node_id".into()));
-        assert_eq!(builder.endpoint(), Some("endpoint".into()));
+        assert_eq!(builder.endpoints(), Some(vec!["endpoint".into()]));
 
         let node = builder.build().expect("failed to build node");
         assert_eq!(&node.node_id, "node_id");
-        assert_eq!(&node.endpoint, "endpoint");
+        assert_eq!(&node.endpoints, &["endpoint".to_string()]);
     }
 
     /// Verify that the `SplinterNodeBuilder` fails to build when `node_id` is not set.
     #[test]
     fn node_builder_unset_node_id() {
-        match SplinterNodeBuilder::new().with_endpoint("endpoint").build() {
+        match SplinterNodeBuilder::new()
+            .with_endpoints(&["endpoint".into()])
+            .build()
+        {
             Ok(node) => panic!("Build did not fail; got node: {:?}", node),
             Err(BuilderError::MissingField(_)) => {}
             Err(err) => panic!("Got unexpected error: {}", err),
         }
     }
 
-    /// Verify that the `SplinterNodeBuilder` fails to build when `endpoint` is not set.
+    /// Verify that the `SplinterNodeBuilder` fails to build when `endpoints` is not set.
     #[test]
-    fn node_builder_unset_endpoint() {
+    fn node_builder_unset_endpoints() {
         match SplinterNodeBuilder::new().with_node_id("node_id").build() {
             Ok(node) => panic!("Build did not fail; got node: {:?}", node),
             Err(BuilderError::MissingField(_)) => {}

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -197,7 +197,7 @@ impl Default for RouteType {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SplinterNode {
     pub node_id: String,
-    pub endpoint: String,
+    pub endpoints: Vec<String>,
 }
 
 impl SplinterNode {
@@ -205,7 +205,7 @@ impl SplinterNode {
         let mut proto = admin::SplinterNode::new();
 
         proto.set_node_id(self.node_id);
-        proto.set_endpoint(self.endpoint);
+        proto.set_endpoints(self.endpoints.into());
 
         proto
     }
@@ -213,7 +213,7 @@ impl SplinterNode {
     pub fn from_proto(mut proto: admin::SplinterNode) -> Result<Self, MarshallingError> {
         Ok(Self {
             node_id: proto.take_node_id(),
-            endpoint: proto.take_endpoint(),
+            endpoints: proto.take_endpoints().into(),
         })
     }
 }

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -524,8 +524,8 @@ mod tests {
         proposed_circuit.set_comments("test circuit".into());
 
         proposed_circuit.set_members(protobuf::RepeatedField::from_vec(vec![
-            splinter_node("test-node", "tcp://someplace:8000"),
-            splinter_node("other-node", "tcp://otherplace:8000"),
+            splinter_node("test-node", &["tcp://someplace:8000".into()]),
+            splinter_node("other-node", &["tcp://otherplace:8000".into()]),
         ]));
         proposed_circuit.set_roster(protobuf::RepeatedField::from_vec(vec![
             splinter_service("0123", "sabre", "test-node"),
@@ -594,10 +594,10 @@ mod tests {
         );
     }
 
-    fn splinter_node(node_id: &str, endpoint: &str) -> admin::SplinterNode {
+    fn splinter_node(node_id: &str, endpoints: &[String]) -> admin::SplinterNode {
         let mut node = admin::SplinterNode::new();
         node.set_node_id(node_id.into());
-        node.set_endpoint(endpoint.into());
+        node.set_endpoints(endpoints.into());
         node
     }
 

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -27,7 +27,7 @@ use protobuf::Message;
 // Implements a handler that handles ServiceConnectRequest
 pub struct ServiceConnectRequestHandler {
     node_id: String,
-    endpoint: String,
+    endpoints: Vec<String>,
     state: SplinterState,
 }
 
@@ -93,10 +93,7 @@ impl Handler for ServiceConnectRequestHandler {
                     response.set_status(ServiceConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE);
                     response.set_error_message(format!("{} is not allowed on this node", unique_id))
                 } else {
-                    let node = SplinterNode::new(
-                        self.node_id.to_string(),
-                        vec![self.endpoint.to_string()],
-                    );
+                    let node = SplinterNode::new(self.node_id.to_string(), self.endpoints.to_vec());
                     let service = Service::new(
                         service_id.to_string(),
                         Some(context.source_peer_id().to_string()),
@@ -153,10 +150,10 @@ impl Handler for ServiceConnectRequestHandler {
 }
 
 impl ServiceConnectRequestHandler {
-    pub fn new(node_id: String, endpoint: String, state: SplinterState) -> Self {
+    pub fn new(node_id: String, endpoints: Vec<String>, state: SplinterState) -> Self {
         ServiceConnectRequestHandler {
             node_id,
-            endpoint,
+            endpoints,
             state,
         }
     }
@@ -299,7 +296,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
                 let handler = ServiceConnectRequestHandler::new(
                     "123".to_string(),
-                    "127.0.0.1:0".to_string(),
+                    vec!["127.0.0.1:0".to_string()],
                     state,
                 );
 
@@ -349,7 +346,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
                 let handler = ServiceConnectRequestHandler::new(
                     "123".to_string(),
-                    "127.0.0.1:0".to_string(),
+                    vec!["127.0.0.1:0".to_string()],
                     state,
                 );
 
@@ -399,7 +396,7 @@ mod tests {
                 let state = SplinterState::new("memory".to_string(), circuit_directory);
                 let handler = ServiceConnectRequestHandler::new(
                     "123".to_string(),
-                    "127.0.0.1:0".to_string(),
+                    vec!["127.0.0.1:0".to_string()],
                     state.clone(),
                 );
 
@@ -455,7 +452,7 @@ mod tests {
                 state.add_service(id.clone(), service).unwrap();
                 let handler = ServiceConnectRequestHandler::new(
                     "123".to_string(),
-                    "127.0.0.1:0".to_string(),
+                    vec!["127.0.0.1:0".to_string()],
                     state,
                 );
 

--- a/libsplinter/src/node_registry/error.rs
+++ b/libsplinter/src/node_registry/error.rs
@@ -67,6 +67,7 @@ pub enum InvalidNodeError {
     EmptyIdentity,
     EmptyDisplayName,
     InvalidIdentity(String, String), // (identity, message)
+    MissingEndpoints,
 }
 
 impl Error for InvalidNodeError {
@@ -78,6 +79,7 @@ impl Error for InvalidNodeError {
             InvalidNodeError::EmptyIdentity => None,
             InvalidNodeError::EmptyDisplayName => None,
             InvalidNodeError::InvalidIdentity(..) => None,
+            InvalidNodeError::MissingEndpoints => None,
         }
     }
 }
@@ -91,7 +93,7 @@ impl fmt::Display for InvalidNodeError {
             InvalidNodeError::DuplicateIdentity(identity) => {
                 write!(f, "another node with identity {} exists", identity)
             }
-            InvalidNodeError::EmptyEndpoint => write!(f, "node must have non-empty endpoint"),
+            InvalidNodeError::EmptyEndpoint => write!(f, "node endpoint cannot be empty"),
             InvalidNodeError::EmptyIdentity => write!(f, "node must have non-empty identity"),
             InvalidNodeError::EmptyDisplayName => {
                 write!(f, "node must have non-empty display_name")
@@ -99,6 +101,7 @@ impl fmt::Display for InvalidNodeError {
             InvalidNodeError::InvalidIdentity(identity, msg) => {
                 write!(f, "identity {} is invalid: {}", identity, msg)
             }
+            InvalidNodeError::MissingEndpoints => write!(f, "node must have one or more endpoints"),
         }
     }
 }

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -28,8 +28,8 @@ pub use unified::UnifiedNodeRegistry;
 pub struct Node {
     /// The Splinter identity of the node; must be unique in the registry.
     pub identity: String,
-    /// The endpoint the node can be reached at; must be unique in the registry.
-    pub endpoint: String,
+    /// The endpoints the node can be reached at; each must be unique in the registry.
+    pub endpoints: Vec<String>,
     /// A human-readable name for the node.
     pub display_name: String,
     /// A map with node metadata.
@@ -37,13 +37,13 @@ pub struct Node {
 }
 
 impl Node {
-    /// Constructs a new node with the given identity and endpoint.
+    /// Constructs a new node with the given identity and endpoints.
     ///
     /// The display_name and metadata fields will be empty.
-    pub fn new<S: Into<String>>(identity: S, endpoint: S) -> Self {
+    pub fn new<S: Into<String>, V: Into<Vec<String>>>(identity: S, endpoints: V) -> Self {
         Self {
             identity: identity.into(),
-            endpoint: endpoint.into(),
+            endpoints: endpoints.into(),
             display_name: String::new(),
             metadata: Default::default(),
         }

--- a/libsplinter/src/node_registry/rest_api.rs
+++ b/libsplinter/src/node_registry/rest_api.rs
@@ -477,7 +477,7 @@ mod tests {
 
             // Verify that updating an existing node gets an OK response and the fetched node has
             // the updated values
-            node.endpoint = "12.0.0.123:8432".to_string();
+            node.endpoints = vec!["12.0.0.123:8432".to_string()];
             node.metadata
                 .insert("location".to_string(), "Minneapolis".to_string());
 
@@ -732,7 +732,7 @@ mod tests {
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
         Node {
             identity: "Node-123".to_string(),
-            endpoint: "12.0.0.123:8431".to_string(),
+            endpoints: vec!["12.0.0.123:8431".to_string()],
             display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
@@ -743,7 +743,7 @@ mod tests {
         metadata.insert("company".to_string(), "Cargill".to_string());
         Node {
             identity: "Node-456".to_string(),
-            endpoint: "13.0.0.123:8434".to_string(),
+            endpoints: vec!["13.0.0.123:8434".to_string()],
             display_name: "Cargill - Node 1".to_string(),
             metadata,
         }

--- a/libsplinter/src/node_registry/unified.rs
+++ b/libsplinter/src/node_registry/unified.rs
@@ -197,7 +197,7 @@ mod test {
     use super::*;
 
     fn new_node(id: &str, endpoint: &str, metadata: &[(&str, &str)]) -> Node {
-        let mut node = Node::new(id, endpoint);
+        let mut node = Node::new(id, vec![endpoint.into()]);
         for (key, val) in metadata {
             node.metadata.insert(key.to_string(), val.to_string());
         }
@@ -382,7 +382,7 @@ mod test {
     /// 1. Add the same node to the local registry and two read-only registries with different
     ///    endpoints and metadata.
     /// 2. Add the registries to a unified registry.
-    /// 3. Fetch the node and verify that it has the correct data (endpoint from local registry,
+    /// 3. Fetch the node and verify that it has the correct data (endpoints from local registry,
     ///    metadata merged from all sources).
     #[test]
     fn fetch_node_local_precedence() {

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1574,9 +1574,15 @@ components:
           description: Node id
           type: string
           example: node-009
-        endpoint:
+        service_endpoint:
           description: The node's service endpoint
           example: tcp://foo.bar.biz
+        network_endpoints:
+          description: The node's network endpoints
+          type: array
+          items:
+            type: string
+            example: tcp://foo.bar.biz
       required:
         - version
 

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1602,15 +1602,18 @@ components:
       properties:
         identity:
           type: string
-        endpoint:
-          type: string
+        endpoints:
+          type: array
+          items:
+            type: string
         display_name:
           type: string
         metadata:
           type: object
       example:
         identity: node-123123-asdf
-        endpoint: tcps://12.0.0.123:8431
+        endpoints:
+          - tcps://12.0.0.123:8431
         display_name: Cargill - Node 1
         metadata:
           company: Cargill
@@ -1766,9 +1769,11 @@ components:
         node_id:
           type: string
           example: alpha-node-000
-        endpoint:
-          type: string
-          example: tcps://12.0.0.123:8431
+        endpoints:
+          type: array
+          items:
+            type: string
+            example: tcps://12.0.0.123:8431
 
     ProposedCircuitService:
       type: object

--- a/splinterd/packaging/nodes.yaml.example
+++ b/splinterd/packaging/nodes.yaml.example
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 - identity: 'acme-node-000'
-  endpoint: 'tcps://acme-node-000:8044'
+  endpoints:
+    - 'tcps://acme-node-000:8044'
   display_name: 'acme-node-000'
   metadata:
     organization: 'ACME Corporation'
 - identity: 'acme-node-001'
-  endpoint: 'tcps://acme-node-001:8044'
+  endpoints:
+    - 'tcps://acme-node-001:8044'
   display_name: 'acme-node-001'
   metadata:
     organization: 'ACME Corporation'
 - identity: 'acme-node-002'
-  endpoint: 'tcps://acme-node-002:8044'
+  endpoints:
+    - 'tcps://acme-node-002:8044'
   display_name: 'acme-node-002'
   metadata:
     organization: 'ACME Corporation'

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -18,8 +18,8 @@ node_id = "acme-node-000"
 # Endpoint used for service to daemon communication
 service_endpoint = "tcps://localhost:8043"
 
-# Endpoint used for daemon to daemon communication
-network_endpoint = "tcps://localhost:8044"
+# Endpoints used for daemon to daemon communication
+network_endpoints = ["tcps://localhost:8044"]
 
 # A comma separated list of splinter nodes the daemon will automatically
 # attempt to connect to on start up

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -18,8 +18,8 @@ node_id = "012"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8044"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -18,8 +18,8 @@ node_id = "012"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8043"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8044"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -18,8 +18,8 @@ node_id = "345"
 # Endpoint used for service to daemon communication.
 service_endpoint = "127.0.0.1:8045"
 
-# Endpoint used for daemon to daemon communication.
-network_endpoint = "127.0.0.1:8046"
+# Endpoints used for daemon to daemon communication.
+network_endpoints = ["127.0.0.1:8046"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/splinterd/sample_node_registries/nodes.yaml
+++ b/splinterd/sample_node_registries/nodes.yaml
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 - identity: "Node-123"
-  endpoint: "tcps://123.0.0.123:8080"
+  endpoints:
+    - "tcps://123.0.0.123:8080"
   display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
 - identity: "Node-456"
-  endpoint: "tcps://456.0.0.456:8080"
+  endpoints:
+    - "tcps://456.0.0.456:8080"
   display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -203,6 +203,14 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("node id".to_string()))?,
+            display_name: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.display_name() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                })
+                .ok_or_else(|| ConfigError::MissingValue("display name".to_string()))?,
             bind: self
                 .partial_configs
                 .iter()
@@ -292,6 +300,7 @@ mod tests {
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
+    static EXAMPLE_DISPLAY_NAME: &str = "Node 1";
 
     /// Asserts the example configuration values.
     fn assert_config_values(config: PartialConfig) {
@@ -317,6 +326,10 @@ mod tests {
         );
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
+        assert_eq!(
+            config.display_name(),
+            Some(EXAMPLE_DISPLAY_NAME.to_string())
+        );
         assert_eq!(config.bind(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
@@ -352,6 +365,7 @@ mod tests {
             .with_advertised_endpoints(Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()]))
             .with_peers(Some(vec![]))
             .with_node_id(Some(EXAMPLE_NODE_ID.to_string()))
+            .with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()))
             .with_bind(None)
             .with_registries(Some(vec![]))
             .with_heartbeat_interval(None)
@@ -389,6 +403,7 @@ mod tests {
             .with_advertised_endpoints(Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()]));
         partial_config = partial_config.with_peers(Some(vec![]));
         partial_config = partial_config.with_node_id(Some(EXAMPLE_NODE_ID.to_string()));
+        partial_config = partial_config.with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()));
         partial_config = partial_config.with_admin_service_coordinator_timeout(None);
         partial_config = partial_config.with_registries(Some(vec![]));
         // Compare the generated PartialConfig object against the expected values.

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -179,6 +179,14 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?,
+            advertised_endpoints: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.advertised_endpoints() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                })
+                .ok_or_else(|| ConfigError::MissingValue("advertised endpoints".to_string()))?,
             peers: self
                 .partial_configs
                 .iter()
@@ -282,6 +290,7 @@ mod tests {
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
     /// Asserts the example configuration values.
@@ -301,6 +310,10 @@ mod tests {
         assert_eq!(
             config.network_endpoints(),
             Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()])
+        );
+        assert_eq!(
+            config.advertised_endpoints(),
+            Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()])
         );
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
@@ -336,6 +349,7 @@ mod tests {
             .with_server_key(Some(EXAMPLE_SERVER_KEY.to_string()))
             .with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()))
             .with_network_endpoints(Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()]))
+            .with_advertised_endpoints(Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()]))
             .with_peers(Some(vec![]))
             .with_node_id(Some(EXAMPLE_NODE_ID.to_string()))
             .with_bind(None)
@@ -371,6 +385,8 @@ mod tests {
             partial_config.with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()));
         partial_config =
             partial_config.with_network_endpoints(Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()]));
+        partial_config = partial_config
+            .with_advertised_endpoints(Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()]));
         partial_config = partial_config.with_peers(Some(vec![]));
         partial_config = partial_config.with_node_id(Some(EXAMPLE_NODE_ID.to_string()));
         partial_config = partial_config.with_admin_service_coordinator_timeout(None);

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -171,14 +171,14 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("service endpoint".to_string()))?,
-            network_endpoint: self
+            network_endpoints: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.network_endpoint() {
+                .find_map(|p| match p.network_endpoints() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
-                .ok_or_else(|| ConfigError::MissingValue("network endpoint".to_string()))?,
+                .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?,
             peers: self
                 .partial_configs
                 .iter()
@@ -299,8 +299,8 @@ mod tests {
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
         );
         assert_eq!(
-            config.network_endpoint(),
-            Some(EXAMPLE_NETWORK_ENDPOINT.to_string())
+            config.network_endpoints(),
+            Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()])
         );
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
@@ -335,7 +335,7 @@ mod tests {
             .with_server_cert(Some(EXAMPLE_SERVER_CERT.to_string()))
             .with_server_key(Some(EXAMPLE_SERVER_KEY.to_string()))
             .with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()))
-            .with_network_endpoint(Some(EXAMPLE_NETWORK_ENDPOINT.to_string()))
+            .with_network_endpoints(Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()]))
             .with_peers(Some(vec![]))
             .with_node_id(Some(EXAMPLE_NODE_ID.to_string()))
             .with_bind(None)
@@ -370,7 +370,7 @@ mod tests {
         partial_config =
             partial_config.with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()));
         partial_config =
-            partial_config.with_network_endpoint(Some(EXAMPLE_NETWORK_ENDPOINT.to_string()));
+            partial_config.with_network_endpoints(Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()]));
         partial_config = partial_config.with_peers(Some(vec![]));
         partial_config = partial_config.with_node_id(Some(EXAMPLE_NODE_ID.to_string()));
         partial_config = partial_config.with_admin_service_coordinator_timeout(None);

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -66,6 +66,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                     .map(|values| values.map(String::from).collect::<Vec<String>>()),
             )
             .with_node_id(self.matches.value_of("node_id").map(String::from))
+            .with_display_name(self.matches.value_of("display_name").map(String::from))
             .with_bind(self.matches.value_of("bind").map(String::from))
             .with_registries(
                 self.matches
@@ -116,6 +117,7 @@ mod tests {
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
+    static EXAMPLE_DISPLAY_NAME: &str = "Node 1";
 
     /// Asserts config values based on the example values.
     fn assert_config_values(config: PartialConfig) {
@@ -141,6 +143,10 @@ mod tests {
         );
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
+        assert_eq!(
+            config.display_name(),
+            Some(EXAMPLE_DISPLAY_NAME.to_string())
+        );
         assert_eq!(config.bind(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
@@ -157,6 +163,7 @@ mod tests {
             (about: "Config-Test")
             (@arg config: -c --config +takes_value)
             (@arg node_id: --("node-id") +takes_value)
+            (@arg display_name: --("display-name") +takes_value)
             (@arg storage: --("storage") +takes_value)
             (@arg transport: --("transport") +takes_value)
             (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
@@ -191,6 +198,8 @@ mod tests {
             "configtest",
             "--node-id",
             EXAMPLE_NODE_ID,
+            "--display-name",
+            EXAMPLE_DISPLAY_NAME,
             "--storage",
             EXAMPLE_STORAGE,
             "--transport",

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -50,7 +50,11 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
             .with_server_cert(self.matches.value_of("server_cert").map(String::from))
             .with_server_key(self.matches.value_of("server_key").map(String::from))
             .with_service_endpoint(self.matches.value_of("service_endpoint").map(String::from))
-            .with_network_endpoint(self.matches.value_of("network_endpoint").map(String::from))
+            .with_network_endpoints(
+                self.matches
+                    .values_of("network_endpoints")
+                    .map(|values| values.map(String::from).collect::<Vec<String>>()),
+            )
             .with_peers(
                 self.matches
                     .values_of("peers")
@@ -122,8 +126,8 @@ mod tests {
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
         );
         assert_eq!(
-            config.network_endpoint(),
-            Some(EXAMPLE_NETWORK_ENDPOINT.to_string())
+            config.network_endpoints(),
+            Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()])
         );
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
@@ -145,7 +149,7 @@ mod tests {
             (@arg node_id: --("node-id") +takes_value)
             (@arg storage: --("storage") +takes_value)
             (@arg transport: --("transport") +takes_value)
-            (@arg network_endpoint: -n --("network-endpoint") +takes_value)
+            (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
             (@arg peers: --peer +takes_value +multiple)
             (@arg ca_file: --("ca-file") +takes_value)

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -55,6 +55,11 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                     .values_of("network_endpoints")
                     .map(|values| values.map(String::from).collect::<Vec<String>>()),
             )
+            .with_advertised_endpoints(
+                self.matches
+                    .values_of("advertised_endpoints")
+                    .map(|values| values.map(String::from).collect::<Vec<String>>()),
+            )
             .with_peers(
                 self.matches
                     .values_of("peers")
@@ -109,6 +114,7 @@ mod tests {
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
     /// Asserts config values based on the example values.
@@ -128,6 +134,10 @@ mod tests {
         assert_eq!(
             config.network_endpoints(),
             Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()])
+        );
+        assert_eq!(
+            config.advertised_endpoints(),
+            Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()])
         );
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
@@ -150,6 +160,7 @@ mod tests {
             (@arg storage: --("storage") +takes_value)
             (@arg transport: --("transport") +takes_value)
             (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
+            (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
             (@arg peers: --peer +takes_value +multiple)
             (@arg ca_file: --("ca-file") +takes_value)
@@ -186,6 +197,8 @@ mod tests {
             EXAMPLE_TRANSPORT,
             "--network-endpoint",
             EXAMPLE_NETWORK_ENDPOINT,
+            "--advertised-endpoint",
+            EXAMPLE_ADVERTISED_ENDPOINT,
             "--service-endpoint",
             EXAMPLE_SERVICE_ENDPOINT,
             "--ca-file",

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -51,6 +51,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
             .with_advertised_endpoints(Some(vec![]))
             .with_peers(Some(vec![]))
+            .with_display_name(Some(String::new()))
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
             .with_heartbeat_interval(Some(HEARTBEAT_DEFAULT))
@@ -101,6 +102,7 @@ mod tests {
         assert_eq!(config.advertised_endpoints(), Some(vec![]));
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);
+        assert_eq!(config.display_name(), Some(String::new()));
         assert_eq!(config.bind(), Some(String::from("127.0.0.1:8080")));
         #[cfg(feature = "database")]
         assert_eq!(config.database(), Some(String::from("127.0.0.1:5432")));

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -49,6 +49,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_server_key(Some(String::from(SERVER_KEY)))
             .with_service_endpoint(Some(String::from("127.0.0.1:8043")))
             .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
+            .with_advertised_endpoints(Some(vec![]))
             .with_peers(Some(vec![]))
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
@@ -97,6 +98,7 @@ mod tests {
             config.network_endpoints(),
             Some(vec![String::from("127.0.0.1:8044")])
         );
+        assert_eq!(config.advertised_endpoints(), Some(vec![]));
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);
         assert_eq!(config.bind(), Some(String::from("127.0.0.1:8080")));

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -48,7 +48,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_server_cert(Some(String::from(SERVER_CERT)))
             .with_server_key(Some(String::from(SERVER_KEY)))
             .with_service_endpoint(Some(String::from("127.0.0.1:8043")))
-            .with_network_endpoint(Some(String::from("127.0.0.1:8044")))
+            .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
             .with_peers(Some(vec![]))
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
@@ -94,8 +94,8 @@ mod tests {
             Some(String::from("127.0.0.1:8043"))
         );
         assert_eq!(
-            config.network_endpoint(),
-            Some(String::from("127.0.0.1:8044"))
+            config.network_endpoints(),
+            Some(vec![String::from("127.0.0.1:8044")])
         );
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -730,7 +730,7 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `database` (source
+        // The DefaultPartialConfigBuilder is the only config with a value for `peers` (source
         // should be Default).
         assert_eq!(
             (final_config.peers(), final_config.peers_source()),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -52,6 +52,7 @@ pub struct Config {
     server_key: (String, ConfigSource),
     service_endpoint: (String, ConfigSource),
     network_endpoints: (Vec<String>, ConfigSource),
+    advertised_endpoints: (Vec<String>, ConfigSource),
     peers: (Vec<String>, ConfigSource),
     node_id: (String, ConfigSource),
     bind: (String, ConfigSource),
@@ -105,6 +106,10 @@ impl Config {
 
     pub fn network_endpoints(&self) -> &[String] {
         &self.network_endpoints.0
+    }
+
+    pub fn advertised_endpoints(&self) -> &[String] {
+        &self.advertised_endpoints.0
     }
 
     pub fn peers(&self) -> &[String] {
@@ -187,6 +192,10 @@ impl Config {
 
     fn network_endpoints_source(&self) -> &ConfigSource {
         &self.network_endpoints.1
+    }
+
+    fn advertised_endpoints_source(&self) -> &ConfigSource {
+        &self.advertised_endpoints.1
     }
 
     fn peers_source(&self) -> &ConfigSource {
@@ -284,6 +293,11 @@ impl Config {
             self.network_endpoints_source()
         );
         debug!(
+            "Config: advertised_endpoints: {:?} (source: {:?})",
+            self.advertised_endpoints(),
+            self.advertised_endpoints_source()
+        );
+        debug!(
             "Config: peers: {:?} (source: {:?})",
             self.peers(),
             self.peers_source()
@@ -367,6 +381,7 @@ mod tests {
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
     static DEFAULT_CLIENT_CERT: &str = "client.crt";
@@ -409,6 +424,7 @@ mod tests {
         (@arg storage: --("storage") +takes_value)
         (@arg transport: --("transport") +takes_value)
         (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
+        (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
         (@arg service_endpoint: --("service-endpoint") +takes_value)
         (@arg peers: --peer +takes_value +multiple)
         (@arg ca_file: --("ca-file") +takes_value)
@@ -511,6 +527,8 @@ mod tests {
             EXAMPLE_TRANSPORT,
             "--network-endpoint",
             EXAMPLE_NETWORK_ENDPOINT,
+            "--advertised-endpoint",
+            EXAMPLE_ADVERTISED_ENDPOINT,
             "--service-endpoint",
             EXAMPLE_SERVICE_ENDPOINT,
             "--ca-file",
@@ -729,6 +747,15 @@ mod tests {
                 &[EXAMPLE_NETWORK_ENDPOINT.to_string()] as &[String],
                 &ConfigSource::Default,
             )
+        );
+        // The DefaultPartialConfigBuilder is the only config with a value for
+        // `advertised_endpoints` (source should be Default).
+        assert_eq!(
+            (
+                final_config.advertised_endpoints(),
+                final_config.advertised_endpoints_source()
+            ),
+            (&[] as &[String], &ConfigSource::Default,)
         );
         // The DefaultPartialConfigBuilder is the only config with a value for `peers` (source
         // should be Default).

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -40,6 +40,7 @@ pub struct PartialConfig {
     server_key: Option<String>,
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
+    advertised_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
@@ -69,6 +70,7 @@ impl PartialConfig {
             server_key: None,
             service_endpoint: None,
             network_endpoints: None,
+            advertised_endpoints: None,
             peers: None,
             node_id: None,
             bind: None,
@@ -126,6 +128,10 @@ impl PartialConfig {
 
     pub fn network_endpoints(&self) -> Option<Vec<String>> {
         self.network_endpoints.clone()
+    }
+
+    pub fn advertised_endpoints(&self) -> Option<Vec<String>> {
+        self.advertised_endpoints.clone()
     }
 
     pub fn peers(&self) -> Option<Vec<String>> {
@@ -289,6 +295,18 @@ impl PartialConfig {
     ///
     pub fn with_network_endpoints(mut self, network_endpoints: Option<Vec<String>>) -> Self {
         self.network_endpoints = network_endpoints;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Adds a `advertised_endpoints` value to the PartialConfig object.
+    ///
+    /// # Arguments
+    ///
+    /// * `advertised_endpoints` - Publicly visible network endpoints.
+    ///
+    pub fn with_advertised_endpoints(mut self, advertised_endpoints: Option<Vec<String>>) -> Self {
+        self.advertised_endpoints = advertised_endpoints;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -39,7 +39,7 @@ pub struct PartialConfig {
     server_cert: Option<String>,
     server_key: Option<String>,
     service_endpoint: Option<String>,
-    network_endpoint: Option<String>,
+    network_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
@@ -68,7 +68,7 @@ impl PartialConfig {
             server_cert: None,
             server_key: None,
             service_endpoint: None,
-            network_endpoint: None,
+            network_endpoints: None,
             peers: None,
             node_id: None,
             bind: None,
@@ -124,8 +124,8 @@ impl PartialConfig {
         self.service_endpoint.clone()
     }
 
-    pub fn network_endpoint(&self) -> Option<String> {
-        self.network_endpoint.clone()
+    pub fn network_endpoints(&self) -> Option<Vec<String>> {
+        self.network_endpoints.clone()
     }
 
     pub fn peers(&self) -> Option<Vec<String>> {
@@ -281,14 +281,14 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `network_endpoint` value to the PartialConfig object.
+    /// Adds a `network_endpoints` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `network_endpoint` - Endpoint used for daemon to daemon communication.
+    /// * `network_endpoints` - Endpoints used for daemon to daemon communication.
     ///
-    pub fn with_network_endpoint(mut self, network_endpoint: Option<String>) -> Self {
-        self.network_endpoint = network_endpoint;
+    pub fn with_network_endpoints(mut self, network_endpoints: Option<Vec<String>>) -> Self {
+        self.network_endpoints = network_endpoints;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -43,6 +43,7 @@ pub struct PartialConfig {
     advertised_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
+    display_name: Option<String>,
     bind: Option<String>,
     #[cfg(feature = "database")]
     database: Option<String>,
@@ -73,6 +74,7 @@ impl PartialConfig {
             advertised_endpoints: None,
             peers: None,
             node_id: None,
+            display_name: None,
             bind: None,
             #[cfg(feature = "database")]
             database: None,
@@ -140,6 +142,10 @@ impl PartialConfig {
 
     pub fn node_id(&self) -> Option<String> {
         self.node_id.clone()
+    }
+
+    pub fn display_name(&self) -> Option<String> {
+        self.display_name.clone()
     }
 
     pub fn bind(&self) -> Option<String> {
@@ -331,6 +337,18 @@ impl PartialConfig {
     ///
     pub fn with_node_id(mut self, node_id: Option<String>) -> Self {
         self.node_id = node_id;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Adds a `display_name` value to the PartialConfig object.
+    ///
+    /// # Arguments
+    ///
+    /// * `display_name` - Human-readable name for the node.
+    ///
+    pub fn with_display_name(mut self, display_name: Option<String>) -> Self {
+        self.display_name = display_name;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -34,6 +34,7 @@ struct TomlConfig {
     server_key: Option<String>,
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
+    advertised_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
@@ -80,6 +81,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_server_key(self.toml_config.server_key)
             .with_service_endpoint(self.toml_config.service_endpoint)
             .with_network_endpoints(self.toml_config.network_endpoints)
+            .with_advertised_endpoints(self.toml_config.advertised_endpoints)
             .with_peers(self.toml_config.peers)
             .with_node_id(self.toml_config.node_id)
             .with_bind(self.toml_config.bind)
@@ -157,6 +159,7 @@ mod tests {
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
         );
         assert_eq!(config.network_endpoints(), None);
+        assert_eq!(config.advertised_endpoints(), None);
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
         assert_eq!(config.bind(), None);

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -37,6 +37,7 @@ struct TomlConfig {
     advertised_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
+    display_name: Option<String>,
     bind: Option<String>,
     #[cfg(feature = "database")]
     database: Option<String>,
@@ -84,6 +85,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_advertised_endpoints(self.toml_config.advertised_endpoints)
             .with_peers(self.toml_config.peers)
             .with_node_id(self.toml_config.node_id)
+            .with_display_name(self.toml_config.display_name)
             .with_bind(self.toml_config.bind)
             .with_registries(self.toml_config.registries)
             .with_heartbeat_interval(self.toml_config.heartbeat_interval)
@@ -119,6 +121,7 @@ mod tests {
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NODE_ID: &str = "012";
+    static EXAMPLE_DISPLAY_NAME: &str = "Node 1";
 
     /// Converts a list of tuples to a toml Table Value used to write a toml file.
     fn get_toml_value() -> Value {
@@ -135,6 +138,7 @@ mod tests {
                 EXAMPLE_SERVICE_ENDPOINT.to_string(),
             ),
             ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
+            ("display_name".to_string(), EXAMPLE_DISPLAY_NAME.to_string()),
         ];
 
         let mut config_values = Map::new();
@@ -162,6 +166,10 @@ mod tests {
         assert_eq!(config.advertised_endpoints(), None);
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
+        assert_eq!(
+            config.display_name(),
+            Some(EXAMPLE_DISPLAY_NAME.to_string())
+        );
         assert_eq!(config.bind(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -33,7 +33,7 @@ struct TomlConfig {
     server_cert: Option<String>,
     server_key: Option<String>,
     service_endpoint: Option<String>,
-    network_endpoint: Option<String>,
+    network_endpoints: Option<Vec<String>>,
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     bind: Option<String>,
@@ -79,7 +79,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_server_cert(self.toml_config.server_cert)
             .with_server_key(self.toml_config.server_key)
             .with_service_endpoint(self.toml_config.service_endpoint)
-            .with_network_endpoint(self.toml_config.network_endpoint)
+            .with_network_endpoints(self.toml_config.network_endpoints)
             .with_peers(self.toml_config.peers)
             .with_node_id(self.toml_config.node_id)
             .with_bind(self.toml_config.bind)
@@ -116,7 +116,6 @@ mod tests {
     static EXAMPLE_SERVER_CERT: &str = "certs/server.crt";
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
-    static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_NODE_ID: &str = "012";
 
     /// Converts a list of tuples to a toml Table Value used to write a toml file.
@@ -132,10 +131,6 @@ mod tests {
             (
                 "service_endpoint".to_string(),
                 EXAMPLE_SERVICE_ENDPOINT.to_string(),
-            ),
-            (
-                "network_endpoint".to_string(),
-                EXAMPLE_NETWORK_ENDPOINT.to_string(),
             ),
             ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
         ];
@@ -161,10 +156,7 @@ mod tests {
             config.service_endpoint(),
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
         );
-        assert_eq!(
-            config.network_endpoint(),
-            Some(EXAMPLE_NETWORK_ENDPOINT.to_string())
-        );
+        assert_eq!(config.network_endpoints(), None);
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), Some(EXAMPLE_NODE_ID.to_string()));
         assert_eq!(config.bind(), None);

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -115,6 +115,7 @@ pub struct SplinterDaemon {
     initial_peers: Vec<String>,
     network: Network,
     node_id: String,
+    display_name: String,
     rest_api_endpoint: String,
     #[cfg(feature = "database")]
     db_url: Option<String>,
@@ -422,6 +423,7 @@ impl SplinterDaemon {
             create_node_registry(&self.local_node_registry_location, &self.registries)?;
 
         let node_id = self.node_id.clone();
+        let display_name = self.display_name.clone();
         let service_endpoint = self.service_endpoint.clone();
         let network_endpoints = self.network_endpoints.clone();
         let advertised_endpoints = self.advertised_endpoints.clone();
@@ -440,6 +442,7 @@ impl SplinterDaemon {
                 Resource::build("/status").add_method(Method::Get, move |_, _| {
                     routes::get_status(
                         node_id.clone(),
+                        display_name.clone(),
                         service_endpoint.clone(),
                         network_endpoints.clone(),
                         advertised_endpoints.clone(),
@@ -730,6 +733,7 @@ pub struct SplinterDaemonBuilder {
     advertised_endpoints: Option<Vec<String>>,
     initial_peers: Option<Vec<String>>,
     node_id: Option<String>,
+    display_name: Option<String>,
     rest_api_endpoint: Option<String>,
     #[cfg(feature = "database")]
     db_url: Option<String>,
@@ -785,6 +789,11 @@ impl SplinterDaemonBuilder {
 
     pub fn with_node_id(mut self, value: String) -> Self {
         self.node_id = Some(value);
+        self
+    }
+
+    pub fn with_display_name(mut self, value: String) -> Self {
+        self.display_name = Some(value);
         self
     }
 
@@ -874,6 +883,10 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: node_id".to_string())
         })?;
 
+        let display_name = self.display_name.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: display_name".to_string())
+        })?;
+
         let rest_api_endpoint = self.rest_api_endpoint.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: rest_api_endpoint".to_string())
         })?;
@@ -902,6 +915,7 @@ impl SplinterDaemonBuilder {
             initial_peers,
             network,
             node_id,
+            display_name,
             rest_api_endpoint,
             #[cfg(feature = "database")]
             db_url,

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -422,6 +422,7 @@ impl SplinterDaemon {
 
         let node_id = self.node_id.clone();
         let service_endpoint = self.service_endpoint.clone();
+        let network_endpoints = self.network_endpoints.clone();
 
         let circuit_resource_provider =
             CircuitResourceProvider::new(self.node_id.to_string(), state);
@@ -435,7 +436,11 @@ impl SplinterDaemon {
             )
             .add_resource(
                 Resource::build("/status").add_method(Method::Get, move |_, _| {
-                    routes::get_status(node_id.clone(), service_endpoint.clone())
+                    routes::get_status(
+                        node_id.clone(),
+                        service_endpoint.clone(),
+                        network_endpoints.clone(),
+                    )
                 }),
             )
             .add_resource(make_nodes_identity_resource(node_registry.clone()))

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -110,7 +110,7 @@ pub struct SplinterDaemon {
     key_registry_location: String,
     local_node_registry_location: String,
     service_endpoint: String,
-    network_endpoint: String,
+    network_endpoints: Vec<String>,
     initial_peers: Vec<String>,
     network: Network,
     node_id: String,
@@ -156,10 +156,17 @@ impl SplinterDaemon {
         let state = SplinterState::new(self.storage_location.to_string(), circuit_directory);
 
         // set up the listeners on the transport
-        let mut network_listener = transport.listen(&self.network_endpoint)?;
+        let network_listeners = self
+            .network_endpoints
+            .iter()
+            .map(|endpoint| transport.listen(endpoint))
+            .collect::<Result<Vec<_>, _>>()?;
         debug!(
-            "Listening for peer connections on {}",
-            network_listener.endpoint()
+            "Listening for peer connections on {:?}",
+            network_listeners
+                .iter()
+                .map(|listener| listener.endpoint())
+                .collect::<Vec<_>>(),
         );
         let service_listener = transport.listen(&self.service_endpoint)?;
         debug!(
@@ -202,7 +209,7 @@ impl SplinterDaemon {
         let circuit_dispatcher = set_up_circuit_dispatcher(
             network_sender.clone(),
             &self.node_id,
-            &self.network_endpoint,
+            &self.network_endpoints,
             state.clone(),
         );
         let circuit_dispatch_loop = DispatchLoopBuilder::new()
@@ -249,34 +256,38 @@ impl SplinterDaemon {
         let network_dispatch_send = network_dispatch_loop.new_dispatcher_sender();
         let network_dispatcher_shutdown = network_dispatch_loop.shutdown_signaler();
 
-        // setup a thread to listen on the network port and add incoming connection to the network
-        let network_clone = self.network.clone();
-
-        // this thread will just be dropped on shutdown
-        let _ = thread::spawn(move || {
-            for connection_result in network_listener.incoming() {
-                let connection = match connection_result {
-                    Ok(connection) => connection,
-                    Err(AcceptError::ProtocolError(msg)) => {
-                        warn!("Failed to accept connection due to {}", msg);
-                        continue;
+        // setup threads to listen on the network ports and add incoming connections to the network
+        // these threads will just be dropped on shutdown
+        let _ = network_listeners
+            .into_iter()
+            .map(|mut network_listener| {
+                let network_clone = self.network.clone();
+                thread::spawn(move || {
+                    for connection_result in network_listener.incoming() {
+                        let connection = match connection_result {
+                            Ok(connection) => connection,
+                            Err(AcceptError::ProtocolError(msg)) => {
+                                warn!("Failed to accept connection due to {}", msg);
+                                continue;
+                            }
+                            Err(AcceptError::IoError(err)) => {
+                                error!("Unable to receive new connections; exiting: {:?}", err);
+                                return Err(StartError::TransportError(format!(
+                                    "Accept Error: {:?}",
+                                    err
+                                )));
+                            }
+                        };
+                        debug!("Received connection from {}", connection.remote_endpoint());
+                        match network_clone.add_connection(connection) {
+                            Ok(peer_id) => debug!("Added connection with ID {}", peer_id),
+                            Err(err) => error!("Failed to add connection to network: {}", err),
+                        };
                     }
-                    Err(AcceptError::IoError(err)) => {
-                        error!("Unable to receive new connections; exiting: {:?}", err);
-                        return Err(StartError::TransportError(format!(
-                            "Accept Error: {:?}",
-                            err
-                        )));
-                    }
-                };
-                debug!("Received connection from {}", connection.remote_endpoint());
-                match network_clone.add_connection(connection) {
-                    Ok(peer_id) => debug!("Added connection with ID {}", peer_id),
-                    Err(err) => error!("Failed to add connection to network: {}", err),
-                };
-            }
-            Ok(())
-        });
+                    Ok(())
+                })
+            })
+            .collect::<Vec<_>>();
 
         // For provided initial peers, try to connect to them
         for peer in self.initial_peers.iter() {
@@ -288,8 +299,8 @@ impl SplinterDaemon {
         // For each node in the circuit_directory, try to connect and add them to the network
         for (node_id, node) in state.nodes()?.iter() {
             if node_id != &self.node_id {
-                if let Some(endpoint) = node.endpoints().get(0) {
-                    if let Err(err) = peer_connector.connect_peer(node_id, endpoint) {
+                if !node.endpoints().is_empty() {
+                    if let Err(err) = peer_connector.connect_peer(node_id, node.endpoints()) {
                         debug!("Unable to connect to node: {} Error: {:?}", node_id, err);
                     }
                 } else {
@@ -707,7 +718,7 @@ pub struct SplinterDaemonBuilder {
     key_registry_location: Option<String>,
     local_node_registry_location: Option<String>,
     service_endpoint: Option<String>,
-    network_endpoint: Option<String>,
+    network_endpoints: Option<Vec<String>>,
     initial_peers: Option<Vec<String>>,
     node_id: Option<String>,
     rest_api_endpoint: Option<String>,
@@ -748,8 +759,8 @@ impl SplinterDaemonBuilder {
         self
     }
 
-    pub fn with_network_endpoint(mut self, value: String) -> Self {
-        self.network_endpoint = Some(value);
+    pub fn with_network_endpoints(mut self, value: Vec<String>) -> Self {
+        self.network_endpoints = Some(value);
         self
     }
 
@@ -833,8 +844,8 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: service_location".to_string())
         })?;
 
-        let network_endpoint = self.network_endpoint.ok_or_else(|| {
-            CreateError::MissingRequiredField("Missing field: network_endpoint".to_string())
+        let network_endpoints = self.network_endpoints.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: network_endpoints".to_string())
         })?;
 
         let initial_peers = self.initial_peers.ok_or_else(|| {
@@ -868,7 +879,7 @@ impl SplinterDaemonBuilder {
         Ok(SplinterDaemon {
             storage_location,
             service_endpoint,
-            network_endpoint,
+            network_endpoints,
             initial_peers,
             network,
             node_id,
@@ -922,13 +933,13 @@ fn set_up_network_dispatcher(
 fn set_up_circuit_dispatcher(
     network_sender: NetworkMessageSender,
     node_id: &str,
-    endpoint: &str,
+    endpoints: &[String],
     state: SplinterState,
 ) -> Dispatcher<CircuitMessageType> {
     let mut dispatcher = Dispatcher::<CircuitMessageType>::new(network_sender);
 
     let service_connect_request_handler =
-        ServiceConnectRequestHandler::new(node_id.to_string(), endpoint.to_string(), state.clone());
+        ServiceConnectRequestHandler::new(node_id.to_string(), endpoints.to_vec(), state.clone());
     dispatcher.set_handler(Box::new(service_connect_request_handler));
 
     let service_disconnect_request_handler = ServiceDisconnectRequestHandler::new(state.clone());

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -111,6 +111,7 @@ pub struct SplinterDaemon {
     local_node_registry_location: String,
     service_endpoint: String,
     network_endpoints: Vec<String>,
+    advertised_endpoints: Vec<String>,
     initial_peers: Vec<String>,
     network: Network,
     node_id: String,
@@ -423,6 +424,7 @@ impl SplinterDaemon {
         let node_id = self.node_id.clone();
         let service_endpoint = self.service_endpoint.clone();
         let network_endpoints = self.network_endpoints.clone();
+        let advertised_endpoints = self.advertised_endpoints.clone();
 
         let circuit_resource_provider =
             CircuitResourceProvider::new(self.node_id.to_string(), state);
@@ -440,6 +442,7 @@ impl SplinterDaemon {
                         node_id.clone(),
                         service_endpoint.clone(),
                         network_endpoints.clone(),
+                        advertised_endpoints.clone(),
                     )
                 }),
             )
@@ -724,6 +727,7 @@ pub struct SplinterDaemonBuilder {
     local_node_registry_location: Option<String>,
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
+    advertised_endpoints: Option<Vec<String>>,
     initial_peers: Option<Vec<String>>,
     node_id: Option<String>,
     rest_api_endpoint: Option<String>,
@@ -766,6 +770,11 @@ impl SplinterDaemonBuilder {
 
     pub fn with_network_endpoints(mut self, value: Vec<String>) -> Self {
         self.network_endpoints = Some(value);
+        self
+    }
+
+    pub fn with_advertised_endpoints(mut self, value: Vec<String>) -> Self {
+        self.advertised_endpoints = Some(value);
         self
     }
 
@@ -853,6 +862,10 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: network_endpoints".to_string())
         })?;
 
+        let advertised_endpoints = self.advertised_endpoints.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: advertised_endpoints".to_string())
+        })?;
+
         let initial_peers = self.initial_peers.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: initial_peers".to_string())
         })?;
@@ -885,6 +898,7 @@ impl SplinterDaemonBuilder {
             storage_location,
             service_endpoint,
             network_endpoints,
+            advertised_endpoints,
             initial_peers,
             network,
             node_id,

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -126,6 +126,8 @@ fn main() {
           "Transport type for sockets, either raw or tls")
         (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple
           "Endpoints to connect to the network, tcp://ip:port")
+        (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple
+          "Publicly-visible network endpoints")
         (@arg service_endpoint: --("service-endpoint") +takes_value
           "Endpoint that service will connect to, tcp://ip:port")
         (@arg peers: --peer +takes_value +multiple
@@ -290,6 +292,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_key_registry_location(key_registry_location)
         .with_local_node_registry_location(local_node_registry_location)
         .with_network_endpoints(config.network_endpoints().to_vec())
+        .with_advertised_endpoints(config.advertised_endpoints().to_vec())
         .with_service_endpoint(String::from(config.service_endpoint()))
         .with_initial_peers(config.peers().to_vec())
         .with_node_id(String::from(config.node_id()))

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -124,8 +124,8 @@ fn main() {
           "Storage type used for the node; defaults to yaml")
         (@arg transport: --("transport") +takes_value
           "Transport type for sockets, either raw or tls")
-        (@arg network_endpoint: -n --("network-endpoint") +takes_value
-          "Endpoint to connect to the network, tcp://ip:port")
+        (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple
+          "Endpoints to connect to the network, tcp://ip:port")
         (@arg service_endpoint: --("service-endpoint") +takes_value
           "Endpoint that service will connect to, tcp://ip:port")
         (@arg peers: --peer +takes_value +multiple
@@ -289,7 +289,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_storage_location(storage_location)
         .with_key_registry_location(key_registry_location)
         .with_local_node_registry_location(local_node_registry_location)
-        .with_network_endpoint(String::from(config.network_endpoint()))
+        .with_network_endpoints(config.network_endpoints().to_vec())
         .with_service_endpoint(String::from(config.service_endpoint()))
         .with_initial_peers(config.peers().to_vec())
         .with_node_id(String::from(config.node_id()))

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -120,6 +120,8 @@ fn main() {
         (@arg config: -c --config +takes_value)
         (@arg node_id: --("node-id") +takes_value
           "Unique ID for the node ")
+        (@arg display_name: --("display-name") +takes_value
+          "Human-readable name for the node")
         (@arg storage: --("storage") +takes_value
           "Storage type used for the node; defaults to yaml")
         (@arg transport: --("transport") +takes_value
@@ -296,6 +298,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_service_endpoint(String::from(config.service_endpoint()))
         .with_initial_peers(config.peers().to_vec())
         .with_node_id(String::from(config.node_id()))
+        .with_display_name(String::from(config.display_name()))
         .with_rest_api_endpoint(String::from(rest_api_endpoint))
         .with_storage_type(String::from(config.storage()))
         .with_registries(config.registries().to_vec())

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -18,6 +18,7 @@ use splinter::futures::{Future, IntoFuture};
 #[derive(Debug, Serialize, Deserialize)]
 struct Status {
     node_id: String,
+    display_name: String,
     service_endpoint: String,
     network_endpoints: Vec<String>,
     advertised_endpoints: Vec<String>,
@@ -26,12 +27,14 @@ struct Status {
 
 pub fn get_status(
     node_id: String,
+    display_name: String,
     service_endpoint: String,
     network_endpoints: Vec<String>,
     advertised_endpoints: Vec<String>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let status = Status {
         node_id,
+        display_name,
         service_endpoint,
         network_endpoints,
         advertised_endpoints,

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -20,6 +20,7 @@ struct Status {
     node_id: String,
     service_endpoint: String,
     network_endpoints: Vec<String>,
+    advertised_endpoints: Vec<String>,
     version: String,
 }
 
@@ -27,11 +28,13 @@ pub fn get_status(
     node_id: String,
     service_endpoint: String,
     network_endpoints: Vec<String>,
+    advertised_endpoints: Vec<String>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let status = Status {
         node_id,
         service_endpoint,
         network_endpoints,
+        advertised_endpoints,
         version: get_version(),
     };
 

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -18,17 +18,20 @@ use splinter::futures::{Future, IntoFuture};
 #[derive(Debug, Serialize, Deserialize)]
 struct Status {
     node_id: String,
-    endpoint: String,
+    service_endpoint: String,
+    network_endpoints: Vec<String>,
     version: String,
 }
 
 pub fn get_status(
     node_id: String,
-    endpoint: String,
+    service_endpoint: String,
+    network_endpoints: Vec<String>,
 ) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let status = Status {
         node_id,
-        endpoint,
+        service_endpoint,
+        network_endpoints,
         version: get_version(),
     };
 


### PR DESCRIPTION
- Make network endpoints for splinter nodes a list instead of a single value
- Add `advertised_endpoints` configuration to splinterd
- Add `display_name` configuration to splinterd
- Update the response of splinterd's `GET /status` endpoint