### PR TITLE
Include identity in connection results

### DIFF
--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -1091,8 +1091,9 @@ fn send_heartbeats<T: MatrixLifeCycle, U: MatrixSender>(
                             endpoint: endpoint.clone(),
                         });
                     }
+                } else {
+                    *disconnected = false;
                 }
-                *.disconnected = false;
             }
         }
     }

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -28,6 +28,7 @@ pub enum ConnectionManagerNotification {
     InboundConnection {
         endpoint: String,
         connection_id: String,
+        identity: String,
     },
     Disconnected {
         endpoint: String,

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -347,7 +347,7 @@ fn add_peer(
     // If new, try to create a connection
     for endpoint in endpoints.iter() {
         match connector.request_connection(&endpoint, &connection_id) {
-            Ok(()) => {
+            Ok(_identity) => {
                 debug!("Peer {} connected via {}", peer_id, endpoint);
                 peers.insert(
                     peer_id.clone(),
@@ -450,7 +450,7 @@ fn retry_endpoints(
     debug!("Trying to find active endpoint for {}", peer_metadata.id);
     for endpoint in peer_metadata.endpoints.iter() {
         match connector.request_connection(&endpoint, &peer_metadata.connection_id) {
-            Ok(()) => {
+            Ok(_identity) => {
                 debug!("Peered with {}: {}", peer_metadata.id, endpoint);
                 if endpoint != &peer_metadata.active_endpoint {
                     // Remove old active endpoint from peer_manager


### PR DESCRIPTION
When requesting or adding an inbound connection, the identity that has been returned based on the authorization handshake is included in either the result of the request or on the notification for the new inbound connection.  This allows layers, such as the peer manager or service connection manager to make use of these identities.

This PR also includes several refactors and a bug fix to the connection manager