### PR TITLE
Remove keygen feature from splinter cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 splinter = { path = "../libsplinter", features = ["sawtooth-signing-compat"] }
-whoami = { version = "0.7.0", optional = true }
+whoami = "0.7.0"
 
 [dev-dependencies]
 gag = "0.1"
@@ -65,7 +65,6 @@ experimental = [
     "health",
     "database",
     "postgres",
-    "keygen",
     "circuit-auth-type",
 ]
 
@@ -74,7 +73,6 @@ circuit-template = ["splinter/circuit-template"]
 database-migrate-biome = ["splinter/biome"]
 
 health = []
-keygen = ["whoami"]
 
 database = ["splinter/postgres", "diesel", "postgres"]
 postgres = [

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -19,7 +19,6 @@ pub mod circuit;
 pub mod database;
 #[cfg(feature = "health")]
 pub mod health;
-#[cfg(feature = "keygen")]
 pub mod keygen;
 
 use std::collections::HashMap;


### PR DESCRIPTION
Stabilize keygen feature by removing feature and related feature guards.
`splinter keygen` will now be available when the cli is compiled with
no feature flags.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>