### PR TITLE
Remove biome-refresh-tokens feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -95,7 +95,6 @@ experimental = [
     "stable",
     # The following features are experimental:
     "biome-notifications",
-    "biome-refresh-tokens",
     "biome-user",
     "circuit-template",
     "connection-manager",
@@ -115,7 +114,6 @@ biome = []
 biome-credentials = ["biome", "biome-user", "bcrypt"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
-biome-refresh-tokens = []
 biome-user = ["biome"]
 circuit-template = []
 connection-manager = ["matrix"]

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -36,7 +36,7 @@ pub mod migrations;
 #[cfg(feature = "biome-notifications")]
 pub mod notifications;
 
-#[cfg(feature = "biome-refresh-tokens")]
+#[cfg(feature = "biome-credentials")]
 pub mod refresh_tokens;
 
 #[cfg(feature = "rest-api")]
@@ -47,7 +47,7 @@ mod user;
 pub use credentials::store::{diesel::DieselCredentialsStore, memory::MemoryCredentialsStore};
 #[cfg(all(feature = "biome-key-management", feature = "diesel"))]
 pub use key_management::store::{diesel::DieselKeyStore, memory::MemoryKeyStore};
-#[cfg(all(feature = "biome-refresh-tokens", feature = "diesel"))]
+#[cfg(all(feature = "biome-credentials", feature = "diesel"))]
 pub use refresh_tokens::store::{diesel::DieselRefreshTokenStore, memory::MemoryRefreshTokenStore};
 #[cfg(feature = "diesel")]
 pub use user::store::{diesel::DieselUserStore, memory::MemoryUserStore};

--- a/libsplinter/src/biome/rest_api/actix/login.rs
+++ b/libsplinter/src/biome/rest_api/actix/login.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
-#[cfg(feature = "biome-refresh-tokens")]
 use crate::biome::refresh_tokens::store::RefreshTokenStore;
 use crate::futures::{Future, IntoFuture};
 use crate::protocol;
@@ -35,7 +34,7 @@ use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
 ///   }
 pub fn make_login_route(
     credentials_store: Arc<dyn CredentialsStore>,
-    #[cfg(feature = "biome-refresh-tokens")] refresh_token_store: Arc<dyn RefreshTokenStore>,
+    refresh_token_store: Arc<dyn RefreshTokenStore>,
     rest_config: Arc<BiomeRestConfig>,
     token_issuer: Arc<AccessTokenIssuer>,
 ) -> Resource {
@@ -48,7 +47,6 @@ pub fn make_login_route(
             let credentials_store = credentials_store.clone();
             let rest_config = rest_config.clone();
             let token_issuer = token_issuer.clone();
-            #[cfg(feature = "biome-refresh-tokens")]
             let refresh_token_store = refresh_token_store.clone();
             Box::new(into_bytes(payload).and_then(move |bytes| {
                 let username_password = match serde_json::from_slice::<UsernamePassword>(&bytes) {
@@ -117,64 +115,50 @@ pub fn make_login_route(
                                 }
                             };
 
-                            #[cfg(feature = "biome-refresh-tokens")]
+                            let refresh_claims = match ClaimsBuilder::default()
+                                .with_user_id(&credentials.user_id)
+                                .with_issuer(&rest_config.issuer())
+                                .with_duration(rest_config.refresh_token_duration())
+                                .build()
                             {
-                                let refresh_claims = match ClaimsBuilder::default()
-                                    .with_user_id(&credentials.user_id)
-                                    .with_issuer(&rest_config.issuer())
-                                    .with_duration(rest_config.refresh_token_duration())
-                                    .build()
-                                {
-                                    Ok(claims) => claims,
-                                    Err(err) => {
-                                        debug!("Failed to build refresh claim {}", err);
-                                        return HttpResponse::InternalServerError()
-                                            .json(ErrorResponse::internal_error())
-                                            .into_future();
-                                    }
-                                };
-
-                                let refresh_token = match token_issuer
-                                    .issue_refresh_token_with_claims(refresh_claims)
-                                {
-                                    Ok(token) => token,
-                                    Err(err) => {
-                                        debug!("Failed to issue refresh token {}", err);
-                                        return HttpResponse::InternalServerError()
-                                            .json(ErrorResponse::internal_error())
-                                            .into_future();
-                                    }
-                                };
-
-                                if let Err(err) = refresh_token_store
-                                    .add_token(&credentials.user_id, &refresh_token)
-                                {
-                                    debug!("Failed to store refresh token {}", err);
+                                Ok(claims) => claims,
+                                Err(err) => {
+                                    debug!("Failed to build refresh claim {}", err);
                                     return HttpResponse::InternalServerError()
                                         .json(ErrorResponse::internal_error())
                                         .into_future();
                                 }
+                            };
 
-                                HttpResponse::Ok()
-                                    .json(json!({
-                                        "message": "Successful login",
-                                        "user_id": credentials.user_id,
-                                        "token": token,
-                                        "refresh_token": refresh_token,
-                                    }))
-                                    .into_future()
-                            }
-
-                            #[cfg(not(feature = "biome-refresh-tokens"))]
+                            let refresh_token = match token_issuer
+                                .issue_refresh_token_with_claims(refresh_claims)
                             {
-                                HttpResponse::Ok()
-                                    .json(json!({
-                                        "message": "Successful login",
-                                        "user_id": credentials.user_id,
-                                        "token": token,
-                                    }))
-                                    .into_future()
+                                Ok(token) => token,
+                                Err(err) => {
+                                    debug!("Failed to issue refresh token {}", err);
+                                    return HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                        .into_future();
+                                }
+                            };
+
+                            if let Err(err) =
+                                refresh_token_store.add_token(&credentials.user_id, &refresh_token)
+                            {
+                                debug!("Failed to store refresh token {}", err);
+                                return HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                                    .into_future();
                             }
+
+                            HttpResponse::Ok()
+                                .json(json!({
+                                    "message": "Successful login",
+                                    "user_id": credentials.user_id,
+                                    "token": token,
+                                    "refresh_token": refresh_token,
+                                }))
+                                .into_future()
                         } else {
                             HttpResponse::BadRequest()
                                 .json(ErrorResponse::bad_request("Invalid password"))

--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -18,11 +18,11 @@ pub(crate) mod authorize;
 pub(super) mod key_management;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod login;
-#[cfg(feature = "biome-refresh-tokens")]
+#[cfg(feature = "biome-credentials")]
 pub(super) mod logout;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod register;
-#[cfg(all(feature = "biome-credentials", feature = "biome-refresh-tokens",))]
+#[cfg(feature = "biome-credentials")]
 pub(super) mod token;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod user;

--- a/libsplinter/src/biome/rest_api/config.rs
+++ b/libsplinter/src/biome/rest_api/config.rs
@@ -20,7 +20,7 @@ use crate::biome::credentials::store::PasswordEncryptionCost;
 
 const DEFAULT_ISSUER: &str = "self-issued";
 const DEFAULT_DURATION: u64 = 5400; // in seconds = 90 minutes
-#[cfg(feature = "biome-refresh-tokens")]
+#[cfg(feature = "biome-credentials")]
 const DEFAULT_REFRESH_DURATION: u64 = 5_184_000; // in seconds = 60 days
 
 /// Configuration for Biome REST resources
@@ -31,7 +31,7 @@ pub struct BiomeRestConfig {
     /// Duration of JWT tokens issued by this service
     access_token_duration: Duration,
     /// Duration of refresh tokens issued by this service
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     refresh_token_duration: Duration,
     #[cfg(feature = "biome-credentials")]
     /// Cost for encrypting user's password
@@ -52,7 +52,7 @@ impl BiomeRestConfig {
 
     /// Returns durations the refresh token is valid.
     /// Defaults to 60 days.
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     pub fn refresh_token_duration(&self) -> Duration {
         self.refresh_token_duration.to_owned()
     }
@@ -70,7 +70,7 @@ impl BiomeRestConfig {
 pub struct BiomeRestConfigBuilder {
     issuer: Option<String>,
     access_token_duration: Option<Duration>,
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     refresh_token_duration: Option<Duration>,
     #[cfg(feature = "biome-credentials")]
     password_encryption_cost: Option<String>,
@@ -81,7 +81,7 @@ impl Default for BiomeRestConfigBuilder {
         BiomeRestConfigBuilder {
             issuer: Some(DEFAULT_ISSUER.to_string()),
             access_token_duration: Some(Duration::from_secs(DEFAULT_DURATION)),
-            #[cfg(feature = "biome-refresh-tokens")]
+            #[cfg(feature = "biome-credentials")]
             refresh_token_duration: Some(Duration::from_secs(DEFAULT_REFRESH_DURATION)),
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost: Some("high".to_string()),
@@ -95,7 +95,7 @@ impl BiomeRestConfigBuilder {
         BiomeRestConfigBuilder {
             issuer: None,
             access_token_duration: None,
-            #[cfg(feature = "biome-refresh-tokens")]
+            #[cfg(feature = "biome-credentials")]
             refresh_token_duration: None,
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost: None,
@@ -115,7 +115,7 @@ impl BiomeRestConfigBuilder {
     }
 
     /// Adds a refresh token duration in seconds.
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     pub fn with_refresh_token_duration_in_secs(mut self, duration: u64) -> Self {
         self.refresh_token_duration = Some(Duration::from_secs(duration));
         self
@@ -140,7 +140,7 @@ impl BiomeRestConfigBuilder {
             debug!("Using default value for access_token_duration");
             Duration::from_secs(DEFAULT_DURATION)
         });
-        #[cfg(feature = "biome-refresh-tokens")]
+        #[cfg(feature = "biome-credentials")]
         let refresh_token_duration = self
             .refresh_token_duration
             .unwrap_or_else(|| Duration::from_secs(DEFAULT_REFRESH_DURATION));
@@ -155,7 +155,7 @@ impl BiomeRestConfigBuilder {
         Ok(BiomeRestConfig {
             issuer,
             access_token_duration,
-            #[cfg(feature = "biome-refresh-tokens")]
+            #[cfg(feature = "biome-credentials")]
             refresh_token_duration,
             #[cfg(feature = "biome-credentials")]
             password_encryption_cost,

--- a/libsplinter/src/biome/rest_api/resources/mod.rs
+++ b/libsplinter/src/biome/rest_api/resources/mod.rs
@@ -20,7 +20,7 @@ pub(in crate::biome::rest_api) mod authorize;
 pub(in crate::biome::rest_api) mod credentials;
 #[cfg(feature = "biome-key-management")]
 pub(in crate::biome::rest_api) mod key_management;
-#[cfg(feature = "biome-refresh-tokens")]
+#[cfg(feature = "biome-credentials")]
 pub(in crate::biome::rest_api) mod token;
 #[cfg(all(feature = "biome-key-management", feature = "biome-credentials"))]
 pub(in crate::biome::rest_api) mod user;

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -34,7 +34,7 @@ pub trait TokenIssuer<T: Serialize> {
     /// Issues a JWT token with the given claims
     fn issue_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
 
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     fn issue_refresh_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
 }
 
@@ -47,7 +47,7 @@ pub(crate) fn default_validation(issuer: &str) -> Validation {
 }
 
 /// Validates authorization token but ignores the expiration date
-#[cfg(feature = "biome-refresh-tokens")]
+#[cfg(feature = "biome-credentials")]
 pub(crate) fn ignore_exp_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();
     validation.leeway = DEFAULT_LEEWAY;

--- a/libsplinter/src/rest_api/sessions/token_issuer.rs
+++ b/libsplinter/src/rest_api/sessions/token_issuer.rs
@@ -24,7 +24,7 @@ use crate::rest_api::secrets::SecretManager;
 /// Issues JWT access tokens
 pub struct AccessTokenIssuer {
     secret_manager: Arc<dyn SecretManager>,
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     refresh_secret_manager: Arc<dyn SecretManager>,
 }
 
@@ -32,11 +32,11 @@ impl AccessTokenIssuer {
     /// Creates a new AccessTokenIssuer that will use the given secret manager for issuing tokens
     pub fn new(
         secret_manager: Arc<dyn SecretManager>,
-        #[cfg(feature = "biome-refresh-tokens")] refresh_secret_manager: Arc<dyn SecretManager>,
+        #[cfg(feature = "biome-credentials")] refresh_secret_manager: Arc<dyn SecretManager>,
     ) -> AccessTokenIssuer {
         AccessTokenIssuer {
             secret_manager,
-            #[cfg(feature = "biome-refresh-tokens")]
+            #[cfg(feature = "biome-credentials")]
             refresh_secret_manager,
         }
     }
@@ -52,7 +52,7 @@ impl TokenIssuer<Claims> for AccessTokenIssuer {
         Ok(token)
     }
 
-    #[cfg(feature = "biome-refresh-tokens")]
+    #[cfg(feature = "biome-credentials")]
     fn issue_refresh_token_with_claims(&self, claims: Claims) -> Result<String, TokenIssuerError> {
         let token = encode(
             &Header::default(),

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -61,7 +61,6 @@ experimental = [
     "biome",
     "biome-credentials",
     "biome-key-management",
-    "biome-refresh-tokens",
     "health",
     "rest-api-cors",
     "scabbard-get-state",
@@ -70,9 +69,8 @@ experimental = [
 ]
 
 biome = ["splinter/biome", "database"]
-biome-credentials = ["splinter/biome-credentials", "biome-refresh-tokens", "biome"]
-biome-key-management = ["splinter/biome-key-management", "biome-refresh-tokens", "biome"]
-biome-refresh-tokens = ["splinter/biome-refresh-tokens"]
+biome-credentials = ["splinter/biome-credentials", "biome"]
+biome-key-management = ["splinter/biome-key-management", "biome"]
 config-default = []
 config-command-line = []
 config-env-var = []

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -27,14 +27,12 @@ use splinter::admin::rest_api::CircuitResourceProvider;
 use splinter::admin::service::{admin_service_id, AdminService};
 #[cfg(feature = "biome")]
 use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
-#[cfg(feature = "biome-credentials")]
-use splinter::biome::DieselCredentialsStore;
 #[cfg(feature = "biome-key-management")]
 use splinter::biome::DieselKeyStore;
-#[cfg(feature = "biome-refresh-tokens")]
-use splinter::biome::DieselRefreshTokenStore;
 #[cfg(feature = "biome")]
 use splinter::biome::DieselUserStore;
+#[cfg(feature = "biome-credentials")]
+use splinter::biome::{DieselCredentialsStore, DieselRefreshTokenStore};
 use splinter::circuit::directory::CircuitDirectory;
 use splinter::circuit::handlers::{
     AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
@@ -704,17 +702,14 @@ fn build_biome_routes(db_url: &str) -> Result<BiomeRestResourceManager, StartErr
     #[cfg(feature = "biome-credentials")]
     {
         biome_rest_provider_builder = biome_rest_provider_builder
+            .with_refresh_token_store(DieselRefreshTokenStore::new(connection_pool.clone()));
+        biome_rest_provider_builder = biome_rest_provider_builder
             .with_credentials_store(DieselCredentialsStore::new(connection_pool.clone()));
     }
     #[cfg(feature = "biome-key-management")]
     {
         biome_rest_provider_builder =
-            biome_rest_provider_builder.with_key_store(DieselKeyStore::new(connection_pool.clone()))
-    }
-    #[cfg(feature = "biome-refresh-tokens")]
-    {
-        biome_rest_provider_builder = biome_rest_provider_builder
-            .with_refresh_token_store(DieselRefreshTokenStore::new(connection_pool));
+            biome_rest_provider_builder.with_key_store(DieselKeyStore::new(connection_pool))
     }
     let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
         StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))


### PR DESCRIPTION
Removes the biome-refresh-token feature from libsplinter and splinterd.
This feature offered little value without biome-credentials-store also being
enabled. As such, the functionality offered by biome-refresh-tokens is
now accessible via the biome-credentials feature. As a result,
biome-credentials needs to be enabled to access the RefreshTokenStore,
and the following endpoints.

`PATCH biome/logout`
`POST biome/tokens`

Signed-off-by: Ryan Banks <rbanks@bitwise.io>