### PR TITLE
Support ./ and ../ in config file paths

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -24,12 +24,15 @@ pub trait PartialConfigBuilder {
 }
 
 fn get_file_path(cert_dir: &str, file: &str) -> String {
-    let cert_dir_path = Path::new(&cert_dir);
-    let cert_file_path = cert_dir_path.join(file);
-    cert_file_path
-        .to_str()
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| String::from(file))
+    if file.starts_with("./") || file.starts_with("../") {
+        String::from(file)
+    } else {
+        Path::new(cert_dir)
+            .join(file)
+            .to_str()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| String::from(file))
+    }
 }
 
 /// ConfigBuilder collects PartialConfig objects from various sources to be used to generate a


### PR DESCRIPTION
Adds support to './' and '../' in file paths for files necessary
to the splinterd config. This ensures that these file paths will
not be prepended with the default certificate directory in case
'./' or '../' are present in the file path.

Signed-off-by: Shannyn Telander <telander@bitwise.io>