### PR TITLE
Update protocol prefix for TLS transport to tcps://

### DIFF
--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -122,15 +122,15 @@ EXAMPLES
 ========
 This command proposes a simple circuit with one other node.
 
-* The proposing node has ID `alpha001` and endpoint `tls://splinterd-node-acme001:8044`.
-* The other node has ID `beta001` and endpoint `tls://splinterd-node-beta001:8044`.
+* The proposing node has ID `alpha001` and endpoint `tcps://splinterd-node-acme001:8044`.
+* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`.
 * There is one service with ID `AA01`. This service has no service
   arguments, service type, or service group.
 
 ```
 $ splinter circuit propose \
-  --node alpha001::tls://splinterd-node-alpha001:8044 \
-  --node beta001::tls://splinterd-node-beta001:8044 \
+  --node alpha001::tcps://splinterd-node-alpha001:8044 \
+  --node beta001::tcps://splinterd-node-beta001:8044 \
   --service AA01::alpha001 \
   --key PRIVATE-KEY-FILE
   --url URL-of-splinterd-REST-API
@@ -139,8 +139,8 @@ $ splinter circuit propose \
 The next command proposes a circuit with one other node, with multiple services
 and multiple service-args.
 
-* The proposing node has ID `alpha001` and endpoint `tls://splinterd-node-alpha001:8044`.
-* The other node has ID `beta001` and endpoint `tls://splinterd-node-beta001:8044`.
+* The proposing node has ID `alpha001` and endpoint `tcps://splinterd-node-alpha001:8044`.
+* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`.
 * There are two services for each member node with a `service-type` of `scabbard`
   for each. The service ID for the alpha node service is `AA01` and the
   beta node service ID is `BB01`. Each of these services are specified
@@ -152,8 +152,8 @@ and multiple service-args.
 splinter circuit propose \
   --key PRIVATE-KEY-FILE \
   --url URL-of-splinterd-REST-API \
-  --node alpha001::tls://splinterd-node-alpha001:8044 \
-  --node beta001::tls://splinterd-node-beta001:8044 \
+  --node alpha001::tcps://splinterd-node-alpha001:8044 \
+  --node beta001::tcps://splinterd-node-beta001:8044 \
   --service AA01::alpha-node-001 \
   --service BB01::beta-node-001 \
   --service-type AA01::scabbard \

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -57,9 +57,9 @@ formatting, which intends to use indentation and labels to make the circuit
 information understandable.
 
 * The proposing node has ID `alpha001` and endpoint
-  `tls://splinterd-node-alpha001:8044`, and a service ID of `AA01`.
+  `tcps://splinterd-node-alpha001:8044`, and a service ID of `AA01`.
 * The proposed member node has ID `beta001` and endpoint
-  `tls://splinterd-node-beta001:8044`, and a service ID of `BB01`.
+  `tcps://splinterd-node-beta001:8044`, and a service ID of `BB01`.
 * The command shows a circuit that was proposed by node alpha001 but has yet to
   be voted on by beta001, with a circuit ID of `01234-ABCDE`.
 
@@ -75,7 +75,7 @@ $ splinter circuit show 01234-ABCDE \
 Proposal to create: 01234-ABCDE
     Management Type: mgmt001
 
