### PR TITLE
Set default display name for nodes

### DIFF
--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -127,6 +127,7 @@ mod test {
         http::{header, StatusCode},
         test, web, App,
     };
+    use splinter::node_registry::NodeBuilder;
 
     static SPLINTERD_URL: &str = "http://splinterd-node:8085";
 
@@ -265,25 +266,21 @@ mod test {
     }
 
     fn get_node_1() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Bitwise IO".to_string());
-        Node {
-            identity: "Node-123".to_string(),
-            endpoints: vec!["tcps://127.0.0.1:8080".to_string()],
-            display_name: "Bitwise IO - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-123")
+            .with_endpoint("tcps://127.0.0.1:8080")
+            .with_display_name("Bitwise IO - Node 1")
+            .with_metadata("company", "Bitwise IO")
+            .build()
+            .expect("Failed to build node1")
     }
 
     fn get_node_2() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Cargill".to_string());
-        Node {
-            identity: "Node-456".to_string(),
-            endpoints: vec!["tcps://127.0.0.1:8082".to_string()],
-            display_name: "Cargill - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-456")
+            .with_endpoint("tcps://127.0.0.1:8082")
+            .with_display_name("Cargill - Node 1")
+            .with_metadata("company", "Cargill")
+            .build()
+            .expect("Failed to build node2")
     }
 
     fn create_test_paging_response(

--- a/libsplinter/src/node_registry/mod.rs
+++ b/libsplinter/src/node_registry/mod.rs
@@ -247,3 +247,47 @@ where
         (**self).delete_node(identity)
     }
 }
+
+/// Returns `Err` if not all `nodes` are valid.
+fn validate_nodes(nodes: &[Node]) -> Result<(), InvalidNodeError> {
+    for (idx, node) in nodes.iter().enumerate() {
+        check_node_required_fields_are_not_empty(node)?;
+        check_if_node_is_duplicate(node, &nodes[idx + 1..])?;
+    }
+    Ok(())
+}
+
+/// Checks emptiness properties of all fields on the given `node`.
+fn check_node_required_fields_are_not_empty(node: &Node) -> Result<(), InvalidNodeError> {
+    if node.identity.is_empty() {
+        Err(InvalidNodeError::EmptyIdentity)
+    } else if node.endpoints.is_empty() {
+        Err(InvalidNodeError::MissingEndpoints)
+    } else if node.endpoints.iter().any(|endpoint| endpoint.is_empty()) {
+        Err(InvalidNodeError::EmptyEndpoint)
+    } else if node.display_name.is_empty() {
+        Err(InvalidNodeError::EmptyDisplayName)
+    } else {
+        Ok(())
+    }
+}
+
+/// Checks if the given `node` is a duplicate of any in the slice of `existing_nodes`.
+fn check_if_node_is_duplicate(
+    node: &Node,
+    existing_nodes: &[Node],
+) -> Result<(), InvalidNodeError> {
+    existing_nodes.iter().try_for_each(|existing_node| {
+        if existing_node.identity == node.identity {
+            Err(InvalidNodeError::DuplicateIdentity(node.identity.clone()))
+        } else if let Some(endpoint) = existing_node
+            .endpoints
+            .iter()
+            .find(|endpoint| node.endpoints.contains(endpoint))
+        {
+            Err(InvalidNodeError::DuplicateEndpoint(endpoint.clone()))
+        } else {
+            Ok(())
+        }
+    })
+}

--- a/libsplinter/src/node_registry/rest_api.rs
+++ b/libsplinter/src/node_registry/rest_api.rs
@@ -391,7 +391,7 @@ mod tests {
         http::{header, StatusCode},
         test, web, App,
     };
-    use crate::node_registry::LocalYamlNodeRegistry;
+    use crate::node_registry::{LocalYamlNodeRegistry, NodeBuilder};
 
     fn new_yaml_node_registry(file_path: &str) -> LocalYamlNodeRegistry {
         LocalYamlNodeRegistry::new(file_path).expect("Error creating LocalYamlNodeRegistry")
@@ -728,25 +728,21 @@ mod tests {
     }
 
     fn get_node_1() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Bitwise IO".to_string());
-        Node {
-            identity: "Node-123".to_string(),
-            endpoints: vec!["12.0.0.123:8431".to_string()],
-            display_name: "Bitwise IO - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-123")
+            .with_endpoint("12.0.0.123:8431")
+            .with_display_name("Bitwise IO - Node 1")
+            .with_metadata("company", "Bitwise IO")
+            .build()
+            .expect("Failed to build node1")
     }
 
     fn get_node_2() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Cargill".to_string());
-        Node {
-            identity: "Node-456".to_string(),
-            endpoints: vec!["13.0.0.123:8434".to_string()],
-            display_name: "Cargill - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-456")
+            .with_endpoint("13.0.0.123:8434")
+            .with_display_name("Cargill - Node 1")
+            .with_metadata("company", "Cargill")
+            .build()
+            .expect("Failed to build node2")
     }
 
     fn run_test<T>(test: T) -> ()

