### PR TITLE
Rename splinter keygen key directory option

### DIFF
--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -18,7 +18,7 @@ This command generates secp256k1 public/private keys for Splinter.
 If no option is specified, this command generates user keys that are stored in
 the directory `$HOME/splinter/keys`. The `--system` flag generates keys for the
 Splinter daemon (`splinterd`) that are stored in `/etc/splinter/keys`. The
-`-o`/`--output-dir` option generates keys in the specified directory.
+`--key-dir` option generates keys in the specified directory.
 
 The file names are determined by the user name, unless the `*KEY-NAME*` argument
 is used.
@@ -49,7 +49,7 @@ FLAGS
 OPTIONS
 =======
 
-`-o, --output-dir DIRECTORY`
+`--key-dir DIRECTORY`
 : Generates keys in the given `DIRECTORY`, creating the directory if it does not
   already exist.
 
@@ -75,7 +75,7 @@ writing file: "/Users/paulbunyan/splinter/keys/paulbunyan.pub"
 This example generates keys for the user `babe` in the `/tmp` directory:
 
 ```
-$ splinter keygen --output-dir /tmp babe
+$ splinter keygen --key-dir /tmp babe
 writing file: "/tmp/babe.priv"
 writing file: "/tmp/babe.pub"
 ```

--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -43,7 +43,7 @@ impl Action for KeyGenAction {
             .map(String::from)
             .unwrap_or_else(whoami::username);
 
-        let key_dir = if let Some(dir) = args.value_of("output_dir") {
+        let key_dir = if let Some(dir) = args.value_of("key_dir") {
             PathBuf::from(dir)
         } else if args.is_present("system") {
             PathBuf::from(SYSTEM_KEY_PATH)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -501,9 +501,8 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .help("Name of keys generated; defaults to user name"),
                 )
                 .arg(
-                    Arg::with_name("output_dir")
-                        .short("o")
-                        .long("output-dir")
+                    Arg::with_name("key_dir")
+                        .long("key-dir")
                         .takes_value(true)
                         .conflicts_with("system")
                         .help(


### PR DESCRIPTION
Renames the `-o`/`--output-dir` option for `splinter keygen` to
`--key-dir` to prevent confusion.

Signed-off-by: Logan Seeley <seeley@bitwise.io>