### PR TITLE
Add config_dir option to config objects

### DIFF
--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -112,6 +112,12 @@ OPTIONS
   Any options on the command line will override the settings in the
   configuration file.
 
+`--config-dir CONFIG-DIR`
+: Specifies the directory containing configuration files.
+  (Default: `/etc/splinter`.)
+
+  This option overrides the `SPLINTER_CONFIG_DIR` environment variable, if set.
+
 `--display-name DISPLAY-NAME`
 : Specifies a human-readable name for the node (Default: "Node NODE-ID")
 
@@ -241,6 +247,10 @@ ENVIRONMENT VARIABLES
 : Specifies where to store the circuit state YAML file, if `--storage` is
   set to `yaml`. (See `--storage`.) By default, this file is stored in
   `/var/lib/splinter`.
+
+**SPLINTER_CONFIG_DIR**
+: Specifies the directory containing configuration files.
+  (See: `--config-dir`.)
 
 FILES
 =====

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -63,6 +63,14 @@ impl ConfigBuilder {
     /// Builds a Config object by incorporating the values from each PartialConfig object.
     ///
     pub fn build(self) -> Result<Config, ConfigError> {
+        let config_dir = self
+            .partial_configs
+            .iter()
+            .find_map(|p| match p.config_dir() {
+                Some(v) => Some((v, p.source())),
+                None => None,
+            })
+            .ok_or_else(|| ConfigError::MissingValue("config directory".to_string()))?;
         let tls_cert_dir = self
             .partial_configs
             .iter()
@@ -160,6 +168,7 @@ impl ConfigBuilder {
         // Iterates over the list of PartialConfig objects to find the first config with a value
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
+            config_dir,
             storage: self
                 .partial_configs
                 .iter()
@@ -324,11 +333,11 @@ mod tests {
 
     /// Example configuration values.
     static EXAMPLE_STORAGE: &str = "yaml";
-    static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
-    static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
-    static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
-    static EXAMPLE_SERVER_CERT: &str = "certs/server.crt";
-    static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
+    static EXAMPLE_CA_CERTS: &str = "/etc/splinter/certs/ca.pem";
+    static EXAMPLE_CLIENT_CERT: &str = "/etc/splinter/certs/client.crt";
+    static EXAMPLE_CLIENT_KEY: &str = "/etc/splinter/certs/client.key";
+    static EXAMPLE_SERVER_CERT: &str = "/etc/splinter/certs/server.crt";
+    static EXAMPLE_SERVER_KEY: &str = "/etc/splinter/certs/server.key";
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
     static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -23,12 +23,16 @@ pub trait PartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError>;
 }
 
-fn get_file_path(cert_dir: &str, file: &str) -> String {
-    if file.starts_with("./") || file.starts_with("../") {
-        String::from(file)
+fn get_tls_file_path(cert_dir: &str, file: &str) -> String {
+    let file_path = Path::new(file);
+    if file_path.is_absolute() || file_path.starts_with("../") || file_path.starts_with("./") {
+        file_path
+            .to_str()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| String::from(file))
     } else {
         Path::new(cert_dir)
-            .join(file)
+            .join(file_path)
             .to_str()
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| String::from(file))
@@ -83,13 +87,7 @@ impl ConfigBuilder {
             .partial_configs
             .iter()
             .find_map(|p| match p.tls_ca_file() {
-                Some(v) => {
-                    if p.source() != ConfigSource::Default {
-                        Some((v, p.source()))
-                    } else {
-                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
-                    }
-                }
+                Some(v) => Some((get_tls_file_path(&tls_cert_dir.0, &v), p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("ca file".to_string()))?;
@@ -97,13 +95,7 @@ impl ConfigBuilder {
             .partial_configs
             .iter()
             .find_map(|p| match p.tls_client_cert() {
-                Some(v) => {
-                    if p.source() != ConfigSource::Default {
-                        Some((v, p.source()))
-                    } else {
-                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
-                    }
-                }
+                Some(v) => Some((get_tls_file_path(&tls_cert_dir.0, &v), p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("client certificate".to_string()))?;
@@ -111,13 +103,7 @@ impl ConfigBuilder {
             .partial_configs
             .iter()
             .find_map(|p| match p.tls_client_key() {
-                Some(v) => {
-                    if p.source() != ConfigSource::Default {
-                        Some((v, p.source()))
-                    } else {
-                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
-                    }
-                }
+                Some(v) => Some((get_tls_file_path(&tls_cert_dir.0, &v), p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("client key".to_string()))?;
@@ -125,13 +111,7 @@ impl ConfigBuilder {
             .partial_configs
             .iter()
             .find_map(|p| match p.tls_server_cert() {
-                Some(v) => {
-                    if p.source() != ConfigSource::Default {
-                        Some((v, p.source()))
-                    } else {
-                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
-                    }
-                }
+                Some(v) => Some((get_tls_file_path(&tls_cert_dir.0, &v), p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("server certificate".to_string()))?;
@@ -139,13 +119,7 @@ impl ConfigBuilder {
             .partial_configs
             .iter()
             .find_map(|p| match p.tls_server_key() {
-                Some(v) => {
-                    if p.source() != ConfigSource::Default {
-                        Some((v, p.source()))
-                    } else {
-                        Some((get_file_path(&tls_cert_dir.0, &v), p.source()))
-                    }
-                }
+                Some(v) => Some((get_tls_file_path(&tls_cert_dir.0, &v), p.source())),
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("server key".to_string()))?;

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -41,6 +41,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
         let mut partial_config = PartialConfig::new(ConfigSource::CommandLine);
 
         partial_config = partial_config
+            .with_config_dir(self.matches.value_of("config_dir").map(String::from))
             .with_storage(self.matches.value_of("storage").map(String::from))
             .with_tls_cert_dir(self.matches.value_of("tls_cert_dir").map(String::from))
             .with_tls_ca_file(self.matches.value_of("tls_ca_file").map(String::from))

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -14,8 +14,9 @@
 
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 
-const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs/";
-const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
+const DEFAULT_CONFIG_DIR: &str = "/etc/splinter";
+const DEFAULT_CERT_DIR: &str = "/etc/splinter/certs";
+const DEFAULT_STATE_DIR: &str = "/var/lib/splinter";
 
 const CLIENT_CERT: &str = "client.crt";
 const CLIENT_KEY: &str = "private/client.key";
@@ -41,6 +42,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
 
         partial_config = partial_config
+            .with_config_dir(Some(String::from(DEFAULT_CONFIG_DIR)))
             .with_storage(Some(String::from("yaml")))
             .with_tls_cert_dir(Some(String::from(DEFAULT_CERT_DIR)))
             .with_tls_ca_file(Some(String::from(CA_PEM)))

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -16,6 +16,7 @@ use std::env;
 
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 
+const CONFIG_DIR_ENV: &str = "SPLINTER_CONFIG_DIR";
 const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
 
@@ -31,6 +32,7 @@ impl EnvPartialConfigBuilder {
 impl PartialConfigBuilder for EnvPartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         Ok(PartialConfig::new(ConfigSource::Environment)
+            .with_config_dir(env::var(CONFIG_DIR_ENV).ok())
             .with_tls_cert_dir(env::var(CERT_DIR_ENV).ok())
             .with_state_dir(env::var(STATE_DIR_ENV).ok()))
     }

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -30,6 +30,7 @@ pub enum ConfigSource {
 #[derive(Deserialize, Debug)]
 pub struct PartialConfig {
     source: ConfigSource,
+    config_dir: Option<String>,
     storage: Option<String>,
     tls_cert_dir: Option<String>,
     tls_ca_file: Option<String>,
@@ -65,6 +66,7 @@ impl PartialConfig {
     pub fn new(source: ConfigSource) -> Self {
         PartialConfig {
             source,
+            config_dir: None,
             storage: None,
             tls_cert_dir: None,
             tls_ca_file: None,
@@ -98,6 +100,10 @@ impl PartialConfig {
 
     pub fn source(&self) -> ConfigSource {
         self.source.clone()
+    }
+
+    pub fn config_dir(&self) -> Option<String> {
+        self.config_dir.clone()
     }
 
     pub fn storage(&self) -> Option<String> {
@@ -201,6 +207,17 @@ impl PartialConfig {
     #[cfg(feature = "rest-api-cors")]
     pub fn whitelist(&self) -> Option<Vec<String>> {
         self.whitelist.clone()
+    }
+
+    /// Adds a `config_dir` value to the PartialConfig object.
+    ///
+    /// # Arguments
+    ///
+    /// * `config_dir` - Directory containing the configuration directories and files.
+    ///
+    pub fn with_config_dir(mut self, config_dir: Option<String>) -> Self {
+        self.config_dir = config_dir;
+        self
     }
 
     #[allow(dead_code)]

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -159,6 +159,13 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("config_dir")
+                .long("config-dir")
+                .help("Path to the directory containing configuration files")
+                .takes_value(true)
+                .alias("config-dir"),
+        )
+        .arg(
             Arg::with_name("tls_cert_dir")
                 .long("tls-cert-dir")
                 .help("Path to the directory where the certificates and keys are")


### PR DESCRIPTION
Adds a `config_dir` option to the DefaultPartialConfigBuilder, EnvPartialConfigBuilder, and the ClapPartialConfigBuilder. The `config_dir`, default `/etc/splinter`, is appended to the beginning of the `tls_cert_dir` if the `tls_cert_dir` does not begin with "/" (in which case we assume this is the full path)

This pr also adds another step to building the config file paths to check if the file starts with "/", in which case we assume this is the full path. If it does not start with "/", the default / set tls cert directory will be appended to the beginning of the file. 

This also updates the tests to reflect these changes.