### PR TITLE
Authorize connections within the connection manager

### DIFF
--- a/libsplinter/src/network/auth2/connection_manager.rs
+++ b/libsplinter/src/network/auth2/connection_manager.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::network::connection_manager::{
+    AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
+};
+use crate::transport::Connection;
+
+use super::{AuthorizationPoolError, ConnectionAuthorizationState, PoolAuthorizer};
+
+impl Authorizer for PoolAuthorizer {
+    fn authorize_connection(
+        &self,
+        connection_id: String,
+        connection: Box<dyn Connection>,
+        callback: AuthorizerCallback,
+    ) -> Result<(), AuthorizerError> {
+        self.add_connection(
+            connection_id,
+            connection,
+            Box::new(move |state| (*callback)(state.into())),
+        )
+        .map_err(AuthorizerError::from)
+    }
+}
+
+impl From<ConnectionAuthorizationState> for AuthorizationResult {
+    fn from(state: ConnectionAuthorizationState) -> Self {
+        match state {
+            ConnectionAuthorizationState::Authorized {
+                connection_id,
+                connection,
+                identity,
+            } => AuthorizationResult::Authorized {
+                connection_id,
+                connection,
+                identity,
+            },
+
+            ConnectionAuthorizationState::Unauthorized {
+                connection_id,
+                connection,
+            } => AuthorizationResult::Unauthorized {
+                connection_id,
+                connection,
+            },
+        }
+    }
+}
+
+impl From<AuthorizationPoolError> for AuthorizerError {
+    fn from(err: AuthorizationPoolError) -> Self {
+        AuthorizerError(err.to_string())
+    }
+}

