### PR TITLE
Remove --transport option from splinterd

### DIFF
--- a/docker/kubernetes/arcade.yaml
+++ b/docker/kubernetes/arcade.yaml
@@ -125,11 +125,10 @@ items:
                 splinterd -vv \
                 --registry file:///etc/splinter/nodes.yaml \
                 --bind $HOSTNAME:8085 \
-                --network-endpoint $HOSTNAME:8044 \
+                --network-endpoint tcps://$HOSTNAME:8044 \
                 --node-id acme \
-                --service-endpoint $HOSTNAME:8043 \
+                --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \
-                --transport tls \
                 --insecure
             volumeMounts:
               - name: node-registry-volume
@@ -298,11 +297,10 @@ items:
                 splinterd -vv \
                 --registry file:///etc/splinter/nodes.yaml \
                 --bind $HOSTNAME:8085 \
-                --network-endpoint $HOSTNAME:8044 \
+                --network-endpoint tcps://$HOSTNAME:8044 \
                 --node-id bubba \
-                --service-endpoint $HOSTNAME:8043 \
+                --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \
-                --transport tls \
                 --insecure
             volumeMounts:
               - name: node-registry-volume

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -117,8 +117,8 @@ services:
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
-              --service-endpoint 0.0.0.0:8043 \
-              --network-endpoint 0.0.0.0:8044 \
+              --service-endpoint tcp://0.0.0.0:8043 \
+              --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --insecure
         "
@@ -203,8 +203,8 @@ services:
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
-              --service-endpoint 0.0.0.0:8043 \
-              --network-endpoint 0.0.0.0:8044 \
+              --service-endpoint tcp://0.0.0.0:8043 \
+              --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --insecure
         "

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -147,8 +147,8 @@ services:
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
-              --service-endpoint 0.0.0.0:8043 \
-              --network-endpoint 0.0.0.0:8044 \
+              --service-endpoint tcp://0.0.0.0:8043 \
+              --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --insecure
         "
@@ -257,8 +257,8 @@ services:
           cp -a /key_registry_shared/keys.yaml /var/lib/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
-              --service-endpoint 0.0.0.0:8043 \
-              --network-endpoint 0.0.0.0:8044 \
+              --service-endpoint tcp://0.0.0.0:8043 \
+              --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --insecure
         "

--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -19,7 +19,7 @@ node_id = "acme-node-000"
 service_endpoint = "127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
-network_endpoints = ["127.0.0.1:8044"]
+network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.
@@ -28,9 +28,6 @@ peers = []
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory"
 storage = "yaml"
-
-# Which transport type this splinterd node supports. Options are "raw" or "tls"
-transport = "tls"
 
 # Rest api address.
 bind = "localhost:8085"

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -19,7 +19,7 @@ node_id = "bubba-node-000"
 service_endpoint = "127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
-network_endpoints = ["127.0.0.1:8044"]
+network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/examples/private_counter/docker-compose.yaml
+++ b/examples/private_counter/docker-compose.yaml
@@ -32,12 +32,12 @@ services:
     command: >
       bash -c "
         splinterd -vv \
-                --transport raw \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8043 \
                 --network-endpoint 0.0.0.0:8044 \
                 --node-id 012 \
-                --registry file:///node_registry/nodes.yaml
+                --registry file:///node_registry/nodes.yaml \
+                --no-tls
       "
     environment:
       SPLINTER_STATE_DIR: /splinter_state/
@@ -58,12 +58,12 @@ services:
     command: >
       bash -c "
         splinterd -vv \
-                --transport raw \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8045 \
                 --network-endpoint 0.0.0.0:8046 \
                 --node-id 345 \
-                --registry file:///node_registry/nodes.yaml
+                --registry file:///node_registry/nodes.yaml \
+                --no-tls
       "
     environment:
       SPLINTER_STATE_DIR: /splinter_state/
@@ -84,12 +84,12 @@ services:
     command: >
       bash -c "
         splinterd -vv \
-                --transport raw \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8047 \
                 --network-endpoint 0.0.0.0:8048 \
                 --node-id 678 \
-                --registry file:///node_registry/nodes.yaml
+                --registry file:///node_registry/nodes.yaml \
+                --no-tls
       "
     environment:
       SPLINTER_STATE_DIR: /splinter_state/

