### PR TITLE
Peer interconnect lookups

### DIFF
--- a/libsplinter/src/network/peer_manager/connector.rs
+++ b/libsplinter/src/network/peer_manager/connector.rs
@@ -102,7 +102,7 @@ impl PeerManagerConnector {
     pub fn list_unreferenced_peers(&self) -> Result<Vec<String>, PeerListError> {
         let (sender, recv) = channel();
         let message =
-            PeerManagerMessage::Request(PeerManagerRequest::ListTemporaryPeers { sender });
+            PeerManagerMessage::Request(PeerManagerRequest::ListUnreferencedPeers { sender });
 
         match self.sender.send(message) {
             Ok(()) => (),

--- a/libsplinter/src/network/peer_manager/connector.rs
+++ b/libsplinter/src/network/peer_manager/connector.rs
@@ -17,11 +17,34 @@ use std::sync::mpsc::{channel, Sender};
 use crate::collections::BiHashMap;
 
 use super::error::{
-    PeerConnectionIdError, PeerListError, PeerManagerError, PeerRefAddError, PeerRefRemoveError,
+    PeerConnectionIdError, PeerListError, PeerLookupError, PeerManagerError, PeerRefAddError,
+    PeerRefRemoveError,
 };
 use super::notification::PeerNotificationIter;
 use super::PeerRef;
 use super::{PeerManagerMessage, PeerManagerRequest};
+
+/// The PeerLookup trait provides an interface for looking up details about individual peer
+/// connections.
+pub trait PeerLookup: Send {
+    /// Retrieves the connection id for a given peer id, if found.
+    ///
+    /// # Errors
+    ///
+    /// Returns a PeerLookupError if the connection id cannot be retrieved.
+    fn connection_id(&self, peer_id: &str) -> Result<Option<String>, PeerLookupError>;
+
+    /// Retrieves the peer id for a given connection id, if found.
+    ///
+    /// # Errors
+    ///
+    /// Returns a PeerLookupError if the peer id cannot be retrieved.
+    fn peer_id(&self, connection_id: &str) -> Result<Option<String>, PeerLookupError>;
+}
+
+pub trait PeerLookupProvider {
+    fn peer_lookup(&self) -> Box<dyn PeerLookup>;
+}
 
 /// The PeerManagerConnector will be used to make requests to the PeerManager.
 ///
@@ -149,6 +172,54 @@ impl PeerManagerConnector {
                 "The peer manager is no longer running".into(),
             )),
         }
+    }
+}
+
+impl PeerLookup for PeerManagerConnector {
+    fn connection_id(&self, peer_id: &str) -> Result<Option<String>, PeerLookupError> {
+        let (sender, recv) = channel();
+        let message = PeerManagerMessage::Request(PeerManagerRequest::GetConnectionId {
+            peer_id: peer_id.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerLookupError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerLookupError(format!("{:?}", err)))?
+    }
+
+    fn peer_id(&self, connection_id: &str) -> Result<Option<String>, PeerLookupError> {
+        let (sender, recv) = channel();
+        let message = PeerManagerMessage::Request(PeerManagerRequest::GetPeerId {
+            connection_id: connection_id.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerLookupError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerLookupError(format!("{:?}", err)))?
+    }
+}
+
+impl PeerLookupProvider for PeerManagerConnector {
+    fn peer_lookup(&self) -> Box<dyn PeerLookup> {
+        Box::new(self.clone())
     }
 }
 

--- a/libsplinter/src/network/peer_manager/error.rs
+++ b/libsplinter/src/network/peer_manager/error.rs
@@ -152,3 +152,14 @@ impl fmt::Display for PeerInterconnectError {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct PeerLookupError(pub String);
+
+impl error::Error for PeerLookupError {}
+
+impl fmt::Display for PeerLookupError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -148,7 +148,7 @@ where
     /// # Arguments
     ///
     /// * `network_dispatcher` - a Dispatcher that is loaded with the Handlers for
-    ////       NetworkMessageTypes
+    ///    NetworkMessageTypes
     pub fn with_network_dispatcher(
         mut self,
         network_dispatcher: Dispatcher<NetworkMessageType>,

--- a/libsplinter/src/network/peer_manager/peer_map.rs
+++ b/libsplinter/src/network/peer_manager/peer_map.rs
@@ -132,6 +132,16 @@ impl PeerMap {
             None
         }
     }
+
+    pub fn get_by_peer_id(&self, peer_id: &str) -> Option<&PeerMetadata> {
+        self.peers.get(peer_id)
+    }
+
+    pub fn get_by_connection_id(&self, connection_id: &str) -> Option<&PeerMetadata> {
+        self.peers
+            .values()
+            .find(|meta| meta.connection_id == connection_id)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace the use of the PeerConnector with a PeerLookup trait that only provides the functionality for looking up connection_id <-> peer_id

This includes several refactors:

- Renaming `TemporaryPeer` to `UnreferencedPeer`
- Extracting the runtime logic of the interconnect's send and receive threads into their own functions.
- removing the shared state between the threads - each thread only needs a cache of one side of the connection_id <-> peer_id relationship