--- a/libsplinter/src/network/auth2/handlers.rs
+++ b/libsplinter/src/network/auth2/handlers.rs
@@ -1,0 +1,644 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::Message;
+
+use crate::network::dispatch::{
+    ConnectionId, DispatchError, Dispatcher, Handler, MessageContext, MessageSender,
+};
+use crate::protocol::authorization::{
+    AuthorizationError, AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest,
+    ConnectResponse, TrustRequest,
+};
+use crate::protos::authorization;
+use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::protos::prelude::*;
+
+use super::{
+    AuthorizationAction, AuthorizationMessageSender, AuthorizationPoolStateMachine,
+    AuthorizationState,
+};
+
+/// Create a Dispatcher for Authorization messages
+///
+/// Creates and configures a Dispatcher to handle messages from an AuthorizationMessage envelope.
+/// The dispatcher is provided the given network sender for response messages, and the network
+/// itself to handle updating identities (or removing connections with authorization failures).
+///
+/// The identity provided is sent to connections for Trust authorizations.
+pub fn create_authorization_dispatcher<T>(
+    identity: String,
+    auth_manager: AuthorizationPoolStateMachine,
+    auth_msg_sender: T,
+) -> Dispatcher<NetworkMessageType, ConnectionId>
+where
+    T: Into<Box<dyn MessageSender<ConnectionId>>> + Clone,
+{
+    let mut auth_dispatcher = Dispatcher::new(auth_msg_sender.clone());
+
+    auth_dispatcher.set_handler(Box::new(ConnectRequestHandler::new(auth_manager.clone())));
+
+    auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(identity)));
+
+    auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
+
+    auth_dispatcher.set_handler(Box::new(AuthorizedHandler));
+
+    auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
+
+    let mut network_msg_dispatcher = Dispatcher::new(auth_msg_sender);
+
+    network_msg_dispatcher.set_handler(Box::new(AuthorizationMessageHandler::new(auth_dispatcher)));
+
+    network_msg_dispatcher
+}
+
+/// The Handler for authorization network messages.
+///
+/// This Handler accepts authorization network messages, unwraps the envelope, and forwards the
+/// message contents to an authorization dispatcher.
+pub struct AuthorizationMessageHandler {
+    auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
+}
+
+impl AuthorizationMessageHandler {
+    /// Constructs a new AuthorizationMessageHandler
+    ///
+    /// This constructs an AuthorizationMessageHandler with a sender that will dispatch messages
+    /// to a authorization dispatcher.
+    pub fn new(
+        auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
+    ) -> Self {
+        AuthorizationMessageHandler { auth_dispatcher }
+    }
+}
+
+impl Handler for AuthorizationMessageHandler {
+    type Source = ConnectionId;
+    type MessageType = NetworkMessageType;
+    type Message = authorization::AuthorizationMessage;
+
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::AUTHORIZATION
+    }
+
+    fn handle(
+        &self,
+        mut msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let msg_type = msg.get_message_type();
+        let payload = msg.take_payload();
+        self.auth_dispatcher
+            .dispatch(context.source_id().clone(), &msg_type, payload)
+    }
+}
+
+pub struct AuthorizedHandler;
+
+impl Handler for AuthorizedHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthorizedMessage;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTHORIZE
+    }
+
+    fn handle(
+        &self,
+        _: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!("Connection {} authorized", context.source_connection_id());
+        Ok(())
+    }
+}
+///
+/// Handler for the Connect Request Authorization Message Type
+struct ConnectRequestHandler {
+    auth_manager: AuthorizationPoolStateMachine,
+}
+
+impl ConnectRequestHandler {
+    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+        ConnectRequestHandler { auth_manager }
+    }
+}
+
+impl Handler for ConnectRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::ConnectRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::CONNECT_REQUEST
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let connect_request = ConnectRequest::from_proto(msg)?;
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::Connecting,
+        ) {
+            Err(err) => {
+                debug!(
+                    "Ignoring duplicate connect message from {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationState::Connecting) => {
+                debug!("Beginning handshake for {}", context.source_connection_id(),);
+                // Send a connect request of our own
+
+                match connect_request {
+                    ConnectRequest::Bidirectional => {
+                        let connect_req =
+                            AuthorizationMessage::ConnectRequest(ConnectRequest::Unidirectional);
+                        let mut msg = NetworkMessage::new();
+                        msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                        msg.set_payload(
+                            IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+                                connect_req,
+                            )?,
+                        );
+                        sender
+                            .send(context.source_id().clone(), msg.write_to_bytes()?)
+                            .map_err(|(recipient, payload)| {
+                                DispatchError::NetworkSendError((recipient.into(), payload))
+                            })?;
+
+                        debug!(
+                            "Sent bidirectional connect request to {}",
+                            context.source_connection_id()
+                        );
+                    }
+                    ConnectRequest::Unidirectional => (),
+                }
+
+                let response = AuthorizationMessage::ConnectResponse(ConnectResponse {
+                    accepted_authorization_types: vec![AuthorizationType::Trust],
+                });
+
+                let mut msg = NetworkMessage::new();
+                msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                msg.set_payload(
+                    IntoBytes::<authorization::AuthorizationMessage>::into_bytes(response)?,
+                );
+
+                sender
+                    .send(context.source_id().clone(), msg.write_to_bytes()?)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        Ok(())
+    }
+}
+
+/// Handler for the ConnectResponse Authorization Message Type
+struct ConnectResponseHandler {
+    identity: String,
+}
+
+impl ConnectResponseHandler {
+    fn new(identity: String) -> Self {
+        ConnectResponseHandler { identity }
+    }
+}
+
+impl Handler for ConnectResponseHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::ConnectResponse;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::CONNECT_RESPONSE
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let connect_response = ConnectResponse::from_proto(msg)?;
+        debug!(
+            "Receive connect response from connection {}: {:?}",
+            context.source_connection_id(),
+            connect_response,
+        );
+
+        if connect_response
+            .accepted_authorization_types
+            .iter()
+            .any(|t| matches!(t, AuthorizationType::Trust))
+        {
+            let trust_request = AuthorizationMessage::TrustRequest(TrustRequest {
+                identity: self.identity.clone(),
+            });
+            let mut msg = NetworkMessage::new();
+            msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+            msg.set_payload(
+                IntoBytes::<authorization::AuthorizationMessage>::into_bytes(trust_request)?,
+            );
+            sender
+                .send(context.source_id().clone(), msg.write_to_bytes()?)
+                .map_err(|(recipient, payload)| {
+                    DispatchError::NetworkSendError((recipient.into(), payload))
+                })?;
+        }
+        Ok(())
+    }
+}
+
+/// Handler for the TrustRequest Authorization Message Type
+struct TrustRequestHandler {
+    auth_manager: AuthorizationPoolStateMachine,
+}
+
+impl TrustRequestHandler {
+    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+        TrustRequestHandler { auth_manager }
+    }
+}
+
+impl Handler for TrustRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::TrustRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::TRUST_REQUEST
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let trust_request = TrustRequest::from_proto(msg)?;
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::TrustIdentifying(trust_request.identity),
+        ) {
+            Err(err) => {
+                debug!(
+                    "Ignoring trust request message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationState::Authorized) => {
+                debug!(
+                    "Sending Authorized message to connection {}",
+                    context.source_connection_id()
+                );
+                let auth_msg = AuthorizationMessage::Authorized(Authorized);
+                let mut msg = NetworkMessage::new();
+                msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                msg.set_payload(
+                    IntoBytes::<authorization::AuthorizationMessage>::into_bytes(auth_msg)?,
+                );
+                sender
+                    .send(context.source_id().clone(), msg.write_to_bytes()?)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Error Message Type
+struct AuthorizationErrorHandler {
+    auth_manager: AuthorizationPoolStateMachine,
+}
+
+impl AuthorizationErrorHandler {
+    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+        AuthorizationErrorHandler { auth_manager }
+    }
+}
+
+impl Handler for AuthorizationErrorHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthorizationError;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTHORIZATION_ERROR
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let auth_error = AuthorizationError::from_proto(msg)?;
+        match auth_error {
+            AuthorizationError::AuthorizationRejected(err_msg) => {
+                match self.auth_manager.next_state(
+                    context.source_connection_id(),
+                    AuthorizationAction::Unauthorizing,
+                ) {
+                    Ok(AuthorizationState::Unauthorized) => {
+                        info!(
+                            "Connection unauthorized by connection {}: {}",
+                            context.source_connection_id(),
+                            &err_msg
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Unable to handle unauthorizing by connection {}: {}",
+                            context.source_connection_id(),
+                            err
+                        );
+                    }
+                    Ok(next_state) => {
+                        panic!("Should not have been able to transition to {}", next_state)
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl MessageSender<ConnectionId> for AuthorizationMessageSender {
+    fn send(&self, id: ConnectionId, message: Vec<u8>) -> Result<(), (ConnectionId, Vec<u8>)> {
+        AuthorizationMessageSender::send(self, message).map_err(|msg| (id, msg))
+    }
+}
+
+impl Into<Box<dyn MessageSender<ConnectionId>>> for AuthorizationMessageSender {
+    fn into(self) -> Box<dyn MessageSender<ConnectionId>> {
+        Box::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use protobuf::Message;
+
+    use crate::protos::authorization;
+    use crate::protos::network::{NetworkMessage, NetworkMessageType};
+
+    /// Test that an connect request is properly handled via the dispatcher.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send out two messages, a Unidirectional connect request and a connect
+    ///    response.
+    #[test]
+    fn connect_request_dispatch() {
+        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let dispatcher =
+            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+
+        let connection_id = "test_connection".to_string();
+        let mut msg = authorization::ConnectRequest::new();
+        msg.set_handshake_mode(authorization::ConnectRequest_HandshakeMode::BIDIRECTIONAL);
+        let mut auth_msg = authorization::AuthorizationMessage::new();
+        auth_msg.set_message_type(authorization::AuthorizationMessageType::CONNECT_REQUEST);
+        auth_msg.set_payload(msg.write_to_bytes().unwrap());
+        let msg_bytes = auth_msg.write_to_bytes().unwrap();
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+        let connect_req_msg: authorization::ConnectRequest = expect_auth_message(
+            authorization::AuthorizationMessageType::CONNECT_REQUEST,
+            &message_bytes,
+        );
+        assert_eq!(
+            authorization::ConnectRequest_HandshakeMode::UNIDIRECTIONAL,
+            connect_req_msg.get_handshake_mode()
+        );
+
+        let (_, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+
+        let connect_res_msg: authorization::ConnectResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::CONNECT_RESPONSE,
+            &message_bytes,
+        );
+        assert_eq!(
+            vec![authorization::ConnectResponse_AuthorizationType::TRUST],
+            connect_res_msg.get_accepted_authorization_types().to_vec()
+        );
+    }
+
+    /// Test that a connect response is properly handled via the dispatcher.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) a trust request is sent to the remote connection
+    /// 2) the trust request includes the local identity
+    #[test]
+    fn connect_response_dispatch() {
+        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let dispatcher =
+            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+        let connection_id = "test_connection".to_string();
+        let mut msg = authorization::ConnectResponse::new();
+        msg.set_accepted_authorization_types(
+            vec![authorization::ConnectResponse_AuthorizationType::TRUST].into(),
+        );
+        let mut auth_msg = authorization::AuthorizationMessage::new();
+        auth_msg.set_message_type(authorization::AuthorizationMessageType::CONNECT_RESPONSE);
+        auth_msg.set_payload(msg.write_to_bytes().unwrap());
+        let msg_bytes = auth_msg.write_to_bytes().unwrap();
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (_, msg_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+
+        let trust_req: authorization::TrustRequest = expect_auth_message(
+            authorization::AuthorizationMessageType::TRUST_REQUEST,
+            &msg_bytes,
+        );
+        assert_eq!("mock_identity", trust_req.get_identity());
+    }
+
+    /// Test a trust request is properly handled via the dispatcher
+    ///
+    /// This is verified by:
+    ///
+    /// 1). sending a ConnectRequest, to get the state for the connection into the proper state
+    /// 2). sending a TrustRequest, which would be the next step in authorization
+    /// 3). receiving an Authorize message, which is the result of successful authorization
+    #[test]
+    fn trust_request_dispatch() {
+        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let dispatcher =
+            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+        let connection_id = "test_connection".to_string();
+        // Begin the connection process, otherwise, the response will fail
+        let mut msg = authorization::ConnectRequest::new();
+        msg.set_handshake_mode(authorization::ConnectRequest_HandshakeMode::UNIDIRECTIONAL);
+        let mut auth_msg = authorization::AuthorizationMessage::new();
+        auth_msg.set_message_type(authorization::AuthorizationMessageType::CONNECT_REQUEST);
+        auth_msg.set_payload(msg.write_to_bytes().unwrap());
+
+        let msg_bytes = auth_msg.write_to_bytes().unwrap();
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (_, msg_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+
+        let _connect_res_msg: authorization::ConnectResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::CONNECT_RESPONSE,
+            &msg_bytes,
+        );
+
+        let mut trust_req = authorization::TrustRequest::new();
+        trust_req.set_identity("my_identity".into());
+        let mut auth_msg = authorization::AuthorizationMessage::new();
+        auth_msg.set_message_type(authorization::AuthorizationMessageType::TRUST_REQUEST);
+        auth_msg.set_payload(trust_req.write_to_bytes().unwrap());
+        let msg_bytes = auth_msg.write_to_bytes().unwrap();
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (_, msg_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+
+        let _auth_msg: authorization::AuthorizedMessage = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTHORIZE,
+            &msg_bytes,
+        );
+    }
+
+    fn expect_auth_message<M: protobuf::Message>(
+        message_type: authorization::AuthorizationMessageType,
+        msg_bytes: &[u8],
+    ) -> M {
+        let network_msg: NetworkMessage =
+            protobuf::parse_from_bytes(msg_bytes).expect("Unable to parse network message");
+        assert_eq!(NetworkMessageType::AUTHORIZATION, network_msg.message_type);
+
+        let auth_msg: authorization::AuthorizationMessage =
+            protobuf::parse_from_bytes(network_msg.get_payload())
+                .expect("Unable to parse auth message");
+
+        assert_eq!(message_type, auth_msg.message_type);
+
+        match protobuf::parse_from_bytes(auth_msg.get_payload()) {
+            Ok(msg) => msg,
+            Err(err) => panic!(
+                "unable to parse message for type {:?}: {:?}",
+                message_type, err
+            ),
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockSender {
+        outbound: Arc<Mutex<VecDeque<(ConnectionId, Vec<u8>)>>>,
+    }
+
+    impl MockSender {
+        fn new() -> Self {
+            Self {
+                outbound: Arc::new(Mutex::new(VecDeque::new())),
+            }
+        }
+
+        fn next_outbound(&self) -> Option<(ConnectionId, Vec<u8>)> {
+            self.outbound.lock().expect("lock was poisoned").pop_front()
+        }
+    }
+
+    impl MessageSender<ConnectionId> for MockSender {
+        fn send(&self, id: ConnectionId, message: Vec<u8>) -> Result<(), (ConnectionId, Vec<u8>)> {
+            self.outbound
+                .lock()
+                .expect("lock was poisoned")
+                .push_back((id, message));
+
+            Ok(())
+        }
+    }
+
+    impl Into<Box<dyn MessageSender<ConnectionId>>> for MockSender {
+        fn into(self) -> Box<dyn MessageSender<ConnectionId>> {
+            Box::new(self)
+        }
+    }
+}

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -12,4 +12,531 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod handlers;
 mod pool;
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{mpsc, Arc, Mutex};
+
+use protobuf::Message;
+
+use crate::protocol::authorization::{AuthorizationMessage, ConnectRequest};
+use crate::protos::authorization;
+use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::protos::prelude::*;
+use crate::transport::{Connection, RecvError};
+
+use self::handlers::create_authorization_dispatcher;
+use self::pool::{ThreadPool, ThreadPoolBuilder};
+
+/// The states of a connection during authorization.
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum AuthorizationState {
+    Unknown,
+    Connecting,
+    Authorized,
+    Unauthorized,
+}
+
+impl fmt::Display for AuthorizationState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            AuthorizationState::Unknown => "Unknown",
+            AuthorizationState::Connecting => "Connecting",
+            AuthorizationState::Authorized => "Authorized",
+            AuthorizationState::Unauthorized => "Unauthorized",
+        })
+    }
+}
+
+type Identity = String;
+
+/// The state transitions that can be applied on an connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum AuthorizationAction {
+    Connecting,
+    TrustIdentifying(Identity),
+    Unauthorizing,
+}
+
+impl fmt::Display for AuthorizationAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationAction::Connecting => f.write_str("Connecting"),
+            AuthorizationAction::TrustIdentifying(_) => f.write_str("TrustIdentifying"),
+            AuthorizationAction::Unauthorizing => f.write_str("Unauthorizing"),
+        }
+    }
+}
+
+/// The errors that may occur for a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum AuthorizationActionError {
+    AlreadyConnecting,
+    InvalidMessageOrder(AuthorizationState, AuthorizationAction),
+    SystemFailure(String),
+}
+
+impl fmt::Display for AuthorizationActionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationActionError::AlreadyConnecting => {
+                f.write_str("Already attempting to connect.")
+            }
+            AuthorizationActionError::InvalidMessageOrder(start, action) => {
+                write!(f, "Attempting to transition from {} via {}.", start, action)
+            }
+            AuthorizationActionError::SystemFailure(msg) => f.write_str(&msg),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AuthorizationPoolError(pub String);
+
+impl std::error::Error for AuthorizationPoolError {}
+
+impl fmt::Display for AuthorizationPoolError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Manages authorization states for connections on a network.
+pub struct AuthorizationPool {
+    local_identity: String,
+    thread_pool: ThreadPool,
+    shared: Arc<Mutex<ManagedAuthorizations>>,
+}
+
+impl AuthorizationPool {
+    /// Constructs an AuthorizationManager
+    pub fn new(local_identity: String) -> Result<Self, AuthorizationPoolError> {
+        let thread_pool = ThreadPoolBuilder::new()
+            .with_size(8)
+            .with_prefix("AuthorizationPool-".into())
+            .build()
+            .map_err(|err| AuthorizationPoolError(err.to_string()))?;
+
+        let shared = Arc::new(Mutex::new(ManagedAuthorizations::new()));
+
+        Ok(Self {
+            thread_pool,
+            shared,
+            local_identity,
+        })
+    }
+
+    pub fn shutdown_signaler(&self) -> ShutdownSignaler {
+        ShutdownSignaler {
+            thread_pool_signaler: self.thread_pool.shutdown_signaler(),
+        }
+    }
+
+    pub fn wait_for_shutdown(self) {
+        self.thread_pool.join_all()
+    }
+
+    pub fn pool_authorizer(&self) -> PoolAuthorizer {
+        PoolAuthorizer {
+            local_identity: self.local_identity.clone(),
+            shared: Arc::clone(&self.shared),
+            executor: self.thread_pool.executor(),
+        }
+    }
+}
+
+pub struct ShutdownSignaler {
+    thread_pool_signaler: pool::ShutdownSignaler,
+}
+
+impl ShutdownSignaler {
+    pub fn shutdown(&self) {
+        self.thread_pool_signaler.shutdown();
+    }
+}
+
+pub struct PoolAuthorizer {
+    local_identity: String,
+    shared: Arc<Mutex<ManagedAuthorizations>>,
+    executor: pool::JobExecutor,
+}
+
+impl PoolAuthorizer {
+    pub fn add_connection(
+        &self,
+        connection_id: String,
+        connection: Box<dyn Connection>,
+        on_complete_callback: Callback,
+    ) -> Result<(), AuthorizationPoolError> {
+        let mut connection = connection;
+
+        let (tx, rx) = mpsc::channel();
+        let connection_shared = Arc::clone(&self.shared);
+        let state_machine = AuthorizationPoolStateMachine {
+            shared: Arc::clone(&self.shared),
+        };
+        let msg_sender = AuthorizationMessageSender { sender: tx };
+        let dispatcher =
+            create_authorization_dispatcher(self.local_identity.clone(), state_machine, msg_sender);
+        self.executor.execute(move || {
+            let connect_request_bytes = match connect_msg_bytes() {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    error!(
+                        "Unable to create connect request for {}; aborting auth: {}",
+                        &connection_id, err
+                    );
+                    return;
+                }
+            };
+            if let Err(err) = connection.send(&connect_request_bytes) {
+                error!(
+                    "Unable to send connect request to {}; aborting auth: {}",
+                    &connection_id, err
+                );
+                return;
+            }
+
+            let authed = 'main: loop {
+                match connection.recv() {
+                    Ok(bytes) => {
+                        let mut msg: NetworkMessage = match protobuf::parse_from_bytes(&bytes) {
+                            Ok(msg) => msg,
+                            Err(err) => {
+                                warn!("Received invalid network message: {}", err);
+                                continue;
+                            }
+                        };
+
+                        let message_type = msg.get_message_type();
+                        if let Err(err) = dispatcher.dispatch(
+                            connection_id.clone().into(),
+                            &message_type,
+                            msg.take_payload(),
+                        ) {
+                            error!(
+                                "Unable to dispatch message of type {:?}: {}",
+                                message_type, err
+                            );
+                        }
+                    }
+                    Err(RecvError::Disconnected) => {
+                        error!("Connection unexpectedly disconnected; aborting authorization");
+                        break 'main false;
+                    }
+                    Err(RecvError::IoError(err)) => {
+                        error!("Unable to authorize connection due to I/O error: {}", err);
+                        break 'main false;
+                    }
+                    Err(RecvError::ProtocolError(msg)) => {
+                        error!(
+                            "Unable to authorize connection due to protocol error: {}",
+                            msg
+                        );
+                        break 'main false;
+                    }
+                    Err(RecvError::WouldBlock) => continue,
+                }
+
+                while let Ok(outgoing) = rx.try_recv() {
+                    match connection.send(&outgoing) {
+                        Ok(()) => (),
+                        Err(err) => {
+                            error!("Unable to send outgoing message; aborting auth: {}", err);
+                            break 'main false;
+                        }
+                    }
+                }
+
+                let mut shared = match connection_shared.lock() {
+                    Ok(shared) => shared,
+                    Err(_) => {
+                        error!("connection authorization lock poisoned; aborting auth");
+                        break 'main false;
+                    }
+                };
+
+                if let Some(authed) = shared.is_authorized(&connection_id).copied() {
+                    shared.cleanup_connection_state(&connection_id);
+                    break 'main authed;
+                }
+            };
+
+            let auth_state = if authed {
+                ConnectionAuthorizationState::Authorized {
+                    connection_id,
+                    connection,
+                    identity: "".into(),
+                }
+            } else {
+                ConnectionAuthorizationState::Unauthorized {
+                    connection_id,
+                    connection,
+                }
+            };
+            if let Err(err) = on_complete_callback(auth_state) {
+                error!("unable to pass auth result to callback: {}", err);
+            }
+        });
+
+        Ok(())
+    }
+}
+
+fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationPoolError> {
+    let mut network_msg = NetworkMessage::new();
+    network_msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+
+    let connect_msg = AuthorizationMessage::ConnectRequest(ConnectRequest::Bidirectional);
+    network_msg.set_payload(
+        IntoBytes::<authorization::AuthorizationMessage>::into_bytes(connect_msg).map_err(
+            |err| AuthorizationPoolError(format!("Unable to send connect request: {}", err)),
+        )?,
+    );
+
+    network_msg
+        .write_to_bytes()
+        .map_err(|err| AuthorizationPoolError(format!("Unable to send connect request: {}", err)))
+}
+
+#[derive(Clone)]
+pub struct AuthorizationMessageSender {
+    sender: mpsc::Sender<Vec<u8>>,
+}
+
+impl AuthorizationMessageSender {
+    pub fn send(&self, msg: Vec<u8>) -> Result<(), Vec<u8>> {
+        self.sender.send(msg).map_err(|err| err.0)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AuthorizationPoolStateMachine {
+    shared: Arc<Mutex<ManagedAuthorizations>>,
+}
+
+impl AuthorizationPoolStateMachine {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_state(
+        &self,
+        connection_id: &str,
+        action: AuthorizationAction,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        let mut shared = self.shared.lock().map_err(|_| {
+            AuthorizationActionError::SystemFailure("Authorization pool lock was poisoned".into())
+        })?;
+
+        let cur_state = shared
+            .states
+            .get(connection_id)
+            .unwrap_or(&AuthorizationState::Unknown);
+        match *cur_state {
+            AuthorizationState::Unknown => match action {
+                AuthorizationAction::Connecting => {
+                    // Here the decision for Challenges will be made.
+                    shared
+                        .states
+                        .insert(connection_id.to_string(), AuthorizationState::Connecting);
+                    Ok(AuthorizationState::Connecting)
+                }
+                AuthorizationAction::Unauthorizing => {
+                    shared.mark_complete(connection_id, true);
+                    Ok(AuthorizationState::Unauthorized)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Unknown,
+                    action,
+                )),
+            },
+            AuthorizationState::Connecting => match action {
+                AuthorizationAction::Connecting => Err(AuthorizationActionError::AlreadyConnecting),
+                AuthorizationAction::TrustIdentifying(_identity) => {
+                    // Verify pub key allowed
+                    shared.mark_complete(connection_id, true);
+                    Ok(AuthorizationState::Authorized)
+                }
+                AuthorizationAction::Unauthorizing => {
+                    shared.mark_complete(connection_id, false);
+
+                    Ok(AuthorizationState::Unauthorized)
+                }
+            },
+            AuthorizationState::Authorized => match action {
+                AuthorizationAction::Unauthorizing => {
+                    shared.mark_complete(connection_id, false);
+
+                    Ok(AuthorizationState::Unauthorized)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Authorized,
+                    action,
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                cur_state.clone(),
+                action,
+            )),
+        }
+    }
+}
+
+type Callback =
+    Box<dyn Fn(ConnectionAuthorizationState) -> Result<(), Box<dyn std::error::Error>> + Send>;
+
+#[derive(Default)]
+struct ManagedAuthorizations {
+    states: HashMap<String, AuthorizationState>,
+    complete_and_authorized: HashMap<String, bool>,
+}
+
+impl ManagedAuthorizations {
+    fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+            complete_and_authorized: HashMap::new(),
+        }
+    }
+
+    fn cleanup_connection_state(&mut self, connection_id: &str) {
+        self.states.remove(connection_id);
+        self.complete_and_authorized.remove(connection_id);
+    }
+
+    fn mark_complete(&mut self, connection_id: &str, is_authorized: bool) {
+        self.complete_and_authorized
+            .insert(connection_id.to_string(), is_authorized);
+    }
+
+    fn is_authorized(&self, connection_id: &str) -> Option<&bool> {
+        self.complete_and_authorized.get(connection_id)
+    }
+}
+
+pub enum ConnectionAuthorizationState {
+    Authorized {
+        connection_id: String,
+        identity: String,
+        connection: Box<dyn Connection>,
+    },
+    Unauthorized {
+        connection_id: String,
+        connection: Box<dyn Connection>,
+    },
+}
+
+#[cfg(test)]
+pub(in crate::network) mod tests {
+    use super::*;
+
+    use protobuf::Message;
+
+    use crate::mesh::{Envelope, Mesh};
+    use crate::protocol::authorization::{
+        AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest, ConnectResponse,
+        TrustRequest,
+    };
+    use crate::protos::authorization;
+    use crate::protos::network::{NetworkMessage, NetworkMessageType};
+
+    impl AuthorizationPool {
+        /// A test friendly shutdown and wait method.
+        pub fn shutdown_and_await(self) {
+            self.shutdown_signaler().shutdown();
+            self.wait_for_shutdown();
+        }
+    }
+
+    pub(in crate::network) fn negotiation_connection_auth(mesh: &Mesh, connection_id: &str) {
+        let env = mesh.recv().expect("unable to receive from mesh");
+
+        // receive the connect request from the connection manager
+        assert_eq!(connection_id, env.id());
+        let connect_request = read_auth_message(env.payload());
+        assert!(matches!(
+            connect_request,
+            AuthorizationMessage::ConnectRequest(ConnectRequest::Bidirectional)
+        ));
+
+        // send our own connect request
+        let env = write_auth_message(
+            connection_id,
+            AuthorizationMessage::ConnectRequest(ConnectRequest::Unidirectional),
+        );
+        mesh.send(env).expect("Unable to send connect response");
+
+        let env = write_auth_message(
+            connection_id,
+            AuthorizationMessage::ConnectResponse(ConnectResponse {
+                accepted_authorization_types: vec![AuthorizationType::Trust],
+            }),
+        );
+        mesh.send(env).expect("Unable to send connect response");
+
+        // receive the connect response
+        let env = mesh.recv().expect("unable to receive from mesh");
+        assert_eq!(connection_id, env.id());
+        let connect_response = read_auth_message(env.payload());
+        assert!(matches!(
+            connect_response,
+            AuthorizationMessage::ConnectResponse(_)
+        ));
+
+        // receive the trust request
+        let env = mesh.recv().expect("unable to receive from mesh");
+        assert_eq!(connection_id, env.id());
+        let trust_request = read_auth_message(env.payload());
+        assert!(matches!(
+            trust_request,
+            AuthorizationMessage::TrustRequest(TrustRequest { .. })
+        ));
+
+        // send authorized
+        let env = write_auth_message(connection_id, AuthorizationMessage::Authorized(Authorized));
+        mesh.send(env).expect("unable to send authorized");
+
+        // send trust request
+        let env = write_auth_message(
+            connection_id,
+            AuthorizationMessage::TrustRequest(TrustRequest {
+                identity: "test_identity".to_string(),
+            }),
+        );
+        mesh.send(env).expect("unable to send authorized");
+
+        // receive authorized
+        let env = mesh.recv().expect("unable to receive from mesh");
+        assert_eq!(connection_id, env.id());
+        let trust_request = read_auth_message(env.payload());
+        assert!(matches!(trust_request, AuthorizationMessage::Authorized(_)));
+    }
+
+    fn read_auth_message(bytes: &[u8]) -> AuthorizationMessage {
+        let msg: NetworkMessage =
+            protobuf::parse_from_bytes(bytes).expect("Cannot parse network message");
+
+        assert_eq!(NetworkMessageType::AUTHORIZATION, msg.get_message_type());
+
+        FromBytes::<authorization::AuthorizationMessage>::from_bytes(msg.get_payload())
+            .expect("Unable to parse bytes")
+    }
+
+    fn write_auth_message(connection_id: &str, auth_msg: AuthorizationMessage) -> Envelope {
+        let mut msg = NetworkMessage::new();
+        msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+        msg.set_payload(
+            IntoBytes::<authorization::AuthorizationMessage>::into_bytes(auth_msg)
+                .expect("Unable to convert into bytes"),
+        );
+
+        Envelope::new(
+            connection_id.to_string(),
+            msg.write_to_bytes().expect("Unable to write to bytes"),
+        )
+    }
+}

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod connection_manager;
 mod handlers;
 mod pool;
 

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -11,3 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+mod pool;