--- a/examples/private_xo/docker-compose.yaml
+++ b/examples/private_xo/docker-compose.yaml
@@ -32,12 +32,12 @@ services:
     command: >
       bash -c "
         splinterd -vv \
-                --transport raw \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8043 \
                 --network-endpoint 0.0.0.0:8044 \
                 --node-id 012 \
-                --registries file:///node_registry/nodes.yaml
+                --registry file:///node_registry/nodes.yaml \
+                --no-tls
       "
     environment:
       SPLINTER_STATE_DIR: /splinter_state/
@@ -58,12 +58,12 @@ services:
     command: >
       bash -c "
         splinterd -vv \
-                --transport raw \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8045 \
                 --network-endpoint 0.0.0.0:8046 \
                 --node-id 345 \
-                --registries file:///node_registry/nodes.yaml
+                --registry file:///node_registry/nodes.yaml \
+                --no-tls
       "
     environment:
       SPLINTER_STATE_DIR: /splinter_state/

--- a/libsplinter/src/biome/credentials/store/error.rs
+++ b/libsplinter/src/biome/credentials/store/error.rs
@@ -155,7 +155,7 @@ impl fmt::Display for CredentialsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CredentialsError::VerificationError(ref s) => {
-                write!(f, "failed to build verify password: {}", s)
+                write!(f, "failed to verify password: {}", s)
             }
         }
     }

--- a/libsplinter/src/biome/credentials/store/mod.rs
+++ b/libsplinter/src/biome/credentials/store/mod.rs
@@ -246,7 +246,7 @@ impl Into<NewCredentialsModel> for Credentials {
     }
 }
 
-/// Cost to encrypt password. The recommneded value is HIGH. Values LOW and MEDIUM may be used for
+/// Cost to encrypt password. The recommended value is HIGH. Values LOW and MEDIUM may be used for
 /// development and testing as hashing and verifying passwords will be completed faster.
 #[derive(Debug, Deserialize, Clone)]
 pub enum PasswordEncryptionCost {

--- a/libsplinter/src/transport/inproc.rs
+++ b/libsplinter/src/transport/inproc.rs
@@ -62,7 +62,7 @@ impl Transport for InprocTransport {
             }
             None => Err(ConnectError::IoError(io::Error::new(
                 ErrorKind::ConnectionRefused,
-                "No Listener",
+                format!("No InprocListener for {}", endpoint),
             ))),
         }
     }

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -16,9 +16,11 @@
 node_id = "acme-node-000"
 
 # Endpoint used for service to daemon communication
-service_endpoint = "tcps://localhost:8043"
+service_endpoint = "tcp://localhost:8043"
 
-# Endpoints used for daemon to daemon communication
+# Endpoints used for daemon to daemon communication. Transport type is
+# determined by the protocol prefix. Use tcp:// for TCP connections and tcps://
+# for TLS connections
 network_endpoints = ["tcps://localhost:8044"]
 
 # A comma separated list of splinter nodes the daemon will automatically
@@ -35,9 +37,6 @@ bind = "localhost:8085"
 
 # Node Registry file
 registries = ["file:///etc/splinter/nodes.yaml"]
-
-# Which transport type this splinter node supports. Options are "raw" or "tls"
-transport = "tls"
 
 # List of certificate authority certificates (*.pem files).
 ca_certs = "/etc/splinter/certs/ca.pem"

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -19,7 +19,7 @@ node_id = "012"
 service_endpoint = "127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
-network_endpoints = ["127.0.0.1:8044"]
+network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.
@@ -28,9 +28,6 @@ peers = []
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory"
 storage = "memory"
-
-# Which transport type this splinterd node supports. Options are "raw" or "tls"
-transport = "tls"
 
 # Rest api address.
 bind = "0.0.0.0:8080"

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -19,7 +19,7 @@ node_id = "012"
 service_endpoint = "127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
-network_endpoints = ["127.0.0.1:8044"]
+network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.
@@ -28,9 +28,6 @@ peers = []
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory"
 storage = "yaml"
-
-# Which transport type this splinterd node supports. Options are "raw" or "tls"
-transport = "tls"
 
 # List of certificate authority certificates (*.pem files).
 ca_certs = "certs/ca.pem"

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -19,7 +19,7 @@ node_id = "345"
 service_endpoint = "127.0.0.1:8045"
 
 # Endpoints used for daemon to daemon communication.
