### PR TITLE
Fix missed column rename in gameroom migration

### DIFF
--- a/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/down.sql
+++ b/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/down.sql
@@ -17,3 +17,4 @@ ALTER TABLE gameroom_member ALTER COLUMN endpoints DROP DEFAULT;
 ALTER TABLE gameroom_member ALTER COLUMN endpoints
   TYPE TEXT USING coalesce(endpoints[1],'');
 ALTER TABLE gameroom_member ALTER COLUMN endpoints SET DEFAULT '';
+ALTER TABLE gameroom_member RENAME COLUMN endpoints TO endpoint;

--- a/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/up.sql
+++ b/examples/gameroom/database/migrations/2020-04-13-202220_multiple_endpoints/up.sql
@@ -13,6 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
+ALTER TABLE gameroom_member RENAME COLUMN endpoint TO endpoints;
 ALTER TABLE gameroom_member ALTER COLUMN endpoints DROP DEFAULT;
 ALTER TABLE gameroom_member ALTER COLUMN endpoints
   TYPE TEXT[] USING array[endpoints];


### PR DESCRIPTION
Updates the gameroom database migration for changing member `endpoint`
column to `endpoints` to actually change the name of the column; this
was overlooked in the original PR.

Signed-off-by: Logan Seeley <seeley@bitwise.io>