--- a/libsplinter/src/network/auth2/pool.rs
+++ b/libsplinter/src/network/auth2/pool.rs
@@ -1,0 +1,217 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License atJJKK http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+trait FnBox {
+    fn call_box(self: Box<Self>);
+}
+
+impl<F: FnOnce()> FnBox for F {
+    fn call_box(self: Box<F>) {
+        (*self)()
+    }
+}
+
+type Job = Box<dyn FnBox + Send + 'static>;
+
+fn new_job<F>(f: F) -> Job
+where
+    F: FnBox + Send + 'static,
+{
+    Box::new(f)
+}
+
+enum Message {
+    NewJob(Job),
+    Terminate,
+}
+
+#[derive(Debug)]
+pub struct ThreadPoolBuildError(pub String);
+
+impl std::error::Error for ThreadPoolBuildError {}
+
+impl std::fmt::Display for ThreadPoolBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Default)]
+pub struct ThreadPoolBuilder {
+    size: Option<usize>,
+    prefix: Option<String>,
+}
+
+impl ThreadPoolBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_size(mut self, size: usize) -> Self {
+        self.size = Some(size);
+        self
+    }
+
+    pub fn with_prefix(mut self, prefix: String) -> Self {
+        self.prefix = Some(prefix);
+        self
+    }
+
+    pub fn build(self) -> Result<ThreadPool, ThreadPoolBuildError> {
+        let size = self
+            .size
+            .ok_or_else(|| ThreadPoolBuildError("Must configure thread pool size".into()))
+            .and_then(|size| {
+                if size == 0 {
+                    Err(ThreadPoolBuildError(
+                        "Must configure more than 0 threads".into(),
+                    ))
+                } else {
+                    Ok(size)
+                }
+            })?;
+
+        let prefix = self.prefix.unwrap_or_else(|| "ThreadPool-".into());
+
+        let (sender, receiver) = mpsc::channel();
+
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        let mut workers = Vec::with_capacity(size);
+        for id in 0..size {
+            workers.push(Worker::new(&prefix, id, receiver.clone())?);
+        }
+
+        Ok(ThreadPool { workers, sender })
+    }
+}
+
+pub struct ThreadPool {
+    workers: Vec<Worker>,
+    sender: mpsc::Sender<Message>,
+}
+
+impl ThreadPool {
+    pub fn executor(&self) -> JobExecutor {
+        JobExecutor {
+            sender: self.sender.clone(),
+        }
+    }
+
+    pub fn shutdown_signaler(&self) -> ShutdownSignaler {
+        ShutdownSignaler {
+            worker_count: self.workers.len(),
+            sender: self.sender.clone(),
+        }
+    }
+
+    pub fn join_all(mut self) {
+        for worker in &mut self.workers {
+            debug!("Shutting down worker {}", worker.id);
+            if let Some(thread) = worker.thread.take() {
+                if let Err(_err) = thread.join() {
+                    warn!("Failed to cleanly join worker thread {}", worker.id);
+                }
+            }
+        }
+    }
+}
+
+pub struct ShutdownSignaler {
+    worker_count: usize,
+    sender: mpsc::Sender<Message>,
+}
+
+impl ShutdownSignaler {
+    pub fn shutdown(&self) {
+        // Terminate all
+        for _ in 0..self.worker_count {
+            if let Err(_err) = self.sender.send(Message::Terminate) {
+                // ignore a dropped receiver
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct JobExecutor {
+    sender: mpsc::Sender<Message>,
+}
+
+impl JobExecutor {
+    pub fn execute<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let job = new_job(f);
+        if self.sender.send(Message::NewJob(job)).is_err() {
+            // ignore the dropped receiver
+        }
+    }
+}
+
+struct Worker {
+    id: usize,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Worker {
+    fn new(
+        prefix: &str,
+        id: usize,
+        receiver: Arc<Mutex<mpsc::Receiver<Message>>>,
+    ) -> Result<Worker, ThreadPoolBuildError> {
+        let thread = Some(
+            thread::Builder::new()
+                .name(format!("{}-{}", prefix, id))
+                .spawn(move || loop {
+                    let msg = {
+                        let receiver = match receiver.lock() {
+                            Ok(recv) => recv,
+                            Err(err) => {
+                                warn!(
+                                    "Attempting to recover from a poisoned lock in worker {}",
+                                    id
+                                );
+                                err.into_inner()
+                            }
+                        };
+
+                        match receiver.recv() {
+                            Ok(msg) => msg,
+                            Err(_) => break,
+                        }
+                    };
+
+                    match msg {
+                        Message::NewJob(job) => {
+                            debug!("Worker {} received job; executing.", id);
+                            job.call_box();
+                        }
+                        Message::Terminate => {
+                            debug!("Worker {} received terminate cmd.", id);
+                            break;
+                        }
+                    }
+                })
+                .map_err(|err| {
+                    ThreadPoolBuildError(format!("Unable to spawn worker thread: {}", err))
+                })?,
+        );
+
+        Ok(Worker { id, thread })
+    }
+}

--- a/libsplinter/src/network/connection_manager/error.rs
+++ b/libsplinter/src/network/connection_manager/error.rs
@@ -24,6 +24,7 @@ pub enum ConnectionManagerError {
     ConnectionCreationError(String),
     ConnectionRemovalError(String),
     ConnectionReconnectError(String),
+    Unauthorized(String),
     StatePoisoned,
 }
 
@@ -40,6 +41,9 @@ impl fmt::Display for ConnectionManagerError {
             ConnectionManagerError::ConnectionCreationError(ref s) => f.write_str(s),
             ConnectionManagerError::ConnectionRemovalError(ref s) => f.write_str(s),
             ConnectionManagerError::ConnectionReconnectError(ref s) => f.write_str(s),
+            ConnectionManagerError::Unauthorized(ref connection_id) => {
+                write!(f, "Connection {} failed authorization", connection_id)
+            }
             ConnectionManagerError::StatePoisoned => {
                 f.write_str("Connection state has been poisoned")
             }

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -16,7 +16,6 @@ mod error;
 mod notification;
 mod pacemaker;
 
-use std;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Sender};

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 pub mod auth;
 #[cfg(feature = "connection-manager")]
+pub mod auth2;
+#[cfg(feature = "connection-manager")]
 pub mod connection_manager;
 pub mod dispatch;
 mod dispatch_peer;

--- a/libsplinter/src/protocol/authorization.rs
+++ b/libsplinter/src/protocol/authorization.rs
@@ -1,0 +1,283 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Protocol structs for splinter connection authorization.
+//!
+//! These structs are used to operate on the messages that are sent and received during the
+//! authorization process for connections.
+
+use crate::protos::authorization;
+use crate::protos::prelude::*;
+
+/// The authorization message envelope.
+#[derive(Debug)]
+pub enum AuthorizationMessage {
+    ConnectRequest(ConnectRequest),
+    ConnectResponse(ConnectResponse),
+    Authorized(Authorized),
+    AuthorizationError(AuthorizationError),
+
+    TrustRequest(TrustRequest),
+}
+
+/// The possible types of authorization that may be computed during the handshake.
+#[derive(Debug)]
+pub enum AuthorizationType {
+    Trust,
+}
+
+/// A connection request message.
+///
+/// This message provides information from the incoming connection.
+#[derive(Debug)]
+pub enum ConnectRequest {
+    Bidirectional,
+    Unidirectional,
+}
+
+/// A connection response message.
+///
+/// This message provides information for the incoming peer regarding the types of authorization
+/// accepted.
+#[derive(Debug)]
+pub struct ConnectResponse {
+    pub accepted_authorization_types: Vec<AuthorizationType>,
+}
+
+/// A trust request.
+///
+/// A trust request is sent in response to a Connect Message, if the node is using trust
+/// authentication as its means of allowing a node to connect.
+#[derive(Debug)]
+pub struct TrustRequest {
+    pub identity: String,
+}
+
+/// A successful authorization message.
+///
+/// This message is returned after either a TrustResponse has been returned by the remote
+/// connection.
+#[derive(Debug)]
+pub struct Authorized;
+
+/// A message indicating an error in authorization.
+///
+/// This includes failed authorizations, or invalid messages during the authorization handshake
+/// conversation.
+#[derive(Debug)]
+pub enum AuthorizationError {
+    AuthorizationRejected(String),
+}
+
+impl FromProto<authorization::ConnectRequest> for ConnectRequest {
+    fn from_proto(source: authorization::ConnectRequest) -> Result<Self, ProtoConversionError> {
+        use authorization::ConnectRequest_HandshakeMode::*;
+        match source.handshake_mode {
+            BIDIRECTIONAL => Ok(ConnectRequest::Bidirectional),
+            UNIDIRECTIONAL => Ok(ConnectRequest::Unidirectional),
+            UNSET_HANDSHAKE_MODE => Err(ProtoConversionError::InvalidTypeError(
+                "No handshake mode was set".into(),
+            )),
+        }
+    }
+}
+
+impl FromNative<ConnectRequest> for authorization::ConnectRequest {
+    fn from_native(req: ConnectRequest) -> Result<Self, ProtoConversionError> {
+        let mut proto_request = authorization::ConnectRequest::new();
+        use authorization::ConnectRequest_HandshakeMode::*;
+        proto_request.set_handshake_mode(match req {
+            ConnectRequest::Bidirectional => BIDIRECTIONAL,
+            ConnectRequest::Unidirectional => UNIDIRECTIONAL,
+        });
+        Ok(proto_request)
+    }
+}
+
+impl FromProto<authorization::ConnectResponse> for ConnectResponse {
+    fn from_proto(source: authorization::ConnectResponse) -> Result<Self, ProtoConversionError> {
+        use authorization::ConnectResponse_AuthorizationType::*;
+        Ok(Self {
+            accepted_authorization_types: source
+                .get_accepted_authorization_types()
+                .iter()
+                .map(|t| match t {
+                    TRUST => Ok(AuthorizationType::Trust),
+                    UNSET_AUTHORIZATION_TYPE => Err(ProtoConversionError::InvalidTypeError(
+                        "no authorization type was set".into(),
+                    )),
+                })
+                .collect::<Result<Vec<AuthorizationType>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<ConnectResponse> for authorization::ConnectResponse {
+    fn from_native(source: ConnectResponse) -> Result<Self, ProtoConversionError> {
+        let mut response = authorization::ConnectResponse::new();
+
+        response.set_accepted_authorization_types(
+            source
+                .accepted_authorization_types
+                .into_iter()
+                .map(|auth_type| match auth_type {
+                    AuthorizationType::Trust => {
+                        authorization::ConnectResponse_AuthorizationType::TRUST
+                    }
+                })
+                .collect(),
+        );
+
+        Ok(response)
+    }
+}
+
+impl FromProto<authorization::TrustRequest> for TrustRequest {
+    fn from_proto(mut source: authorization::TrustRequest) -> Result<Self, ProtoConversionError> {
+        Ok(Self {
+            identity: source.take_identity(),
+        })
+    }
+}
+
+impl FromNative<TrustRequest> for authorization::TrustRequest {
+    fn from_native(source: TrustRequest) -> Result<Self, ProtoConversionError> {
+        let mut request = authorization::TrustRequest::new();
+        request.set_identity(source.identity);
+
+        Ok(request)
+    }
+}
+
+impl FromProto<authorization::AuthorizedMessage> for Authorized {
+    fn from_proto(_: authorization::AuthorizedMessage) -> Result<Self, ProtoConversionError> {
+        Ok(Authorized)
+    }
+}
+
+impl FromNative<Authorized> for authorization::AuthorizedMessage {
+    fn from_native(_: Authorized) -> Result<Self, ProtoConversionError> {
+        Ok(authorization::AuthorizedMessage::new())
+    }
+}
+
+impl FromProto<authorization::AuthorizationError> for AuthorizationError {
+    fn from_proto(
+        mut source: authorization::AuthorizationError,
+    ) -> Result<Self, ProtoConversionError> {
+        use authorization::AuthorizationError_AuthorizationErrorType::*;
+        match source.error_type {
+            AUTHORIZATION_REJECTED => Ok(AuthorizationError::AuthorizationRejected(
+                source.take_error_message(),
+            )),
+            UNSET_AUTHORIZATION_ERROR_TYPE => Err(ProtoConversionError::InvalidTypeError(
+                "No error type set".into(),
+            )),
+        }
+    }
+}
+
+impl FromNative<AuthorizationError> for authorization::AuthorizationError {
+    fn from_native(source: AuthorizationError) -> Result<Self, ProtoConversionError> {
+        use authorization::AuthorizationError_AuthorizationErrorType::*;
+        let mut error = authorization::AuthorizationError::new();
+        match source {
+            AuthorizationError::AuthorizationRejected(message) => {
+                error.set_error_type(AUTHORIZATION_REJECTED);
+                error.set_error_message(message);
+            }
+        }
+        Ok(error)
+    }
+}
+
+impl FromProto<authorization::AuthorizationMessage> for AuthorizationMessage {
+    fn from_proto(
+        source: authorization::AuthorizationMessage,
+    ) -> Result<Self, ProtoConversionError> {
+        use authorization::AuthorizationMessageType::*;
+        match source.message_type {
+            CONNECT_REQUEST => Ok(AuthorizationMessage::ConnectRequest(FromBytes::<
+                authorization::ConnectRequest,
+            >::from_bytes(
+                source.get_payload(),
+            )?)),
+            CONNECT_RESPONSE => Ok(AuthorizationMessage::ConnectResponse(FromBytes::<
+                authorization::ConnectResponse,
+            >::from_bytes(
+                source.get_payload(),
+            )?)),
+            AUTHORIZE => Ok(AuthorizationMessage::Authorized(FromBytes::<
+                authorization::AuthorizedMessage,
+            >::from_bytes(
+                source.get_payload()
+            )?)),
+            AUTHORIZATION_ERROR => Ok(AuthorizationMessage::AuthorizationError(FromBytes::<
+                authorization::AuthorizationError,
+            >::from_bytes(
+                source.get_payload(),
+            )?)),
+            TRUST_REQUEST => Ok(AuthorizationMessage::TrustRequest(FromBytes::<
+                authorization::TrustRequest,
+            >::from_bytes(
+                source.get_payload()
+            )?)),
+            UNSET_AUTHORIZATION_MESSAGE_TYPE => Err(ProtoConversionError::InvalidTypeError(
+                "no message type was set".into(),
+            )),
+        }
+    }
+}
+
+impl FromNative<AuthorizationMessage> for authorization::AuthorizationMessage {
+    fn from_native(source: AuthorizationMessage) -> Result<Self, ProtoConversionError> {
+        use authorization::AuthorizationMessageType::*;
+
+        let mut message = authorization::AuthorizationMessage::new();
+        match source {
+            AuthorizationMessage::ConnectRequest(payload) => {
+                message.set_message_type(CONNECT_REQUEST);
+                message.set_payload(IntoBytes::<authorization::ConnectRequest>::into_bytes(
+                    payload,
+                )?);
+            }
+            AuthorizationMessage::ConnectResponse(payload) => {
+                message.set_message_type(CONNECT_RESPONSE);
+                message.set_payload(IntoBytes::<authorization::ConnectResponse>::into_bytes(
+                    payload,
+                )?);
+            }
+            AuthorizationMessage::Authorized(payload) => {
+                message.set_message_type(AUTHORIZE);
+                message.set_payload(IntoBytes::<authorization::AuthorizedMessage>::into_bytes(
+                    payload,
+                )?);
+            }
+
+            AuthorizationMessage::AuthorizationError(payload) => {
+                message.set_message_type(AUTHORIZATION_ERROR);
+                message.set_payload(IntoBytes::<authorization::AuthorizationError>::into_bytes(
+                    payload,
+                )?);
+            }
+            AuthorizationMessage::TrustRequest(payload) => {
+                message.set_message_type(TRUST_REQUEST);
+                message.set_payload(IntoBytes::<authorization::TrustRequest>::into_bytes(
+                    payload,
+                )?);
+            }
+        }
+        Ok(message)
+    }
+}

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -14,6 +14,8 @@
 
 //! Protocol versions for various endpoints provided by splinter.
 
+pub mod authorization;
+
 pub const ADMIN_PROTOCOL_VERSION: u32 = 1;
 
 #[cfg(feature = "rest-api")]


### PR DESCRIPTION
This PR introduces authorization at the connection level, instead of at the peer level.  This ensures that any connection requested or added to the connection manager is authorized before the connection is usable by the layers above (like the peer manager or the service connection manager).

It copies (for the time being) the existing authorization code from network and reworks the the authorization manager into pool that owns the connections until they have finished the authorization process. Once done, it returns the connection to the connection manager, so it can proceed as usual.