-network_endpoints = ["127.0.0.1:8046"]
+network_endpoints = ["tcps://127.0.0.1:8046"]
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.
@@ -30,9 +30,6 @@ peers = [
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory"
 storage = "yaml"
-
-# Which transport type this splinterd node supports. Options are "raw" or "tls"
-transport = "tls"
 
 # List of certificate authority certificates (*.pem files).
 ca_certs = "certs/ca.pem"

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -149,14 +149,6 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("storage".to_string()))?,
-            transport: self
-                .partial_configs
-                .iter()
-                .find_map(|p| match p.transport() {
-                    Some(v) => Some((v, p.source())),
-                    None => None,
-                })
-                .ok_or_else(|| ConfigError::MissingValue("transport".to_string()))?,
             cert_dir,
             ca_certs,
             client_cert,
@@ -271,6 +263,14 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("insecure".to_string()))?,
+            no_tls: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.no_tls() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                })
+                .ok_or_else(|| ConfigError::MissingValue("no tls".to_string()))?,
             #[cfg(feature = "biome")]
             biome_enabled: self
                 .partial_configs
@@ -290,7 +290,6 @@ mod tests {
 
     /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
-    static EXAMPLE_TRANSPORT: &str = "tls";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
@@ -305,7 +304,6 @@ mod tests {
     /// Asserts the example configuration values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
-        assert_eq!(config.transport(), Some(EXAMPLE_TRANSPORT.to_string()));
         assert_eq!(config.cert_dir(), None);
         assert_eq!(config.ca_certs(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(config.client_cert(), Some(EXAMPLE_CLIENT_CERT.to_string()));
@@ -353,7 +351,6 @@ mod tests {
         // Populate the PartialConfig fields by chaining the builder methods.
         partial_config = partial_config
             .with_storage(Some(EXAMPLE_STORAGE.to_string()))
-            .with_transport(Some(EXAMPLE_TRANSPORT.to_string()))
             .with_cert_dir(None)
             .with_ca_certs(Some(EXAMPLE_CA_CERTS.to_string()))
             .with_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()))
@@ -389,7 +386,6 @@ mod tests {
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the PartialConfig fields by separately applying the builder methods.
         partial_config = partial_config.with_storage(Some(EXAMPLE_STORAGE.to_string()));
-        partial_config = partial_config.with_transport(Some(EXAMPLE_TRANSPORT.to_string()));
         partial_config = partial_config.with_ca_certs(Some(EXAMPLE_CA_CERTS.to_string()));
         partial_config = partial_config.with_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()));
         partial_config = partial_config.with_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()));

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -42,7 +42,6 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
 
         partial_config = partial_config
             .with_storage(self.matches.value_of("storage").map(String::from))
-            .with_transport(self.matches.value_of("transport").map(String::from))
             .with_cert_dir(self.matches.value_of("cert_dir").map(String::from))
             .with_ca_certs(self.matches.value_of("ca_file").map(String::from))
             .with_client_cert(self.matches.value_of("client_cert").map(String::from))
@@ -78,6 +77,11 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 Some(true)
             } else {
                 None
+            })
+            .with_no_tls(if self.matches.is_present("no_tls") {
+                Some(true)
+            } else {
+                None
             });
 
         #[cfg(feature = "biome")]
