### PR TITLE
Add whitelist option to config objects

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -307,6 +307,14 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("biome_enabled".to_string()))?,
+            #[cfg(feature = "rest-api-cors")]
+            whitelist: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.whitelist() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }),
         })
     }
 }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -113,6 +113,15 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 )?)
         }
 
+        #[cfg(feature = "rest-api-cors")]
+        {
+            partial_config = partial_config.with_whitelist(
+                self.matches
+                    .values_of("whitelist")
+                    .map(|values| values.map(String::from).collect::<Vec<String>>()),
+            )
+        }
+
         Ok(partial_config)
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -70,6 +70,8 @@ pub struct Config {
     no_tls: (bool, ConfigSource),
     #[cfg(feature = "biome")]
     biome_enabled: (bool, ConfigSource),
+    #[cfg(feature = "rest-api-cors")]
+    whitelist: Option<(Vec<String>, ConfigSource)>,
 }
 
 impl Config {
@@ -173,6 +175,15 @@ impl Config {
         self.biome_enabled.0
     }
 
+    #[cfg(feature = "rest-api-cors")]
+    pub fn whitelist(&self) -> Option<&[String]> {
+        if let Some((list, _)) = &self.whitelist {
+            Some(list)
+        } else {
+            None
+        }
+    }
+
     fn storage_source(&self) -> &ConfigSource {
         &self.storage.1
     }
@@ -271,6 +282,15 @@ impl Config {
     #[cfg(feature = "biome")]
     fn biome_enabled_source(&self) -> &ConfigSource {
         &self.biome_enabled.1
+    }
+
+    #[cfg(feature = "rest-api-cors")]
+    pub fn whitelist_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.whitelist {
+            Some(source)
+        } else {
+            None
+        }
     }
 
     /// Displays the configuration value along with where the value was sourced from.
@@ -399,6 +419,19 @@ impl Config {
             self.biome_enabled(),
             self.biome_enabled_source()
         );
+        #[cfg(feature = "rest-api-cors")]
+        self.log_whitelist();
+    }
+
+    #[cfg(feature = "rest-api-cors")]
+    fn log_whitelist(&self) {
+        if let Some(list) = self.whitelist() {
+            debug!(
+                "Config: whitelist: {:?} (source: {:?})",
+                list,
+                self.whitelist_source()
+            );
+        }
     }
 }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -58,6 +58,8 @@ pub struct PartialConfig {
     no_tls: Option<bool>,
     #[cfg(feature = "biome")]
     biome_enabled: Option<bool>,
+    #[cfg(feature = "rest-api-cors")]
+    whitelist: Option<Vec<String>>,
 }
 
 impl PartialConfig {
@@ -93,6 +95,8 @@ impl PartialConfig {
             no_tls: None,
             #[cfg(feature = "biome")]
             biome_enabled: None,
+            #[cfg(feature = "rest-api-cors")]
+            whitelist: None,
         }
     }
 
@@ -198,6 +202,11 @@ impl PartialConfig {
     #[cfg(feature = "biome")]
     pub fn biome_enabled(&self) -> Option<bool> {
         self.biome_enabled
+    }
+
+    #[cfg(feature = "rest-api-cors")]
+    pub fn whitelist(&self) -> Option<Vec<String>> {
+        self.whitelist.clone()
     }
 
     #[allow(dead_code)]
@@ -500,6 +509,18 @@ impl PartialConfig {
     ///
     pub fn with_biome_enabled(mut self, biome_enabled: Option<bool>) -> Self {
         self.biome_enabled = biome_enabled;
+        self
+    }
+
+    #[cfg(feature = "rest-api-cors")]
+    /// Adds a `whitelist` value to the PartialConfig object.
+    ///
+    /// # Arguments
+    ///
+    /// * `whitelist` - Add whitelist to the REST API CORS configuration
+    ///
+    pub fn with_whitelist(mut self, whitelist: Option<Vec<String>>) -> Self {
+        self.whitelist = whitelist;
         self
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -50,6 +50,8 @@ struct TomlConfig {
     heartbeat_interval: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
     version: Option<String>,
+    #[cfg(feature = "rest-api-cors")]
+    whitelist: Option<Vec<String>>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -127,6 +129,11 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_registry_forced_refresh_interval(
                     self.toml_config.registry_forced_refresh_interval,
                 );
+        }
+
+        #[cfg(feature = "rest-api-cors")]
+        {
+            partial_config = partial_config.with_whitelist(self.toml_config.whitelist);
         }
 
         Ok(partial_config)

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -341,11 +341,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     #[cfg(feature = "rest-api-cors")]
     {
-        daemon_builder = daemon_builder.with_whitelist(
-            matches
-                .values_of("whitelist")
-                .map(|values| values.map(String::from).collect::<Vec<String>>()),
-        );
+        daemon_builder = daemon_builder.with_whitelist(config.whitelist().map(ToOwned::to_owned));
     }
 
     let mut node = daemon_builder.build().map_err(|err| {


### PR DESCRIPTION
Adds an optional whitelist option to the config objects,
including the TomlConfig and ClapConfig.

Signed-off-by: Shannyn Telander <telander@bitwise.io>