### PR TITLE
Only use authorized connections and handle incoming connections

### DIFF
--- a/libsplinter/src/network/peer_manager/connector.rs
+++ b/libsplinter/src/network/peer_manager/connector.rs
@@ -128,7 +128,7 @@ impl PeerManagerConnector {
             .map_err(|err| PeerListError::ReceiveError(format!("{:?}", err)))?
     }
 
-    // Request the map of currently connected peers to connection id
+    /// Request the map of currently connected peers to connection id
     ///
     /// Returns a map of peer id to connection id
     pub fn connection_ids(&self) -> Result<BiHashMap<String, String>, PeerConnectionIdError> {

--- a/libsplinter/src/network/peer_manager/connector.rs
+++ b/libsplinter/src/network/peer_manager/connector.rs
@@ -18,7 +18,6 @@ use crate::collections::BiHashMap;
 
 use super::error::{
     PeerConnectionIdError, PeerListError, PeerManagerError, PeerRefAddError, PeerRefRemoveError,
-    PeerRefUpdateError,
 };
 use super::notification::PeerNotificationIter;
 use super::PeerRef;
@@ -73,39 +72,6 @@ impl PeerManagerConnector {
 
         recv.recv()
             .map_err(|err| PeerRefAddError::ReceiveError(format!("{:?}", err)))?
-    }
-
-    /// Request that a peer is updated. If a peer already exists, update a peer id. Redirections
-    /// will be added to the peer map and reference count so the old PeerRef will still work.
-    ///
-    /// # Arguments
-    ///
-    /// * `old_peer_id` -  The old peer_id of the peer.
-    /// * `new_peer_id` -  The new peer_id of the peer.
-    pub fn update_peer_ref(
-        &self,
-        old_peer_id: &str,
-        new_peer_id: &str,
-    ) -> Result<(), PeerRefUpdateError> {
-        let (sender, recv) = channel();
-
-        let message = PeerManagerMessage::Request(PeerManagerRequest::UpdatePeer {
-            old_peer_id: old_peer_id.to_string(),
-            new_peer_id: new_peer_id.to_string(),
-            sender,
-        });
-
-        match self.sender.send(message) {
-            Ok(()) => (),
-            Err(_) => {
-                return Err(PeerRefUpdateError::InternalError(
-                    "Unable to send message to PeerManager, receiver dropped".to_string(),
-                ))
-            }
-        };
-
-        recv.recv()
-            .map_err(|err| PeerRefUpdateError::ReceiveError(format!("{:?}", err)))?
     }
 
     /// Request the list of currently connected peers.

--- a/libsplinter/src/network/peer_manager/error.rs
+++ b/libsplinter/src/network/peer_manager/error.rs
@@ -80,27 +80,6 @@ impl fmt::Display for PeerRefRemoveError {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum PeerRefUpdateError {
-    InternalError(String),
-    ReceiveError(String),
-    UpdateError(String),
-}
-
-impl error::Error for PeerRefUpdateError {}
-
-impl fmt::Display for PeerRefUpdateError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            PeerRefUpdateError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
-            PeerRefUpdateError::ReceiveError(msg) => {
-                write!(f, "Unable to receive response from PeerManager: {}", msg)
-            }
-            PeerRefUpdateError::UpdateError(msg) => write!(f, "Unable to update peer: {}", msg),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
 pub enum PeerListError {
     InternalError(String),
     ReceiveError(String),

--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -523,7 +523,7 @@ pub mod tests {
         });
 
         let mut cm = ConnectionManager::new(
-            Box::new(NoopAuthorizer::new("test_identity")),
+            Box::new(NoopAuthorizer::new("test_peer")),
             mesh1.get_life_cycle(),
             mesh1.get_sender(),
             transport,
@@ -570,7 +570,7 @@ pub mod tests {
         let mesh = Mesh::new(512, 128);
 
         let mut cm = ConnectionManager::new(
-            Box::new(NoopAuthorizer::new("test_identity")),
+            Box::new(NoopAuthorizer::new("test_peer")),
             mesh.get_life_cycle(),
             mesh.get_sender(),
             transport,

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -633,6 +633,7 @@ pub mod tests {
         assert_eq!(peer_ref.peer_id, "test_peer");
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that a call to add_peer_ref, where the authorizer returns an different id than
@@ -674,6 +675,7 @@ pub mod tests {
 
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that a call to add_peer_ref with a peer with multiple endpoints is successful, even if
@@ -716,6 +718,7 @@ pub mod tests {
         assert_eq!(peer_ref.peer_id, "test_peer");
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that the same peer can be added multiple times.
@@ -756,6 +759,7 @@ pub mod tests {
         assert_eq!(peer_ref.peer_id, "test_peer");
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that list_peer returns the correct list of peers
@@ -814,6 +818,7 @@ pub mod tests {
         );
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that list_peer returns the correct list of peers
@@ -869,6 +874,7 @@ pub mod tests {
         assert!(peers.get_by_key("test_peer").is_some());
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that when a PeerRef is dropped, a remove peer request is properly sent and the peer
@@ -925,6 +931,7 @@ pub mod tests {
         assert_eq!(peer_list, Vec::<String>::new());
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that if a peer's endpoint disconnects and does not reconnect during a set timeout, the
@@ -953,6 +960,7 @@ pub mod tests {
             .expect("Cannot listen for connections");
         let endpoint2 = listener2.endpoint();
 
+        let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
             // accept incoming connection and add it to mesh2
             let conn = listener.accept().expect("Cannot accept connection");
@@ -982,6 +990,10 @@ pub mod tests {
                 .add(conn, "test_id".to_string())
                 .expect("Cannot add connection to mesh");
             mesh2.recv().expect("Cannot receive message");
+
+            rx.recv().unwrap();
+
+            mesh2.shutdown_signaler().shutdown();
         });
 
         let mut cm = ConnectionManager::new(
@@ -1025,8 +1037,11 @@ pub mod tests {
                 }
         );
 
+        tx.send(()).unwrap();
+
         peer_manager.shutdown_and_wait();
         cm.shutdown_and_wait();
+        mesh1.shutdown_signaler().shutdown();
     }
 
     // Test that the PeerManager can be started and stopped
@@ -1048,6 +1063,7 @@ pub mod tests {
         peer_manager.start().expect("Cannot start peer_manager");
 
         peer_manager.shutdown_and_wait();
+        mesh.shutdown_signaler().shutdown();
     }
 
     // Test that the PeerManager can receive incoming peer requests and handle them appropriately.


### PR DESCRIPTION
This PR does two things with the PeerManager, with respect to authorized connections:

* Validate identity returned is same as requested

    If the peer requested doesn't return the identity requested, the peer should be considered invalid and dropped.

* Accept temporary peers

    Accept incoming connections as temporary peers.  This state for the peer means that an remote node has peered with the local node, but that remote peer is not yet referenced locally for any reason.

    Once the local peer has referenced the peer id, the peer is promoted into the reference map and can participate in the fallback endpoint cascade.

    For example, it is not yet in any circuit relationship yet - either via negotiating a circuit or an existing circuit. In either of those circumstances, the admin service will add a peer reference, which would promote the peer connection.

Additionally,

- In order to enable this, it removes the special handling of inproc connections.  This should be left to the authorization code to determine what sort of conversation needs to be had with the remote connection. Most likely, they should still provide a valid identity.
- peers can no longer change their id, as this is determined via the authorization process.