### PR TITLE
 Negotiate protocol version between Admin Services

### DIFF
--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -281,6 +281,9 @@ message AdminMessage {
         CONSENSUS_MESSAGE = 1;
         PROPOSED_CIRCUIT = 2;
         MEMBER_READY = 3;
+
+        SERVICE_PROTOCOL_VERSION_REQUEST = 100;
+        SERVICE_PROTOCOL_VERSION_RESPONSE = 101;
     }
 
     Type message_type = 1;
@@ -288,6 +291,10 @@ message AdminMessage {
     bytes consensus_message = 2;
     ProposedCircuit proposed_circuit = 3;
     MemberReady member_ready = 4;
+
+    // Messages to agree on protocol version
+    ServiceProtocolVersionRequest protocol_request = 100;
+    ServiceProtocolVersionResponse protocol_response = 101;
 }
 
 message ProposedCircuit {
@@ -304,4 +311,21 @@ message ProposedCircuit {
 message MemberReady {
     string circuit_id = 1;
     string member_node_id = 2;
+}
+
+// This message is sent to a connection AdminService to agree upon prtocol
+// version.
+//
+// The sending service will provide the min and max protocol versions they
+// support.
+message ServiceProtocolVersionRequest {
+    uint32 protocol_min = 1;
+    uint32 protocol_max = 2;
+}
+
+// This message is a response ServiceProtocolVersionRequest. It contains the
+// protocol version that the responder can support. If no matching protocol can
+// be supported 0 is returned.
+message ServiceProtocolVersionResponse {
+    uint32 protocol = 1;
 }

--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -134,6 +134,8 @@ pub enum AdminSharedError {
     // Returned if a circuit cannot be added to splinter state
     CommitError(String),
     UpdateProposalsError(OpenProposalError),
+    // An error occured while trying to negotiated protocol versions
+    ServiceProtocolError(String),
 }
 
 impl Error for AdminSharedError {
@@ -158,6 +160,7 @@ impl Error for AdminSharedError {
             AdminSharedError::CommitError(_) => None,
             AdminSharedError::UpdateProposalsError(err) => Some(err),
             AdminSharedError::UnableToAddSubscriber(_) => None,
+            AdminSharedError::ServiceProtocolError(_) => None,
         }
     }
 }
@@ -203,6 +206,11 @@ impl fmt::Display for AdminSharedError {
             AdminSharedError::UnableToAddSubscriber(msg) => {
                 write!(f, "unable to add admin service event subscriber: {}", msg)
             }
+            AdminSharedError::ServiceProtocolError(msg) => write!(
+                f,
+                "error occured while trying to agree on protocol: {}",
+                msg
+            ),
         }
     }
 }

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -526,9 +526,11 @@ fn run_inbound_loop(
                             correlation_id: admin_direct_message.take_correlation_id(),
                         };
 
-                        service
-                            .handle_message(admin_direct_message.get_payload(), &msg_context)
-                            .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
+                        if let Err(err) =
+                            service.handle_message(admin_direct_message.get_payload(), &msg_context)
+                        {
+                            error!("unable to handle admin direct message: {}", err);
+                        }
                     }
                     None => warn!(
                         "Service with id {} does not exist on circuit {}; ignoring message",
@@ -562,9 +564,11 @@ fn run_inbound_loop(
                             correlation_id: circuit_direct_message.take_correlation_id(),
                         };
 
-                        service
+                        if let Err(err) = service
                             .handle_message(circuit_direct_message.get_payload(), &msg_context)
-                            .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
+                        {
+                            error!("unable to handle direct message: {}", err);
+                        }
                     }
                     None => warn!(
                         "Service with id {} does not exist on circuit {}; ignoring message",

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -20,6 +20,7 @@ pub const ADMIN_PROTOCOL_VERSION: u32 = 1;
 
 #[cfg(feature = "rest-api-actix")]
 pub(crate) const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
+pub(crate) const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "rest-api-actix")]
 pub(crate) const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
 

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -525,9 +525,11 @@ fn run_service_loop(
                     correlation_id: admin_direct_message.take_correlation_id(),
                 };
 
-                service
-                    .handle_message(admin_direct_message.get_payload(), &msg_context)
-                    .map_err(to_process_err!("unable to handle admin direct message"))?;
+                if let Err(err) =
+                    service.handle_message(admin_direct_message.get_payload(), &msg_context)
+                {
+                    error!("unable to handle admin direct message: {}", err);
+                }
             }
             ServiceMessage::CircuitDirectMessage(mut direct_message) => {
                 let msg_context = ServiceMessageContext {
@@ -536,9 +538,10 @@ fn run_service_loop(
                     correlation_id: direct_message.take_correlation_id(),
                 };
 
-                service
-                    .handle_message(direct_message.get_payload(), &msg_context)
-                    .map_err(to_process_err!("unable to handle circuit direct message"))?;
+                if let Err(err) = service.handle_message(direct_message.get_payload(), &msg_context)
+                {
+                    error!("unable to handle circuit direct message: {}", err);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds a step after authorization but before
processing a circuit request that requires the admin
services to agree on a protocol version. After a
peer is authorized, the local admin service will send
a request for a protocol version, providing its own
min and max supported protocol versions. The remote
admin service will respond with the agreed protocol,
sending 0 if there is not a matching protocol version.

This is a breaking change because an older AdminService
will not be able to respond with the required response
and therefore will never enter consensus for a proposal.

Finally, Renames UnpeeredPendingPayload to PendingPaylaod
because it now includes tracking for which services need to
agree on a protocol version.