-    alpha-001 (tls://splinterd-node-alpha001:8044)
+    alpha-001 (tcps://splinterd-node-alpha001:8044)
         Vote: ACCEPT (implied as requester):
             ALPHA-PUBLIC-KEY
         Service: AA01
@@ -84,7 +84,7 @@ Proposal to create: 01234-ABCDE
             peer_services:
                 BB01
 
-    beta-001 (tls://splinterd-node-beta001:8044)
+    beta-001 (tcps://splinterd-node-beta001:8044)
         Vote: PENDING
         Service: AA01
             admin_keys:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,9 +47,9 @@ const CIRCUIT_PROPOSE_AFTER_HELP: &str = r"DETAILS:
     where each node has an 'identity' or 'node_id' field, as well as an 'endpoint' field. Example:
         ---
         - identity: 'node-1'
-          endpoint: tls://node-1-endpoint:8044
+          endpoint: tcps://node-1-endpoint:8044
         - node_id: 'node-2'
-          endpoint: tls://node-2-endpoint:8045
+          endpoint: tcps://node-2-endpoint:8045
 
     For the --service-arg, --service-peer-group, and --service-type options, service IDs can be
     wildcarded with '*' to match multiple services. For example, '--service-type *::scabbard' match

--- a/cli/src/tests/circuit/list.rs
+++ b/cli/src/tests/circuit/list.rs
@@ -39,8 +39,8 @@ fn list_successful() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -56,8 +56,8 @@ fn list_successful() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -133,8 +133,8 @@ fn list_format_human() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -189,8 +189,8 @@ fn list_format_csv() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \

--- a/cli/src/tests/circuit/proposals.rs
+++ b/cli/src/tests/circuit/proposals.rs
@@ -39,8 +39,8 @@ fn proposals_successful_basic() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -89,8 +89,8 @@ fn proposals_successful_with_management_type() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -106,8 +106,8 @@ fn proposals_successful_with_management_type() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -156,8 +156,8 @@ fn proposals_format_human() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -209,8 +209,8 @@ fn proposals_format_csv() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \

--- a/cli/src/tests/circuit/propose.rs
+++ b/cli/src/tests/circuit/propose.rs
@@ -39,8 +39,8 @@ fn propose_successful_basic() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -118,8 +118,8 @@ fn propose_successful_with_individual_service_types() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type sc00::scabbard \
@@ -159,8 +159,8 @@ fn propose_successful_with_individual_service_args() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -201,8 +201,8 @@ fn propose_successful_with_json_metadata() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -264,8 +264,8 @@ fn propose_too_few_services() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service-type *::scabbard \
          --management custom \
          --service-arg *::admin_keys={} \
@@ -282,8 +282,8 @@ fn propose_too_few_services() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service-type *::scabbard \
          --management custom \
@@ -308,8 +308,8 @@ fn propose_multiple_string_metadata() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -336,8 +336,8 @@ fn propose_metadata_encoding_without_metadata() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \

--- a/cli/src/tests/circuit/show.rs
+++ b/cli/src/tests/circuit/show.rs
@@ -40,8 +40,8 @@ fn show_successful() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -97,8 +97,8 @@ fn show_format_json() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -178,8 +178,8 @@ fn show_format_yaml() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \

--- a/cli/src/tests/circuit/vote.rs
+++ b/cli/src/tests/circuit/vote.rs
@@ -36,8 +36,8 @@ fn vote_accept_successful() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \
@@ -77,8 +77,8 @@ fn vote_reject_successful() {
         "splinter circuit propose \
          --url http://localhost:8088 \
          --key /tmp/alice.priv \
-         --node acme-node-000::tls://splinterd-node-acme:8044 \
-         --node bubba-node-000::tls://splinterd-node-bubba:8044 \
+         --node acme-node-000::tcps://splinterd-node-acme:8044 \
+         --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
          --service sc00::acme-node-000 \
          --service sc01::bubba-node-000 \
          --service-type *::scabbard \

--- a/client/src/splinter_client.rs
+++ b/client/src/splinter_client.rs
@@ -89,7 +89,7 @@ impl SplinterClient {
 
         Ok(SplinterClient {
             socket: transport
-                .connect(&format!("tls://{}:{}", hostname, port))
+                .connect(&format!("tcps://{}:{}", hostname, port))
                 .map_err(|err| {
                     SplinterError::TLSError(format!(
                         "Unable to connect to \"{}:{}\":h  {}",

--- a/docker/kubernetes/README.md
+++ b/docker/kubernetes/README.md
@@ -119,13 +119,13 @@ walkthrough. For installation instructions, see the
     ----
     ---
     - identity: "acme"
-      endpoint: "tls://acme.default.svc.cluster.local:8044"
+      endpoint: "tcps://acme.default.svc.cluster.local:8044"
       display_name: "Acme"
       metadata:
         organization: "Acme Corporation"
 
     - identity: "bubba"
-      endpoint: "tls://bubba.default.svc.cluster.local:8044"
+      endpoint: "tcps://bubba.default.svc.cluster.local:8044"
       display_name: "Bubba Bakery"
       metadata:
         organization: "Bubba Bakery"
@@ -139,7 +139,7 @@ walkthrough. For installation instructions, see the
 
    ```
    $ kubectl apply -f https://raw.githubusercontent.com/Cargill/splinter/master/docker/kubernetes/arcade.yaml
-   
+
    deployment.apps/acme created
    service/acme-splinterd created
    service/acme-http created

--- a/docker/kubernetes/node-registry.yaml
+++ b/docker/kubernetes/node-registry.yaml
@@ -14,13 +14,13 @@
 
 ---
 - identity: "acme"
-  endpoint: "tls://acme.default.svc.cluster.local:8044"
+  endpoint: "tcps://acme.default.svc.cluster.local:8044"
   display_name: "Acme"
   metadata:
     organization: "Acme Corporation"
 
 - identity: "bubba"
-  endpoint: "tls://bubba.default.svc.cluster.local:8044"
+  endpoint: "tcps://bubba.default.svc.cluster.local:8044"
   display_name: "Bubba Bakery"
   metadata:
     organization: "Bubba Bakery"

--- a/examples/gameroom/daemon/openapi.yml
+++ b/examples/gameroom/daemon/openapi.yml
@@ -906,7 +906,7 @@ components:
           example: acme-node-000
         endpoint:
           type: string
-          example: tls://127.0.0.1:8080
+          example: tcps://127.0.0.1:8080
 
     ApiGameroom:
       type: object
@@ -962,7 +962,7 @@ components:
           type: object
       example:
         identity: node-123123-asdf
-        endpoint: tls://12.0.0.123:8431
+        endpoint: tcps://12.0.0.123:8431
         display_name: Cargill - Node 1
         metadata:
           company: Cargill

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -269,7 +269,7 @@ mod test {
         metadata.insert("company".to_string(), "Bitwise IO".to_string());
         Node {
             identity: "Node-123".to_string(),
-            endpoint: "tls://127.0.0.1:8080".to_string(),
+            endpoint: "tcps://127.0.0.1:8080".to_string(),
             display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
@@ -280,7 +280,7 @@ mod test {
         metadata.insert("company".to_string(), "Cargill".to_string());
         Node {
             identity: "Node-456".to_string(),
-            endpoint: "tls://127.0.0.1:8082".to_string(),
+            endpoint: "tcps://127.0.0.1:8082".to_string(),
             display_name: "Cargill - Node 1".to_string(),
             metadata,
         }

--- a/examples/gameroom/node_registry/nodes.yaml
+++ b/examples/gameroom/node_registry/nodes.yaml
@@ -14,12 +14,12 @@
 # -----------------------------------------------------------------------------
 
 - identity: 'bubba-node-000'
-  endpoint: 'tls://splinterd-node-bubba:8044'
+  endpoint: 'tcps://splinterd-node-bubba:8044'
   display_name: 'Bubba - Node 1'
   metadata:
     organization: 'Bubba Bakery'
 - identity: 'acme-node-000'
-  endpoint: 'tls://splinterd-node-acme:8044'
+  endpoint: 'tcps://splinterd-node-acme:8044'
   display_name: 'Acme - Node 1'
   metadata:
     organization: 'ACME Corporation'

--- a/examples/gameroom/tests/sample_node_registry.yaml
+++ b/examples/gameroom/tests/sample_node_registry.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 - identity: "Node-123"
-  endpoint: "tls://127.0.0.1:8080"
+  endpoint: "tcps://127.0.0.1:8080"
   display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
 - identity: "Node-456"
-  endpoint: "tls://127.0.0.1:8082"
+  endpoint: "tcps://127.0.0.1:8082"
   display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"

--- a/libsplinter/src/node_registry/yaml/mod.rs
+++ b/libsplinter/src/node_registry/yaml/mod.rs
@@ -723,7 +723,7 @@ mod test {
         metadata.insert("admin".to_string(), "Bob".to_string());
         Node {
             identity: "Node-123".to_string(),
-            endpoint: "tls://12.0.0.123:8431".to_string(),
+            endpoint: "tcps://12.0.0.123:8431".to_string(),
             display_name: "Bitwise IO - Node 1".to_string(),
             metadata,
         }
@@ -735,7 +735,7 @@ mod test {
         metadata.insert("admin".to_string(), "Carol".to_string());
         Node {
             identity: "Node-456".to_string(),
-            endpoint: "tls://12.0.0.123:8434".to_string(),
+            endpoint: "tcps://12.0.0.123:8434".to_string(),
             display_name: "Cargill - Node 1".to_string(),
             metadata,
         }
@@ -747,7 +747,7 @@ mod test {
         metadata.insert("admin".to_string(), "Charlie".to_string());
         Node {
             identity: "Node-789".to_string(),
-            endpoint: "tls://12.0.0.123:8435".to_string(),
+            endpoint: "tcps://12.0.0.123:8435".to_string(),
             display_name: "Cargill - Node 2".to_string(),
             metadata,
         }

--- a/libsplinter/src/transport/multi.rs
+++ b/libsplinter/src/transport/multi.rs
@@ -18,7 +18,7 @@ type SendableTransport = Box<dyn Transport + Send>;
 /// A MultiTransport holds a collection of transports, referenced by protocol.
 ///
 /// Endpoints and bind strings are specified using standard url-style strings.  For example,
-/// connecting over TLS would be handled with the connect string `"tls://<some-address>:<port>"`
+/// connecting over TLS would be handled with the connect string `"tcps://<some-address>:<port>"`
 ///
 /// Endpoints and bind strings provided without a protocol will use the provided default transport
 /// protocol type.
@@ -80,6 +80,8 @@ mod tests {
         let transport = MultiTransport::new(vec![raw_transport, tls_transport]);
         assert!(transport.accepts("127.0.0.1:0"));
         assert!(transport.accepts("tcp://127.0.0.1:0"));
+        assert!(transport.accepts("tcps://127.0.0.1:0"));
+        // test deprecated
         assert!(transport.accepts("tls://127.0.0.1:0"));
         assert!(!transport.accepts("foo://127.0.0.1:0"));
     }

--- a/libsplinter/src/transport/socket/tcp.rs
+++ b/libsplinter/src/transport/socket/tcp.rs
@@ -170,6 +170,7 @@ mod tests {
         assert!(transport.accepts("tcp://somewhere.example.com:4000"));
 
         assert!(!transport.accepts("tls://somewhere.example.com:4000"));
+        assert!(!transport.accepts("tcps://somewhere.example.com:4000"));
     }
 
     #[test]

--- a/splinterd/api/static/openapi.yml
+++ b/splinterd/api/static/openapi.yml
@@ -1610,7 +1610,7 @@ components:
           type: object
       example:
         identity: node-123123-asdf
-        endpoint: tls://12.0.0.123:8431
+        endpoint: tcps://12.0.0.123:8431
         display_name: Cargill - Node 1
         metadata:
           company: Cargill
@@ -1768,7 +1768,7 @@ components:
           example: alpha-node-000
         endpoint:
           type: string
-          example: tls://12.0.0.123:8431
+          example: tcps://12.0.0.123:8431
 
     ProposedCircuitService:
       type: object

--- a/splinterd/packaging/nodes.yaml.example
+++ b/splinterd/packaging/nodes.yaml.example
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 - identity: 'acme-node-000'
-  endpoint: 'tls://acme-node-000:8044'
+  endpoint: 'tcps://acme-node-000:8044'
   display_name: 'acme-node-000'
   metadata:
     organization: 'ACME Corporation'
 - identity: 'acme-node-001'
-  endpoint: 'tls://acme-node-001:8044'
+  endpoint: 'tcps://acme-node-001:8044'
   display_name: 'acme-node-001'
   metadata:
     organization: 'ACME Corporation'
 - identity: 'acme-node-002'
-  endpoint: 'tls://acme-node-002:8044'
+  endpoint: 'tcps://acme-node-002:8044'
   display_name: 'acme-node-002'
   metadata:
     organization: 'ACME Corporation'

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -16,14 +16,14 @@
 node_id = "acme-node-000"
 
 # Endpoint used for service to daemon communication
-service_endpoint = "tls://localhost:8043"
+service_endpoint = "tcps://localhost:8043"
 
 # Endpoint used for daemon to daemon communication
-network_endpoint = "tls://localhost:8044"
+network_endpoint = "tcps://localhost:8044"
 
 # A comma separated list of splinter nodes the daemon will automatically
 # attempt to connect to on start up
-# example: peers = ["tls://acme-node-001:8044", "tls://acme-node-002:8044"]
+# example: peers = ["tcps://acme-node-001:8044", "tcps://acme-node-002:8044"]
 peers = []
 
 # The type of storage that should be used to store circuit state. Options are

--- a/splinterd/sample_node_registries/nodes.yaml
+++ b/splinterd/sample_node_registries/nodes.yaml
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 - identity: "Node-123"
-  endpoint: "tls://123.0.0.123:8080"
+  endpoint: "tcps://123.0.0.123:8080"
   display_name: "Bitwise IO - Node 1"
   metadata:
     company: "Bitwise IO"
 - identity: "Node-456"
-  endpoint: "tls://456.0.0.456:8080"
+  endpoint: "tcps://456.0.0.456:8080"
   display_name: "Cargill - Node 1"
   metadata:
     company: "Cargill"


### PR DESCRIPTION
This is being changed for consistency. For example when
we have ws:// and wss:// it will match tcp:// and tcps://.

The old prefix, tls://, is still supported but is considered
deprecated.