### PR TITLE
Change remaining differing config/cli options to match 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
         splinter cert generate --skip && \
         splinterd \
             -c ./configs/splinterd-node-0-docker.toml \
-            --registry file://./node_registries/nodes.yaml \
+            --registries file://./node_registries/nodes.yaml \
             --tls-insecure \
             --enable-biome \
             --database postgres://splinter_admin:splinter_test@splinter-db:5432/splinter \

--- a/docker/kubernetes/arcade.yaml
+++ b/docker/kubernetes/arcade.yaml
@@ -123,9 +123,9 @@ items:
                 cp /config/nodes.yaml /etc/splinter/nodes.yaml && \
                 cp /config/key-registry.yaml /var/lib/splinter/keys.yaml && \
                 splinterd -vv \
-                --registry file:///etc/splinter/nodes.yaml \
+                --registries file:///etc/splinter/nodes.yaml \
                 --bind $HOSTNAME:8085 \
-                --network-endpoint tcps://$HOSTNAME:8044 \
+                --network-endpoints tcps://$HOSTNAME:8044 \
                 --node-id acme \
                 --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \
@@ -295,9 +295,9 @@ items:
                 cp /config/nodes.yaml /etc/splinter/nodes.yaml && \
                 cp /config/key-registry.yaml /var/lib/splinter/keys.yaml && \
                 splinterd -vv \
-                --registry file:///etc/splinter/nodes.yaml \
+                --registries file:///etc/splinter/nodes.yaml \
                 --bind $HOSTNAME:8085 \
-                --network-endpoint tcps://$HOSTNAME:8044 \
+                --network-endpoints tcps://$HOSTNAME:8044 \
                 --node-id bubba \
                 --service-endpoint tcp://$HOSTNAME:8043 \
                 --storage yaml \

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -118,7 +118,7 @@ services:
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint tcp://0.0.0.0:8043 \
-              --network-endpoint tcps://0.0.0.0:8044 \
+              --network-endpoints tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --tls-insecure
         "
@@ -204,7 +204,7 @@ services:
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint tcp://0.0.0.0:8043 \
-              --network-endpoint tcps://0.0.0.0:8044 \
+              --network-endpoints tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --tls-insecure
         "

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -148,7 +148,7 @@ services:
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --service-endpoint tcp://0.0.0.0:8043 \
-              --network-endpoint tcps://0.0.0.0:8044 \
+              --network-endpoints tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --tls-insecure
         "
@@ -256,7 +256,7 @@ services:
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --service-endpoint tcp://0.0.0.0:8043 \
-              --network-endpoint tcps://0.0.0.0:8044 \
+              --network-endpoints tcps://0.0.0.0:8044 \
               --bind 0.0.0.0:8085 \
               --tls-insecure
         "

--- a/examples/private_counter/docker-compose.yaml
+++ b/examples/private_counter/docker-compose.yaml
@@ -34,9 +34,9 @@ services:
         splinterd -vv \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8043 \
-                --network-endpoint 0.0.0.0:8044 \
+                --network-endpoints 0.0.0.0:8044 \
                 --node-id 012 \
-                --registry file:///node_registry/nodes.yaml \
+                --registries file:///node_registry/nodes.yaml \
                 --no-tls
       "
     environment:
@@ -60,9 +60,9 @@ services:
         splinterd -vv \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8045 \
-                --network-endpoint 0.0.0.0:8046 \
+                --network-endpoints 0.0.0.0:8046 \
                 --node-id 345 \
-                --registry file:///node_registry/nodes.yaml \
+                --registries file:///node_registry/nodes.yaml \
                 --no-tls
       "
     environment:
@@ -86,9 +86,9 @@ services:
         splinterd -vv \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8047 \
-                --network-endpoint 0.0.0.0:8048 \
+                --network-endpoints 0.0.0.0:8048 \
                 --node-id 678 \
-                --registry file:///node_registry/nodes.yaml \
+                --registries file:///node_registry/nodes.yaml \
                 --no-tls
       "
     environment:

--- a/examples/private_xo/docker-compose.yaml
+++ b/examples/private_xo/docker-compose.yaml
@@ -34,9 +34,9 @@ services:
         splinterd -vv \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8043 \
-                --network-endpoint 0.0.0.0:8044 \
+                --network-endpoints 0.0.0.0:8044 \
                 --node-id 012 \
-                --registry file:///node_registry/nodes.yaml \
+                --registries file:///node_registry/nodes.yaml \
                 --no-tls
       "
     environment:
@@ -60,9 +60,9 @@ services:
         splinterd -vv \
                 --storage yaml \
                 --service-endpoint 0.0.0.0:8045 \
-                --network-endpoint 0.0.0.0:8046 \
+                --network-endpoints 0.0.0.0:8046 \
                 --node-id 345 \
-                --registry file:///node_registry/nodes.yaml \
+                --registries file:///node_registry/nodes.yaml \
                 --no-tls
       "
     environment:

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -140,13 +140,13 @@ OPTIONS
 : (Required) Sets a new ID for the node. The node ID must be unique across the
   network (for all Splinter nodes that could participate on the same circuit).
 
-`--peer PEER-URL` `[,...]`
+`--peers PEER-URL` `[,...]`
 : Specifies one or more Splinter nodes that `splinterd` will automatically
   connect to when it starts. The *PEER-URL* argument must specify another node's
   network endpoint, using the format `protocol_prefix://ip:port`.
 
   Specify multiple nodes in a comma-separated list or by repeating the
-  `--peer` option. The protocol prefix part of the peer URL specifies the
+  `--peers` option. The protocol prefix part of the peer URL specifies the
   type of connection that is created.
 
 `--registry REGISTRY-FILE` `[,...]`

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -149,7 +149,7 @@ OPTIONS
   `--peers` option. The protocol prefix part of the peer URL specifies the
   type of connection that is created.
 
-`--registry REGISTRY-FILE` `[,...]`
+`--registries REGISTRY-FILE` `[,...]`
 : Specifies one or more read-only node registry files.
 
 `--service-endpoint SERVICE-ENDPOINT`

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -285,8 +285,8 @@ the heartbeat interval to 60 seconds.
 node_id = "mynode"
 
 # The number of seconds between network keep-alive heartbeat messages.
-# Setting heartbeat_interval to 0 disables this feature.
-heartbeat_interval = 60
+# Setting heartbeat to 0 disables this feature.
+heartbeat = 60
 ```
 
 SEE ALSO

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -91,7 +91,7 @@ OPTIONS
   (functions that use the two-phase commit agreement protocol in the Scabbard
   service).
 
-`--advertised-endpoint` `ADVERTISED-ENDPOINT`
+`--advertised-endpoints` `ADVERTISED-ENDPOINT`
 : Specifies the public network endpoint for daemon-to-daemon communication
   between Splinter nodes, if the network endpoint is not public. Use the format
   `tcp://ip:port`. (Default: Same as the network endpoint; see

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -95,7 +95,7 @@ OPTIONS
 : Specifies the public network endpoint for daemon-to-daemon communication
   between Splinter nodes, if the network endpoint is not public. Use the format
   `tcp://ip:port`. (Default: Same as the network endpoint; see
-  `-n`, `--network-endpoint`.)
+  `-n`, `--network-endpoints`.)
 
 `--bind BIND-ENDPOINT`
 : Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
@@ -132,7 +132,7 @@ OPTIONS
   This heartbeat is used to check the health of connections to other Splinter
   nodes.
 
-`-n`, `--network-endpoint` `NETWORK-ENDPOINT`
+`-n`, `--network-endpoints` `NETWORK-ENDPOINT`
 : Specifies the endpoint for daemon-to-daemon communication between Splinter
   nodes, using the format `tcp://ip:port`. (Default: 127.0.0.1:8044.)
 

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -56,5 +56,5 @@ server_cert = "/etc/splinter/certs/private/acme.crt"
 server_key = "/etc/splinter/certs/private/acme.key"
 
 # The number of seconds between network keep-alive heartbeat messages.
-# Setting heartbeat_interval to 0 disables this feature.
-heartbeat_interval = 30
+# Setting heartbeat to 0 disables this feature.
+heartbeat = 30

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -281,14 +281,14 @@ impl ConfigBuilder {
                 })
                 .ok_or_else(|| ConfigError::MissingValue("no tls".to_string()))?,
             #[cfg(feature = "biome")]
