### PR TITLE
Prefix TLS specific splinterd options with tls

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
         splinterd \
             -c ./configs/splinterd-node-0-docker.toml \
             --registry file://./node_registries/nodes.yaml \
-            --insecure \
+            --tls-insecure \
             --enable-biome \
             --database postgres://splinter_admin:splinter_test@splinter-db:5432/splinter \
             $SPLINTERD_ARGS \

--- a/docker/kubernetes/arcade.yaml
+++ b/docker/kubernetes/arcade.yaml
@@ -129,7 +129,7 @@ items:
                 --node-id acme \
                 --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \
-                --insecure
+                --tls-insecure
             volumeMounts:
               - name: node-registry-volume
                 mountPath: /config/nodes.yaml
@@ -301,7 +301,7 @@ items:
                 --node-id bubba \
                 --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \
-                --insecure
+                --tls-insecure
             volumeMounts:
               - name: node-registry-volume
                 mountPath: /config/nodes.yaml

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -120,7 +120,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
-              --insecure
+              --tls-insecure
         "
 
     db-bubba:
@@ -206,5 +206,5 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
-              --insecure
+              --tls-insecure
         "

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -150,7 +150,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
-              --insecure
+              --tls-insecure
         "
 
     db-bubba:
@@ -260,5 +260,5 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoint tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
-              --insecure
+              --tls-insecure
         "

--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -37,6 +37,3 @@ bind = "localhost:8085"
 
 # Node Registry file
 registries = ["file:///node_registry/nodes.yaml"]
-
-# List of certificate authority certificates (*.pem files).
-ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -32,14 +32,8 @@ peers = []
 # currently "yaml" or "memory"
 storage = "yaml"
 
-# Which transport type this splinterd node supports. Options are "raw" or "tls"
-transport = "tls"
-
 # Rest api address.
 bind = "localhost:8085"
 
 # Node Registry file
 registries = ["file:///node_registry/nodes.yaml"]
-
-# List of certificate authority certificates (*.pem files).
-ca_certs = "/etc/splinter/certs/generated_ca.pem"

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
     entrypoint: |
       bash -c "
         splinter cert generate --skip && \
-        splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
+        splinterd -c ./project/tests/splinterd-node-0-docker.toml --tls-insecure -vv
       "
 
   db-cypress-test:

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
     entrypoint: |
       bash -c "
         splinter cert generate --skip &&
-        splinterd -c ./project/tests/splinterd-node-0-docker.toml --insecure -vv
+        splinterd -c ./project/tests/splinterd-node-0-docker.toml --tls-insecure -vv
       "
 
   db-test:

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -58,11 +58,6 @@ FLAGS
 `-h`, `--help`
 : Prints help information.
 
-`--insecure`
-: Turns off certificate authority validation for TLS connections; all peer
-  certificates are accepted. This flag is intended for development environments
-  using self-signed certificates.
-
 `--no-tls`
 : Turns off TLS configuration and restricts `splinterd` to TCP (`raw`)
   connections. This flag allows `splinterd` to start without the certificates
@@ -72,6 +67,11 @@ FLAGS
 `-q`, `--quiet`
 : Decreases verbosity (the opposite of `-v`). When specified, only errors or
   warnings will be displayed.
+
+`--tls-insecure`
+: Turns off certificate authority validation for TLS connections; all peer
+  certificates are accepted. This flag is intended for development environments
+  using self-signed certificates.
 
 `-V`, `--version`
 : Prints version information.
@@ -99,28 +99,6 @@ OPTIONS
 
 `--bind BIND-ENDPOINT`
 : Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
-
-`--ca-file CERT-FILE`
-: Specifies the path and file name for the trusted CA certificate.
-  (Default: `/etc/splinter/certs/ca_pem`.)
-
-  Do not use this option with the `--insecure` flag.
-
-`--cert-dir CERT-DIR`
-: Specifies the directory that contains the trusted CA certificates and
-  associated key files. (Default: `/etc/splinter/certs/`.)
-
-  This option overrides the `SPLINTER_CERT_DIR` environment variable, if set,
-  and any setting in the `splinterd` configuration file.
-
-`--client-cert CERT-FILE`
-: Specifies the path and file name for the client certificate, which is
-  used by `splinterd` when it is sending messages over TLS. (Default:
-  `/etc/splinter/certs/client.crt`.)
-
-`--client-key CLIENT-KEY`
-: Specifies the path and file name for the client key.
-  (Default: `/etc/splinter/certs/client.key`.)
 
 `-c`, `--config` `CONFIG-FILE`
 : Specifies the path and file name for a `splinterd` configuration file, which
@@ -164,15 +142,6 @@ OPTIONS
 `--registry REGISTRY-FILE` `[,...]`
 : Specifies one or more read-only node registry files.
 
-`--server-cert SERVER-CERT`
-: Specifies the path and file name for the server certificate, which is used by
-  `splinterd` when it is receiving messages over TLS.
-  (Default: `/etc/splinter/certs/server.crt`.)
-
-`--server-key SERVER-KEY`
-: Specifies the path and file name for the server key.
-  (Default: `/etc/splinter/certs/server.key`.)
-
 `--service-endpoint SERVICE-ENDPOINT`
 : Specifies the endpoint for service-to-daemon communication, using the format
   `tcp://ip:port`. (Default: `127.0.0.1:8043`.)
@@ -185,6 +154,37 @@ OPTIONS
 
   Using `memory` for storage means that circuits will not persist when
   `splinterd` restarts.
+
+`--tls-ca-file CERT-FILE`
+: Specifies the path and file name for the trusted CA certificate.
+  (Default: `/etc/splinter/certs/ca_pem`.)
+
+  Do not use this option with the `--tls-insecure` flag.
+
+`--tls-cert-dir CERT-DIR`
+: Specifies the directory that contains the trusted CA certificates and
+  associated key files. (Default: `/etc/splinter/certs/`.)
+
+  This option overrides the `SPLINTER_CERT_DIR` environment variable, if set,
+  and any setting in the `splinterd` configuration file.
+
+`--tls-client-cert CERT-FILE`
+: Specifies the path and file name for the client certificate, which is
+  used by `splinterd` when it is sending messages over TLS. (Default:
+  `/etc/splinter/certs/client.crt`.)
+
+`--tls-client-key CLIENT-KEY`
+: Specifies the path and file name for the client key.
+  (Default: `/etc/splinter/certs/client.key`.)
+
+`--tls-server-cert SERVER-CERT`
+: Specifies the path and file name for the server certificate, which is used by
+  `splinterd` when it is receiving messages over TLS.
+  (Default: `/etc/splinter/certs/server.crt`.)
+
+`--tls-server-key SERVER-KEY`
+: Specifies the path and file name for the server key.
+  (Default: `/etc/splinter/certs/server.key`.)
 
 `--whitelist WHITELIST` `[,...]`
 : Lists one or more trusted domains for cross-origin resource sharing (CORS).
@@ -202,7 +202,7 @@ When the Splinter daemon runs in TLS mode (using `tcps` connections at the
 transport layer), it requires certificate authority (CA) certificates and
 associated keys that are stored in `/etc/splinter/certs/` by default.
 
-You can change the certificate directory by using the `--cert-dir` option,
+You can change the certificate directory by using the `--tls-cert-dir` option,
 setting the `SPLINTER_CERT_DIR` environment variable, or specifying the
 location in a `splinterd` configuration file.
 
@@ -215,11 +215,11 @@ associated keys:
 * `server.crt`
 * `server.key`
 