--- a/libsplinter/src/node_registry/unified.rs
+++ b/libsplinter/src/node_registry/unified.rs
@@ -203,14 +203,16 @@ mod test {
     use std::iter::FromIterator;
     use std::sync::{Arc, Mutex};
 
+    use crate::node_registry::NodeBuilder;
+
     use super::*;
 
     fn new_node(id: &str, endpoint: &str, metadata: &[(&str, &str)]) -> Node {
-        let mut node = Node::new(id, vec![endpoint.into()]);
+        let mut builder = NodeBuilder::new(id).with_endpoint(endpoint);
         for (key, val) in metadata {
-            node.metadata.insert(key.to_string(), val.to_string());
+            builder = builder.with_metadata(*key, *val);
         }
-        node
+        builder.build().expect("Failed to build node")
     }
 
     /// Verify that the number of nodes is correctly reported when all registries are empty.

--- a/libsplinter/src/node_registry/yaml/local.rs
+++ b/libsplinter/src/node_registry/yaml/local.rs
@@ -219,13 +219,12 @@ impl RwNodeRegistry for LocalYamlNodeRegistry {
 mod test {
     use super::*;
 
-    use std::collections::HashMap;
     use std::env;
     use std::fs::{remove_file, File};
     use std::panic;
     use std::thread;
 
-    use crate::node_registry::InvalidNodeError;
+    use crate::node_registry::{InvalidNodeError, NodeBuilder};
 
     ///
     /// Verifies that reading from a YAML file that contains two nodes with the same identity
@@ -789,39 +788,33 @@ mod test {
     }
 
     fn get_node_1() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Bitwise IO".to_string());
-        metadata.insert("admin".to_string(), "Bob".to_string());
-        Node {
-            identity: "Node-123".to_string(),
-            endpoints: vec!["tcps://12.0.0.123:8431".to_string()],
-            display_name: "Bitwise IO - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-123")
+            .with_endpoint("tcps://12.0.0.123:8431")
+            .with_display_name("Bitwise IO - Node 1")
+            .with_metadata("company", "Bitwise IO")
+            .with_metadata("admin", "Bob")
+            .build()
+            .expect("Failed to build node1")
     }
 
     fn get_node_2() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Cargill".to_string());
-        metadata.insert("admin".to_string(), "Carol".to_string());
-        Node {
-            identity: "Node-456".to_string(),
-            endpoints: vec!["tcps://12.0.0.123:8434".to_string()],
-            display_name: "Cargill - Node 1".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-456")
+            .with_endpoint("tcps://12.0.0.123:8434")
+            .with_display_name("Cargill - Node 1")
+            .with_metadata("company", "Cargill")
+            .with_metadata("admin", "Carol")
+            .build()
+            .expect("Failed to build node2")
     }
 
     fn get_node_3() -> Node {
-        let mut metadata = HashMap::new();
-        metadata.insert("company".to_string(), "Cargill".to_string());
-        metadata.insert("admin".to_string(), "Charlie".to_string());
-        Node {
-            identity: "Node-789".to_string(),
-            endpoints: vec!["tcps://12.0.0.123:8435".to_string()],
-            display_name: "Cargill - Node 2".to_string(),
-            metadata,
-        }
+        NodeBuilder::new("Node-789")
+            .with_endpoint("tcps://12.0.0.123:8435")
+            .with_display_name("Cargill - Node 2")
+            .with_metadata("company", "Cargill")
+            .with_metadata("admin", "Charlie")
+            .build()
+            .expect("Failed to build node3")
     }
 
     fn write_to_file(data: &[Node], file_path: &str) {

--- a/libsplinter/src/node_registry/yaml/local.rs
+++ b/libsplinter/src/node_registry/yaml/local.rs
@@ -25,11 +25,10 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::node_registry::{
+    check_if_node_is_duplicate, check_node_required_fields_are_not_empty, validate_nodes,
     MetadataPredicate, Node, NodeRegistryError, NodeRegistryReader, NodeRegistryWriter,
     RwNodeRegistry,
 };
-
-use super::{check_if_node_is_duplicate, check_node_required_fields_are_not_empty, validate_nodes};
 
 /// A local, read/write node registry.
 ///

--- a/libsplinter/src/node_registry/yaml/mod.rs
+++ b/libsplinter/src/node_registry/yaml/mod.rs
@@ -18,52 +18,6 @@ mod local;
 #[cfg(feature = "registry-remote")]
 mod remote;
 
-use super::{InvalidNodeError, Node};
-
 pub use local::LocalYamlNodeRegistry;
 #[cfg(feature = "registry-remote")]
 pub use remote::{RemoteYamlNodeRegistry, ShutdownHandle as RemoteYamlShutdownHandle};
-
-/// Returns `Err` if not all `nodes` are valid.
-fn validate_nodes(nodes: &[Node]) -> Result<(), InvalidNodeError> {
-    for (idx, node) in nodes.iter().enumerate() {
-        check_node_required_fields_are_not_empty(node)?;
-        check_if_node_is_duplicate(node, &nodes[idx + 1..])?;
-    }
-    Ok(())
-}
-
-/// Checks emptiness properties of all fields on the given `node`.
-fn check_node_required_fields_are_not_empty(node: &Node) -> Result<(), InvalidNodeError> {
-    if node.identity.is_empty() {
-        Err(InvalidNodeError::EmptyIdentity)
-    } else if node.endpoints.is_empty() {
-        Err(InvalidNodeError::MissingEndpoints)
-    } else if node.endpoints.iter().any(|endpoint| endpoint.is_empty()) {
-        Err(InvalidNodeError::EmptyEndpoint)
-    } else if node.display_name.is_empty() {
-        Err(InvalidNodeError::EmptyDisplayName)
-    } else {
-        Ok(())
-    }
-}
-
-/// Checks if the given `node` is a duplicate of any in the slice of `existing_nodes`.
-fn check_if_node_is_duplicate(
-    node: &Node,
-    existing_nodes: &[Node],
-) -> Result<(), InvalidNodeError> {
-    existing_nodes.iter().try_for_each(|existing_node| {
-        if existing_node.identity == node.identity {
-            Err(InvalidNodeError::DuplicateIdentity(node.identity.clone()))
-        } else if let Some(endpoint) = existing_node
-            .endpoints
-            .iter()
-            .find(|endpoint| node.endpoints.contains(endpoint))
-        {
-            Err(InvalidNodeError::DuplicateEndpoint(endpoint.clone()))
-        } else {
-            Ok(())
-        }
-    })
-}

--- a/libsplinter/src/node_registry/yaml/remote.rs
+++ b/libsplinter/src/node_registry/yaml/remote.rs
@@ -31,9 +31,11 @@ use std::time::{Duration, Instant};
 use openssl::hash::{hash, MessageDigest};
 
 use crate::hex::to_hex;
-use crate::node_registry::{MetadataPredicate, Node, NodeRegistryError, NodeRegistryReader};
+use crate::node_registry::{
+    validate_nodes, MetadataPredicate, Node, NodeRegistryError, NodeRegistryReader,
+};
 
-use super::{validate_nodes, LocalYamlNodeRegistry};
+use super::LocalYamlNodeRegistry;
 
 /// A remote, read-only node registry.
 ///

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -149,6 +149,14 @@ impl ConfigBuilder {
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?;
+        let node_id = self
+            .partial_configs
+            .iter()
+            .find_map(|p| match p.node_id() {
+                Some(v) => Some((v, p.source())),
+                None => None,
+            })
+            .ok_or_else(|| ConfigError::MissingValue("node id".to_string()))?;
         // Iterates over the list of PartialConfig objects to find the first config with a value
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
@@ -192,14 +200,6 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("peers".to_string()))?,
-            node_id: self
-                .partial_configs
-                .iter()
-                .find_map(|p| match p.node_id() {
-                    Some(v) => Some((v, p.source())),
-                    None => None,
-                })
-                .ok_or_else(|| ConfigError::MissingValue("node id".to_string()))?,
             display_name: self
                 .partial_configs
                 .iter()
@@ -207,7 +207,8 @@ impl ConfigBuilder {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
-                .ok_or_else(|| ConfigError::MissingValue("display name".to_string()))?,
+                .unwrap_or((format!("Node {}", node_id.0), ConfigSource::Default)),
+            node_id,
             bind: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -53,7 +53,6 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_service_endpoint(Some(String::from("127.0.0.1:8043")))
             .with_network_endpoints(Some(vec![String::from("127.0.0.1:8044")]))
             .with_peers(Some(vec![]))
-            .with_display_name(Some(String::new()))
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
             .with_heartbeat_interval(Some(HEARTBEAT_DEFAULT))
@@ -110,7 +109,7 @@ mod tests {
         );
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);
-        assert_eq!(config.display_name(), Some(String::new()));
+        assert_eq!(config.display_name(), None);
         assert_eq!(config.bind(), Some(String::from("127.0.0.1:8080")));
         #[cfg(feature = "database")]
         assert_eq!(config.database(), Some(String::from("127.0.0.1:5432")));

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -829,9 +829,9 @@ mod tests {
             (final_config.node_id(), final_config.node_id_source()),
             ("123", &ConfigSource::CommandLine)
         );
-        // The DefaultPartialConfigBuilder, TomlPartialConfigBuilder, and ClapPartialConfigBuilder
-        // had values for `display_name`, but the ClapPartialConfigBuilder value should have
-        // precedence (source should be CommandLine).
+        // The TomlPartialConfigBuilder and ClapPartialConfigBuilder had values for `display_name`,
+        // but the ClapPartialConfigBuilder value should have precedence (source should be
+        // CommandLine).
         assert_eq!(
             (
                 final_config.display_name(),


### PR DESCRIPTION
Updates the splinterd config to set a default display name for the node if none is provided, and updates the node registry to provide a default display name for new nodes.

Also removes the node registry's `Node::new` method in favor of a `NodeBuilder` for creating new nodes.