-            biome_enabled: self
+            enable_biome: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.biome_enabled() {
+                .find_map(|p| match p.enable_biome() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
-                .ok_or_else(|| ConfigError::MissingValue("biome_enabled".to_string()))?,
+                .ok_or_else(|| ConfigError::MissingValue("enable_biome".to_string()))?,
             #[cfg(feature = "rest-api-cors")]
             whitelist: self
                 .partial_configs

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -217,10 +217,10 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("registries".to_string()))?,
-            registry_auto_refresh_interval: self
+            registry_auto_refresh: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.registry_auto_refresh_interval() {
+                .find_map(|p| match p.registry_auto_refresh() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -237,10 +237,10 @@ impl ConfigBuilder {
                 .ok_or_else(|| {
                     ConfigError::MissingValue("registry forced refresh interval".to_string())
                 })?,
-            heartbeat_interval: self
+            heartbeat: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.heartbeat_interval() {
+                .find_map(|p| match p.heartbeat() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
@@ -361,7 +361,7 @@ mod tests {
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), Some(vec![]));
-        assert_eq!(config.heartbeat_interval(), None);
+        assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
     }
 
@@ -394,7 +394,7 @@ mod tests {
             .with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()))
             .with_bind(None)
             .with_registries(Some(vec![]))
-            .with_heartbeat_interval(None)
+            .with_heartbeat(None)
             .with_admin_service_coordinator_timeout(None);
         // Compare the generated PartialConfig object against the expected values.
         assert_config_values(partial_config);

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -227,10 +227,10 @@ impl ConfigBuilder {
                 .ok_or_else(|| {
                     ConfigError::MissingValue("registry auto refresh interval".to_string())
                 })?,
-            registry_forced_refresh_interval: self
+            registry_forced_refresh: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.registry_forced_refresh_interval() {
+                .find_map(|p| match p.registry_forced_refresh() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -245,10 +245,10 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("heartbeat interval".to_string()))?,
-            admin_service_coordinator_timeout: self
+            admin_timeout: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.admin_service_coordinator_timeout() {
+                .find_map(|p| match p.admin_timeout() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), Some(vec![]));
         assert_eq!(config.heartbeat(), None);
-        assert_eq!(config.admin_service_coordinator_timeout(), None);
+        assert_eq!(config.admin_timeout(), None);
     }
 
     #[test]
@@ -395,7 +395,7 @@ mod tests {
             .with_bind(None)
             .with_registries(Some(vec![]))
             .with_heartbeat(None)
-            .with_admin_service_coordinator_timeout(None);
+            .with_admin_timeout(None);
         // Compare the generated PartialConfig object against the expected values.
         assert_config_values(partial_config);
     }
@@ -429,7 +429,7 @@ mod tests {
         partial_config = partial_config.with_peers(Some(vec![]));
         partial_config = partial_config.with_node_id(Some(EXAMPLE_NODE_ID.to_string()));
         partial_config = partial_config.with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()));
-        partial_config = partial_config.with_admin_service_coordinator_timeout(None);
+        partial_config = partial_config.with_admin_timeout(None);
         partial_config = partial_config.with_registries(Some(vec![]));
         // Compare the generated PartialConfig object against the expected values.
         assert_config_values(partial_config);

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -81,7 +81,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 &self.matches,
                 "registry_forced_refresh_interval",
             )?)
-            .with_heartbeat_interval(parse_value(&self.matches, "heartbeat_interval")?)
+            .with_heartbeat(parse_value(&self.matches, "heartbeat")?)
             .with_tls_insecure(if self.matches.is_present("tls_insecure") {
                 Some(true)
             } else {
@@ -185,7 +185,7 @@ mod tests {
         assert_eq!(config.registries(), None);
         assert_eq!(config.registry_auto_refresh_interval(), None);
         assert_eq!(config.registry_forced_refresh_interval(), None);
-        assert_eq!(config.heartbeat_interval(), None);
+        assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
         assert_eq!(config.tls_insecure(), Some(true));
         assert_eq!(config.no_tls(), Some(true));

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -195,7 +195,7 @@ mod tests {
             (@arg display_name: --("display-name") +takes_value)
             (@arg storage: --("storage") +takes_value)
             (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
-            (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
+            (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
             (@arg peers: --peer +takes_value +multiple)
             (@arg tls_ca_file: --("tls-ca-file") +takes_value)
@@ -233,7 +233,7 @@ mod tests {
             EXAMPLE_STORAGE,
             "--network-endpoints",
             EXAMPLE_NETWORK_ENDPOINT,
-            "--advertised-endpoint",
+            "--advertised-endpoints",
             EXAMPLE_ADVERTISED_ENDPOINT,
             "--service-endpoint",
             EXAMPLE_SERVICE_ENDPOINT,

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -73,10 +73,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                     .values_of("registries")
                     .map(|values| values.map(String::from).collect::<Vec<String>>()),
             )
-            .with_registry_auto_refresh_interval(parse_value(
-                &self.matches,
-                "registry_auto_refresh_interval",
-            )?)
+            .with_registry_auto_refresh(parse_value(&self.matches, "registry_auto_refresh")?)
             .with_registry_forced_refresh_interval(parse_value(
                 &self.matches,
                 "registry_forced_refresh_interval",
@@ -183,7 +180,7 @@ mod tests {
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
-        assert_eq!(config.registry_auto_refresh_interval(), None);
+        assert_eq!(config.registry_auto_refresh(), None);
         assert_eq!(config.registry_forced_refresh_interval(), None);
         assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -90,7 +90,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
         #[cfg(feature = "biome")]
         {
             partial_config =
-                partial_config.with_biome_enabled(if self.matches.is_present("biome_enabled") {
+                partial_config.with_enable_biome(if self.matches.is_present("enable_biome") {
                     Some(true)
                 } else {
                     None

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -197,7 +197,7 @@ mod tests {
             (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
             (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
-            (@arg peers: --peer +takes_value +multiple)
+            (@arg peers: --peers +takes_value +multiple)
             (@arg tls_ca_file: --("tls-ca-file") +takes_value)
             (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
             (@arg tls_client_cert: --("tls-client-cert") +takes_value)

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(config.registry_auto_refresh(), None);
         assert_eq!(config.registry_forced_refresh(), None);
         assert_eq!(config.heartbeat(), None);
-        assert_eq!(config.admin_service_coordinator_timeout(), None);
+        assert_eq!(config.admin_timeout(), None);
         assert_eq!(config.tls_insecure(), Some(true));
         assert_eq!(config.no_tls(), Some(true));
     }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -74,10 +74,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                     .map(|values| values.map(String::from).collect::<Vec<String>>()),
             )
             .with_registry_auto_refresh(parse_value(&self.matches, "registry_auto_refresh")?)
-            .with_registry_forced_refresh_interval(parse_value(
-                &self.matches,
-                "registry_forced_refresh_interval",
-            )?)
+            .with_registry_forced_refresh(parse_value(&self.matches, "registry_forced_refresh")?)
             .with_heartbeat(parse_value(&self.matches, "heartbeat")?)
             .with_tls_insecure(if self.matches.is_present("tls_insecure") {
                 Some(true)
@@ -181,7 +178,7 @@ mod tests {
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
         assert_eq!(config.registry_auto_refresh(), None);
-        assert_eq!(config.registry_forced_refresh_interval(), None);
+        assert_eq!(config.registry_forced_refresh(), None);
         assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
         assert_eq!(config.tls_insecure(), Some(true));

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -194,7 +194,7 @@ mod tests {
             (@arg node_id: --("node-id") +takes_value)
             (@arg display_name: --("display-name") +takes_value)
             (@arg storage: --("storage") +takes_value)
-            (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple)
+            (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
             (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple)
             (@arg service_endpoint: --("service-endpoint") +takes_value)
             (@arg peers: --peer +takes_value +multiple)
@@ -231,7 +231,7 @@ mod tests {
             EXAMPLE_DISPLAY_NAME,
             "--storage",
             EXAMPLE_STORAGE,
-            "--network-endpoint",
+            "--network-endpoints",
             EXAMPLE_NETWORK_ENDPOINT,
             "--advertised-endpoint",
             EXAMPLE_ADVERTISED_ENDPOINT,

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -58,7 +58,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_registry_auto_refresh(Some(REGISTRY_AUTO_REFRESH_DEFAULT))
             .with_registry_forced_refresh(Some(REGISTRY_FORCED_REFRESH_DEFAULT))
             .with_heartbeat(Some(HEARTBEAT_DEFAULT))
-            .with_admin_service_coordinator_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
+            .with_admin_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
             .with_tls_insecure(Some(false))
             .with_no_tls(Some(false));
@@ -117,7 +117,7 @@ mod tests {
         );
         assert_eq!(config.heartbeat(), Some(HEARTBEAT_DEFAULT));
         assert_eq!(
-            config.admin_service_coordinator_timeout(),
+            config.admin_timeout(),
             Some(Duration::from_secs(
                 DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT
             ))

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -65,7 +65,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
 
         #[cfg(feature = "biome")]
         {
-            partial_config = partial_config.with_biome_enabled(Some(false));
+            partial_config = partial_config.with_enable_biome(Some(false));
         }
 
         #[cfg(feature = "database")]
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(config.tls_insecure(), Some(false));
         assert_eq!(config.no_tls(), Some(false));
         #[cfg(feature = "biome")]
-        assert_eq!(config.biome_enabled(), Some(false));
+        assert_eq!(config.enable_biome(), Some(false));
         // Assert the source is correctly identified for this PartialConfig object.
         assert_eq!(config.source(), ConfigSource::Default);
     }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -57,7 +57,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_registries(Some(vec![]))
             .with_registry_auto_refresh_interval(Some(REGISTRY_AUTO_REFRESH_DEFAULT))
             .with_registry_forced_refresh_interval(Some(REGISTRY_FORCED_REFRESH_DEFAULT))
-            .with_heartbeat_interval(Some(HEARTBEAT_DEFAULT))
+            .with_heartbeat(Some(HEARTBEAT_DEFAULT))
             .with_admin_service_coordinator_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
             .with_tls_insecure(Some(false))
@@ -115,7 +115,7 @@ mod tests {
             config.registry_forced_refresh_interval(),
             Some(REGISTRY_FORCED_REFRESH_DEFAULT)
         );
-        assert_eq!(config.heartbeat_interval(), Some(HEARTBEAT_DEFAULT));
+        assert_eq!(config.heartbeat(), Some(HEARTBEAT_DEFAULT));
         assert_eq!(
             config.admin_service_coordinator_timeout(),
             Some(Duration::from_secs(

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -56,7 +56,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
             .with_registry_auto_refresh(Some(REGISTRY_AUTO_REFRESH_DEFAULT))
-            .with_registry_forced_refresh_interval(Some(REGISTRY_FORCED_REFRESH_DEFAULT))
+            .with_registry_forced_refresh(Some(REGISTRY_FORCED_REFRESH_DEFAULT))
             .with_heartbeat(Some(HEARTBEAT_DEFAULT))
             .with_admin_service_coordinator_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
             .with_state_dir(Some(String::from(DEFAULT_STATE_DIR)))
@@ -112,7 +112,7 @@ mod tests {
             Some(REGISTRY_AUTO_REFRESH_DEFAULT)
         );
         assert_eq!(
-            config.registry_forced_refresh_interval(),
+            config.registry_forced_refresh(),
             Some(REGISTRY_FORCED_REFRESH_DEFAULT)
         );
         assert_eq!(config.heartbeat(), Some(HEARTBEAT_DEFAULT));

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -55,7 +55,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_peers(Some(vec![]))
             .with_bind(Some(String::from("127.0.0.1:8080")))
             .with_registries(Some(vec![]))
-            .with_registry_auto_refresh_interval(Some(REGISTRY_AUTO_REFRESH_DEFAULT))
+            .with_registry_auto_refresh(Some(REGISTRY_AUTO_REFRESH_DEFAULT))
             .with_registry_forced_refresh_interval(Some(REGISTRY_FORCED_REFRESH_DEFAULT))
             .with_heartbeat(Some(HEARTBEAT_DEFAULT))
             .with_admin_service_coordinator_timeout(Some(DEFAULT_ADMIN_SERVICE_COORDINATOR_TIMEOUT))
@@ -108,7 +108,7 @@ mod tests {
         assert_eq!(config.database(), Some(String::from("127.0.0.1:5432")));
         assert_eq!(config.registries(), Some(vec![]));
         assert_eq!(
-            config.registry_auto_refresh_interval(),
+            config.registry_auto_refresh(),
             Some(REGISTRY_AUTO_REFRESH_DEFAULT)
         );
         assert_eq!(

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -68,7 +68,7 @@ pub struct Config {
     tls_insecure: (bool, ConfigSource),
     no_tls: (bool, ConfigSource),
     #[cfg(feature = "biome")]
-    biome_enabled: (bool, ConfigSource),
+    enable_biome: (bool, ConfigSource),
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<(Vec<String>, ConfigSource)>,
 }
@@ -172,8 +172,8 @@ impl Config {
     }
 
     #[cfg(feature = "biome")]
-    pub fn biome_enabled(&self) -> bool {
-        self.biome_enabled.0
+    pub fn enable_biome(&self) -> bool {
+        self.enable_biome.0
     }
 
     #[cfg(feature = "rest-api-cors")]
@@ -283,8 +283,8 @@ impl Config {
     }
 
     #[cfg(feature = "biome")]
-    fn biome_enabled_source(&self) -> &ConfigSource {
-        &self.biome_enabled.1
+    fn enable_biome_source(&self) -> &ConfigSource {
+        &self.enable_biome.1
     }
 
     #[cfg(feature = "rest-api-cors")]
@@ -422,9 +422,9 @@ impl Config {
         );
         #[cfg(feature = "biome")]
         debug!(
-            "Config: biome_enabled: {:?} (source: {:?})",
-            self.biome_enabled(),
-            self.biome_enabled_source()
+            "Config: enable_biome: {:?} (source: {:?})",
+            self.enable_biome(),
+            self.enable_biome_source()
         );
         #[cfg(feature = "rest-api-cors")]
         self.log_whitelist();
@@ -535,7 +535,7 @@ mod tests {
         (@arg bind: --("bind") +takes_value)
         (@arg tls_insecure: --("tls-insecure"))
         (@arg no_tls: --("no-tls"))
-        (@arg biome_enabled: --("enable-biome")))
+        (@arg enable_biome: --("enable-biome")))
         .get_matches_from(args)
     }
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -61,7 +61,7 @@ pub struct Config {
     database: (String, ConfigSource),
     registries: (Vec<String>, ConfigSource),
     registry_auto_refresh: (u64, ConfigSource),
-    registry_forced_refresh_interval: (u64, ConfigSource),
+    registry_forced_refresh: (u64, ConfigSource),
     heartbeat: (u64, ConfigSource),
     admin_service_coordinator_timeout: (Duration, ConfigSource),
     state_dir: (String, ConfigSource),
@@ -147,8 +147,8 @@ impl Config {
         self.registry_auto_refresh.0
     }
 
-    pub fn registry_forced_refresh_interval(&self) -> u64 {
-        self.registry_forced_refresh_interval.0
+    pub fn registry_forced_refresh(&self) -> u64 {
+        self.registry_forced_refresh.0
     }
 
     pub fn heartbeat(&self) -> u64 {
@@ -258,8 +258,8 @@ impl Config {
         &self.registry_auto_refresh.1
     }
 
-    fn registry_forced_refresh_interval_source(&self) -> &ConfigSource {
-        &self.registry_forced_refresh_interval.1
+    fn registry_forced_refresh_source(&self) -> &ConfigSource {
+        &self.registry_forced_refresh.1
     }
 
     fn heartbeat_source(&self) -> &ConfigSource {
@@ -385,9 +385,9 @@ impl Config {
             self.registry_auto_refresh_source()
         );
         debug!(
-            "Config: registry_forced_refresh_interval: {} (source: {:?})",
-            self.registry_forced_refresh_interval(),
-            self.registry_forced_refresh_interval_source()
+            "Config: registry_forced_refresh: {} (source: {:?})",
+            self.registry_forced_refresh(),
+            self.registry_forced_refresh_source()
         );
         debug!(
             "Config: state_dir: {} (source: {:?})",
@@ -922,11 +922,11 @@ mod tests {
             (600, &ConfigSource::Default)
         );
         // The DefaultPartialConfigBuilder is the only config with a value for
-        // `registry_forced_refresh_interval` (source should be Default).
+        // `registry_forced_refresh` (source should be Default).
         assert_eq!(
             (
-                final_config.registry_forced_refresh_interval(),
-                final_config.registry_forced_refresh_interval_source()
+                final_config.registry_forced_refresh(),
+                final_config.registry_forced_refresh_source()
             ),
             (10, &ConfigSource::Default)
         );

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -60,7 +60,7 @@ pub struct Config {
     #[cfg(feature = "database")]
     database: (String, ConfigSource),
     registries: (Vec<String>, ConfigSource),
-    registry_auto_refresh_interval: (u64, ConfigSource),
+    registry_auto_refresh: (u64, ConfigSource),
     registry_forced_refresh_interval: (u64, ConfigSource),
     heartbeat: (u64, ConfigSource),
     admin_service_coordinator_timeout: (Duration, ConfigSource),
@@ -143,8 +143,8 @@ impl Config {
         &self.registries.0
     }
 
-    pub fn registry_auto_refresh_interval(&self) -> u64 {
-        self.registry_auto_refresh_interval.0
+    pub fn registry_auto_refresh(&self) -> u64 {
+        self.registry_auto_refresh.0
     }
 
     pub fn registry_forced_refresh_interval(&self) -> u64 {
@@ -254,8 +254,8 @@ impl Config {
         &self.registries.1
     }
 
-    fn registry_auto_refresh_interval_source(&self) -> &ConfigSource {
-        &self.registry_auto_refresh_interval.1
+    fn registry_auto_refresh_source(&self) -> &ConfigSource {
+        &self.registry_auto_refresh.1
     }
 
     fn registry_forced_refresh_interval_source(&self) -> &ConfigSource {
@@ -380,9 +380,9 @@ impl Config {
             self.registries_source()
         );
         debug!(
-            "Config: registry_auto_refresh_interval: {} (source: {:?})",
-            self.registry_auto_refresh_interval(),
-            self.registry_auto_refresh_interval_source()
+            "Config: registry_auto_refresh: {} (source: {:?})",
+            self.registry_auto_refresh(),
+            self.registry_auto_refresh_source()
         );
         debug!(
             "Config: registry_forced_refresh_interval: {} (source: {:?})",
@@ -913,11 +913,11 @@ mod tests {
             ("127.0.0.1:5432", &ConfigSource::Default)
         );
         // The DefaultPartialConfigBuilder is the only config with a value for
-        // `registry_auto_refresh_interval` (source should be Default).
+        // `registry_auto_refresh` (source should be Default).
         assert_eq!(
             (
-                final_config.registry_auto_refresh_interval(),
-                final_config.registry_auto_refresh_interval_source()
+                final_config.registry_auto_refresh(),
+                final_config.registry_auto_refresh_source()
             ),
             (600, &ConfigSource::Default)
         );

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -63,7 +63,7 @@ pub struct Config {
     registry_auto_refresh: (u64, ConfigSource),
     registry_forced_refresh: (u64, ConfigSource),
     heartbeat: (u64, ConfigSource),
-    admin_service_coordinator_timeout: (Duration, ConfigSource),
+    admin_timeout: (Duration, ConfigSource),
     state_dir: (String, ConfigSource),
     tls_insecure: (bool, ConfigSource),
     no_tls: (bool, ConfigSource),
@@ -155,8 +155,8 @@ impl Config {
         self.heartbeat.0
     }
 
-    pub fn admin_service_coordinator_timeout(&self) -> Duration {
-        self.admin_service_coordinator_timeout.0
+    pub fn admin_timeout(&self) -> Duration {
+        self.admin_timeout.0
     }
 
     pub fn state_dir(&self) -> &str {
@@ -266,8 +266,8 @@ impl Config {
         &self.heartbeat.1
     }
 
-    fn admin_service_coordinator_timeout_source(&self) -> &ConfigSource {
-        &self.admin_service_coordinator_timeout.1
+    fn admin_timeout_source(&self) -> &ConfigSource {
+        &self.admin_timeout.1
     }
 
     fn state_dir_source(&self) -> &ConfigSource {
@@ -400,9 +400,9 @@ impl Config {
             self.heartbeat_source()
         );
         debug!(
-            "Config: admin_service_coordinator_timeout: {:?} (source: {:?})",
-            self.admin_service_coordinator_timeout(),
-            self.admin_service_coordinator_timeout_source()
+            "Config: admin_timeout: {:?} (source: {:?})",
+            self.admin_timeout(),
+            self.admin_timeout_source()
         );
         #[cfg(feature = "database")]
         debug!(
@@ -937,11 +937,11 @@ mod tests {
             (30, &ConfigSource::Default)
         );
         // The DefaultPartialConfigBuilder is the only config with a value for
-        // `admin_service_coordinator_timeout` (source should be Default).
+        // `admin_timeout` (source should be Default).
         assert_eq!(
             (
-                final_config.admin_service_coordinator_timeout(),
-                final_config.admin_service_coordinator_timeout_source()
+                final_config.admin_timeout(),
+                final_config.admin_timeout_source()
             ),
             (Duration::from_secs(30), &ConfigSource::Default)
         );

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -62,7 +62,7 @@ pub struct Config {
     registries: (Vec<String>, ConfigSource),
     registry_auto_refresh_interval: (u64, ConfigSource),
     registry_forced_refresh_interval: (u64, ConfigSource),
-    heartbeat_interval: (u64, ConfigSource),
+    heartbeat: (u64, ConfigSource),
     admin_service_coordinator_timeout: (Duration, ConfigSource),
     state_dir: (String, ConfigSource),
     tls_insecure: (bool, ConfigSource),
@@ -151,8 +151,8 @@ impl Config {
         self.registry_forced_refresh_interval.0
     }
 
-    pub fn heartbeat_interval(&self) -> u64 {
-        self.heartbeat_interval.0
+    pub fn heartbeat(&self) -> u64 {
+        self.heartbeat.0
     }
 
     pub fn admin_service_coordinator_timeout(&self) -> Duration {
@@ -262,8 +262,8 @@ impl Config {
         &self.registry_forced_refresh_interval.1
     }
 
-    fn heartbeat_interval_source(&self) -> &ConfigSource {
-        &self.heartbeat_interval.1
+    fn heartbeat_source(&self) -> &ConfigSource {
+        &self.heartbeat.1
     }
 
     fn admin_service_coordinator_timeout_source(&self) -> &ConfigSource {
@@ -395,9 +395,9 @@ impl Config {
             self.state_dir_source()
         );
         debug!(
-            "Config: heartbeat_interval: {} (source: {:?})",
-            self.heartbeat_interval(),
-            self.heartbeat_interval_source()
+            "Config: heartbeat: {} (source: {:?})",
+            self.heartbeat(),
+            self.heartbeat_source()
         );
         debug!(
             "Config: admin_service_coordinator_timeout: {:?} (source: {:?})",
@@ -930,13 +930,10 @@ mod tests {
             ),
             (10, &ConfigSource::Default)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `heartbeat_interval`
+        // The DefaultPartialConfigBuilder is the only config with a value for `heartbeat`
         // (source should be Default).
         assert_eq!(
-            (
-                final_config.heartbeat_interval(),
-                final_config.heartbeat_interval_source()
-            ),
+            (final_config.heartbeat(), final_config.heartbeat_source()),
             (30, &ConfigSource::Default)
         );
         // The DefaultPartialConfigBuilder is the only config with a value for

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -49,7 +49,7 @@ pub struct PartialConfig {
     database: Option<String>,
     registries: Option<Vec<String>>,
     registry_auto_refresh: Option<u64>,
-    registry_forced_refresh_interval: Option<u64>,
+    registry_forced_refresh: Option<u64>,
     heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<Duration>,
     state_dir: Option<String>,
@@ -85,7 +85,7 @@ impl PartialConfig {
             database: None,
             registries: None,
             registry_auto_refresh: None,
-            registry_forced_refresh_interval: None,
+            registry_forced_refresh: None,
             heartbeat: None,
             admin_service_coordinator_timeout: None,
             state_dir: None,
@@ -175,8 +175,8 @@ impl PartialConfig {
         self.registry_auto_refresh
     }
 
-    pub fn registry_forced_refresh_interval(&self) -> Option<u64> {
-        self.registry_forced_refresh_interval
+    pub fn registry_forced_refresh(&self) -> Option<u64> {
+        self.registry_forced_refresh
     }
 
     pub fn heartbeat(&self) -> Option<u64> {
@@ -429,18 +429,15 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `registry_forced_refresh_interval` value to the PartialConfig object.
+    /// Adds a `registry_forced_refresh` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `registry_forced_refresh_interval` - How long before remote registries should be
+    /// * `registry_forced_refresh` - How long before remote registries should be
     ///   refreshed on read.
     ///
-    pub fn with_registry_forced_refresh_interval(
-        mut self,
-        registry_forced_refresh_interval: Option<u64>,
-    ) -> Self {
-        self.registry_forced_refresh_interval = registry_forced_refresh_interval;
+    pub fn with_registry_forced_refresh(mut self, registry_forced_refresh: Option<u64>) -> Self {
+        self.registry_forced_refresh = registry_forced_refresh;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -51,7 +51,7 @@ pub struct PartialConfig {
     registry_auto_refresh: Option<u64>,
     registry_forced_refresh: Option<u64>,
     heartbeat: Option<u64>,
-    admin_service_coordinator_timeout: Option<Duration>,
+    admin_timeout: Option<Duration>,
     state_dir: Option<String>,
     tls_insecure: Option<bool>,
     no_tls: Option<bool>,
@@ -87,7 +87,7 @@ impl PartialConfig {
             registry_auto_refresh: None,
             registry_forced_refresh: None,
             heartbeat: None,
-            admin_service_coordinator_timeout: None,
+            admin_timeout: None,
             state_dir: None,
             tls_insecure: None,
             no_tls: None,
@@ -183,8 +183,8 @@ impl PartialConfig {
         self.heartbeat
     }
 
-    pub fn admin_service_coordinator_timeout(&self) -> Option<Duration> {
-        self.admin_service_coordinator_timeout
+    pub fn admin_timeout(&self) -> Option<Duration> {
+        self.admin_timeout
     }
 
     pub fn state_dir(&self) -> Option<String> {
@@ -460,12 +460,12 @@ impl PartialConfig {
     ///
     /// * `timeout` - The coordinator timeout for admin service proposals (in milliseconds).
     ///
-    pub fn with_admin_service_coordinator_timeout(mut self, timeout: Option<u64>) -> Self {
+    pub fn with_admin_timeout(mut self, timeout: Option<u64>) -> Self {
         let duration: Option<Duration> = match timeout {
             Some(t) => Some(Duration::from_secs(t)),
             _ => None,
         };
-        self.admin_service_coordinator_timeout = duration;
+        self.admin_timeout = duration;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -56,7 +56,7 @@ pub struct PartialConfig {
     tls_insecure: Option<bool>,
     no_tls: Option<bool>,
     #[cfg(feature = "biome")]
-    biome_enabled: Option<bool>,
+    enable_biome: Option<bool>,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
 }
@@ -92,7 +92,7 @@ impl PartialConfig {
             tls_insecure: None,
             no_tls: None,
             #[cfg(feature = "biome")]
-            biome_enabled: None,
+            enable_biome: None,
             #[cfg(feature = "rest-api-cors")]
             whitelist: None,
         }
@@ -200,8 +200,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "biome")]
-    pub fn biome_enabled(&self) -> Option<bool> {
-        self.biome_enabled
+    pub fn enable_biome(&self) -> Option<bool> {
+        self.enable_biome
     }
 
     #[cfg(feature = "rest-api-cors")]
@@ -506,14 +506,14 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "biome")]
-    /// Adds a `biome_enabled` value to the PartialConfig object.
+    /// Adds a `enable_biome` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `biome_enabled` - Enable biome REST API routes
+    /// * `enable_biome` - Enable biome REST API routes
     ///
-    pub fn with_biome_enabled(mut self, biome_enabled: Option<bool>) -> Self {
-        self.biome_enabled = biome_enabled;
+    pub fn with_enable_biomed(mut self, enable_biomed: Option<bool>) -> Self {
+        self.enable_biomed = enable_biomed;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -50,7 +50,7 @@ pub struct PartialConfig {
     registries: Option<Vec<String>>,
     registry_auto_refresh_interval: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
-    heartbeat_interval: Option<u64>,
+    heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<Duration>,
     state_dir: Option<String>,
     tls_insecure: Option<bool>,
@@ -86,7 +86,7 @@ impl PartialConfig {
             registries: None,
             registry_auto_refresh_interval: None,
             registry_forced_refresh_interval: None,
-            heartbeat_interval: None,
+            heartbeat: None,
             admin_service_coordinator_timeout: None,
             state_dir: None,
             tls_insecure: None,
@@ -179,8 +179,8 @@ impl PartialConfig {
         self.registry_forced_refresh_interval
     }
 
-    pub fn heartbeat_interval(&self) -> Option<u64> {
-        self.heartbeat_interval
+    pub fn heartbeat(&self) -> Option<u64> {
+        self.heartbeat
     }
 
     pub fn admin_service_coordinator_timeout(&self) -> Option<Duration> {
@@ -448,14 +448,14 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `heartbeat_interval` value to the PartialConfig object.
+    /// Adds a `heartbeat` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `heartbeat_interval` - How often heartbeat should be sent.
+    /// * `heartbeat` - How often heartbeat should be sent.
     ///
-    pub fn with_heartbeat_interval(mut self, heartbeat_interval: Option<u64>) -> Self {
-        self.heartbeat_interval = heartbeat_interval;
+    pub fn with_heartbeat(mut self, heartbeat: Option<u64>) -> Self {
+        self.heartbeat = heartbeat;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -48,7 +48,7 @@ pub struct PartialConfig {
     #[cfg(feature = "database")]
     database: Option<String>,
     registries: Option<Vec<String>>,
-    registry_auto_refresh_interval: Option<u64>,
+    registry_auto_refresh: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
     heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<Duration>,
@@ -84,7 +84,7 @@ impl PartialConfig {
             #[cfg(feature = "database")]
             database: None,
             registries: None,
-            registry_auto_refresh_interval: None,
+            registry_auto_refresh: None,
             registry_forced_refresh_interval: None,
             heartbeat: None,
             admin_service_coordinator_timeout: None,
@@ -171,8 +171,8 @@ impl PartialConfig {
         self.registries.clone()
     }
 
-    pub fn registry_auto_refresh_interval(&self) -> Option<u64> {
-        self.registry_auto_refresh_interval
+    pub fn registry_auto_refresh(&self) -> Option<u64> {
+        self.registry_auto_refresh
     }
 
     pub fn registry_forced_refresh_interval(&self) -> Option<u64> {
@@ -416,18 +416,15 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `registry_auto_refresh_interval` value to the PartialConfig object.
+    /// Adds a `registry_auto_refresh` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `registry_auto_refresh_interval` - How often remote registries should be refreshed in the
+    /// * `registry_auto_refresh` - How often remote registries should be refreshed in the
     ///   background.
     ///
-    pub fn with_registry_auto_refresh_interval(
-        mut self,
-        registry_auto_refresh_interval: Option<u64>,
-    ) -> Self {
-        self.registry_auto_refresh_interval = registry_auto_refresh_interval;
+    pub fn with_registry_auto_refresh(mut self, registry_auto_refresh: Option<u64>) -> Self {
+        self.registry_auto_refresh = registry_auto_refresh;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -512,8 +512,8 @@ impl PartialConfig {
     ///
     /// * `enable_biome` - Enable biome REST API routes
     ///
-    pub fn with_enable_biomed(mut self, enable_biomed: Option<bool>) -> Self {
-        self.enable_biomed = enable_biomed;
+    pub fn with_enable_biome(mut self, enable_biome: Option<bool>) -> Self {
+        self.enable_biome = enable_biome;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -41,7 +41,7 @@ struct TomlConfig {
     #[cfg(feature = "database")]
     database: Option<String>,
     registries: Option<Vec<String>>,
-    registry_auto_refresh_interval: Option<u64>,
+    registry_auto_refresh: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
     heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
@@ -57,6 +57,7 @@ struct TomlConfig {
     server_cert: Option<String>,
     server_key: Option<String>,
     heartbeat_interval: Option<u64>,
+    registry_auto_refresh_interval: Option<u64>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -116,7 +117,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_display_name(self.toml_config.display_name)
             .with_bind(self.toml_config.bind)
             .with_registries(self.toml_config.registries)
-            .with_registry_auto_refresh_interval(self.toml_config.registry_auto_refresh_interval)
+            .with_registry_auto_refresh(self.toml_config.registry_auto_refresh)
             .with_registry_forced_refresh_interval(
                 self.toml_config.registry_forced_refresh_interval,
             )
@@ -156,6 +157,10 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         }
         if partial_config.heartbeat().is_none() {
             partial_config = partial_config.with_heartbeat(self.toml_config.heartbeat_interval)
+        }
+        if partial_config.registry_auto_refresh().is_none() {
+            partial_config = partial_config
+                .with_registry_auto_refresh(self.toml_config.registry_auto_refresh_interval)
         }
 
         Ok(partial_config)
@@ -270,7 +275,7 @@ mod tests {
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
-        assert_eq!(config.registry_auto_refresh_interval(), None);
+        assert_eq!(config.registry_auto_refresh(), None);
         assert_eq!(config.registry_forced_refresh_interval(), None);
         assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -177,6 +177,8 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
 mod tests {
     use super::*;
 
+    use std::time::Duration;
+
     use toml::{map::Map, Value};
 
     /// Path to an example config toml file.
@@ -193,6 +195,10 @@ mod tests {
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NODE_ID: &str = "012";
     static EXAMPLE_DISPLAY_NAME: &str = "Node 1";
+    static EXAMPLE_HEARTBEAT: u64 = 20;
+    static EXAMPLE_REGISTRY_AUTO: u64 = 19;
+    static EXAMPLE_REGISTRY_FORCE: u64 = 18;
+    static EXAMPLE_ADMIN_TIMEOUT: u64 = 17;
 
     /// Converts a list of tuples to a toml Table Value used to write a toml file.
     fn get_toml_value() -> Value {
@@ -240,6 +246,26 @@ mod tests {
         let mut config_values = Map::new();
         values.iter().for_each(|v| {
             config_values.insert(v.0.clone(), Value::String(v.1.clone()));
+        });
+
+        let u64_values = vec![
+            ("heartbeat_interval".to_string(), EXAMPLE_HEARTBEAT),
+            (
+                "registry_auto_refresh_interval".to_string(),
+                EXAMPLE_REGISTRY_AUTO,
+            ),
+            (
+                "registry_forced_refresh_interval".to_string(),
+                EXAMPLE_REGISTRY_FORCE,
+            ),
+            (
+                "admin_service_coordinator_timeout".to_string(),
+                EXAMPLE_ADMIN_TIMEOUT,
+            ),
+        ];
+
+        u64_values.iter().for_each(|v| {
+            config_values.insert(v.0.clone(), Value::Integer(v.1.clone() as i64));
         });
         Value::Table(config_values)
     }
@@ -318,8 +344,10 @@ mod tests {
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
-        assert_eq!(config.heartbeat(), None);
-        assert_eq!(config.admin_timeout(), None);
+        assert_eq!(config.heartbeat(), Some(20));
+        assert_eq!(config.registry_auto_refresh(), Some(19));
+        assert_eq!(config.registry_forced_refresh(), Some(18));
+        assert_eq!(config.admin_timeout(), Some(Duration::from_secs(17)));
     }
 
     #[test]

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -44,7 +44,7 @@ struct TomlConfig {
     registry_auto_refresh: Option<u64>,
     registry_forced_refresh: Option<u64>,
     heartbeat: Option<u64>,
-    admin_service_coordinator_timeout: Option<u64>,
+    admin_timeout: Option<u64>,
     version: Option<String>,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
@@ -59,6 +59,7 @@ struct TomlConfig {
     heartbeat_interval: Option<u64>,
     registry_auto_refresh_interval: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
+    admin_service_coordinator_timeout: Option<u64>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -121,9 +122,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_registry_auto_refresh(self.toml_config.registry_auto_refresh)
             .with_registry_forced_refresh(self.toml_config.registry_forced_refresh)
             .with_heartbeat(self.toml_config.heartbeat)
-            .with_admin_service_coordinator_timeout(
-                self.toml_config.admin_service_coordinator_timeout,
-            );
+            .with_admin_timeout(self.toml_config.admin_timeout);
 
         #[cfg(feature = "database")]
         {
@@ -164,6 +163,10 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         if partial_config.registry_forced_refresh().is_none() {
             partial_config = partial_config
                 .with_registry_forced_refresh(self.toml_config.registry_forced_refresh_interval)
+        }
+        if partial_config.admin_timeout().is_none() {
+            partial_config = partial_config
+                .with_admin_timeout(self.toml_config.admin_service_coordinator_timeout)
         }
 
         Ok(partial_config)
@@ -281,7 +284,7 @@ mod tests {
         assert_eq!(config.registry_auto_refresh(), None);
         assert_eq!(config.registry_forced_refresh(), None);
         assert_eq!(config.heartbeat(), None);
-        assert_eq!(config.admin_service_coordinator_timeout(), None);
+        assert_eq!(config.admin_timeout(), None);
     }
 
     /// Asserts config values based on the example configuration values.
@@ -316,7 +319,7 @@ mod tests {
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
         assert_eq!(config.heartbeat(), None);
-        assert_eq!(config.admin_service_coordinator_timeout(), None);
+        assert_eq!(config.admin_timeout(), None);
     }
 
     #[test]

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -42,7 +42,7 @@ struct TomlConfig {
     database: Option<String>,
     registries: Option<Vec<String>>,
     registry_auto_refresh: Option<u64>,
-    registry_forced_refresh_interval: Option<u64>,
+    registry_forced_refresh: Option<u64>,
     heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
     version: Option<String>,
@@ -58,6 +58,7 @@ struct TomlConfig {
     server_key: Option<String>,
     heartbeat_interval: Option<u64>,
     registry_auto_refresh_interval: Option<u64>,
+    registry_forced_refresh_interval: Option<u64>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -118,9 +119,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_bind(self.toml_config.bind)
             .with_registries(self.toml_config.registries)
             .with_registry_auto_refresh(self.toml_config.registry_auto_refresh)
-            .with_registry_forced_refresh_interval(
-                self.toml_config.registry_forced_refresh_interval,
-            )
+            .with_registry_forced_refresh(self.toml_config.registry_forced_refresh)
             .with_heartbeat(self.toml_config.heartbeat)
             .with_admin_service_coordinator_timeout(
                 self.toml_config.admin_service_coordinator_timeout,
@@ -161,6 +160,10 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         if partial_config.registry_auto_refresh().is_none() {
             partial_config = partial_config
                 .with_registry_auto_refresh(self.toml_config.registry_auto_refresh_interval)
+        }
+        if partial_config.registry_forced_refresh().is_none() {
+            partial_config = partial_config
+                .with_registry_forced_refresh(self.toml_config.registry_forced_refresh_interval)
         }
 
         Ok(partial_config)
@@ -276,7 +279,7 @@ mod tests {
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
         assert_eq!(config.registry_auto_refresh(), None);
-        assert_eq!(config.registry_forced_refresh_interval(), None);
+        assert_eq!(config.registry_forced_refresh(), None);
         assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
     }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -43,7 +43,7 @@ struct TomlConfig {
     registries: Option<Vec<String>>,
     registry_auto_refresh_interval: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
-    heartbeat_interval: Option<u64>,
+    heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
     version: Option<String>,
     #[cfg(feature = "rest-api-cors")]
@@ -56,6 +56,7 @@ struct TomlConfig {
     client_key: Option<String>,
     server_cert: Option<String>,
     server_key: Option<String>,
+    heartbeat_interval: Option<u64>,
 }
 
 pub struct TomlPartialConfigBuilder {
@@ -119,7 +120,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_registry_forced_refresh_interval(
                 self.toml_config.registry_forced_refresh_interval,
             )
-            .with_heartbeat_interval(self.toml_config.heartbeat_interval)
+            .with_heartbeat(self.toml_config.heartbeat)
             .with_admin_service_coordinator_timeout(
                 self.toml_config.admin_service_coordinator_timeout,
             );
@@ -152,6 +153,9 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         }
         if partial_config.tls_server_key().is_none() {
             partial_config = partial_config.with_tls_server_key(self.toml_config.server_key)
+        }
+        if partial_config.heartbeat().is_none() {
+            partial_config = partial_config.with_heartbeat(self.toml_config.heartbeat_interval)
         }
 
         Ok(partial_config)
@@ -268,7 +272,7 @@ mod tests {
         assert_eq!(config.registries(), None);
         assert_eq!(config.registry_auto_refresh_interval(), None);
         assert_eq!(config.registry_forced_refresh_interval(), None);
-        assert_eq!(config.heartbeat_interval(), None);
+        assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
     }
 
@@ -303,7 +307,7 @@ mod tests {
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
-        assert_eq!(config.heartbeat_interval(), None);
+        assert_eq!(config.heartbeat(), None);
         assert_eq!(config.admin_service_coordinator_timeout(), None);
     }
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -730,7 +730,7 @@ pub struct SplinterDaemonBuilder {
     registry_auto_refresh_interval: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
     storage_type: Option<String>,
-    heartbeat_interval: Option<u64>,
+    heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Duration,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
@@ -823,8 +823,8 @@ impl SplinterDaemonBuilder {
         self
     }
 
-    pub fn with_heartbeat_interval(mut self, value: u64) -> Self {
-        self.heartbeat_interval = Some(value);
+    pub fn with_heartbeat(mut self, value: u64) -> Self {
+        self.heartbeat = Some(value);
         self
     }
 
@@ -840,12 +840,12 @@ impl SplinterDaemonBuilder {
     }
 
     pub fn build(self) -> Result<SplinterDaemon, CreateError> {
-        let heartbeat_interval = self.heartbeat_interval.ok_or_else(|| {
-            CreateError::MissingRequiredField("Missing field: heartbeat_interval".to_string())
+        let heartbeat = self.heartbeat.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: heartbeat".to_string())
         })?;
 
         let mesh = Mesh::new(512, 128);
-        let network = Network::new(mesh, heartbeat_interval)
+        let network = Network::new(mesh, heartbeat)
             .map_err(|err| CreateError::NetworkError(err.to_string()))?;
 
         let storage_location = self.storage_location.ok_or_else(|| {

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -118,7 +118,7 @@ pub struct SplinterDaemon {
     #[cfg(feature = "database")]
     db_url: Option<String>,
     #[cfg(feature = "biome")]
-    biome_enabled: bool,
+    enable_biome: bool,
     registries: Vec<String>,
     registry_auto_refresh: u64,
     registry_forced_refresh: u64,
@@ -473,7 +473,7 @@ impl SplinterDaemon {
 
         #[cfg(feature = "biome")]
         {
-            if self.biome_enabled {
+            if self.enable_biome {
                 let db_url = self.db_url.as_ref().ok_or_else(|| {
                     StartError::StorageError(
                         "biome was enabled but the builder failed to require the db URL".into(),
@@ -725,7 +725,7 @@ pub struct SplinterDaemonBuilder {
     #[cfg(feature = "database")]
     db_url: Option<String>,
     #[cfg(feature = "biome")]
-    biome_enabled: bool,
+    enable_biome: bool,
     registries: Vec<String>,
     registry_auto_refresh: Option<u64>,
     registry_forced_refresh: Option<u64>,
@@ -799,7 +799,7 @@ impl SplinterDaemonBuilder {
 
     #[cfg(feature = "biome")]
     pub fn enable_biome(mut self, enabled: bool) -> Self {
-        self.biome_enabled = enabled;
+        self.enable_biome = enabled;
         self
     }
 
@@ -893,7 +893,7 @@ impl SplinterDaemonBuilder {
 
         #[cfg(feature = "biome")]
         {
-            if self.biome_enabled && db_url.is_none() {
+            if self.enable_biome && db_url.is_none() {
                 return Err(CreateError::MissingRequiredField(
                     "db_url is required to enable biome features.".to_string(),
                 ));
@@ -925,7 +925,7 @@ impl SplinterDaemonBuilder {
             #[cfg(feature = "database")]
             db_url,
             #[cfg(feature = "biome")]
-            biome_enabled: self.biome_enabled,
+            enable_biome: self.enable_biome,
             registries: self.registries,
             registry_auto_refresh,
             registry_forced_refresh,

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -121,7 +121,7 @@ pub struct SplinterDaemon {
     biome_enabled: bool,
     registries: Vec<String>,
     registry_auto_refresh: u64,
-    registry_forced_refresh_interval: u64,
+    registry_forced_refresh: u64,
     storage_type: String,
     admin_service_coordinator_timeout: Duration,
     #[cfg(feature = "rest-api-cors")]
@@ -427,7 +427,7 @@ impl SplinterDaemon {
             &self.node_registry_directory,
             &self.registries,
             self.registry_auto_refresh,
-            self.registry_forced_refresh_interval,
+            self.registry_forced_refresh,
         )?;
 
         let node_id = self.node_id.clone();
@@ -728,7 +728,7 @@ pub struct SplinterDaemonBuilder {
     biome_enabled: bool,
     registries: Vec<String>,
     registry_auto_refresh: Option<u64>,
-    registry_forced_refresh_interval: Option<u64>,
+    registry_forced_refresh: Option<u64>,
     storage_type: Option<String>,
     heartbeat: Option<u64>,
     admin_service_coordinator_timeout: Duration,
@@ -813,8 +813,8 @@ impl SplinterDaemonBuilder {
         self
     }
 
-    pub fn with_registry_forced_refresh_interval(mut self, value: u64) -> Self {
-        self.registry_forced_refresh_interval = Some(value);
+    pub fn with_registry_forced_refresh(mut self, value: u64) -> Self {
+        self.registry_forced_refresh = Some(value);
         self
     }
 
@@ -904,12 +904,9 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: registry_auto_refresh".to_string())
         })?;
 
-        let registry_forced_refresh_interval =
-            self.registry_forced_refresh_interval.ok_or_else(|| {
-                CreateError::MissingRequiredField(
-                    "Missing field: registry_forced_refresh_interval".to_string(),
-                )
-            })?;
+        let registry_forced_refresh = self.registry_forced_refresh.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: registry_forced_refresh".to_string())
+        })?;
 
         let storage_type = self.storage_type.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: storage_type".to_string())
@@ -931,7 +928,7 @@ impl SplinterDaemonBuilder {
             biome_enabled: self.biome_enabled,
             registries: self.registries,
             registry_auto_refresh,
-            registry_forced_refresh_interval,
+            registry_forced_refresh,
             key_registry_location,
             node_registry_directory,
             storage_type,

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -120,7 +120,7 @@ pub struct SplinterDaemon {
     #[cfg(feature = "biome")]
     biome_enabled: bool,
     registries: Vec<String>,
-    registry_auto_refresh_interval: u64,
+    registry_auto_refresh: u64,
     registry_forced_refresh_interval: u64,
     storage_type: String,
     admin_service_coordinator_timeout: Duration,
@@ -426,7 +426,7 @@ impl SplinterDaemon {
         let (node_registry, registry_shutdown) = create_node_registry(
             &self.node_registry_directory,
             &self.registries,
-            self.registry_auto_refresh_interval,
+            self.registry_auto_refresh,
             self.registry_forced_refresh_interval,
         )?;
 
@@ -727,7 +727,7 @@ pub struct SplinterDaemonBuilder {
     #[cfg(feature = "biome")]
     biome_enabled: bool,
     registries: Vec<String>,
-    registry_auto_refresh_interval: Option<u64>,
+    registry_auto_refresh: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
     storage_type: Option<String>,
     heartbeat: Option<u64>,
@@ -808,8 +808,8 @@ impl SplinterDaemonBuilder {
         self
     }
 
-    pub fn with_registry_auto_refresh_interval(mut self, value: u64) -> Self {
-        self.registry_auto_refresh_interval = Some(value);
+    pub fn with_registry_auto_refresh(mut self, value: u64) -> Self {
+        self.registry_auto_refresh = Some(value);
         self
     }
 
@@ -900,12 +900,9 @@ impl SplinterDaemonBuilder {
             }
         }
 
-        let registry_auto_refresh_interval =
-            self.registry_auto_refresh_interval.ok_or_else(|| {
-                CreateError::MissingRequiredField(
-                    "Missing field: registry_auto_refresh_interval".to_string(),
-                )
-            })?;
+        let registry_auto_refresh = self.registry_auto_refresh.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: registry_auto_refresh".to_string())
+        })?;
 
         let registry_forced_refresh_interval =
             self.registry_forced_refresh_interval.ok_or_else(|| {
@@ -933,7 +930,7 @@ impl SplinterDaemonBuilder {
             #[cfg(feature = "biome")]
             biome_enabled: self.biome_enabled,
             registries: self.registries,
-            registry_auto_refresh_interval,
+            registry_auto_refresh,
             registry_forced_refresh_interval,
             key_registry_location,
             node_registry_directory,

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -123,7 +123,7 @@ pub struct SplinterDaemon {
     registry_auto_refresh: u64,
     registry_forced_refresh: u64,
     storage_type: String,
-    admin_service_coordinator_timeout: Duration,
+    admin_timeout: Duration,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
 }
@@ -416,7 +416,7 @@ impl SplinterDaemon {
             key_registry.clone(),
             Box::new(AllowAllKeyPermissionManager),
             &self.storage_type,
-            Some(self.admin_service_coordinator_timeout),
+            Some(self.admin_timeout),
         )
         .map_err(|err| {
             StartError::AdminServiceError(format!("unable to create admin service: {}", err))
@@ -731,7 +731,7 @@ pub struct SplinterDaemonBuilder {
     registry_forced_refresh: Option<u64>,
     storage_type: Option<String>,
     heartbeat: Option<u64>,
-    admin_service_coordinator_timeout: Duration,
+    admin_timeout: Duration,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
 }
@@ -828,8 +828,8 @@ impl SplinterDaemonBuilder {
         self
     }
 
-    pub fn with_admin_service_coordinator_timeout(mut self, value: Duration) -> Self {
-        self.admin_service_coordinator_timeout = value;
+    pub fn with_admin_timeout(mut self, value: Duration) -> Self {
+        self.admin_timeout = value;
         self
     }
 
@@ -932,7 +932,7 @@ impl SplinterDaemonBuilder {
             key_registry_location,
             node_registry_directory,
             storage_type,
-            admin_service_coordinator_timeout: self.admin_service_coordinator_timeout,
+            admin_timeout: self.admin_timeout,
             #[cfg(feature = "rest-api-cors")]
             whitelist: self.whitelist,
         })

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
         (@arg registry_auto_refresh: --("registry-auto-refresh") +takes_value
             "How often remote node registries should attempt to fetch upstream changes in the \
              background (in seconds); default is 600 (10 minutes), 0 means off")
-        (@arg registry_forced_refresh_interval: --("registry-forced-refresh") +takes_value
+        (@arg registry_forced_refresh: --("registry-forced-refresh") +takes_value
             "How long before remote node registries should fetch upstream changes when read \
              (in seconds); default is 10, 0 means off")
         (@arg admin_service_coordinator_timeout: --("admin-timeout") +takes_value
@@ -352,7 +352,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_storage_type(String::from(config.storage()))
         .with_registries(config.registries().to_vec())
         .with_registry_auto_refresh(config.registry_auto_refresh())
-        .with_registry_forced_refresh_interval(config.registry_forced_refresh_interval())
+        .with_registry_forced_refresh(config.registry_forced_refresh())
         .with_heartbeat(config.heartbeat())
         .with_admin_service_coordinator_timeout(admin_service_coordinator_timeout);
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -132,7 +132,6 @@ fn main() {
         (@arg no_tls:  --("no-tls") "Turn off tls configuration")
         (@arg bind: --("bind") +takes_value
           "Connection endpoint for REST API")
-        (@arg registries: --("registry") +takes_value +multiple "Read-only node registries")
         (@arg registry_auto_refresh: --("registry-auto-refresh") +takes_value
             "How often remote node registries should attempt to fetch upstream changes in the \
              background (in seconds); default is 600 (10 minutes), 0 means off")
@@ -187,6 +186,14 @@ fn main() {
               .takes_value(true)
               .multiple(true)
               .alias("peer"),
+        )
+        .arg(
+            Arg::with_name("registries")
+              .long("registries")
+              .help("Read-only node registries")
+              .takes_value(true)
+              .multiple(true)
+              .alias("registry"),
         )
         .arg(
             Arg::with_name("tls_cert_dir")

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -181,19 +181,19 @@ fn main() {
         )
         .arg(
             Arg::with_name("peers")
-              .long("peers")
-              .help("Endpoint that service will connect to, protocol-prefix://ip:port")
-              .takes_value(true)
-              .multiple(true)
-              .alias("peer"),
+                .long("peers")
+                .help("Endpoint that service will connect to, protocol-prefix://ip:port")
+                .takes_value(true)
+                .multiple(true)
+                .alias("peer"),
         )
         .arg(
             Arg::with_name("registries")
-              .long("registries")
-              .help("Read-only node registries")
-              .takes_value(true)
-              .multiple(true)
-              .alias("registry"),
+                .long("registries")
+                .help("Read-only node registries")
+                .takes_value(true)
+                .multiple(true)
+                .alias("registry"),
         )
         .arg(
             Arg::with_name("tls_cert_dir")
@@ -254,7 +254,7 @@ fn main() {
 
     #[cfg(feature = "biome")]
     let app = app.arg(
-        Arg::with_name("biome_enabled")
+        Arg::with_name("enable-biome")
             .long("enable-biome")
             .long_help("Enable the biome subsystem"),
     );
@@ -390,7 +390,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     #[cfg(feature = "biome")]
     {
-        daemon_builder = daemon_builder.enable_biome(config.biome_enabled());
+        daemon_builder = daemon_builder.enable_biome(config.enable_biome());
     }
 
     #[cfg(feature = "rest-api-cors")]

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -129,8 +129,6 @@ fn main() {
           "Storage type used for the node; defaults to yaml")
         (@arg service_endpoint: --("service-endpoint") +takes_value
           "Endpoint that service will connect to, tcp://ip:port")
-        (@arg peers: --peer +takes_value +multiple
-          "Endpoint that service will connect to, protocol-prefix://ip:port")
         (@arg no_tls:  --("no-tls") "Turn off tls configuration")
         (@arg bind: --("bind") +takes_value
           "Connection endpoint for REST API")
@@ -181,6 +179,14 @@ fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .alias("network-endpoint"),
+        )
+        .arg(
+            Arg::with_name("peers")
+              .long("peers")
+              .help("Endpoint that service will connect to, protocol-prefix://ip:port")
+              .takes_value(true)
+              .multiple(true)
+              .alias("peer"),
         )
         .arg(
             Arg::with_name("tls_cert_dir")

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -127,8 +127,6 @@ fn main() {
           "Human-readable name for the node")
         (@arg storage: --("storage") +takes_value
           "Storage type used for the node; defaults to yaml")
-        (@arg network_endpoints: -n --("network-endpoint") +takes_value +multiple
-          "Endpoints to connect to the network, protocol-prefix://ip:port")
         (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple
           "Publicly-visible network endpoints")
         (@arg service_endpoint: --("service-endpoint") +takes_value
@@ -167,6 +165,15 @@ fn main() {
                 .help("Path to the directory containing configuration files")
                 .takes_value(true)
                 .alias("config-dir"),
+        )
+        .arg(
+            Arg::with_name("network_endpoints")
+                .long("network-endpoints")
+                .short("n")
+                .long_help("Endpoints to connect to the network, protocol-prefix://ip:port")
+                .takes_value(true)
+                .multiple(true)
+                .alias("network-endpoint"),
         )
         .arg(
             Arg::with_name("tls_cert_dir")

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -145,7 +145,7 @@ fn main() {
         (@arg registry_forced_refresh: --("registry-forced-refresh") +takes_value
             "How long before remote node registries should fetch upstream changes when read \
              (in seconds); default is 10, 0 means off")
-        (@arg admin_service_coordinator_timeout: --("admin-timeout") +takes_value
+        (@arg admin_timeout: --("admin-timeout") +takes_value
             "The coordinator timeout for admin service proposals (in seconds); default is \
              30 seconds")
         (@arg verbose: -v --verbose +multiple
@@ -332,7 +332,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     #[cfg(feature = "database")]
     let db_url = config.database();
 
-    let admin_service_coordinator_timeout = config.admin_service_coordinator_timeout();
+    let admin_timeout = config.admin_timeout();
 
     config.log_as_debug();
 
@@ -354,7 +354,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_registry_auto_refresh(config.registry_auto_refresh())
         .with_registry_forced_refresh(config.registry_forced_refresh())
         .with_heartbeat(config.heartbeat())
-        .with_admin_service_coordinator_timeout(admin_service_coordinator_timeout);
+        .with_admin_timeout(admin_timeout);
 
     #[cfg(feature = "database")]
     {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
         (@arg bind: --("bind") +takes_value
           "Connection endpoint for REST API")
         (@arg registries: --("registry") +takes_value +multiple "Read-only node registries")
-        (@arg registry_auto_refresh_interval: --("registry-auto-refresh") +takes_value
+        (@arg registry_auto_refresh: --("registry-auto-refresh") +takes_value
             "How often remote node registries should attempt to fetch upstream changes in the \
              background (in seconds); default is 600 (10 minutes), 0 means off")
         (@arg registry_forced_refresh_interval: --("registry-forced-refresh") +takes_value
@@ -351,7 +351,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_rest_api_endpoint(String::from(rest_api_endpoint))
         .with_storage_type(String::from(config.storage()))
         .with_registries(config.registries().to_vec())
-        .with_registry_auto_refresh_interval(config.registry_auto_refresh_interval())
+        .with_registry_auto_refresh(config.registry_auto_refresh())
         .with_registry_forced_refresh_interval(config.registry_forced_refresh_interval())
         .with_heartbeat(config.heartbeat())
         .with_admin_service_coordinator_timeout(admin_service_coordinator_timeout);

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
 
     let app = app
         .arg(
-            Arg::with_name("heartbeat_interval")
+            Arg::with_name("heartbeat")
                 .long("heartbeat")
                 .long_help(
                     "How often heartbeat should be sent, in seconds; defaults to 30 seconds,\
@@ -353,7 +353,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_registries(config.registries().to_vec())
         .with_registry_auto_refresh_interval(config.registry_auto_refresh_interval())
         .with_registry_forced_refresh_interval(config.registry_forced_refresh_interval())
-        .with_heartbeat_interval(config.heartbeat_interval())
+        .with_heartbeat(config.heartbeat())
         .with_admin_service_coordinator_timeout(admin_service_coordinator_timeout);
 
     #[cfg(feature = "database")]

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -127,8 +127,6 @@ fn main() {
           "Human-readable name for the node")
         (@arg storage: --("storage") +takes_value
           "Storage type used for the node; defaults to yaml")
-        (@arg advertised_endpoints: -a --("advertised-endpoint") +takes_value +multiple
-          "Publicly-visible network endpoints")
         (@arg service_endpoint: --("service-endpoint") +takes_value
           "Endpoint that service will connect to, tcp://ip:port")
         (@arg peers: --peer +takes_value +multiple
@@ -150,6 +148,15 @@ fn main() {
           "Increase output verbosity"));
 
     let app = app
+        .arg(
+            Arg::with_name("advertised_endpoints")
+                .long("advertised-endpoints")
+                .short("a")
+                .long_help("Publicly-visible network endpoints")
+                .takes_value(true)
+                .multiple(true)
+                .alias("advertised-endpoint"),
+        )
         .arg(
             Arg::with_name("heartbeat")
                 .long("heartbeat")


### PR DESCRIPTION
Config Changes:
registry_auto_refresh_interval -> registry_auto_refresh
registry_forced_refresh_interval -> registry_force_refresh
heartbeat_interval-> heartbeat
admin_service_coordinator_timeout -> admin_timeout
biome_enabled -> enable_biome

CLI changes: 
--peer -> --peers
--advertised-endpoint -> --advertised-endpoints
--network-endpoint -> --network-endpoints
--registry -> --registries


All old values are still supported with aliases. 