-You can specify different paths and file names with the `--ca-file`,
-`--client-cert`, `--client-key`, `--server-cert`, and `--server-key`
-options (or related settings in the configuration file).
+You can specify different paths and file names with the `--tls-ca-file`,
+`--tls-client-cert`, `--tls-client-key`, `--tls-server-cert`, and
+`--tls-server-key` options (or related settings in the configuration file).
 
-In a development environment, you can use the `--insecure` flag to use
+In a development environment, you can use the `--tls-insecure` flag to use
 self-signed certificates and keys (which can be generated by the
 `splinter cert generate` command). For more information, see
 "[Generating Insecure Certificates for
@@ -231,7 +231,7 @@ ENVIRONMENT VARIABLES
 
 **SPLINTER_CERT_DIR**
 : Specifies the directory containing certificate and associated key files.
-  (See `--cert-dir`.)
+  (See `--tls-cert-dir`.)
 
 **SPLINTER_STATE_DIR**
 : Specifies where to store the circuit state YAML file, if `--storage` is
@@ -279,6 +279,5 @@ SEE ALSO
 ========
 | `splinter-circuit-propose(1)`
 | `splinter-cert-generate(1)`
-| 
+|
 | Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -35,7 +35,5 @@ storage = "memory"
 # Rest api address.
 bind = "0.0.0.0:8080"
 
-# List of certificate authority certificates (*.pem files).
-ca_certs = "/etc/splinter/certs/generated_ca.pem"
 # db address
 database = "postgres://splinter_admin:splinter_test@127.0.0.1:5432/splinter"

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -33,20 +33,20 @@ peers = []
 storage = "yaml"
 
 # List of certificate authority certificates (*.pem files).
-ca_certs = "certs/ca.pem"
+tls_ca_file = "certs/ca.pem"
 
 # A certificate signed by a certificate authority.
 # Used by the daemon when it is acting as a client
 # (sending messages).
-client_cert = "certs/client.crt"
+tls_client_cert = "certs/client.crt"
 
 # Private key used by daemon when it is acting as a client.
-client_key = "certs/client.key"
+tls_client_key = "certs/client.key"
 
 # A certificate signed by a certificate authority.
 # Used by the daemon when it is acting as a server
 # (receiving messages).
-server_cert = "certs/server.crt"
+tls_server_cert = "certs/server.crt"
 
 # Private key used by daemon when it is acting as a server.
