### PR TITLE
Update default for advertised_endpoints config

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -138,6 +138,14 @@ impl ConfigBuilder {
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("server key".to_string()))?;
+        let network_endpoints = self
+            .partial_configs
+            .iter()
+            .find_map(|p| match p.network_endpoints() {
+                Some(v) => Some((v, p.source())),
+                None => None,
+            })
+            .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?;
         // Iterates over the list of PartialConfig objects to find the first config with a value
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
@@ -171,14 +179,6 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("service endpoint".to_string()))?,
-            network_endpoints: self
-                .partial_configs
-                .iter()
-                .find_map(|p| match p.network_endpoints() {
-                    Some(v) => Some((v, p.source())),
-                    None => None,
-                })
-                .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?,
             advertised_endpoints: self
                 .partial_configs
                 .iter()
@@ -186,7 +186,9 @@ impl ConfigBuilder {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
-                .ok_or_else(|| ConfigError::MissingValue("advertised endpoints".to_string()))?,
+                // Default to whatever `network_endpoints` is set to
+                .unwrap_or((network_endpoints.0.clone(), ConfigSource::Default)),
+            network_endpoints,
             peers: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -49,7 +49,6 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_server_key(Some(String::from(SERVER_KEY)))
             .with_service_endpoint(Some(String::from("127.0.0.1:8043")))
             .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
-            .with_advertised_endpoints(Some(vec![]))
             .with_peers(Some(vec![]))
             .with_display_name(Some(String::new()))
             .with_bind(Some(String::from("127.0.0.1:8080")))
@@ -99,7 +98,6 @@ mod tests {
             config.network_endpoints(),
             Some(vec![String::from("127.0.0.1:8044")])
         );
-        assert_eq!(config.advertised_endpoints(), Some(vec![]));
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);
         assert_eq!(config.display_name(), Some(String::new()));

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -767,14 +767,16 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for
-        // `advertised_endpoints` (source should be Default).
+        // `advertised_endpoints` defaults to `network_endpoints` (source should be Default).
         assert_eq!(
             (
                 final_config.advertised_endpoints(),
                 final_config.advertised_endpoints_source()
             ),
-            (&[] as &[String], &ConfigSource::Default,)
+            (
+                &[EXAMPLE_NETWORK_ENDPOINT.to_string()] as &[String],
+                &ConfigSource::Default,
+            )
         );
         // The DefaultPartialConfigBuilder is the only config with a value for `peers` (source
         // should be Default).


### PR DESCRIPTION
Updates the `advertised_endpoints` config for splinterd to default to
the value of `network_endpoints` if no value is provided. This is
preferable to defaulting to an empty list, because the intent of
`advertised_endpoints` is to mirror the network endpoints except in the
case that the endpoints visible to other daemons is different from what
splinterd binds to.

Signed-off-by: Logan Seeley <seeley@bitwise.io>