### PR TITLE
Improve error message when a service cannot be initialized

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1438,7 +1438,14 @@ impl AdminServiceShared {
                 .collect();
 
             self.orchestrator
-                .initialize_service(service_definition.clone(), service_arguments)?;
+                .initialize_service(service_definition.clone(), service_arguments)
+                .map_err(|err| AdminSharedError::ServiceInitializationFailed {
+                    context: format!(
+                        "Unable to start service {} on circuit {}",
+                        service.service_id, circuit.circuit_id
+                    ),
+                    source: Some(err),
+                })?;
 
             self.running_services.insert(service_definition);
         }
@@ -1507,7 +1514,15 @@ impl AdminServiceShared {
                     .collect();
 
                 self.orchestrator
-                    .initialize_service(service_definition.clone(), service_arguments)?;
+                    .initialize_service(service_definition.clone(), service_arguments)
+                    .map_err(|err| AdminSharedError::ServiceInitializationFailed {
+                        context: format!(
+                            "Unable to start service {} on circuit {}",
+                            service.service_id(),
+                            circuit_name
+                        ),
+                        source: Some(err),
+                    })?;
 
                 self.running_services.insert(service_definition);
             }


### PR DESCRIPTION
If a service cannot be started, an error message will be
printed including the service id and circuit id. This will
be useful when debugging error on restart, when several
service are started at the same time.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>