-server_key = "certs/server.key"
+tls_server_key = "certs/server.key"

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -35,20 +35,20 @@ peers = [
 storage = "yaml"
 
 # List of certificate authority certificates (*.pem files).
-ca_certs = "certs/ca.pem"
+tls_ca_file = "certs/ca.pem"
 
 # A certificate signed by a certificate authority.
 # Used by the daemon when it is acting as a client
 # (sending messages).
-client_cert = "certs/client.crt"
+tls_client_cert = "certs/client.crt"
 
 # Private key used by daemon when it is acting as a client.
-client_key = "certs/client.key"
+tls_client_key = "certs/client.key"
 
 # A certificate signed by a certificate authority.
 # Used by the daemon when it is acting as a server
 # (receiving messages).
-server_cert = "certs/server.crt"
+tls_server_cert = "certs/server.crt"
 
 # Private key used by daemon when it is acting as a server.
-server_key = "certs/server.key"
+tls_server_key = "certs/server.key"

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -63,79 +63,79 @@ impl ConfigBuilder {
     /// Builds a Config object by incorporating the values from each PartialConfig object.
     ///
     pub fn build(self) -> Result<Config, ConfigError> {
-        let cert_dir = self
+        let tls_cert_dir = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.cert_dir() {
+            .find_map(|p| match p.tls_cert_dir() {
                 Some(v) => Some((v, p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("certificate directory".to_string()))?;
-        let ca_certs = self
+        let tls_ca_file = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.ca_certs() {
+            .find_map(|p| match p.tls_ca_file() {
                 Some(v) => {
                     if p.source() != ConfigSource::Default {
                         Some((v, p.source()))
                     } else {
-                        Some((get_file_path(&cert_dir.0, &v), p.source()))
+                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
                     }
                 }
                 None => None,
             })
-            .ok_or_else(|| ConfigError::MissingValue("ca certs".to_string()))?;
-        let client_cert = self
+            .ok_or_else(|| ConfigError::MissingValue("ca file".to_string()))?;
+        let tls_client_cert = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.client_cert() {
+            .find_map(|p| match p.tls_client_cert() {
                 Some(v) => {
                     if p.source() != ConfigSource::Default {
                         Some((v, p.source()))
                     } else {
-                        Some((get_file_path(&cert_dir.0, &v), p.source()))
+                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
                     }
                 }
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("client certificate".to_string()))?;
-        let client_key = self
+        let tls_client_key = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.client_key() {
+            .find_map(|p| match p.tls_client_key() {
                 Some(v) => {
                     if p.source() != ConfigSource::Default {
                         Some((v, p.source()))
                     } else {
-                        Some((get_file_path(&cert_dir.0, &v), p.source()))
+                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
                     }
                 }
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("client key".to_string()))?;
-        let server_cert = self
+        let tls_server_cert = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.server_cert() {
+            .find_map(|p| match p.tls_server_cert() {
                 Some(v) => {
                     if p.source() != ConfigSource::Default {
                         Some((v, p.source()))
                     } else {
-                        Some((get_file_path(&cert_dir.0, &v), p.source()))
+                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
                     }
                 }
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("server certificate".to_string()))?;
-        let server_key = self
+        let tls_server_key = self
             .partial_configs
             .iter()
-            .find_map(|p| match p.server_key() {
+            .find_map(|p| match p.tls_server_key() {
                 Some(v) => {
                     if p.source() != ConfigSource::Default {
                         Some((v, p.source()))
                     } else {
-                        Some((get_file_path(&cert_dir.0, &v), p.source()))
+                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
                     }
                 }
                 None => None,
@@ -160,12 +160,12 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("storage".to_string()))?,
-            cert_dir,
-            ca_certs,
-            client_cert,
-            client_key,
-            server_cert,
-            server_key,
+            tls_cert_dir,
+            tls_ca_file,
+            tls_client_cert,
+            tls_client_key,
+            tls_server_cert,
+            tls_server_key,
             service_endpoint: self
                 .partial_configs
                 .iter()
@@ -282,10 +282,10 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("state directory".to_string()))?,
-            insecure: self
+            tls_insecure: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.insecure() {
+                .find_map(|p| match p.tls_insecure() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
@@ -339,12 +339,24 @@ mod tests {
     /// Asserts the example configuration values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
-        assert_eq!(config.cert_dir(), None);
-        assert_eq!(config.ca_certs(), Some(EXAMPLE_CA_CERTS.to_string()));
-        assert_eq!(config.client_cert(), Some(EXAMPLE_CLIENT_CERT.to_string()));
-        assert_eq!(config.client_key(), Some(EXAMPLE_CLIENT_KEY.to_string()));
-        assert_eq!(config.server_cert(), Some(EXAMPLE_SERVER_CERT.to_string()));
-        assert_eq!(config.server_key(), Some(EXAMPLE_SERVER_KEY.to_string()));
+        assert_eq!(config.tls_cert_dir(), None);
+        assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
+        assert_eq!(
+            config.tls_client_cert(),
+            Some(EXAMPLE_CLIENT_CERT.to_string())
+        );
+        assert_eq!(
+            config.tls_client_key(),
+            Some(EXAMPLE_CLIENT_KEY.to_string())
+        );
+        assert_eq!(
+            config.tls_server_cert(),
+            Some(EXAMPLE_SERVER_CERT.to_string())
+        );
+        assert_eq!(
+            config.tls_server_key(),
+            Some(EXAMPLE_SERVER_KEY.to_string())
+        );
         assert_eq!(
             config.service_endpoint(),
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
@@ -386,12 +398,12 @@ mod tests {
         // Populate the PartialConfig fields by chaining the builder methods.
         partial_config = partial_config
             .with_storage(Some(EXAMPLE_STORAGE.to_string()))
-            .with_cert_dir(None)
-            .with_ca_certs(Some(EXAMPLE_CA_CERTS.to_string()))
-            .with_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()))
-            .with_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()))
-            .with_server_cert(Some(EXAMPLE_SERVER_CERT.to_string()))
-            .with_server_key(Some(EXAMPLE_SERVER_KEY.to_string()))
+            .with_tls_cert_dir(None)
+            .with_tls_ca_file(Some(EXAMPLE_CA_CERTS.to_string()))
+            .with_tls_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()))
+            .with_tls_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()))
+            .with_tls_server_cert(Some(EXAMPLE_SERVER_CERT.to_string()))
+            .with_tls_server_key(Some(EXAMPLE_SERVER_KEY.to_string()))
             .with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()))
             .with_network_endpoints(Some(vec![EXAMPLE_NETWORK_ENDPOINT.to_string()]))
             .with_advertised_endpoints(Some(vec![EXAMPLE_ADVERTISED_ENDPOINT.to_string()]))
@@ -421,11 +433,11 @@ mod tests {
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the PartialConfig fields by separately applying the builder methods.
         partial_config = partial_config.with_storage(Some(EXAMPLE_STORAGE.to_string()));
-        partial_config = partial_config.with_ca_certs(Some(EXAMPLE_CA_CERTS.to_string()));
-        partial_config = partial_config.with_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()));
-        partial_config = partial_config.with_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()));
-        partial_config = partial_config.with_server_cert(Some(EXAMPLE_SERVER_CERT.to_string()));
-        partial_config = partial_config.with_server_key(Some(EXAMPLE_SERVER_KEY.to_string()));
+        partial_config = partial_config.with_tls_ca_file(Some(EXAMPLE_CA_CERTS.to_string()));
+        partial_config = partial_config.with_tls_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()));
+        partial_config = partial_config.with_tls_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()));
+        partial_config = partial_config.with_tls_server_cert(Some(EXAMPLE_SERVER_CERT.to_string()));
+        partial_config = partial_config.with_tls_server_key(Some(EXAMPLE_SERVER_KEY.to_string()));
         partial_config =
             partial_config.with_service_endpoint(Some(EXAMPLE_SERVICE_ENDPOINT.to_string()));
         partial_config =

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -42,12 +42,12 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
 
         partial_config = partial_config
             .with_storage(self.matches.value_of("storage").map(String::from))
-            .with_cert_dir(self.matches.value_of("cert_dir").map(String::from))
-            .with_ca_certs(self.matches.value_of("ca_file").map(String::from))
-            .with_client_cert(self.matches.value_of("client_cert").map(String::from))
-            .with_client_key(self.matches.value_of("client_key").map(String::from))
-            .with_server_cert(self.matches.value_of("server_cert").map(String::from))
-            .with_server_key(self.matches.value_of("server_key").map(String::from))
+            .with_tls_cert_dir(self.matches.value_of("tls_cert_dir").map(String::from))
+            .with_tls_ca_file(self.matches.value_of("tls_ca_file").map(String::from))
+            .with_tls_client_cert(self.matches.value_of("tls_client_cert").map(String::from))
+            .with_tls_client_key(self.matches.value_of("tls_client_key").map(String::from))
+            .with_tls_server_cert(self.matches.value_of("tls_server_cert").map(String::from))
+            .with_tls_server_key(self.matches.value_of("tls_server_key").map(String::from))
             .with_service_endpoint(self.matches.value_of("service_endpoint").map(String::from))
             .with_network_endpoints(
                 self.matches
@@ -73,7 +73,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                     .map(|values| values.map(String::from).collect::<Vec<String>>()),
             )
             .with_heartbeat_interval(parse_value(&self.matches, "heartbeat_interval")?)
-            .with_insecure(if self.matches.is_present("insecure") {
+            .with_tls_insecure(if self.matches.is_present("tls_insecure") {
                 Some(true)
             } else {
                 None
@@ -147,12 +147,24 @@ mod tests {
     /// Asserts config values based on the example values.
     fn assert_config_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
-        assert_eq!(config.cert_dir(), None);
-        assert_eq!(config.ca_certs(), Some(EXAMPLE_CA_CERTS.to_string()));
-        assert_eq!(config.client_cert(), Some(EXAMPLE_CLIENT_CERT.to_string()));
-        assert_eq!(config.client_key(), Some(EXAMPLE_CLIENT_KEY.to_string()));
-        assert_eq!(config.server_cert(), Some(EXAMPLE_SERVER_CERT.to_string()));
-        assert_eq!(config.server_key(), Some(EXAMPLE_SERVER_KEY.to_string()));
+        assert_eq!(config.tls_cert_dir(), None);
+        assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
+        assert_eq!(
+            config.tls_client_cert(),
+            Some(EXAMPLE_CLIENT_CERT.to_string())
+        );
+        assert_eq!(
+            config.tls_client_key(),
+            Some(EXAMPLE_CLIENT_KEY.to_string())
+        );
+        assert_eq!(
+            config.tls_server_cert(),
+            Some(EXAMPLE_SERVER_CERT.to_string())
+        );
+        assert_eq!(
+            config.tls_server_key(),
+            Some(EXAMPLE_SERVER_KEY.to_string())
+        );
         assert_eq!(
             config.service_endpoint(),
             Some(EXAMPLE_SERVICE_ENDPOINT.to_string())
@@ -181,7 +193,7 @@ mod tests {
         assert_eq!(config.registry_forced_refresh_interval(), None);
         assert_eq!(config.heartbeat_interval(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
-        assert_eq!(config.insecure(), Some(true));
+        assert_eq!(config.tls_insecure(), Some(true));
         assert_eq!(config.no_tls(), Some(true));
     }
 
@@ -198,14 +210,14 @@ mod tests {
             (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
             (@arg peers: --peer +takes_value +multiple)
-            (@arg ca_file: --("ca-file") +takes_value)
-            (@arg cert_dir: --("cert-dir") +takes_value)
-            (@arg client_cert: --("client-cert") +takes_value)
-            (@arg server_cert: --("server-cert") +takes_value)
-            (@arg server_key:  --("server-key") +takes_value)
-            (@arg client_key:  --("client-key") +takes_value)
+            (@arg tls_ca_file: --("tls-ca-file") +takes_value)
+            (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
+            (@arg tls_client_cert: --("tls-client-cert") +takes_value)
+            (@arg tls_server_cert: --("tls-server-cert") +takes_value)
+            (@arg tls_server_key:  --("tls-server-key") +takes_value)
+            (@arg tls_client_key:  --("tls-client-key") +takes_value)
             (@arg bind: --("bind") +takes_value)
-            (@arg insecure: --("insecure"))
+            (@arg tls_insecure: --("tls-insecure"))
             (@arg no_tls: --("no-tls")))
         .get_matches_from(args)
     }
@@ -237,17 +249,17 @@ mod tests {
             EXAMPLE_ADVERTISED_ENDPOINT,
             "--service-endpoint",
             EXAMPLE_SERVICE_ENDPOINT,
-            "--ca-file",
+            "--tls-ca-file",
             EXAMPLE_CA_CERTS,
-            "--client-cert",
+            "--tls-client-cert",
             EXAMPLE_CLIENT_CERT,
-            "--client-key",
+            "--tls-client-key",
             EXAMPLE_CLIENT_KEY,
-            "--server-cert",
+            "--tls-server-cert",
             EXAMPLE_SERVER_CERT,
-            "--server-key",
+            "--tls-server-key",
             EXAMPLE_SERVER_KEY,
-            "--insecure",
+            "--tls-insecure",
             "--no-tls",
         ];
         // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -44,12 +44,12 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
 
         partial_config = partial_config
             .with_storage(Some(String::from("yaml")))
-            .with_cert_dir(Some(String::from(DEFAULT_CERT_DIR)))
-            .with_ca_certs(Some(String::from(CA_PEM)))
-            .with_client_cert(Some(String::from(CLIENT_CERT)))
-            .with_client_key(Some(String::from(CLIENT_KEY)))
-            .with_server_cert(Some(String::from(SERVER_CERT)))
-            .with_server_key(Some(String::from(SERVER_KEY)))
+            .with_tls_cert_dir(Some(String::from(DEFAULT_CERT_DIR)))
+            .with_tls_ca_file(Some(String::from(CA_PEM)))
+            .with_tls_client_cert(Some(String::from(CLIENT_CERT)))
+            .with_tls_client_key(Some(String::from(CLIENT_KEY)))
+            .with_tls_server_cert(Some(String::from(SERVER_CERT)))
+            .with_tls_server_key(Some(String::from(SERVER_KEY)))
             .with_service_endpoint(Some(String::from("127.0.0.1:8043")))
             .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
             .with_peers(Some(vec![]))
@@ -61,7 +61,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS,
             ))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
-            .with_insecure(Some(false))
+            .with_tls_insecure(Some(false))
             .with_no_tls(Some(false));
 
         #[cfg(feature = "biome")]
@@ -94,12 +94,12 @@ mod tests {
     /// Asserts config values based on the default values.
     fn assert_default_values(config: PartialConfig) {
         assert_eq!(config.storage(), Some(String::from("yaml")));
-        assert_eq!(config.cert_dir(), Some(String::from(DEFAULT_CERT_DIR)));
-        assert_eq!(config.ca_certs(), Some(String::from(CA_PEM)));
-        assert_eq!(config.client_cert(), Some(String::from(CLIENT_CERT)));
-        assert_eq!(config.client_key(), Some(String::from(CLIENT_KEY)));
-        assert_eq!(config.server_cert(), Some(String::from(SERVER_CERT)));
-        assert_eq!(config.server_key(), Some(String::from(SERVER_KEY)));
+        assert_eq!(config.tls_cert_dir(), Some(String::from(DEFAULT_CERT_DIR)));
+        assert_eq!(config.tls_ca_file(), Some(String::from(CA_PEM)));
+        assert_eq!(config.tls_client_cert(), Some(String::from(CLIENT_CERT)));
+        assert_eq!(config.tls_client_key(), Some(String::from(CLIENT_KEY)));
+        assert_eq!(config.tls_server_cert(), Some(String::from(SERVER_CERT)));
+        assert_eq!(config.tls_server_key(), Some(String::from(SERVER_KEY)));
         assert_eq!(
             config.service_endpoint(),
             Some(String::from("127.0.0.1:8043"))
@@ -133,7 +133,7 @@ mod tests {
             ))
         );
         assert_eq!(config.state_dir(), Some(String::from(DEFAULT_STATE_DIR)));
-        assert_eq!(config.insecure(), Some(false));
+        assert_eq!(config.tls_insecure(), Some(false));
         assert_eq!(config.no_tls(), Some(false));
         #[cfg(feature = "biome")]
         assert_eq!(config.biome_enabled(), Some(false));

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -31,7 +31,7 @@ impl EnvPartialConfigBuilder {
 impl PartialConfigBuilder for EnvPartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         Ok(PartialConfig::new(ConfigSource::Environment)
-            .with_cert_dir(env::var(CERT_DIR_ENV).ok())
+            .with_tls_cert_dir(env::var(CERT_DIR_ENV).ok())
             .with_state_dir(env::var(STATE_DIR_ENV).ok()))
     }
 }
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(unset_config.source(), ConfigSource::Environment);
         // Compare the generated PartialConfig object against the expected values.
         assert_eq!(unset_config.state_dir(), None);
-        assert_eq!(unset_config.cert_dir(), None);
+        assert_eq!(unset_config.tls_cert_dir(), None);
 
         // Set the environment variables.
         env::set_var(STATE_DIR_ENV, "state/test/config");
@@ -89,7 +89,7 @@ mod tests {
             Some(String::from("state/test/config"))
         );
         assert_eq!(
-            set_config.cert_dir(),
+            set_config.tls_cert_dir(),
             Some(String::from("cert/test/config"))
         );
     }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -43,12 +43,12 @@ pub use partial::{ConfigSource, PartialConfig};
 #[derive(Debug)]
 pub struct Config {
     storage: (String, ConfigSource),
-    cert_dir: (String, ConfigSource),
-    ca_certs: (String, ConfigSource),
-    client_cert: (String, ConfigSource),
-    client_key: (String, ConfigSource),
-    server_cert: (String, ConfigSource),
-    server_key: (String, ConfigSource),
+    tls_cert_dir: (String, ConfigSource),
+    tls_ca_file: (String, ConfigSource),
+    tls_client_cert: (String, ConfigSource),
+    tls_client_key: (String, ConfigSource),
+    tls_server_cert: (String, ConfigSource),
+    tls_server_key: (String, ConfigSource),
     service_endpoint: (String, ConfigSource),
     network_endpoints: (Vec<String>, ConfigSource),
     advertised_endpoints: (Vec<String>, ConfigSource),
@@ -66,7 +66,7 @@ pub struct Config {
     heartbeat_interval: (u64, ConfigSource),
     admin_service_coordinator_timeout: (Duration, ConfigSource),
     state_dir: (String, ConfigSource),
-    insecure: (bool, ConfigSource),
+    tls_insecure: (bool, ConfigSource),
     no_tls: (bool, ConfigSource),
     #[cfg(feature = "biome")]
     biome_enabled: (bool, ConfigSource),
@@ -79,28 +79,28 @@ impl Config {
         &self.storage.0
     }
 
-    pub fn cert_dir(&self) -> &str {
-        &self.cert_dir.0
+    pub fn tls_cert_dir(&self) -> &str {
+        &self.tls_cert_dir.0
     }
 
-    pub fn ca_certs(&self) -> &str {
-        &self.ca_certs.0
+    pub fn tls_ca_file(&self) -> &str {
+        &self.tls_ca_file.0
     }
 
-    pub fn client_cert(&self) -> &str {
-        &self.client_cert.0
+    pub fn tls_client_cert(&self) -> &str {
+        &self.tls_client_cert.0
     }
 
-    pub fn client_key(&self) -> &str {
-        &self.client_key.0
+    pub fn tls_client_key(&self) -> &str {
+        &self.tls_client_key.0
     }
 
-    pub fn server_cert(&self) -> &str {
-        &self.server_cert.0
+    pub fn tls_server_cert(&self) -> &str {
+        &self.tls_server_cert.0
     }
 
-    pub fn server_key(&self) -> &str {
-        &self.server_key.0
+    pub fn tls_server_key(&self) -> &str {
+        &self.tls_server_key.0
     }
 
     pub fn service_endpoint(&self) -> &str {
@@ -162,8 +162,8 @@ impl Config {
         &self.state_dir.0
     }
 
-    pub fn insecure(&self) -> bool {
-        self.insecure.0
+    pub fn tls_insecure(&self) -> bool {
+        self.tls_insecure.0
     }
 
     pub fn no_tls(&self) -> bool {
@@ -188,28 +188,28 @@ impl Config {
         &self.storage.1
     }
 
-    fn cert_dir_source(&self) -> &ConfigSource {
-        &self.cert_dir.1
+    fn tls_cert_dir_source(&self) -> &ConfigSource {
+        &self.tls_cert_dir.1
     }
 
-    fn ca_certs_source(&self) -> &ConfigSource {
-        &self.ca_certs.1
+    fn tls_ca_file_source(&self) -> &ConfigSource {
+        &self.tls_ca_file.1
     }
 
-    fn client_cert_source(&self) -> &ConfigSource {
-        &self.client_cert.1
+    fn tls_client_cert_source(&self) -> &ConfigSource {
+        &self.tls_client_cert.1
     }
 
-    fn client_key_source(&self) -> &ConfigSource {
-        &self.client_key.1
+    fn tls_client_key_source(&self) -> &ConfigSource {
+        &self.tls_client_key.1
     }
 
-    fn server_cert_source(&self) -> &ConfigSource {
-        &self.server_cert.1
+    fn tls_server_cert_source(&self) -> &ConfigSource {
+        &self.tls_server_cert.1
     }
 
-    fn server_key_source(&self) -> &ConfigSource {
-        &self.server_key.1
+    fn tls_server_key_source(&self) -> &ConfigSource {
+        &self.tls_server_key.1
     }
 
     fn service_endpoint_source(&self) -> &ConfigSource {
@@ -271,8 +271,8 @@ impl Config {
         &self.state_dir.1
     }
 
-    fn insecure_source(&self) -> &ConfigSource {
-        &self.insecure.1
+    fn tls_insecure_source(&self) -> &ConfigSource {
+        &self.tls_insecure.1
     }
 
     fn no_tls_source(&self) -> &ConfigSource {
@@ -301,34 +301,34 @@ impl Config {
             self.storage_source()
         );
         debug!(
-            "Config: ca_certs: {} (source: {:?})",
-            self.ca_certs(),
-            self.ca_certs_source()
+            "Config: tls_ca_file: {} (source: {:?})",
+            self.tls_ca_file(),
+            self.tls_ca_file_source()
         );
         debug!(
-            "Config: cert_dir: {} (source: {:?})",
-            self.cert_dir(),
-            self.cert_dir_source()
+            "Config: tls_cert_dir: {} (source: {:?})",
+            self.tls_cert_dir(),
+            self.tls_cert_dir_source()
         );
         debug!(
-            "Config: client_cert: {} (source: {:?})",
-            self.client_cert(),
-            self.client_cert_source()
+            "Config: tls_client_cert: {} (source: {:?})",
+            self.tls_client_cert(),
+            self.tls_client_cert_source()
         );
         debug!(
-            "Config: client_key: {} (source: {:?})",
-            self.client_key(),
-            self.client_key_source()
+            "Config: tls_client_key: {} (source: {:?})",
+            self.tls_client_key(),
+            self.tls_client_key_source()
         );
         debug!(
-            "Config: server_cert: {} (source: {:?})",
-            self.server_cert(),
-            self.server_cert_source()
+            "Config: tls_server_cert: {} (source: {:?})",
+            self.tls_server_cert(),
+            self.tls_server_cert_source()
         );
         debug!(
-            "Config: server_key: {} (source: {:?})",
-            self.server_key(),
-            self.server_key_source()
+            "Config: tls_server_key: {} (source: {:?})",
+            self.tls_server_key(),
+            self.tls_server_key_source()
         );
         debug!(
             "Config: service_endpoint: {} (source: {:?})",
@@ -404,9 +404,9 @@ impl Config {
             self.database_source(),
         );
         debug!(
-            "Config: insecure: {:?} (source: {:?})",
-            self.insecure(),
-            self.insecure_source()
+            "Config: tls_insecure: {:?} (source: {:?})",
+            self.tls_insecure(),
+            self.tls_insecure_source()
         );
         debug!(
             "Config: no_tls: {:?} (source: {:?})",
@@ -477,11 +477,17 @@ mod tests {
     pub fn get_toml_value() -> Value {
         let values = vec![
             ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
-            ("ca_certs".to_string(), EXAMPLE_CA_CERTS.to_string()),
-            ("client_cert".to_string(), EXAMPLE_CLIENT_CERT.to_string()),
-            ("client_key".to_string(), EXAMPLE_CLIENT_KEY.to_string()),
-            ("server_cert".to_string(), EXAMPLE_SERVER_CERT.to_string()),
-            ("server_key".to_string(), EXAMPLE_SERVER_KEY.to_string()),
+            ("tls_ca_file".to_string(), EXAMPLE_CA_CERTS.to_string()),
+            (
+                "tls_client_cert".to_string(),
+                EXAMPLE_CLIENT_CERT.to_string(),
+            ),
+            ("tls_client_key".to_string(), EXAMPLE_CLIENT_KEY.to_string()),
+            (
+                "tls_server_cert".to_string(),
+                EXAMPLE_SERVER_CERT.to_string(),
+            ),
+            ("tls_server_key".to_string(), EXAMPLE_SERVER_KEY.to_string()),
             (
                 "service_endpoint".to_string(),
                 EXAMPLE_SERVICE_ENDPOINT.to_string(),
@@ -511,14 +517,14 @@ mod tests {
         (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
         (@arg service_endpoint: --("service-endpoint") +takes_value)
         (@arg peers: --peer +takes_value +multiple)
-        (@arg ca_file: --("ca-file") +takes_value)
-        (@arg cert_dir: --("cert-dir") +takes_value)
-        (@arg client_cert: --("client-cert") +takes_value)
-        (@arg server_cert: --("server-cert") +takes_value)
-        (@arg server_key:  --("server-key") +takes_value)
-        (@arg client_key:  --("client-key") +takes_value)
+        (@arg tls_ca_file: --("tls-ca-file") +takes_value)
+        (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
+        (@arg tls_client_cert: --("tls-client-cert") +takes_value)
+        (@arg tls_server_cert: --("tls-server-cert") +takes_value)
+        (@arg tls_server_key:  --("tls-server-key") +takes_value)
+        (@arg tls_client_key:  --("tls-client-key") +takes_value)
         (@arg bind: --("bind") +takes_value)
-        (@arg insecure: --("insecure"))
+        (@arg tls_insecure: --("tls-insecure"))
         (@arg no_tls: --("no-tls"))
         (@arg biome_enabled: --("enable-biome")))
         .get_matches_from(args)
@@ -616,17 +622,17 @@ mod tests {
             EXAMPLE_ADVERTISED_ENDPOINT,
             "--service-endpoint",
             EXAMPLE_SERVICE_ENDPOINT,
-            "--ca-file",
+            "--tls-ca-file",
             EXAMPLE_CA_CERTS,
-            "--client-cert",
+            "--tls-client-cert",
             EXAMPLE_CLIENT_CERT,
-            "--client-key",
+            "--tls-client-key",
             EXAMPLE_CLIENT_KEY,
-            "--server-cert",
+            "--tls-server-cert",
             EXAMPLE_SERVER_CERT,
-            "--server-key",
+            "--tls-server-key",
             EXAMPLE_SERVER_KEY,
-            "--insecure",
+            "--tls-insecure",
             "--no-tls",
             "--enable-biome",
         ];
@@ -738,18 +744,24 @@ mod tests {
             (true, &ConfigSource::CommandLine)
         );
 
-        // The DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for `cert_dir`,
-        // but the EnvPartialConfigBuilder value should have precedence (source should be
-        // Environment).
+        // The DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for
+        // `tls_cert_dir`, but the EnvPartialConfigBuilder value should have precedence (source
+        // should be Environment).
         assert_eq!(
-            (final_config.cert_dir(), final_config.cert_dir_source()),
+            (
+                final_config.tls_cert_dir(),
+                final_config.tls_cert_dir_source()
+            ),
             ("cert/test/config", &ConfigSource::Environment)
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `ca_certs`, but the TomlPartialConfigBuilder value should have precedence (source should
-        // be Toml).
+        // `tls_ca_file`, but the TomlPartialConfigBuilder value should have precedence (source
+        // should be Toml).
         assert_eq!(
-            (final_config.ca_certs(), final_config.ca_certs_source()),
+            (
+                final_config.tls_ca_file(),
+                final_config.tls_ca_file_source()
+            ),
             (
                 EXAMPLE_CA_CERTS,
                 &ConfigSource::Toml {
@@ -758,12 +770,12 @@ mod tests {
             )
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `client_cert`, but the TomlPartialConfigBuilder value should have precedence (source
+        // `tls_client_cert`, but the TomlPartialConfigBuilder value should have precedence (source
         // should be Toml).
         assert_eq!(
             (
-                final_config.client_cert(),
-                final_config.client_cert_source()
+                final_config.tls_client_cert(),
+                final_config.tls_client_cert_source()
             ),
             (
                 EXAMPLE_CLIENT_CERT,
@@ -773,10 +785,13 @@ mod tests {
             )
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `client_key`, but the TomlPartialConfigBuilder value should have precedence (source
+        // `tls_client_key`, but the TomlPartialConfigBuilder value should have precedence (source
         // should be Toml).
         assert_eq!(
-            (final_config.client_key(), final_config.client_key_source()),
+            (
+                final_config.tls_client_key(),
+                final_config.tls_client_key_source()
+            ),
             (
                 EXAMPLE_CLIENT_KEY,
                 &ConfigSource::Toml {
@@ -785,12 +800,12 @@ mod tests {
             )
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `server_cert`, but the TomlPartialConfigBuilder value should have precedence (source
+        // `tls_server_cert`, but the TomlPartialConfigBuilder value should have precedence (source
         // should be Toml).
         assert_eq!(
             (
-                final_config.server_cert(),
-                final_config.server_cert_source()
+                final_config.tls_server_cert(),
+                final_config.tls_server_cert_source()
             ),
             (
                 EXAMPLE_SERVER_CERT,
@@ -800,10 +815,13 @@ mod tests {
             )
         );
         // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `server_key`, but the TomlPartialConfigBuilder value should have precedence (source
+        // `tls_server_key`, but the TomlPartialConfigBuilder value should have precedence (source
         // should be Toml).
         assert_eq!(
-            (final_config.server_key(), final_config.server_key_source()),
+            (
+                final_config.tls_server_key(),
+                final_config.tls_server_key_source()
+            ),
             (
                 EXAMPLE_SERVER_KEY,
                 &ConfigSource::Toml {
@@ -957,7 +975,7 @@ mod tests {
             "123",
             "--display-name",
             "Node 1",
-            "--cert-dir",
+            "--tls-cert-dir",
             "/my_files/",
         ];
         // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
@@ -983,14 +1001,20 @@ mod tests {
         // but the EnvPartialConfigBuilder value should have precedence (source should be
         // Environment).
         assert_eq!(
-            (final_config.cert_dir(), final_config.cert_dir_source()),
+            (
+                final_config.tls_cert_dir(),
+                final_config.tls_cert_dir_source()
+            ),
             ("/my_files/", &ConfigSource::CommandLine)
         );
-        // The DefaultPartialConfigBuilder had a value for the ca_certs, and since the cert_dir
+        // The DefaultPartialConfigBuilder had a value for the ca_file, and since the cert_dir
         // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
         // appended to the default file name.
         assert_eq!(
-            (final_config.ca_certs(), final_config.ca_certs_source()),
+            (
+                final_config.tls_ca_file(),
+                final_config.tls_ca_file_source()
+            ),
             (
                 format!("{}{}", "/my_files/", DEFAULT_CA_CERT).as_str(),
                 &ConfigSource::Default,
@@ -1001,8 +1025,8 @@ mod tests {
         // appended to the default file name.
         assert_eq!(
             (
-                final_config.client_cert(),
-                final_config.client_cert_source()
+                final_config.tls_client_cert(),
+                final_config.tls_client_cert_source()
             ),
             (
                 format!("{}{}", "/my_files/", DEFAULT_CLIENT_CERT).as_str(),
@@ -1013,7 +1037,10 @@ mod tests {
         // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
         // appended to the default file name.
         assert_eq!(
-            (final_config.client_key(), final_config.client_key_source()),
+            (
+                final_config.tls_client_key(),
+                final_config.tls_client_key_source()
+            ),
             (
                 format!("{}{}", "/my_files/", DEFAULT_CLIENT_KEY).as_str(),
                 &ConfigSource::Default,
@@ -1024,8 +1051,8 @@ mod tests {
         // appended to the default file name.
         assert_eq!(
             (
-                final_config.server_cert(),
-                final_config.server_cert_source()
+                final_config.tls_server_cert(),
+                final_config.tls_server_cert_source()
             ),
             (
                 format!("{}{}", "/my_files/", DEFAULT_SERVER_CERT).as_str(),
@@ -1036,7 +1063,10 @@ mod tests {
         // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
         // appended to the default file name.
         assert_eq!(
-            (final_config.server_key(), final_config.server_key_source()),
+            (
+                final_config.tls_server_key(),
+                final_config.tls_server_key_source()
+            ),
             (
                 format!("{}{}", "/my_files/", DEFAULT_SERVER_KEY).as_str(),
                 &ConfigSource::Default,

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -31,12 +31,12 @@ pub enum ConfigSource {
 pub struct PartialConfig {
     source: ConfigSource,
     storage: Option<String>,
-    cert_dir: Option<String>,
-    ca_certs: Option<String>,
-    client_cert: Option<String>,
-    client_key: Option<String>,
-    server_cert: Option<String>,
-    server_key: Option<String>,
+    tls_cert_dir: Option<String>,
+    tls_ca_file: Option<String>,
+    tls_client_cert: Option<String>,
+    tls_client_key: Option<String>,
+    tls_server_cert: Option<String>,
+    tls_server_key: Option<String>,
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
     advertised_endpoints: Option<Vec<String>>,
@@ -54,7 +54,7 @@ pub struct PartialConfig {
     heartbeat_interval: Option<u64>,
     admin_service_coordinator_timeout: Option<Duration>,
     state_dir: Option<String>,
-    insecure: Option<bool>,
+    tls_insecure: Option<bool>,
     no_tls: Option<bool>,
     #[cfg(feature = "biome")]
     biome_enabled: Option<bool>,
@@ -68,12 +68,12 @@ impl PartialConfig {
         PartialConfig {
             source,
             storage: None,
-            cert_dir: None,
-            ca_certs: None,
-            client_cert: None,
-            client_key: None,
-            server_cert: None,
-            server_key: None,
+            tls_cert_dir: None,
+            tls_ca_file: None,
+            tls_client_cert: None,
+            tls_client_key: None,
+            tls_server_cert: None,
+            tls_server_key: None,
             service_endpoint: None,
             network_endpoints: None,
             advertised_endpoints: None,
@@ -91,7 +91,7 @@ impl PartialConfig {
             heartbeat_interval: None,
             admin_service_coordinator_timeout: None,
             state_dir: None,
-            insecure: None,
+            tls_insecure: None,
             no_tls: None,
             #[cfg(feature = "biome")]
             biome_enabled: None,
@@ -108,28 +108,28 @@ impl PartialConfig {
         self.storage.clone()
     }
 
-    pub fn cert_dir(&self) -> Option<String> {
-        self.cert_dir.clone()
+    pub fn tls_cert_dir(&self) -> Option<String> {
+        self.tls_cert_dir.clone()
     }
 
-    pub fn ca_certs(&self) -> Option<String> {
-        self.ca_certs.clone()
+    pub fn tls_ca_file(&self) -> Option<String> {
+        self.tls_ca_file.clone()
     }
 
-    pub fn client_cert(&self) -> Option<String> {
-        self.client_cert.clone()
+    pub fn tls_client_cert(&self) -> Option<String> {
+        self.tls_client_cert.clone()
     }
 
-    pub fn client_key(&self) -> Option<String> {
-        self.client_key.clone()
+    pub fn tls_client_key(&self) -> Option<String> {
+        self.tls_client_key.clone()
     }
 
-    pub fn server_cert(&self) -> Option<String> {
-        self.server_cert.clone()
+    pub fn tls_server_cert(&self) -> Option<String> {
+        self.tls_server_cert.clone()
     }
 
-    pub fn server_key(&self) -> Option<String> {
-        self.server_key.clone()
+    pub fn tls_server_key(&self) -> Option<String> {
+        self.tls_server_key.clone()
     }
 
     pub fn service_endpoint(&self) -> Option<String> {
@@ -191,8 +191,8 @@ impl PartialConfig {
         self.state_dir.clone()
     }
 
-    pub fn insecure(&self) -> Option<bool> {
-        self.insecure
+    pub fn tls_insecure(&self) -> Option<bool> {
+        self.tls_insecure
     }
 
     pub fn no_tls(&self) -> Option<bool> {
@@ -222,76 +222,76 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `cert_dir` value to the PartialConfig object.
+    /// Adds a `tls_cert_dir` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `cert_dir` - Directory containing any certificates and keys to be used.
+    /// * `tls_cert_dir` - Directory containing any certificates and keys to be used.
     ///
-    pub fn with_cert_dir(mut self, cert_dir: Option<String>) -> Self {
-        self.cert_dir = cert_dir;
+    pub fn with_tls_cert_dir(mut self, tls_cert_dir: Option<String>) -> Self {
+        self.tls_cert_dir = tls_cert_dir;
         self
     }
 
     #[allow(dead_code)]
-    /// Adds a `ca_certs` value to the  PartialConfig object.
+    /// Adds a `tls_ca_file` value to the  PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `ca_certs` - List of certificate authority certificates (*.pem files).
+    /// * `tls_ca_file` - List of certificate authority certificates (*.pem files).
     ///
-    pub fn with_ca_certs(mut self, ca_certs: Option<String>) -> Self {
-        self.ca_certs = ca_certs;
+    pub fn with_tls_ca_file(mut self, tls_ca_file: Option<String>) -> Self {
+        self.tls_ca_file = tls_ca_file;
         self
     }
 
     #[allow(dead_code)]
-    /// Adds a `client_cert` value to the PartialConfig object.
+    /// Adds a `tls_client_cert` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `client_cert` - A certificate signed by a certificate authority. Used by the daemon when
-    ///                   it is acting as a client, sending messages.
+    /// * `tls_client_cert` - A certificate signed by a certificate authority. Used by the daemon
+    ///                   when it is acting as a client, sending messages.
     ///
-    pub fn with_client_cert(mut self, client_cert: Option<String>) -> Self {
-        self.client_cert = client_cert;
+    pub fn with_tls_client_cert(mut self, tls_client_cert: Option<String>) -> Self {
+        self.tls_client_cert = tls_client_cert;
         self
     }
 
     #[allow(dead_code)]
-    /// Adds a `client_key` value to the PartialConfig object.
+    /// Adds a `tls_client_key` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `client_key` - Private key used by daemon when it is acting as a client.
+    /// * `tls_client_key` - Private key used by daemon when it is acting as a client.
     ///
-    pub fn with_client_key(mut self, client_key: Option<String>) -> Self {
-        self.client_key = client_key;
+    pub fn with_tls_client_key(mut self, tls_client_key: Option<String>) -> Self {
+        self.tls_client_key = tls_client_key;
         self
     }
 
     #[allow(dead_code)]
-    /// Adds a `server_cert` value to the PartialConfig object.
+    /// Adds a `tls_server_cert` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `server_cert` - A certificate signed by a certificate authority. Used by the daemon when
-    ///                   it is acting as a server, receiving messages.
+    /// * `tls_server_cert` - A certificate signed by a certificate authority. Used by the daemon
+    ///                   when it is acting as a server, receiving messages.
     ///
-    pub fn with_server_cert(mut self, server_cert: Option<String>) -> Self {
-        self.server_cert = server_cert;
+    pub fn with_tls_server_cert(mut self, tls_server_cert: Option<String>) -> Self {
+        self.tls_server_cert = tls_server_cert;
         self
     }
 
     #[allow(dead_code)]
-    /// Adds a `server_key` value to the PartialConfig object.
+    /// Adds a `tls_server_key` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `server_key` - Private key used by daemon when it is acting as a server.
+    /// * `tls_server_key` - Private key used by daemon when it is acting as a server.
     ///
-    pub fn with_server_key(mut self, server_key: Option<String>) -> Self {
-        self.server_key = server_key;
+    pub fn with_tls_server_key(mut self, tls_server_key: Option<String>) -> Self {
+        self.tls_server_key = tls_server_key;
         self
     }
 
@@ -477,14 +477,14 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `insecure` value to the PartialConfig object.
+    /// Adds a `tls_insecure` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `insecure` - Accept all peer certificates, ignoring TLS verification.
+    /// * `tls_insecure` - Accept all peer certificates, ignoring TLS verification.
     ///
-    pub fn with_insecure(mut self, insecure: Option<bool>) -> Self {
-        self.insecure = insecure;
+    pub fn with_tls_insecure(mut self, tls_insecure: Option<bool>) -> Self {
+        self.tls_insecure = tls_insecure;
         self
     }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -132,20 +132,6 @@ fn main() {
           "Endpoint that service will connect to, tcp://ip:port")
         (@arg peers: --peer +takes_value +multiple
           "Endpoint that service will connect to, ip:port")
-        (@arg ca_file: --("ca-file") +takes_value
-          "File path to the trusted CA certificate")
-        (@arg cert_dir: --("cert-dir") +takes_value
-          "Path to the directory where the certificates and keys are")
-        (@arg client_cert: --("client-cert") +takes_value
-          "File path to the certificate for the node when connecting to a node")
-        (@arg server_cert: --("server-cert") +takes_value
-          "File path to the certificate for the node when connecting to a node")
-        (@arg server_key:  --("server-key") +takes_value
-          "File path to the key for the node when connecting to a node as server")
-        (@arg client_key:  --("client-key") +takes_value
-          "File path to the key for the node when connecting to a node as client")
-        (@arg insecure:  --("insecure")
-          "If set to tls, should accept all peer certificates")
         (@arg no_tls:  --("no-tls") "Turn off tls configuration")
         (@arg bind: --("bind") +takes_value
           "Connection endpoint for REST API")
@@ -156,15 +142,64 @@ fn main() {
         (@arg verbose: -v --verbose +multiple
           "Increase output verbosity"));
 
-    let app = app.arg(
-        Arg::with_name("heartbeat_interval")
-            .long("heartbeat")
-            .long_help(
-                "How often heartbeat should be sent, in seconds; defaults to 30 seconds,\
+    let app = app
+        .arg(
+            Arg::with_name("heartbeat_interval")
+                .long("heartbeat")
+                .long_help(
+                    "How often heartbeat should be sent, in seconds; defaults to 30 seconds,\
                  0 means off",
-            )
-            .takes_value(true),
-    );
+                )
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("tls_cert_dir")
+                .long("tls-cert-dir")
+                .help("Path to the directory where the certificates and keys are")
+                .takes_value(true)
+                .alias("cert-dir"),
+        )
+        .arg(
+            Arg::with_name("tls_ca_file")
+                .long("tls-ca-file")
+                .help("File path to the trusted CA certificate")
+                .takes_value(true)
+                .alias("ca-file"),
+        )
+        .arg(
+            Arg::with_name("tls_client_cert")
+                .long("tls-client-cert")
+                .help("File path to the certificate for the node when connecting to a node")
+                .takes_value(true)
+                .alias("client-cert"),
+        )
+        .arg(
+            Arg::with_name("tls_client_key")
+                .long("tls-client-key")
+                .help("File path to the key for the node when connecting to a node as client")
+                .takes_value(true)
+                .alias("client-key"),
+        )
+        .arg(
+            Arg::with_name("tls_server_cert")
+                .long("tls-server-cert")
+                .help("File path to the certificate for the node when connecting to a node")
+                .takes_value(true)
+                .alias("server-cert"),
+        )
+        .arg(
+            Arg::with_name("tls_server_key")
+                .long("tls-server-key")
+                .help("File path to the key for the node when connecting to a node as server")
+                .takes_value(true)
+                .alias("server-key"),
+        )
+        .arg(
+            Arg::with_name("tls_insecure")
+                .long("tls-insecure")
+                .help("If set to tls, should accept all peer certificates")
+                .alias("insecure"),
+        );
 
     #[cfg(feature = "database")]
     let app = app.arg(

--- a/splinterd/src/transport.rs
+++ b/splinterd/src/transport.rs
@@ -51,7 +51,7 @@ pub fn build_transport(config: &Config) -> Result<MultiTransport, GetTransportEr
 }
 
 fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, GetTransportError> {
-    let client_cert = config.client_cert();
+    let client_cert = config.tls_client_cert();
     if !Path::new(&client_cert).is_file() {
         return Err(GetTransportError::CertError(format!(
             "Must provide a valid client certificate: {}",
@@ -63,7 +63,7 @@ fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, Get
         fs::canonicalize(&client_cert)?
     );
 
-    let server_cert = config.server_cert();
+    let server_cert = config.tls_server_cert();
     if !Path::new(&server_cert).is_file() {
         return Err(GetTransportError::CertError(format!(
             "Must provide a valid server certificate: {}",
@@ -75,7 +75,7 @@ fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, Get
         fs::canonicalize(&server_cert)?
     );
 
-    let server_key_file = config.server_key();
+    let server_key_file = config.tls_server_key();
     if !Path::new(&server_key_file).is_file() {
         return Err(GetTransportError::CertError(format!(
             "Must provide a valid server key path: {}",
@@ -87,7 +87,7 @@ fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, Get
         fs::canonicalize(&server_key_file)?
     );
 
-    let client_key_file = config.client_key();
+    let client_key_file = config.tls_client_key();
     if !Path::new(&client_key_file).is_file() {
         return Err(GetTransportError::CertError(format!(
             "Must provide a valid client key path: {}",
@@ -99,7 +99,7 @@ fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, Get
         fs::canonicalize(&client_key_file)?
     );
 
-    let insecure = config.insecure();
+    let insecure = config.tls_insecure();
     if insecure {
         warn!("Starting TlsTransport in insecure mode");
     }
@@ -107,7 +107,7 @@ fn build_tls_transport(config: &Config) -> Result<Box<dyn Transport + Send>, Get
         if insecure {
             None
         } else {
-            let ca_file = config.ca_certs();
+            let ca_file = config.tls_ca_file();
             if !Path::new(&ca_file).is_file() {
                 return Err(GetTransportError::CertError(format!(
                     "Must provide a valid file containing ca certs: {}",


### PR DESCRIPTION
In both the CLI and the config options that are specific
to tls are now prefixed with tls:

cert_dir  -> tls_cert_dir
ca_file -> tls_ca_file
client_cert -> tls_client_cert
client_key -> tls_client_key
server_cert -> tls_server_cert
server_key -> tls_server_key
insecure -> tls_insecure

The old config options and cli commands will still be accepted
as aliases.

Note that ca_cert in config is not tls_ca_file.

The new (experimental) splinterd help looks like 

```
splinterd 0.3.16
Splinter Daemon

USAGE:
    splinterd [FLAGS] [OPTIONS]

FLAGS:
        --enable-biome    Enable the biome subsystem
    -h, --help            Prints help information
        --no-tls          Turn off tls configuration
        --tls-insecure    If set to tls, should accept all peer certificates
    -V, --version         Prints version information
    -v, --verbose         Increase output verbosity

OPTIONS:
        --admin-timeout <admin_service_coordinator_timeout>
            The coordinator timeout for admin service proposals (in milliseconds); default is 30000 (30 seconds)

    -a, --advertised-endpoint <advertised_endpoints>...        Publicly-visible network endpoints
        --bind <bind>                                          Connection endpoint for REST API
        --cert-dir <cert_dir>                                  Path to the directory where the certificates and keys are
    -c, --config <config>                                      
        --database <database>                                  DB connection URL
        --display-name <display_name>                          Human-readable name for the node
        --heartbeat <heartbeat_interval>                       How often heartbeat should be sent, in seconds; defaults
                                                               to 30 seconds,0 means off
    -n, --network-endpoint <network_endpoints>...
            Endpoints to connect to the network, protocol-prefix://ip:port

        --node-id <node_id>                                    Unique ID for the node 
        --peer <peers>...                                      Endpoint that service will connect to, ip:port
        --registry <registries>...                             Read-only node registries
        --service-endpoint <service_endpoint>                  Endpoint that service will connect to, tcp://ip:port
        --storage <storage>                                    Storage type used for the node; defaults to yaml
        --tls-ca-file <tls_ca_file>                            File path to the trusted CA certificate
        --tls-cert-dir <tls_cert_dir>                          Path to the directory where the certificates and keys are
        --tls-client-cert <tls_client_cert>
            File path to the certificate for the node when connecting to a node

        --tls-client-key <tls_client_key>
            File path to the key for the node when connecting to a node as client

        --tls-server-cert <tls_server_cert>
            File path to the certificate for the node when connecting to a node

        --tls-server-key <tls_server_key>
            File path to the key for the node when connecting to a node as server

        --whitelist <whitelist>...                             Whitelisted domains
```