### PR TITLE
Switch two phase coordinator timeout to seconds

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -55,7 +55,7 @@ use self::shared::AdminServiceShared;
 pub use self::error::AdminServiceError;
 pub use self::error::AdminSubscriberError;
 
-const DEFAULT_COORDINATOR_TIMEOUT_MILLIS: u64 = 30000; // 30 seconds
+const DEFAULT_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
 
 pub trait AdminServiceEventSubscriber: Send {
     fn handle_event(
@@ -133,8 +133,8 @@ impl AdminService {
         // default value will be used (30 seconds).
         coordinator_timeout: Option<Duration>,
     ) -> Result<Self, ServiceError> {
-        let coordinator_timeout = coordinator_timeout
-            .unwrap_or_else(|| Duration::from_millis(DEFAULT_COORDINATOR_TIMEOUT_MILLIS));
+        let coordinator_timeout =
+            coordinator_timeout.unwrap_or_else(|| Duration::from_secs(DEFAULT_COORDINATOR_TIMEOUT));
 
         let new_service = Self {
             service_id: admin_service_id(node_id),

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -60,7 +60,7 @@ use state::{ScabbardState, StateSubscriber};
 
 const SERVICE_TYPE: &str = "scabbard";
 
-const DEFAULT_COORDINATOR_TIMEOUT_MILLIS: u64 = 30000; // 30 seconds
+const DEFAULT_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
 
 /// A service for running Sawtooth Sabre smart contracts with two-phase commit consensus.
 #[derive(Clone)]
@@ -116,8 +116,8 @@ impl Scabbard {
         )
         .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
 
-        let coordinator_timeout = coordinator_timeout
-            .unwrap_or_else(|| Duration::from_millis(DEFAULT_COORDINATOR_TIMEOUT_MILLIS));
+        let coordinator_timeout =
+            coordinator_timeout.unwrap_or_else(|| Duration::from_secs(DEFAULT_COORDINATOR_TIMEOUT));
 
         Ok(Scabbard {
             circuit_id: circuit_id.to_string(),

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -84,8 +84,8 @@ OPTIONS
 =======
 
 `--admin-timeout TIMEOUT`
-: Sets the coordinator timeout, in milliseconds, for admin service proposals.
-  (Default: 30000 ms (30 seconds).)
+: Sets the coordinator timeout, in seconds, for admin service proposals.
+  (Default: 30 seconds.)
 
   This setting affects consensus-related activities for pending circuit changes
   (functions that use the two-phase commit agreement protocol in the Scabbard

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -27,7 +27,7 @@ const REGISTRY_AUTO_REFRESH_DEFAULT: u64 = 600; // 600 seconds = 10 minutes
 #[cfg(feature = "registry-remote")]
 const REGISTRY_FORCED_REFRESH_DEFAULT: u64 = 10; // 10 seconds
 const HEARTBEAT_DEFAULT: u64 = 30;
-const DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS: u64 = 30000;
+const DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
 
 /// Holds the default configuration values.
 pub struct DefaultPartialConfigBuilder;
@@ -56,9 +56,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
             .with_heartbeat_interval(Some(HEARTBEAT_DEFAULT))
-            .with_admin_service_coordinator_timeout(Some(
-                DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS,
-            ))
+            .with_admin_service_coordinator_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
             .with_tls_insecure(Some(false))
             .with_no_tls(Some(false));
@@ -127,8 +125,8 @@ mod tests {
         assert_eq!(config.heartbeat_interval(), Some(HEARTBEAT_DEFAULT));
         assert_eq!(
             config.admin_service_coordinator_timeout(),
-            Some(Duration::from_millis(
-                DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT_MILLIS
+            Some(Duration::from_secs(
+                DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT
             ))
         );
         assert_eq!(config.state_dir(), Some(String::from(DEFAULT_STATE_DIR)));

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -939,7 +939,7 @@ mod tests {
                 final_config.admin_service_coordinator_timeout(),
                 final_config.admin_service_coordinator_timeout_source()
             ),
-            (Duration::from_millis(30000), &ConfigSource::Default)
+            (Duration::from_secs(30), &ConfigSource::Default)
         );
         // Both the DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for
         // `state_dir`, but the EnvPartialConfigBuilder value should have precedence (source should

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -457,7 +457,7 @@ impl PartialConfig {
     ///
     pub fn with_admin_service_coordinator_timeout(mut self, timeout: Option<u64>) -> Self {
         let duration: Option<Duration> = match timeout {
-            Some(t) => Some(Duration::from_millis(t)),
+            Some(t) => Some(Duration::from_secs(t)),
             _ => None,
         };
         self.admin_service_coordinator_timeout = duration;

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -137,8 +137,8 @@ fn main() {
           "Connection endpoint for REST API")
         (@arg registries: --("registry") +takes_value +multiple "Read-only node registries")
         (@arg admin_service_coordinator_timeout: --("admin-timeout") +takes_value
-            "The coordinator timeout for admin service proposals (in milliseconds); default is \
-             30000 (30 seconds)")
+            "The coordinator timeout for admin service proposals (in seconds); default is \
+             30 seconds")
         (@arg verbose: -v --verbose +multiple
           "Increase output verbosity"));
 


### PR DESCRIPTION
This is done in an effort for consistency with other
splinterd options. Heartbeat takes seconds while
coordinator timeout used to take milliseconds.
Now both will take seconds.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>