### PR TITLE
Fix typo in enable-biome splinterd option

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -254,7 +254,7 @@ fn main() {
 
     #[cfg(feature = "biome")]
     let app = app.arg(
-        Arg::with_name("enable-biome")
+        Arg::with_name("enable_biome")
             .long("enable-biome")
             .long_help("Enable the biome subsystem"),
     );


### PR DESCRIPTION
Option had an dash when it should have an underscore

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>