### PR TITLE
Replace "admin keygen" with "keygen"

### DIFF
--- a/docker/kubernetes/create-gameroom-keys.yaml
+++ b/docker/kubernetes/create-gameroom-keys.yaml
@@ -29,8 +29,8 @@ spec:
           - |
               mkdir -p /keys &&
               cd keys &&
-              splinter admin keygen alice -q --force &&
-              splinter admin keygen bob -q --force &&
+              splinter keygen alice --key-dir /keys -q --force &&
+              splinter keygen bob --key-dir /keys -q --force &&
               grep '' * | sed 's/\\.//' | sed 's/:/:\ /'
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
The splinter feature "keygen" was recently stabilized and "admin" functions
will soon be removed.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>