### PR TITLE
Copy all Cargo.toml files during Docker builds

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -12,9 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Copy over source files
 COPY client /build/client

--- a/docker/lint
+++ b/docker/lint
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2
+FROM splintercommunity/splinter-dev:v3
 
 ENV PATH=$PATH:/project/splinter/bin
 

--- a/examples/gameroom/daemon/Dockerfile-installed-bionic
+++ b/examples/gameroom/daemon/Dockerfile-installed-bionic
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Copy over source files
 

--- a/examples/gameroom/tests/Dockerfile
+++ b/examples/gameroom/tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2
+FROM splintercommunity/splinter-dev:v3
 
 RUN apt-get update \
  && apt-get install -y \

--- a/examples/private_counter/cli/Dockerfile-installed-bionic
+++ b/examples/private_counter/cli/Dockerfile-installed-bionic
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Copy over source files
 COPY examples/private_counter/cli/ /build/examples/private_counter/cli

--- a/examples/private_counter/service/Dockerfile-installed-bionic
+++ b/examples/private_counter/service/Dockerfile-installed-bionic
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Copy over source files
 COPY examples/private_counter/protos /build/examples/private_counter/protos

--- a/examples/private_xo/Dockerfile-installed-bionic
+++ b/examples/private_xo/Dockerfile-installed-bionic
@@ -12,8 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
 
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
+
+# Copy source files
 COPY libsplinter /build/libsplinter
 COPY examples/private_xo /build/examples/private_xo
 

--- a/services/scabbard/Dockerfile-installed-bionic
+++ b/services/scabbard/Dockerfile-installed-bionic
@@ -12,7 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
 
 # Copy over source files
 COPY Cargo.toml /build/Cargo.toml

--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -14,10 +14,35 @@
 
 # -------------=== splinterd docker build ===-------------
 
-FROM splintercommunity/splinter-dev:v2 as BUILDER
+FROM splintercommunity/splinter-dev:v3 as BUILDER
 
 ENV SPLINTER_FORCE_PANDOC=true
 
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY client/Cargo.toml /build/client/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/Cargo.toml /build/services/scabbard/Cargo.toml
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+COPY examples/private_counter/cli/Cargo.toml \
+     /build/examples/private_counter/cli/Cargo.toml
+COPY examples/private_counter/service/Cargo.toml \
+     /build/examples/private_counter/service/Cargo.toml
+COPY examples/private_xo/Cargo.toml /build/examples/private_xo/Cargo.toml
+
+# Copy over source files
 COPY cli /build/cli
 COPY libsplinter /build/libsplinter
 COPY services/health /build/services/health

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM splintercommunity/splinter-dev:v2
+FROM splintercommunity/splinter-dev:v3
 
 RUN apt-get update \
  && apt-get install -y \


### PR DESCRIPTION
Updates Dockerfiles to use v3 version of the dev image which removes all
Cargo.toml files to resolve some transient compile issues when features
are moved from experimental to stable.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>