### PR TITLE
Rewrite WsTransport in tungstenite and add SSL support

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -55,10 +55,10 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
+tungstenite = { version = "0.10", optional = true }
 url = "1.7.1"
 ursa = { version = "0.1", optional = true }
 uuid = { version = "0.7", features = ["v4"]}
-websocket = { version = "0.24", optional = true }
 zmq = { version = "0.9", optional = true }
 
 [dev-dependencies]
@@ -125,7 +125,7 @@ rest-api-cors = []
 sawtooth-signing-compat = ["sawtooth-sdk"]
 service-arg-validation = []
 service-network = []
-ws-transport = ["websocket"]
+ws-transport = ["tungstenite"]
 zmq-transport = ["zmq"]
 
 # The following features are broken and should not be used.

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -150,8 +150,11 @@ pub mod tests {
     }
 
     macro_rules! block {
-        ($op:expr, $err:ident) => {
+        ($op:expr, $err:ident) => {{
+            let start = Instant::now();
+            let duration = Duration::from_millis(60000); // 60 seconds
             loop {
+                assert!(start.elapsed() < duration, "blocked for too long");
                 match $op {
                     Err($err::WouldBlock) => {
                         thread::sleep(Duration::from_millis(100));
@@ -161,7 +164,7 @@ pub mod tests {
                     Ok(ok) => break Ok(ok),
                 }
             }
-        };
+        }};
     }
 
     pub fn test_transport<T: Transport + Send + 'static>(mut transport: T, bind: &str) {

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -338,7 +338,7 @@ pub mod tests {
             // a response. Sending a response here will unblock the listener thread, so it is
             // important we do this even in the error case, as the test will hang ohterwise.
             for (mut conn, _token) in connections {
-                assert_eq!(b"hello".to_vec(), conn.recv().unwrap());
+                assert_eq!(b"hello".to_vec(), block!(conn.recv(), RecvError).unwrap());
                 assert_ok(conn.send(b"world"));
             }
 

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -42,7 +42,6 @@ pub mod multi;
 #[deprecated(since = "0.3.14", note = "please use splinter::transport::socket")]
 pub mod raw;
 pub mod socket;
-#[deprecated(since = "0.3.14", note = "please use splinter::transport::socket")]
 pub mod tls;
 #[cfg(feature = "ws-transport")]
 pub mod ws;

--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -349,101 +349,14 @@ impl From<OpensslError> for DisconnectError {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
     use crate::transport::tests;
-    use openssl::asn1::Asn1Time;
-    use openssl::bn::{BigNum, MsbOption};
-    use openssl::hash::MessageDigest;
-    use openssl::pkey::{PKey, PKeyRef, Private};
-    use openssl::rsa::Rsa;
-    use openssl::x509::extension::{BasicConstraints, ExtendedKeyUsage, KeyUsage};
-    use openssl::x509::{X509NameBuilder, X509Ref, X509};
+    use crate::transport::tls::tests::{make_ca_cert, make_ca_signed_cert};
+
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
     use tempdir::TempDir;
-
-    // Make a certificate and private key for the Certificate Authority
-    fn make_ca_cert() -> (PKey<Private>, X509) {
-        let rsa = Rsa::generate(2048).unwrap();
-        let privkey = PKey::from_rsa(rsa).unwrap();
-
-        let mut x509_name = X509NameBuilder::new().unwrap();
-        x509_name.append_entry_by_text("CN", "ca test").unwrap();
-        let x509_name = x509_name.build();
-
-        let mut cert_builder = X509::builder().unwrap();
-        cert_builder.set_version(2).unwrap();
-        cert_builder.set_subject_name(&x509_name).unwrap();
-        cert_builder.set_issuer_name(&x509_name).unwrap();
-        cert_builder.set_pubkey(&privkey).unwrap();
-
-        let not_before = Asn1Time::days_from_now(0).unwrap();
-        cert_builder.set_not_before(&not_before).unwrap();
-        let not_after = Asn1Time::days_from_now(365).unwrap();
-        cert_builder.set_not_after(&not_after).unwrap();
-
-        cert_builder
-            .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
-            .unwrap();
-        cert_builder
-            .append_extension(KeyUsage::new().key_cert_sign().build().unwrap())
-            .unwrap();
-
-        cert_builder
-            .sign(&privkey, MessageDigest::sha256())
-            .unwrap();
-        let cert = cert_builder.build();
-
-        (privkey, cert)
-    }
-
-    // Make a certificate and private key signed by the given CA cert and private key
-    fn make_ca_signed_cert(
-        ca_cert: &X509Ref,
-        ca_privkey: &PKeyRef<Private>,
-    ) -> (PKey<Private>, X509) {
-        let rsa = Rsa::generate(2048).unwrap();
-        let privkey = PKey::from_rsa(rsa).unwrap();
-
-        let mut x509_name = X509NameBuilder::new().unwrap();
-        x509_name.append_entry_by_text("CN", "localhost").unwrap();
-        let x509_name = x509_name.build();
-
-        let mut cert_builder = X509::builder().unwrap();
-        cert_builder.set_version(2).unwrap();
-        let serial_number = {
-            let mut serial = BigNum::new().unwrap();
-            serial.rand(159, MsbOption::MAYBE_ZERO, false).unwrap();
-            serial.to_asn1_integer().unwrap()
-        };
-        cert_builder.set_serial_number(&serial_number).unwrap();
-        cert_builder.set_subject_name(&x509_name).unwrap();
-        cert_builder
-            .set_issuer_name(ca_cert.subject_name())
-            .unwrap();
-        cert_builder.set_pubkey(&privkey).unwrap();
-        let not_before = Asn1Time::days_from_now(0).unwrap();
-        cert_builder.set_not_before(&not_before).unwrap();
-        let not_after = Asn1Time::days_from_now(365).unwrap();
-        cert_builder.set_not_after(&not_after).unwrap();
-
-        cert_builder
-            .append_extension(
-                ExtendedKeyUsage::new()
-                    .server_auth()
-                    .client_auth()
-                    .build()
-                    .unwrap(),
-            )
-            .unwrap();
-
-        cert_builder
-            .sign(&ca_privkey, MessageDigest::sha256())
-            .unwrap();
-        let cert = cert_builder.build();
-
-        (privkey, cert)
-    }
 
     fn write_file(mut temp_dir: PathBuf, file_name: &str, bytes: &[u8]) -> String {
         temp_dir.push(file_name);

--- a/libsplinter/src/transport/tls.rs
+++ b/libsplinter/src/transport/tls.rs
@@ -20,7 +20,6 @@ use openssl::error::ErrorStack;
 #[cfg(feature = "ws-transport")]
 use openssl::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 
-#[cfg(feature = "ws-transport")]
 pub struct TlsConfig {
     ca_certs_file: Option<String>,
     server_cert_file: String,
@@ -29,7 +28,6 @@ pub struct TlsConfig {
     client_private_key_file: String,
 }
 
-#[cfg(feature = "ws-transport")]
 impl TlsConfig {
     pub fn ca_certs_file(&self) -> &Option<String> {
         &self.ca_certs_file
@@ -52,7 +50,6 @@ impl TlsConfig {
     }
 }
 
-#[cfg(feature = "ws-transport")]
 #[derive(Default)]
 pub struct TlsConfigBuilder {
     ca_certs_file: Option<String>,
@@ -62,7 +59,6 @@ pub struct TlsConfigBuilder {
     client_private_key_file: Option<String>,
 }
 
-#[cfg(feature = "ws-transport")]
 impl TlsConfigBuilder {
     pub fn new() -> Self {
         TlsConfigBuilder {
@@ -124,16 +120,13 @@ impl TlsConfigBuilder {
     }
 }
 
-#[cfg(feature = "ws-transport")]
 #[derive(Debug)]
 pub enum TlsConfigBuilderError {
     MissingField(String),
 }
 
-#[cfg(feature = "ws-transport")]
 impl std::error::Error for TlsConfigBuilderError {}
 
-#[cfg(feature = "ws-transport")]
 impl std::fmt::Display for TlsConfigBuilderError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {

--- a/libsplinter/src/transport/tls.rs
+++ b/libsplinter/src/transport/tls.rs
@@ -12,6 +12,174 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use super::socket::TlsConnection;
-pub use super::socket::TlsInitError;
-pub use super::socket::TlsTransport;
+#[cfg(feature = "ws-transport")]
+use std::path::Path;
+
+#[cfg(feature = "ws-transport")]
+use openssl::error::ErrorStack;
+#[cfg(feature = "ws-transport")]
+use openssl::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod, SslVerifyMode};
+
+#[cfg(feature = "ws-transport")]
+pub struct TlsConfig {
+    ca_certs_file: Option<String>,
+    server_cert_file: String,
+    server_private_key_file: String,
+    client_cert_file: String,
+    client_private_key_file: String,
+}
+
+#[cfg(feature = "ws-transport")]
+impl TlsConfig {
+    pub fn ca_certs_file(&self) -> &Option<String> {
+        &self.ca_certs_file
+    }
+
+    pub fn server_cert_file(&self) -> &str {
+        &self.server_cert_file
+    }
+
+    pub fn server_private_key_file(&self) -> &str {
+        &self.server_private_key_file
+    }
+
+    pub fn client_cert_file(&self) -> &str {
+        &self.client_cert_file
+    }
+
+    pub fn client_private_key_file(&self) -> &str {
+        &self.client_private_key_file
+    }
+}
+
+#[cfg(feature = "ws-transport")]
+#[derive(Default)]
+pub struct TlsConfigBuilder {
+    ca_certs_file: Option<String>,
+    server_cert_file: Option<String>,
+    server_private_key_file: Option<String>,
+    client_cert_file: Option<String>,
+    client_private_key_file: Option<String>,
+}
+
+#[cfg(feature = "ws-transport")]
+impl TlsConfigBuilder {
+    pub fn new() -> Self {
+        TlsConfigBuilder {
+            ca_certs_file: None,
+            server_cert_file: None,
+            server_private_key_file: None,
+            client_cert_file: None,
+            client_private_key_file: None,
+        }
+    }
+
+    pub fn with_ca_certs_file(mut self, ca_certs_file: String) -> Self {
+        self.ca_certs_file = Some(ca_certs_file);
+        self
+    }
+
+    pub fn with_server_cert_file(mut self, server_cert_file: String) -> Self {
+        self.server_cert_file = Some(server_cert_file);
+        self
+    }
+
+    pub fn with_server_private_key_file(mut self, server_private_key_file: String) -> Self {
+        self.server_private_key_file = Some(server_private_key_file);
+        self
+    }
+
+    pub fn with_client_cert_file(mut self, client_cert_file: String) -> Self {
+        self.client_cert_file = Some(client_cert_file);
+        self
+    }
+
+    pub fn with_client_private_key_file(mut self, client_private_key_file: String) -> Self {
+        self.client_private_key_file = Some(client_private_key_file);
+        self
+    }
+
+    pub fn build(self) -> Result<TlsConfig, TlsConfigBuilderError> {
+        let ca_certs_file = self.ca_certs_file;
+        let server_cert_file = self
+            .server_cert_file
+            .ok_or_else(|| TlsConfigBuilderError::MissingField("server_cert_file".to_string()))?;
+        let server_private_key_file = self.server_private_key_file.ok_or_else(|| {
+            TlsConfigBuilderError::MissingField("server_private_key_file".to_string())
+        })?;
+        let client_cert_file = self
+            .client_cert_file
+            .ok_or_else(|| TlsConfigBuilderError::MissingField("client_cert_file".to_string()))?;
+        let client_private_key_file = self.client_private_key_file.ok_or_else(|| {
+            TlsConfigBuilderError::MissingField("client_private_key_file".to_string())
+        })?;
+
+        Ok(TlsConfig {
+            ca_certs_file,
+            server_cert_file,
+            server_private_key_file,
+            client_cert_file,
+            client_private_key_file,
+        })
+    }
+}
+
+#[cfg(feature = "ws-transport")]
+#[derive(Debug)]
+pub enum TlsConfigBuilderError {
+    MissingField(String),
+}
+
+#[cfg(feature = "ws-transport")]
+impl std::error::Error for TlsConfigBuilderError {}
+
+#[cfg(feature = "ws-transport")]
+impl std::fmt::Display for TlsConfigBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            TlsConfigBuilderError::MissingField(ref s) => {
+                write!(f, "Missing required field '{}' in TLS configuration", s)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "ws-transport")]
+pub(super) fn build_connector(config: &TlsConfig) -> Result<SslConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+
+    builder.set_private_key_file(
+        Path::new(config.client_private_key_file()),
+        SslFiletype::PEM,
+    )?;
+    builder.set_certificate_chain_file(Path::new(config.client_cert_file()))?;
+    builder.check_private_key()?;
+
+    if let Some(ca_certs_file) = config.ca_certs_file() {
+        builder.set_ca_file(Path::new(ca_certs_file))?;
+    } else {
+        builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    Ok(builder.build())
+}
+
+#[cfg(feature = "ws-transport")]
+pub(super) fn build_acceptor(config: &TlsConfig) -> Result<SslAcceptor, ErrorStack> {
+    let mut builder = SslAcceptor::mozilla_modern(SslMethod::tls())?;
+
+    builder.set_private_key_file(
+        Path::new(config.server_private_key_file()),
+        SslFiletype::PEM,
+    )?;
+    builder.set_certificate_chain_file(Path::new(config.server_cert_file()))?;
+    builder.check_private_key()?;
+
+    if let Some(ca_certs_file) = config.ca_certs_file() {
+        builder.set_ca_file(Path::new(ca_certs_file))?;
+    } else {
+        builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    Ok(builder.build())
+}

--- a/libsplinter/src/transport/ws/connection.rs
+++ b/libsplinter/src/transport/ws/connection.rs
@@ -12,63 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::{self, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::io::{Read, Write};
 
-use mio::{unix::EventedFd, Evented, Poll, PollOpt, Ready, Token};
-use websocket::{
-    client::sync::Client,
-    message::{Message, OwnedMessage::Binary},
-    result::WebSocketError,
-    stream::sync::{AsTcpStream, Stream},
-};
+use mio::Evented;
+use tungstenite::{protocol::WebSocket, Message};
 
 use crate::transport::{Connection, DisconnectError, RecvError, SendError};
 
-pub(super) struct WsClientConnection<S>
+pub(super) struct WsConnection<S>
 where
-    S: Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
-    client: Client<S>,
+    websocket: WebSocket<S>,
     remote_endpoint: String,
     local_endpoint: String,
 }
 
-impl<S> WsClientConnection<S>
+impl<S> WsConnection<S>
 where
-    S: Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
-    pub fn new(client: Client<S>, remote_endpoint: String, local_endpoint: String) -> Self {
-        WsClientConnection {
-            client,
+    pub fn new(websocket: WebSocket<S>, remote_endpoint: String, local_endpoint: String) -> Self {
+        WsConnection {
+            websocket,
             remote_endpoint,
             local_endpoint,
         }
     }
 }
 
-impl<S> Connection for WsClientConnection<S>
+impl<S> Connection for WsConnection<S>
 where
-    S: AsTcpStream + Stream + Read + Write + Send,
+    S: Read + Write + Send + Evented,
 {
     fn send(&mut self, message: &[u8]) -> Result<(), SendError> {
-        Ok(self.client.send_message(&Message::binary(message))?)
+        self.websocket
+            .write_message(Message::Binary(message.to_vec()))?;
+        self.websocket.write_pending()?;
+        Ok(())
     }
 
     fn recv(&mut self) -> Result<Vec<u8>, RecvError> {
-        match self.client.recv_message() {
+        match self.websocket.read_message() {
             Ok(message) => match message {
-                Binary(v) => Ok(v),
+                Message::Binary(v) => Ok(v),
                 _ => Err(RecvError::ProtocolError(
-                    "message received was not
-                        websocket::message::OwnedMessage::Binary"
-                        .to_string(),
+                    "message received was not binary".to_string(),
                 )),
             },
-            Err(WebSocketError::IoError(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                Err(RecvError::WouldBlock)
-            }
-            Err(WebSocketError::NoDataAvailable) => Err(RecvError::WouldBlock),
+            Err(tungstenite::error::Error::Io(e)) => Err(RecvError::from(e)),
             Err(err) => Err(err.into()),
         }
     }
@@ -82,59 +74,38 @@ where
     }
 
     fn disconnect(&mut self) -> Result<(), DisconnectError> {
-        self.client.shutdown().map_err(DisconnectError::from)
+        self.websocket.close(None)?;
+        Ok(())
     }
 
     fn evented(&self) -> &dyn Evented {
-        self
+        self.websocket.get_ref()
     }
 }
 
-impl<S> Evented for WsClientConnection<S>
-where
-    S: AsTcpStream + Stream + Read + Write + Send,
-{
-    fn register(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd())
-            .register(poll, token, interest, opts)
-    }
-
-    fn reregister(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd())
-            .reregister(poll, token, interest, opts)
-    }
-
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.client.stream_ref().as_tcp().as_raw_fd()).deregister(poll)
-    }
-}
-
-impl From<WebSocketError> for RecvError {
-    fn from(err: WebSocketError) -> Self {
+impl From<tungstenite::error::Error> for SendError {
+    fn from(err: tungstenite::error::Error) -> Self {
         match err {
-            WebSocketError::IoError(e) => RecvError::from(e),
-            _ => RecvError::ProtocolError(format!("WebSocketError: {}", err.to_string())),
+            tungstenite::error::Error::Io(io) => SendError::from(io),
+            _ => SendError::ProtocolError(err.to_string()),
         }
     }
 }
 
-impl From<WebSocketError> for SendError {
-    fn from(err: WebSocketError) -> Self {
+impl From<tungstenite::error::Error> for RecvError {
+    fn from(err: tungstenite::error::Error) -> Self {
         match err {
-            WebSocketError::IoError(e) => SendError::from(e),
-            _ => SendError::ProtocolError(format!("WebSocketError: {}", err.to_string())),
+            tungstenite::error::Error::Io(io) => RecvError::from(io),
+            _ => RecvError::ProtocolError(err.to_string()),
+        }
+    }
+}
+
+impl From<tungstenite::error::Error> for DisconnectError {
+    fn from(err: tungstenite::error::Error) -> Self {
+        match err {
+            tungstenite::error::Error::Io(io) => DisconnectError::from(io),
+            _ => DisconnectError::ProtocolError(err.to_string()),
         }
     }
 }

--- a/libsplinter/src/transport/ws/listener.rs
+++ b/libsplinter/src/transport/ws/listener.rs
@@ -12,23 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::TcpStream;
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
 
-use websocket::server::{sync::Server, upgrade::sync::Buffer, InvalidConnection, NoTlsAcceptor};
+use mio::net::TcpStream as MioTcpStream;
+use tungstenite::{accept, handshake::HandshakeError};
 
 use crate::transport::{AcceptError, Connection, Listener};
 
-use super::connection::WsClientConnection;
+use super::connection::WsConnection;
+use super::transport::PROTOCOL_PREFIX;
 
 pub(super) struct WsListener {
-    server: Server<NoTlsAcceptor>,
+    listener: TcpListener,
     local_endpoint: String,
 }
 
 impl WsListener {
-    pub fn new(server: Server<NoTlsAcceptor>, local_endpoint: String) -> Self {
+    pub fn new(listener: TcpListener, local_endpoint: String) -> Self {
         WsListener {
-            server,
+            listener,
             local_endpoint,
         }
     }
@@ -36,14 +40,31 @@ impl WsListener {
 
 impl Listener for WsListener {
     fn accept(&mut self) -> Result<Box<dyn Connection>, AcceptError> {
-        let client = self.server.accept()?.accept()?;
-        client.set_nonblocking(true)?;
+        let (stream, _) = self.listener.accept()?;
+        let remote_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.peer_addr()?);
+        let local_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.local_addr()?);
 
-        let remote_endpoint = format!("ws://{}", client.peer_addr()?);
-        let local_endpoint = format!("ws://{}", client.local_addr()?);
+        let mio_stream = MioTcpStream::from_stream(stream)?;
+        let websocket = accept(mio_stream).map_or_else(
+            {
+                |mut handshake_err| loop {
+                    match handshake_err {
+                        HandshakeError::Interrupted(mid_handshake) => {
+                            thread::sleep(Duration::from_millis(100));
+                            match mid_handshake.handshake() {
+                                Ok(ok) => break Ok(ok),
+                                Err(err) => handshake_err = err,
+                            }
+                        }
+                        HandshakeError::Failure(err) => break Err(err),
+                    }
+                }
+            },
+            Ok,
+        )?;
 
-        Ok(Box::new(WsClientConnection::new(
-            client,
+        Ok(Box::new(WsConnection::new(
+            websocket,
             remote_endpoint,
             local_endpoint,
         )))
@@ -54,14 +75,11 @@ impl Listener for WsListener {
     }
 }
 
-impl From<InvalidConnection<TcpStream, Buffer>> for AcceptError {
-    fn from(iconn: InvalidConnection<TcpStream, Buffer>) -> Self {
-        AcceptError::ProtocolError(format!("HyperIntoWsError: {}", iconn.error.to_string()))
-    }
-}
-
-impl From<(TcpStream, std::io::Error)> for AcceptError {
-    fn from(tuple: (TcpStream, std::io::Error)) -> Self {
-        AcceptError::from(tuple.1)
+impl From<tungstenite::error::Error> for AcceptError {
+    fn from(err: tungstenite::error::Error) -> Self {
+        match err {
+            tungstenite::error::Error::Io(io) => AcceptError::from(io),
+            _ => AcceptError::ProtocolError(format!("handshake failure: {}", err)),
+        }
     }
 }

--- a/libsplinter/src/transport/ws/mod.rs
+++ b/libsplinter/src/transport/ws/mod.rs
@@ -26,26 +26,123 @@ pub use transport::WsTransport;
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::transport::tests;
+    use crate::transport::tls::tests::{make_ca_cert, make_ca_signed_cert};
+    use crate::transport::tls::{TlsConfig, TlsConfigBuilder};
     use crate::transport::Transport;
 
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempdir::TempDir;
+
+    fn write_file(mut temp_dir: PathBuf, file_name: &str, bytes: &[u8]) -> String {
+        temp_dir.push(file_name);
+        let path = temp_dir.to_str().unwrap().to_string();
+        let mut file = File::create(path.to_string()).unwrap();
+        file.write_all(bytes).unwrap();
+
+        path
+    }
+
+    pub fn create_test_tls_config(temp_dir: &TempDir, insecure: bool) -> TlsConfig {
+        let mut builder = TlsConfigBuilder::new();
+
+        // Generate Certificate Authority keys and certificate
+        let (ca_key, ca_cert) = make_ca_cert();
+
+        // create temp directory to store ca.cert
+        let temp_dir_path = temp_dir.path();
+
+        if !insecure {
+            let ca_path_file = write_file(
+                temp_dir_path.to_path_buf(),
+                "ca.cert",
+                &ca_cert.to_pem().unwrap(),
+            );
+            builder = builder.with_ca_certs_file(ca_path_file);
+        }
+
+        // Generate client and server keys and certificates
+        let (client_key, client_cert) = make_ca_signed_cert(&ca_cert, &ca_key);
+        let (server_key, server_cert) = make_ca_signed_cert(&ca_cert, &ca_key);
+
+        let client_cert_file = write_file(
+            temp_dir_path.to_path_buf(),
+            "client.cert",
+            &client_cert.to_pem().unwrap(),
+        );
+
+        let client_key_file = write_file(
+            temp_dir_path.to_path_buf(),
+            "client.key",
+            &client_key.private_key_to_pem_pkcs8().unwrap(),
+        );
+
+        let server_cert_file = write_file(
+            temp_dir_path.to_path_buf(),
+            "server.cert",
+            &server_cert.to_pem().unwrap(),
+        );
+
+        let server_key_file = write_file(
+            temp_dir_path.to_path_buf(),
+            "server.key",
+            &server_key.private_key_to_pem_pkcs8().unwrap(),
+        );
+
+        if !insecure {}
+
+        builder
+            .with_server_cert_file(server_cert_file)
+            .with_server_private_key_file(server_key_file)
+            .with_client_cert_file(client_cert_file)
+            .with_client_private_key_file(client_key_file)
+            .build()
+            .unwrap()
+    }
+
     #[test]
-    fn test_accepts() {
+    fn test_ws_accepts() {
         let transport = WsTransport::default();
         assert!(transport.accepts("ws://127.0.0.1:18080"));
         assert!(transport.accepts("ws://somewhere.example.com:18080"));
     }
 
     #[test]
-    fn test_transport() {
+    fn test_ws_transport() {
         let transport = WsTransport::default();
 
         tests::test_transport(transport, "ws://127.0.0.1:18080");
     }
 
     #[test]
-    fn test_poll() {
+    fn test_ws_poll() {
         let transport = WsTransport::default();
         tests::test_poll(transport, "ws://127.0.0.1:18081");
+    }
+
+    #[test]
+    fn test_wss_accepts() {
+        let transport = WsTransport::default();
+        assert!(transport.accepts("wss://127.0.0.1:18080"));
+        assert!(transport.accepts("wss://somewhere.example.com:18080"));
+    }
+
+    #[test]
+    fn test_wss_transport() {
+        let temp_dir = TempDir::new("test-wss-transport").unwrap();
+        let config = create_test_tls_config(&temp_dir, true);
+        let transport = WsTransport::new(Some(&config)).unwrap();
+        tests::test_transport(transport, "wss://127.0.0.1:18082");
+    }
+
+    #[test]
+    fn test_wss_poll() {
+        let temp_dir = TempDir::new("test-wss-poll").unwrap();
+        let config = create_test_tls_config(&temp_dir, false);
+        let transport = WsTransport::new(Some(&config)).unwrap();
+        tests::test_poll(transport, "wss://127.0.0.1:18083");
     }
 }

--- a/libsplinter/src/transport/ws/transport.rs
+++ b/libsplinter/src/transport/ws/transport.rs
@@ -12,19 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::{TcpListener, TcpStream};
+use std::net::{Ipv4Addr, Ipv6Addr, TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
-use mio::net::TcpStream as MioTcpStream;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslAcceptor, SslConnector};
 use tungstenite::{client, handshake::HandshakeError};
+use url::{ParseError, Url};
 
+use crate::transport::tls::{build_acceptor, build_connector, TlsConfig};
 use crate::transport::{ConnectError, Connection, ListenError, Listener, Transport};
 
 use super::connection::WsConnection;
 use super::listener::WsListener;
 
-pub(super) const PROTOCOL_PREFIX: &str = "ws://";
+pub(super) const WS_PROTOCOL_PREFIX: &str = "ws://";
+pub(super) const WSS_PROTOCOL_PREFIX: &str = "wss://";
+
+struct TlsInner {
+    acceptor: SslAcceptor,
+    connector: SslConnector,
+}
 
 /// A WebSocket-based `Transport`.
 ///
@@ -39,7 +48,7 @@ pub(super) const PROTOCOL_PREFIX: &str = "ws://";
 /// use splinter::transport::ws::WsTransport;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let mut transport = WsTransport::default();
+///     let mut transport = WsTransport::new(None)?;
 ///
 ///     // Connect to a remote endpoint starting wtih `ws://`.
 ///     let mut connection = transport.connect("ws://127.0.0.1:5555")?;
@@ -64,7 +73,7 @@ pub(super) const PROTOCOL_PREFIX: &str = "ws://";
 /// use splinter::transport::ws::WsTransport;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let mut transport = WsTransport::default();
+///     let mut transport = WsTransport::new(None)?;
 ///
 ///     // Create a listener, which will bind to the port
 ///     let mut listener = transport.listen("ws://127.0.0.1:5555")?;
@@ -85,83 +94,176 @@ pub(super) const PROTOCOL_PREFIX: &str = "ws://";
 /// }
 /// ```
 #[derive(Default)]
-pub struct WsTransport {}
+pub struct WsTransport {
+    tls_inner: Option<TlsInner>,
+}
+
+impl WsTransport {
+    pub fn new(config: Option<&TlsConfig>) -> Result<Self, WsInitError> {
+        if let Some(conf) = config {
+            Ok(WsTransport {
+                tls_inner: Some(TlsInner {
+                    acceptor: build_acceptor(&conf)?,
+                    connector: build_connector(&conf)?,
+                }),
+            })
+        } else {
+            Ok(WsTransport { tls_inner: None })
+        }
+    }
+}
+
+fn endpoint_to_dns_name(endpoint: &str) -> Result<String, ParseError> {
+    let mut address = String::from("wss://");
+    address.push_str(endpoint);
+    let url = Url::parse(&address)?;
+    let dns_name = match url.domain() {
+        Some(d) if d.parse::<Ipv4Addr>().is_ok() => "localhost",
+        Some(d) if d.parse::<Ipv6Addr>().is_ok() => "localhost",
+        Some(d) => d,
+        None => "localhost",
+    };
+    Ok(String::from(dns_name))
+}
 
 impl Transport for WsTransport {
     fn accepts(&self, address: &str) -> bool {
-        address.starts_with(PROTOCOL_PREFIX)
+        address.starts_with(WS_PROTOCOL_PREFIX) || address.starts_with(WSS_PROTOCOL_PREFIX)
     }
 
     fn connect(&mut self, endpoint: &str) -> Result<Box<dyn Connection>, ConnectError> {
-        if !self.accepts(endpoint) {
-            return Err(ConnectError::ProtocolError(format!(
-                "Invalid protocol \"{}\"",
-                endpoint
-            )));
-        }
+        if endpoint.starts_with(WS_PROTOCOL_PREFIX) {
+            let address = &endpoint[WS_PROTOCOL_PREFIX.len()..];
+            let stream = TcpStream::connect(address)?;
 
-        let address = if endpoint.starts_with(PROTOCOL_PREFIX) {
-            &endpoint[PROTOCOL_PREFIX.len()..]
-        } else {
-            endpoint
-        };
+            let remote_endpoint = format!("{}{}", WS_PROTOCOL_PREFIX, stream.peer_addr()?);
+            let local_endpoint = format!("{}{}", WS_PROTOCOL_PREFIX, stream.local_addr()?);
 
-        let stream = TcpStream::connect(address)?;
-
-        let remote_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.peer_addr()?);
-        let local_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.local_addr()?);
-
-        let mio_stream = MioTcpStream::from_stream(stream)?;
-
-        let (websocket, _) = client(endpoint, mio_stream).map_or_else(
-            {
-                |mut handshake_err| loop {
-                    match handshake_err {
-                        HandshakeError::Interrupted(mid_handshake) => {
-                            thread::sleep(Duration::from_millis(100));
-                            match mid_handshake.handshake() {
-                                Ok(ok) => break Ok(ok),
-                                Err(err) => handshake_err = err,
+            let (websocket, _) = client(endpoint, stream).map_or_else(
+                {
+                    |mut handshake_err| loop {
+                        match handshake_err {
+                            HandshakeError::Interrupted(mid_handshake) => {
+                                thread::sleep(Duration::from_millis(100));
+                                match mid_handshake.handshake() {
+                                    Ok(ok) => break Ok(ok),
+                                    Err(err) => handshake_err = err,
+                                }
                             }
+                            HandshakeError::Failure(err) => break Err(err),
                         }
-                        HandshakeError::Failure(err) => break Err(err),
                     }
-                }
-            },
-            Ok,
-        )?;
+                },
+                Ok,
+            )?;
 
-        Ok(Box::new(WsConnection::new(
-            websocket,
-            remote_endpoint,
-            local_endpoint,
-        )))
+            Ok(Box::new(WsConnection::new(
+                websocket,
+                remote_endpoint,
+                local_endpoint,
+            )))
+        } else if endpoint.starts_with(WSS_PROTOCOL_PREFIX) {
+            let address = &endpoint[WSS_PROTOCOL_PREFIX.len()..];
+
+            let dns_name = endpoint_to_dns_name(address)?;
+
+            let stream = TcpStream::connect(address)?;
+
+            let remote_endpoint = format!("{}{}", WSS_PROTOCOL_PREFIX, stream.peer_addr()?);
+            let local_endpoint = format!("{}{}", WSS_PROTOCOL_PREFIX, stream.local_addr()?);
+
+            let tls_stream = self
+                .tls_inner
+                .as_ref()
+                .ok_or_else(|| {
+                    ConnectError::ProtocolError(format!(
+                        "Protocol {} requires TLS, which is not configured",
+                        WSS_PROTOCOL_PREFIX
+                    ))
+                })?
+                .connector
+                .connect(&dns_name, stream)?;
+
+            let (websocket, _) = client(endpoint, tls_stream).map_or_else(
+                {
+                    |mut handshake_err| loop {
+                        match handshake_err {
+                            HandshakeError::Interrupted(mid_handshake) => {
+                                thread::sleep(Duration::from_millis(100));
+                                match mid_handshake.handshake() {
+                                    Ok(ok) => break Ok(ok),
+                                    Err(err) => handshake_err = err,
+                                }
+                            }
+                            HandshakeError::Failure(err) => break Err(err),
+                        }
+                    }
+                },
+                Ok,
+            )?;
+
+            Ok(Box::new(WsConnection::new(
+                websocket,
+                remote_endpoint,
+                local_endpoint,
+            )))
+        } else {
+            Err(ConnectError::ProtocolError(format!(
+                "Invalid protocol: {}",
+                endpoint
+            )))
+        }
     }
 
     fn listen(&mut self, bind: &str) -> Result<Box<dyn Listener>, ListenError> {
-        if !self.accepts(bind) {
-            return Err(ListenError::ProtocolError(format!(
-                "Invalid protocol \"{}\"",
-                bind
-            )));
-        }
+        if bind.starts_with(WS_PROTOCOL_PREFIX) {
+            let address = &bind[WS_PROTOCOL_PREFIX.len()..];
+            let tcp_listener = TcpListener::bind(address).map_err(|err| {
+                ListenError::IoError(format!("Failed to bind to {}", address), err)
+            })?;
+            let local_endpoint = format!(
+                "{}{}",
+                WS_PROTOCOL_PREFIX,
+                tcp_listener.local_addr().map_err(|err| {
+                    ListenError::IoError("Failed to get local address".into(), err)
+                })?
+            );
 
-        let address = if bind.starts_with(PROTOCOL_PREFIX) {
-            &bind[PROTOCOL_PREFIX.len()..]
+            Ok(Box::new(WsListener::new(
+                tcp_listener,
+                local_endpoint,
+                None,
+            )))
+        } else if bind.starts_with(WSS_PROTOCOL_PREFIX) {
+            let inner = self.tls_inner.as_ref().ok_or_else(|| {
+                ListenError::ProtocolError(
+                    "TLS support required for the wss:// protocol".to_string(),
+                )
+            })?;
+
+            let address = &bind[WSS_PROTOCOL_PREFIX.len()..];
+            let tcp_listener = TcpListener::bind(address).map_err(|err| {
+                ListenError::IoError(format!("Failed to bind to {}", address), err)
+            })?;
+            let local_endpoint = format!(
+                "{}{}",
+                WSS_PROTOCOL_PREFIX,
+                tcp_listener.local_addr().map_err(|err| {
+                    ListenError::IoError("Failed to get local address".into(), err)
+                })?
+            );
+
+            Ok(Box::new(WsListener::new(
+                tcp_listener,
+                local_endpoint,
+                Some(inner.acceptor.clone()),
+            )))
         } else {
-            bind
-        };
-
-        let tcp_listener = TcpListener::bind(address)
-            .map_err(|err| ListenError::IoError(format!("Failed to bind to {}", address), err))?;
-        let local_endpoint = format!(
-            "ws://{}",
-            tcp_listener.local_addr().map_err(|err| {
-                ListenError::IoError("Failed to get local address".into(), err)
-            })?
-        );
-
-        Ok(Box::new(WsListener::new(tcp_listener, local_endpoint)))
+            Err(ListenError::ProtocolError(format!(
+                "Invalid protocol: {}",
+                bind
+            )))
+        }
     }
 }
 
@@ -171,5 +273,26 @@ impl From<tungstenite::error::Error> for ConnectError {
             tungstenite::error::Error::Io(io) => ConnectError::from(io),
             _ => ConnectError::ProtocolError(format!("handshake failure: {}", err)),
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum WsInitError {
+    ProtocolError(String),
+}
+
+impl std::error::Error for WsInitError {}
+
+impl std::fmt::Display for WsInitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            WsInitError::ProtocolError(msg) => write!(f, "Unable to initialize TLS: {}", msg),
+        }
+    }
+}
+
+impl From<ErrorStack> for WsInitError {
+    fn from(error: ErrorStack) -> Self {
+        WsInitError::ProtocolError(format!("OpenSSL error: {}", error))
     }
 }

--- a/libsplinter/src/transport/ws/transport.rs
+++ b/libsplinter/src/transport/ws/transport.rs
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use websocket::{
-    result::WebSocketError,
-    server::{sync::Server, NoTlsAcceptor},
-    ClientBuilder,
-};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+use mio::net::TcpStream as MioTcpStream;
+use tungstenite::{client, handshake::HandshakeError};
 
 use crate::transport::{ConnectError, Connection, ListenError, Listener, Transport};
 
-use super::connection::WsClientConnection;
+use super::connection::WsConnection;
 use super::listener::WsListener;
 
-const PROTOCOL_PREFIX: &str = "ws://";
+pub(super) const PROTOCOL_PREFIX: &str = "ws://";
 
 /// A WebSocket-based `Transport`.
 ///
@@ -99,14 +100,39 @@ impl Transport for WsTransport {
             )));
         }
 
-        let client = ClientBuilder::new(endpoint)?.connect_insecure()?;
-        client.set_nonblocking(true)?;
+        let address = if endpoint.starts_with(PROTOCOL_PREFIX) {
+            &endpoint[PROTOCOL_PREFIX.len()..]
+        } else {
+            endpoint
+        };
 
-        let remote_endpoint = format!("ws://{}", client.peer_addr()?);
-        let local_endpoint = format!("ws://{}", client.local_addr()?);
+        let stream = TcpStream::connect(address)?;
 
-        Ok(Box::new(WsClientConnection::new(
-            client,
+        let remote_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.peer_addr()?);
+        let local_endpoint = format!("{}{}", PROTOCOL_PREFIX, stream.local_addr()?);
+
+        let mio_stream = MioTcpStream::from_stream(stream)?;
+
+        let (websocket, _) = client(endpoint, mio_stream).map_or_else(
+            {
+                |mut handshake_err| loop {
+                    match handshake_err {
+                        HandshakeError::Interrupted(mid_handshake) => {
+                            thread::sleep(Duration::from_millis(100));
+                            match mid_handshake.handshake() {
+                                Ok(ok) => break Ok(ok),
+                                Err(err) => handshake_err = err,
+                            }
+                        }
+                        HandshakeError::Failure(err) => break Err(err),
+                    }
+                }
+            },
+            Ok,
+        )?;
+
+        Ok(Box::new(WsConnection::new(
+            websocket,
             remote_endpoint,
             local_endpoint,
         )))
@@ -126,24 +152,24 @@ impl Transport for WsTransport {
             bind
         };
 
-        let server: Server<NoTlsAcceptor> = Server::bind(address)
+        let tcp_listener = TcpListener::bind(address)
             .map_err(|err| ListenError::IoError(format!("Failed to bind to {}", address), err))?;
         let local_endpoint = format!(
             "ws://{}",
-            server.local_addr().map_err(|err| {
+            tcp_listener.local_addr().map_err(|err| {
                 ListenError::IoError("Failed to get local address".into(), err)
             })?
         );
 
-        Ok(Box::new(WsListener::new(server, local_endpoint)))
+        Ok(Box::new(WsListener::new(tcp_listener, local_endpoint)))
     }
 }
 
-impl From<WebSocketError> for ConnectError {
-    fn from(err: WebSocketError) -> Self {
+impl From<tungstenite::error::Error> for ConnectError {
+    fn from(err: tungstenite::error::Error) -> Self {
         match err {
-            WebSocketError::IoError(e) => ConnectError::from(e),
-            _ => ConnectError::ProtocolError(format!("WebSocketError: {}", err.to_string())),
+            tungstenite::error::Error::Io(io) => ConnectError::from(io),
+            _ => ConnectError::ProtocolError(format!("handshake failure: {}", err)),
         }
     }
 }


### PR DESCRIPTION
The websocket crate had serious limitations which manifested when attempting to implement TLS support. After more analysis, Tungstenite looks better overall, so re-implemented with that dependency instead.

Added TLS support with wss:// URLs.

To test, you can run two nodes:

Node1:

```
#!/bin/bash

set -e

export SPLINTER_HOME=$(pwd)/home/node1
cargo run \
    --manifest-path cli/Cargo.toml \
    cert generate \
    --skip
cargo run \
    --manifest-path splinterd/Cargo.toml \
    --features experimental \
    -- \
    -vv \
    --tls-insecure \
    --network-endpoints tcp://127.0.0.1:18044 \
    --network-endpoints tcps://127.0.0.1:18045 \
    --network-endpoints ws://127.0.0.1:18046 \
    --network-endpoints wss://127.0.0.1:18047 \
    --service-endpoint tcp://127.0.0.1:18048 \
    --rest-api-endpoint 127.0.0.1:18080 \
    --peers wss://127.0.0.1:28047
```

Node 2:

```
#!/bin/bash

set -e

export SPLINTER_HOME=$(pwd)/home/node2
cargo run \
    --manifest-path cli/Cargo.toml \
    cert generate \
    --skip
cargo run \
    --manifest-path splinterd/Cargo.toml \
    --features experimental \
    -- \
    -vv \
    --tls-insecure \
    --network-endpoints tcp://127.0.0.1:28044 \
    --network-endpoints tcps://127.0.0.1:28045 \
    --network-endpoints ws://127.0.0.1:28046 \
    --network-endpoints wss://127.0.0.1:28047 \
    --service-endpoint tcp://127.0.0.1:28048 \
    --rest-api-endpoint 127.0.0.1:28080
```