### PR TITLE
Add versioning to config objects

### DIFF
--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "acme-node-000"
 
 # Endpoint used for service to daemon communication.

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "bubba-node-000"
 
 # Endpoint used for service to daemon communication.

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "Node-123"
 
 # Endpoint used for service to daemon communication.

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "012"
 
 # Endpoint used for service to daemon communication.

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "012"
 
 # Endpoint used for service to daemon communication.

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# Config file format version
+version = "1"
+
 node_id = "345"
 
 # Endpoint used for service to daemon communication.

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -25,6 +25,7 @@ pub enum ConfigError {
     TomlParseError(TomlError),
     InvalidArgument(clap::Error),
     MissingValue(String),
+    InvalidVersion(String),
 }
 
 impl From<TomlError> for ConfigError {
@@ -46,6 +47,7 @@ impl Error for ConfigError {
             ConfigError::TomlParseError(source) => Some(source),
             ConfigError::InvalidArgument(source) => Some(source),
             ConfigError::MissingValue(_) => None,
+            ConfigError::InvalidVersion(_) => None,
         }
     }
 }
@@ -59,6 +61,7 @@ impl fmt::Display for ConfigError {
                 write!(f, "Unable to parse command line argument: {}", source)
             }
             ConfigError::MissingValue(msg) => write!(f, "Configuration value must be set: {}", msg),
+            ConfigError::InvalidVersion(msg) => write!(f, "{}", msg),
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -599,8 +599,8 @@ mod tests {
     /// asserting each expected value.
     fn test_final_config_precedence() {
         // Set the environment variables to populate the EnvPartialConfigBuilder object.
-        env::set_var("SPLINTER_STATE_DIR", "/state/test/config/");
-        env::set_var("SPLINTER_CERT_DIR", "/cert/test/config/");
+        env::set_var("SPLINTER_STATE_DIR", "state/test/config");
+        env::set_var("SPLINTER_CERT_DIR", "cert/test/config");
         // Create a new ConfigBuilder object.
         let builder = ConfigBuilder::new();
         // Arguments to be used to create a ClapPartialConfigBuilder object.
@@ -672,7 +672,7 @@ mod tests {
         // Environment).
         assert_eq!(
             (final_config.cert_dir(), final_config.cert_dir_source()),
-            ("/cert/test/config/", &ConfigSource::Environment)
+            ("cert/test/config", &ConfigSource::Environment)
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
         // `ca_certs`, but the TomlPartialConfigBuilder value should have precedence (source should
@@ -837,7 +837,7 @@ mod tests {
         // be EnvVarConfig).
         assert_eq!(
             (final_config.state_dir(), final_config.state_dir_source()),
-            ("/state/test/config/", &ConfigSource::Environment)
+            ("state/test/config", &ConfigSource::Environment)
         );
     }
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -421,6 +421,7 @@ mod tests {
             ),
             ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
             ("display_name".to_string(), EXAMPLE_DISPLAY_NAME.to_string()),
+            ("version".to_string(), "1".to_string()),
         ];
 
         let mut config_values = Map::new();

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -19,6 +19,8 @@ use serde_derive::Deserialize;
 
 use toml;
 
+const TOML_VERSION: &str = "1";
+
 /// Holds configuration values defined in a toml file. This struct must be
 /// treated as part of the external API of splinter because changes here
 /// will impact the valid format of the config file.
@@ -44,6 +46,7 @@ struct TomlConfig {
     registries: Option<Vec<String>>,
     heartbeat_interval: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
+    version: Option<String>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -68,6 +71,21 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 file: String::from(""),
             },
         };
+
+        if let Some(version) = self.toml_config.version {
+            if version != TOML_VERSION {
+                let file_path = match &source {
+                    ConfigSource::Toml { file } => file.clone(),
+                    _ => String::from(""),
+                };
+                return Err(ConfigError::InvalidVersion(format!(
+                    "Config file {} has incompatible version {}, supported version is {}",
+                    file_path, version, TOML_VERSION,
+                )));
+            }
+        } else {
+            return Err(ConfigError::MissingValue(format!("{:?} version", &source)));
+        }
 
         let mut partial_config = PartialConfig::new(source);
 
@@ -139,6 +157,7 @@ mod tests {
             ),
             ("node_id".to_string(), EXAMPLE_NODE_ID.to_string()),
             ("display_name".to_string(), EXAMPLE_DISPLAY_NAME.to_string()),
+            ("version".to_string(), TOML_VERSION.to_string()),
         ];
 
         let mut config_values = Map::new();


### PR DESCRIPTION
Adds a required `version` field to all config objects and verifies that each config object added to the final `ConfigBuilder` object has the correct version. 

This also updates the gameroom example to conform with this change. 