### PR TITLE
Rewrite WsTransport in tungstenite

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -58,10 +58,10 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
 transact = { version = "0.2", features = ["sawtooth-compat"] }
+tungstenite = { version = "0.10", optional = true }
 url = "1.7.1"
 ursa = { version = "0.1", optional = true }
 uuid = { version = "0.7", features = ["v4"]}
-websocket = { version = "0.24", optional = true }
 zmq = { version = "0.9", optional = true }
 
 [dev-dependencies]
@@ -138,7 +138,7 @@ sawtooth-signing-compat = ["sawtooth-sdk"]
 scabbard-client = ["reqwest"]
 scabbard-get-state = []
 service-arg-validation = []
-ws-transport = ["websocket"]
+ws-transport = ["tungstenite"]
 zmq-transport = ["zmq"]
 
 # The following features are broken and should not be used.

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -337,7 +337,7 @@ pub mod tests {
             // a response. Sending a response here will unblock the listener thread, so it is
             // important we do this even in the error case, as the test will hang ohterwise.
             for (mut conn, _token) in connections {
-                assert_eq!(b"hello".to_vec(), conn.recv().unwrap());
+                assert_eq!(b"hello".to_vec(), block!(conn.recv(), RecvError).unwrap());
                 assert_ok(conn.send(b"world"));
             }
 

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -149,8 +149,11 @@ pub mod tests {
     }
 
     macro_rules! block {
-        ($op:expr, $err:ident) => {
+        ($op:expr, $err:ident) => {{
+            let start = Instant::now();
+            let duration = Duration::from_millis(60000); // 60 seconds
             loop {
+                assert!(start.elapsed() < duration, "blocked for too long");
                 match $op {
                     Err($err::WouldBlock) => {
                         thread::sleep(Duration::from_millis(100));
@@ -160,7 +163,7 @@ pub mod tests {
                     Ok(ok) => break Ok(ok),
                 }
             }
-        };
+        }};
     }
 
     pub fn test_transport<T: Transport + Send + 'static>(mut transport: T, bind: &str) {

--- a/libsplinter/src/transport/ws/connection.rs
+++ b/libsplinter/src/transport/ws/connection.rs
@@ -12,63 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::{self, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::io::{Read, Write};
 
-use mio::{unix::EventedFd, Evented, Poll, PollOpt, Ready, Token};
-use websocket::{
-    client::sync::Client,
-    message::{Message, OwnedMessage::Binary},
-    result::WebSocketError,
-    stream::sync::{AsTcpStream, Stream},
-};
+use mio::Evented;
+use tungstenite::{protocol::WebSocket, Message};
 
 use crate::transport::{Connection, DisconnectError, RecvError, SendError};
 
-pub(super) struct WsClientConnection<S>
+pub(super) struct WsConnection<S>
 where
-    S: Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
-    client: Client<S>,
+    websocket: WebSocket<S>,
     remote_endpoint: String,
     local_endpoint: String,
 }
 
-impl<S> WsClientConnection<S>
+impl<S> WsConnection<S>
 where
-    S: Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
-    pub fn new(client: Client<S>, remote_endpoint: String, local_endpoint: String) -> Self {
-        WsClientConnection {
-            client,
+    pub fn new(websocket: WebSocket<S>, remote_endpoint: String, local_endpoint: String) -> Self {
+        WsConnection {
+            websocket,
             remote_endpoint,
             local_endpoint,
         }
     }
 }
 
-impl<S> Connection for WsClientConnection<S>
+impl<S> Connection for WsConnection<S>
 where
-    S: AsTcpStream + Stream + Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
     fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
-        Ok(self.client.send_message(&Message::binary(message))?)
+        self.websocket
+            .write_message(Message::Binary(message.to_vec()))?;
+        self.websocket.write_pending()?;
+        Ok(())
     }
 
     fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
-        match self.client.recv_message() {
+        match self.websocket.read_message() {
             Ok(message) => match message {
-                Binary(v) => Ok(v),
+                Message::Binary(v) => Ok(v),
                 _ => Err(RecvError::ProtocolError(
-                    "message received was not
-                        websocket::message::OwnedMessage::Binary"
-                        .to_string(),
+                    "message received was not binary".to_string(),
                 )),
             },
-            Err(WebSocketError::IoError(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                Err(RecvError::WouldBlock)
-            }
-            Err(WebSocketError::NoDataAvailable) => Err(RecvError::WouldBlock),
+            Err(tungstenite::error::Error::Io(e)) => Err(RecvError::from(e)),
             Err(err) => Err(err.into()),
         }
     }
@@ -82,59 +74,38 @@ where
     }
 
     fn disconnect(&mut self) -> Result<(), DisconnectError> {
-        self.client.shutdown().map_err(DisconnectError::from)
+        self.websocket.close(None)?;
+        Ok(())
     }
 
     fn evented(&self) -> &dyn Evented {
-        self
+        self.websocket.get_ref()
     }
 }
 
-impl<S> Evented for WsClientConnection<S>
-where
-    S: AsTcpStream + Stream + Read + Write + Send,
-{
-    fn register(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd())
-            .register(poll, token, interest, opts)
-    }
-
-    fn reregister(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd())
-            .reregister(poll, token, interest, opts)
-    }
-
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd()).deregister(poll)
-    }
-}
-
-impl From<WebSocketError> for RecvError {
-    fn from(err: WebSocketError) -> Self {
+impl From<tungstenite::error::Error> for SendError {
+    fn from(err: tungstenite::error::Error) -> Self {
         match err {
-            WebSocketError::IoError(e) => RecvError::from(e),
-            _ => RecvError::ProtocolError(format!("WebSocketError: {}", err.to_string())),
+            tungstenite::error::Error::Io(io) => SendError::from(io),
+            _ => SendError::ProtocolError(err.to_string()),
         }
     }
 }
 
-impl From<WebSocketError> for SendError {
-    fn from(err: WebSocketError) -> Self {
+impl From<tungstenite::error::Error> for RecvError {
+    fn from(err: tungstenite::error::Error) -> Self {
         match err {
-            WebSocketError::IoError(e) => SendError::from(e),
-            _ => SendError::ProtocolError(format!("WebSocketError: {}", err.to_string())),
+            tungstenite::error::Error::Io(io) => RecvError::from(io),
+            _ => RecvError::ProtocolError(err.to_string()),
+        }
+    }
+}
+
+impl From<tungstenite::error::Error> for DisconnectError {
+    fn from(err: tungstenite::error::Error) -> Self {
+        match err {
+            tungstenite::error::Error::Io(io) => DisconnectError::from(io),
+            _ => DisconnectError::ProtocolError(err.to_string()),
         }
     }
 }

--- a/libsplinter/src/transport/ws/listener.rs
+++ b/libsplinter/src/transport/ws/listener.rs
@@ -12,23 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::TcpStream;
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
 
-use websocket::server::{sync::Server, upgrade::sync::Buffer, InvalidConnection, NoTlsAcceptor};
+use mio::net::TcpStream as MioTcpStream;
+use tungstenite::{accept, handshake::HandshakeError};
 
 use crate::transport::{AcceptError, Connection, Listener};
 
-use super::connection::WsClientConnection;
+use super::connection::WsConnection;
+use super::transport::PROTOCOL_PREFIX;
 
 pub(super) struct WsListener {
-    server: Server<NoTlsAcceptor>,
+    listener: TcpListener,
     local_endpoint: String,
 }
 
 impl WsListener {
-    pub fn new(server: Server<NoTlsAcceptor>, local_endpoint: String) -> Self {
+    pub fn new(listener: TcpListener, local_endpoint: String) -> Self {
         WsListener {
-            server,
+            listener,
             local_endpoint,
         }
     }
@@ -36,14 +40,31 @@ impl WsListener {
 
 impl Listener for WsListener {
     fn accept(&mut self) -> Result<Box<dyn Connection>, AcceptError> {
-        let client = self.server.accept()?.accept()?;
-        client.set_nonblocking(true)?;
+        let (stream, _) = self.listener.accept()?;
+        let remote_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.peer_addr()?);
+        let local_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.local_addr()?);
 
-        let remote_endpoint = format!("ws://{}", client.peer_addr()?);
-        let local_endpoint = format!("ws://{}", client.local_addr()?);
+        let mio_stream = MioTcpStream::from_stream(stream)?;
+        let websocket = accept(mio_stream).map_or_else(
+            {
+                |mut handshake_err| loop {
+                    match handshake_err {
+                        HandshakeError::Interrupted(mid_handshake) => {
+                            thread::sleep(Duration::from_millis(100));
+                            match mid_handshake.handshake() {
+                                Ok(ok) => break Ok(ok),
+                                Err(err) => handshake_err = err,
+                            }
+                        }
+                        HandshakeError::Failure(err) => break Err(err),
+                    }
+                }
+            },
+            Ok,
+        )?;
 
-        Ok(Box::new(WsClientConnection::new(
-            client,
+        Ok(Box::new(WsConnection::new(
+            websocket,
             remote_endpoint,
             local_endpoint,
         )))
@@ -54,14 +75,11 @@ impl Listener for WsListener {
     }
 }
 
-impl From<InvalidConnection<TcpStream, Buffer>> for AcceptError {
-    fn from(iconn: InvalidConnection<TcpStream, Buffer>) -> Self {
-        AcceptError::ProtocolError(format!("HyperIntoWsError: {}", iconn.error.to_string()))
-    }
-}
-
-impl From<(TcpStream, std::io::Error)> for AcceptError {
-    fn from(tuple: (TcpStream, std::io::Error)) -> Self {
-        AcceptError::from(tuple.1)
+impl From<tungstenite::error::Error> for AcceptError {
+    fn from(err: tungstenite::error::Error) -> Self {
+        match err {
+            tungstenite::error::Error::Io(io) => AcceptError::from(io),
+            _ => AcceptError::ProtocolError(format!("handshake failure: {}", err)),
+        }
     }
 }


### PR DESCRIPTION
The websocket crate had serious limitations which manifested when attempting to implement TLS support. After more analysis, Tungstenite looks better overall, so re-implemented with that dependency instead.