@@ -107,7 +111,6 @@ mod tests {
 
     /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
-    static EXAMPLE_TRANSPORT: &str = "tls";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
@@ -122,7 +125,6 @@ mod tests {
     /// Asserts config values based on the example values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
-        assert_eq!(config.transport(), Some(EXAMPLE_TRANSPORT.to_string()));
         assert_eq!(config.cert_dir(), None);
         assert_eq!(config.ca_certs(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(config.client_cert(), Some(EXAMPLE_CLIENT_CERT.to_string()));
@@ -154,6 +156,7 @@ mod tests {
         assert_eq!(config.heartbeat_interval(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
         assert_eq!(config.insecure(), Some(true));
+        assert_eq!(config.no_tls(), Some(true));
     }
 
     /// Creates an ArgMatches object to be used to construct a ClapPartialConfigBuilder object.
@@ -165,7 +168,6 @@ mod tests {
             (@arg node_id: --("node-id") +takes_value)
             (@arg display_name: --("display-name") +takes_value)
             (@arg storage: --("storage") +takes_value)
-            (@arg transport: --("transport") +takes_value)
             (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
             (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
@@ -177,7 +179,8 @@ mod tests {
             (@arg server_key:  --("server-key") +takes_value)
             (@arg client_key:  --("client-key") +takes_value)
             (@arg bind: --("bind") +takes_value)
-            (@arg insecure: --("insecure")))
+            (@arg insecure: --("insecure"))
+            (@arg no_tls: --("no-tls")))
         .get_matches_from(args)
     }
 
@@ -202,8 +205,6 @@ mod tests {
             EXAMPLE_DISPLAY_NAME,
             "--storage",
             EXAMPLE_STORAGE,
-            "--transport",
-            EXAMPLE_TRANSPORT,
             "--network-endpoint",
             EXAMPLE_NETWORK_ENDPOINT,
             "--advertised-endpoint",
@@ -221,6 +222,7 @@ mod tests {
             "--server-key",
             EXAMPLE_SERVER_KEY,
             "--insecure",
+            "--no-tls",
         ];
         // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
         let matches = create_arg_matches(args);

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -40,7 +40,6 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
 
         partial_config = partial_config
             .with_storage(Some(String::from("yaml")))
-            .with_transport(Some(String::from("raw")))
             .with_cert_dir(Some(String::from(DEFAULT_CERT_DIR)))
             .with_ca_certs(Some(String::from(CA_PEM)))
             .with_client_cert(Some(String::from(CLIENT_CERT)))
@@ -59,7 +58,8 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS,
             ))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
-            .with_insecure(Some(false));
+            .with_insecure(Some(false))
+            .with_no_tls(Some(false));
 
         #[cfg(feature = "biome")]
         {
@@ -84,7 +84,6 @@ mod tests {
     /// Asserts config values based on the default values.
     fn assert_default_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(String::from("yaml")));
-        assert_eq!(config.transport(), Some(String::from("raw")));
         assert_eq!(config.cert_dir(), Some(String::from(DEFAULT_CERT_DIR)));
         assert_eq!(config.ca_certs(), Some(String::from(CA_PEM)));
         assert_eq!(config.client_cert(), Some(String::from(CLIENT_CERT)));
@@ -116,6 +115,7 @@ mod tests {
         );
         assert_eq!(config.state_dir(), Some(String::from(DEFAULT_STATE_DIR)));
         assert_eq!(config.insecure(), Some(false));
+        assert_eq!(config.no_tls(), Some(false));
         #[cfg(feature = "biome")]
         assert_eq!(config.biome_enabled(), Some(false));
         // Assert the source is correctly identified for this PartialConfig object.

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -31,7 +31,6 @@ pub enum ConfigSource {
 pub struct PartialConfig {
     source: ConfigSource,
     storage: Option<String>,
-    transport: Option<String>,
     cert_dir: Option<String>,
     ca_certs: Option<String>,
     client_cert: Option<String>,
@@ -52,6 +51,7 @@ pub struct PartialConfig {
     admin_service_coordinator_timeout: Option<Duration>,
     state_dir: Option<String>,
     insecure: Option<bool>,
+    no_tls: Option<bool>,
     #[cfg(feature = "biome")]
     biome_enabled: Option<bool>,
 }
@@ -62,7 +62,6 @@ impl PartialConfig {
         PartialConfig {
             source,
             storage: None,
-            transport: None,
             cert_dir: None,
             ca_certs: None,
             client_cert: None,
@@ -83,6 +82,7 @@ impl PartialConfig {
             admin_service_coordinator_timeout: None,
             state_dir: None,
             insecure: None,
+            no_tls: None,
             #[cfg(feature = "biome")]
             biome_enabled: None,
         }
@@ -94,10 +94,6 @@ impl PartialConfig {
 
     pub fn storage(&self) -> Option<String> {
         self.storage.clone()
-    }
-
-    pub fn transport(&self) -> Option<String> {
-        self.transport.clone()
     }
 
     pub fn cert_dir(&self) -> Option<String> {
@@ -177,6 +173,10 @@ impl PartialConfig {
         self.insecure
     }
 
+    pub fn no_tls(&self) -> Option<bool> {
+        self.no_tls
+    }
+
     #[cfg(feature = "biome")]
     pub fn biome_enabled(&self) -> Option<bool> {
         self.biome_enabled
@@ -191,18 +191,6 @@ impl PartialConfig {
     ///
     pub fn with_storage(mut self, storage: Option<String>) -> Self {
         self.storage = storage;
-        self
-    }
-
-    #[allow(dead_code)]
-    /// Adds a `transport` value to the PartialConfig object.
-    ///
-    /// # Arguments
-    ///
-    /// * `transport` -  Which transport type this splinterd node supports.
-    ///
-    pub fn with_transport(mut self, transport: Option<String>) -> Self {
-        self.transport = transport;
         self
     }
 
@@ -438,6 +426,18 @@ impl PartialConfig {
     ///
     pub fn with_insecure(mut self, insecure: Option<bool>) -> Self {
         self.insecure = insecure;
+        self
+    }
+
+    #[allow(dead_code)]
+    /// Adds a `no-tls` value to the PartialConfig object.
+    ///
+    /// # Arguments
+    ///
+    /// * `no-tls` - Do not configure TLS Transport
+    ///
+    pub fn with_no_tls(mut self, no_tls: Option<bool>) -> Self {
+        self.no_tls = no_tls;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -25,7 +25,6 @@ use toml;
 #[derive(Deserialize, Default, Debug)]
 struct TomlConfig {
     storage: Option<String>,
-    transport: Option<String>,
     cert_dir: Option<String>,
     ca_certs: Option<String>,
     client_cert: Option<String>,
@@ -73,7 +72,6 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
 
         partial_config = partial_config
             .with_storage(self.toml_config.storage)
-            .with_transport(self.toml_config.transport)
             .with_cert_dir(self.toml_config.cert_dir)
             .with_ca_certs(self.toml_config.ca_certs)
             .with_client_cert(self.toml_config.client_cert)
@@ -113,7 +111,6 @@ mod tests {
 
     /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
-    static EXAMPLE_TRANSPORT: &str = "tls";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
@@ -127,7 +124,6 @@ mod tests {
     fn get_toml_value() -> Value {
         let values = vec![
             ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
-            ("transport".to_string(), EXAMPLE_TRANSPORT.to_string()),
             ("ca_certs".to_string(), EXAMPLE_CA_CERTS.to_string()),
             ("client_cert".to_string(), EXAMPLE_CLIENT_CERT.to_string()),
             ("client_key".to_string(), EXAMPLE_CLIENT_KEY.to_string()),
@@ -151,7 +147,6 @@ mod tests {
     /// Asserts config values based on the example configuration values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
-        assert_eq!(config.transport(), Some(EXAMPLE_TRANSPORT.to_string()));
         assert_eq!(config.cert_dir(), None);
         assert_eq!(config.ca_certs(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(config.client_cert(), Some(EXAMPLE_CLIENT_CERT.to_string()));

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -110,7 +110,6 @@ impl From<ConfigError> for UserError {
 #[derive(Debug)]
 pub enum GetTransportError {
     CertError(String),
-    NotSupportedError(String),
     TlsTransportError(TlsInitError),
     IoError(io::Error),
 }
@@ -119,7 +118,6 @@ impl Error for GetTransportError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             GetTransportError::CertError(_) => None,
-            GetTransportError::NotSupportedError(_) => None,
             GetTransportError::TlsTransportError(err) => Some(err),
             GetTransportError::IoError(err) => Some(err),
         }
@@ -131,9 +129,6 @@ impl fmt::Display for GetTransportError {
         match self {
             GetTransportError::CertError(msg) => {
                 write!(f, "unable to retrieve certificate: {}", msg)
-            }
-            GetTransportError::NotSupportedError(msg) => {
-                write!(f, "received transport type that is not supported: {}", msg)
             }
             GetTransportError::TlsTransportError(err) => {
                 write!(f, "unable to create TLS transport: {}", err)

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -50,7 +50,7 @@ use std::path::Path;
 use std::thread;
 
 use error::UserError;
-use transport::get_transport;
+use transport::build_transport;
 
 fn create_config(_toml_path: Option<&str>, _matches: ArgMatches) -> Result<Config, UserError> {
     #[cfg(feature = "default")]
@@ -124,10 +124,8 @@ fn main() {
           "Human-readable name for the node")
         (@arg storage: --("storage") +takes_value
           "Storage type used for the node; defaults to yaml")
-        (@arg transport: --("transport") +takes_value
-          "Transport type for sockets, either raw or tls")
         (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple
-          "Endpoints to connect to the network, tcp://ip:port")
+          "Endpoints to connect to the network, protocol-prefix://ip:port")
         (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple
           "Publicly-visible network endpoints")
         (@arg service_endpoint: --("service-endpoint") +takes_value
@@ -148,6 +146,7 @@ fn main() {
           "File path to the key for the node when connecting to a node as client")
         (@arg insecure:  --("insecure")
           "If set to tls, should accept all peer certificates")
+        (@arg no_tls:  --("no-tls") "Turn off tls configuration")
         (@arg bind: --("bind") +takes_value
           "Connection endpoint for REST API")
         (@arg registries: --("registry") +takes_value +multiple "Read-only node registries")
@@ -232,7 +231,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     let config = create_config(config_file_path, matches.clone())?;
 
-    let transport = get_transport(&config)?;
+    let transport = build_transport(&config)?;
 
     let state_dir = Path::new(config.state_dir());
 

--- a/splinterd/src/transport.rs
+++ b/splinterd/src/transport.rs
@@ -15,6 +15,8 @@
 use std::fs;
 use std::path::Path;
 
+use splinter::transport::inproc::InprocTransport;
+use splinter::transport::multi::MultiTransport;
 use splinter::transport::socket::TcpTransport;
 use splinter::transport::socket::TlsTransport;
 #[cfg(feature = "ws-transport")]
@@ -24,102 +26,113 @@ use splinter::transport::Transport;
 use crate::config::Config;
 use crate::error::GetTransportError;
 
-pub fn get_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTransportError> {
-    match config.transport() {
-        "tls" => {
-            let client_cert = config.client_cert();
-            if !Path::new(&client_cert).is_file() {
-                return Err(GetTransportError::CertError(format!(
-                    "Must provide a valid client certificate: {}",
-                    client_cert
-                )));
-            }
-            debug!(
-                "Using client certificate file: {:?}",
-                fs::canonicalize(&client_cert)?
-            );
+type SendableTransport = Box<dyn Transport + Send>;
 
-            let server_cert = config.server_cert();
-            if !Path::new(&server_cert).is_file() {
-                return Err(GetTransportError::CertError(format!(
-                    "Must provide a valid server certificate: {}",
-                    server_cert
-                )));
-            }
-            debug!(
-                "Using server certificate file: {:?}",
-                fs::canonicalize(&server_cert)?
-            );
+pub fn build_transport(config: &Config) -> Result<MultiTransport, GetTransportError> {
+    let mut transports: Vec<SendableTransport> = vec![];
 
-            let server_key_file = config.server_key();
-            if !Path::new(&server_key_file).is_file() {
-                return Err(GetTransportError::CertError(format!(
-                    "Must provide a valid server key path: {}",
-                    server_key_file
-                )));
-            }
-            debug!(
-                "Using server key file: {:?}",
-                fs::canonicalize(&server_key_file)?
-            );
+    // add tcp transport
+    // this will be default for endpoints without a prefix
+    transports.push(Box::new(TcpTransport::default()));
 
-            let client_key_file = config.client_key();
-            if !Path::new(&client_key_file).is_file() {
-                return Err(GetTransportError::CertError(format!(
-                    "Must provide a valid client key path: {}",
-                    client_key_file
-                )));
-            }
-            debug!(
-                "Using client key file: {:?}",
-                fs::canonicalize(&client_key_file)?
-            );
+    // add inproc transpoort
+    transports.push(Box::new(InprocTransport::default()));
 
-            let insecure = config.insecure();
-            if insecure {
-                warn!("Starting TlsTransport in insecure mode");
-            }
-            let ca_file = {
-                if insecure {
-                    None
-                } else {
-                    let ca_file = config.ca_certs();
-                    if !Path::new(&ca_file).is_file() {
-                        return Err(GetTransportError::CertError(format!(
-                            "Must provide a valid file containing ca certs: {}",
-                            ca_file
-                        )));
-                    }
-                    match fs::canonicalize(&ca_file)?.to_str() {
-                        Some(ca_path) => {
-                            debug!("Using ca certs file: {:?}", ca_path);
-                            Some(ca_path.to_string())
-                        }
-                        None => {
-                            return Err(GetTransportError::CertError(
-                                "CA path is not a valid path".to_string(),
-                            ))
-                        }
-                    }
-                }
-            };
+    // add web socket transport
+    #[cfg(feature = "ws-transport")]
+    transports.push(Box::new(WsTransport::default()));
 
-            let transport = TlsTransport::new(
-                ca_file.map(String::from),
-                String::from(client_key_file),
-                String::from(client_cert),
-                String::from(server_key_file),
-                String::from(server_cert),
-            )?;
-
-            Ok(Box::new(transport))
-        }
-        "raw" => Ok(Box::new(TcpTransport::default())),
-        #[cfg(feature = "ws-transport")]
-        "ws" => Ok(Box::new(WsTransport::default())),
-        _ => Err(GetTransportError::NotSupportedError(format!(
-            "Transport type {} is not supported",
-            config.transport()
-        ))),
+    // add tls transport
+    if !config.no_tls() {
+        transports.push(build_tls_transport(config)?)
     }
+
+    Ok(MultiTransport::new(transports))
+}
+
+fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTransportError> {
+    let client_cert = config.client_cert();
+    if !Path::new(&client_cert).is_file() {
+        return Err(GetTransportError::CertError(format!(
+            "Must provide a valid client certificate: {}",
+            client_cert
+        )));
+    }
+    debug!(
+        "Using client certificate file: {:?}",
+        fs::canonicalize(&client_cert)?
+    );
+
+    let server_cert = config.server_cert();
+    if !Path::new(&server_cert).is_file() {
+        return Err(GetTransportError::CertError(format!(
+            "Must provide a valid server certificate: {}",
+            server_cert
+        )));
+    }
+    debug!(
+        "Using server certificate file: {:?}",
+        fs::canonicalize(&server_cert)?
+    );
+
+    let server_key_file = config.server_key();
+    if !Path::new(&server_key_file).is_file() {
+        return Err(GetTransportError::CertError(format!(
+            "Must provide a valid server key path: {}",
+            server_key_file
+        )));
+    }
+    debug!(
+        "Using server key file: {:?}",
+        fs::canonicalize(&server_key_file)?
+    );
+
+    let client_key_file = config.client_key();
+    if !Path::new(&client_key_file).is_file() {
+        return Err(GetTransportError::CertError(format!(
+            "Must provide a valid client key path: {}",
+            client_key_file
+        )));
+    }
+    debug!(
+        "Using client key file: {:?}",
+        fs::canonicalize(&client_key_file)?
+    );
+
+    let insecure = config.insecure();
+    if insecure {
+        warn!("Starting TlsTransport in insecure mode");
+    }
+    let ca_file = {
+        if insecure {
+            None
+        } else {
+            let ca_file = config.ca_certs();
+            if !Path::new(&ca_file).is_file() {
+                return Err(GetTransportError::CertError(format!(
+                    "Must provide a valid file containing ca certs: {}",
+                    ca_file
+                )));
+            }
+            match fs::canonicalize(&ca_file)?.to_str() {
+                Some(ca_path) => {
+                    debug!("Using ca certs file: {:?}", ca_path);
+                    Some(ca_path.to_string())
+                }
+                None => {
+                    return Err(GetTransportError::CertError(
+                        "CA path is not a valid path".to_string(),
+                    ))
+                }
+            }
+        }
+    };
+
+    Ok(Box::new(TlsTransport::new(
+        ca_file.map(String::from),
+        String::from(client_key_file),
+        String::from(client_cert),
+        String::from(server_key_file),
+        String::from(server_cert),
+    )?))
 }


### PR DESCRIPTION
This commit remove the --transport option from splinterd.

Splinterd will now create a MultiTransport with all configured
transports added. Connections and listeners created is now based
on the protocol prefix in the endpoint.

For example tcps://ip:port will set up TLS listener and
tcp://ip:port will set up a TCP listener.

Splinterd will try to include a TLS listener by default. If the
certificates and keys are not available splinterd will error. To
turn TLS off, a new flag has been added --no-tls.

If a protocol prefix is not provided with the endpoint it will default
to TCP.

This commit also renames ADMIN_SERVICE_ADDRESS to INTERNAL_SERVICE_ADDRESS
to more accurately describe the connection being created.

Also fixes a bug where the health service would never be created because
it was placed after the main_loop.join.