### PR TITLE
Stabilize scabbard-get-state

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -104,7 +104,6 @@ experimental = [
     "matrix",
     "network-peer-manager",
     "network-ref-map",
-    "scabbard-get-state",
     "service-arg-validation",
     "service-network",
     "ws-transport",
@@ -138,7 +137,6 @@ rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
 rest-api-cors = []
 sawtooth-signing-compat = ["sawtooth-sdk"]
 scabbard-client = ["reqwest"]
-scabbard-get-state = []
 service-arg-validation = []
 service-network = ["connection-manager"]
 ws-transport = ["websocket"]

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -46,10 +46,9 @@ pub(crate) const SCABBARD_SUBSCRIBE_PROTOCOL_MIN: u32 = 1;
 pub(crate) const SCABBARD_ADD_BATCHES_PROTOCOL_MIN: u32 = 1;
 #[cfg(feature = "rest-api")]
 pub(crate) const SCABBARD_BATCH_STATUSES_PROTOCOL_MIN: u32 = 1;
-
-#[cfg(all(feature = "scabbard-get-state", feature = "rest-api"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const SCABBARD_GET_STATE_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "scabbard-get-state", feature = "rest-api"))]
+#[cfg(feature = "rest-api")]
 pub(crate) const SCABBARD_LIST_STATE_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(feature = "biome")]

--- a/libsplinter/src/service/scabbard/factory.rs
+++ b/libsplinter/src/service/scabbard/factory.rs
@@ -198,14 +198,13 @@ impl ServiceFactory for ScabbardFactory {
         #[cfg(feature = "rest-api-actix")]
         {
             use super::rest_api::actix;
-            endpoints.push(actix::batches::make_add_batches_to_queue_endpoint());
-            endpoints.push(actix::ws_subscribe::make_subscribe_endpoint());
-            endpoints.push(actix::batch_statuses::make_get_batch_status_endpoint());
-            #[cfg(feature = "scabbard-get-state")]
-            {
-                endpoints.push(actix::state_address::make_get_state_at_address_endpoint());
-                endpoints.push(actix::state::make_get_state_with_prefix_endpoint());
-            }
+            endpoints.append(&mut vec![
+                actix::batches::make_add_batches_to_queue_endpoint(),
+                actix::ws_subscribe::make_subscribe_endpoint(),
+                actix::batch_statuses::make_get_batch_status_endpoint(),
+                actix::state_address::make_get_state_at_address_endpoint(),
+                actix::state::make_get_state_with_prefix_endpoint(),
+            ])
         }
 
         endpoints

--- a/libsplinter/src/service/scabbard/mod.rs
+++ b/libsplinter/src/service/scabbard/mod.rs
@@ -53,9 +53,9 @@ use error::ScabbardError;
 pub use factory::ScabbardArgValidator;
 pub use factory::ScabbardFactory;
 use shared::ScabbardShared;
-#[cfg(feature = "scabbard-get-state")]
-pub use state::StateIter;
-pub use state::{BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent};
+pub use state::{
+    BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent, StateIter,
+};
 use state::{ScabbardState, StateSubscriber};
 
 const SERVICE_TYPE: &str = "scabbard";
@@ -123,7 +123,6 @@ impl Scabbard {
         })
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Fetch the value at the given `address` in the Scabbard service's state. Returns `None` if
     /// the `address` is not set.
     pub fn get_state_at_address(&self, address: &str) -> Result<Option<Vec<u8>>, ScabbardError> {
@@ -134,7 +133,6 @@ impl Scabbard {
             .get_state_at_address(address)?)
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Fetch a list of entries in the Scabbard service's state. If a `prefix` is provided, only
     /// return entries whose addresses are under the given address prefix. If no `prefix` is
     /// provided, return all state entries.

--- a/libsplinter/src/service/scabbard/rest_api/actix/mod.rs
+++ b/libsplinter/src/service/scabbard/rest_api/actix/mod.rs
@@ -14,8 +14,6 @@
 
 pub mod batch_statuses;
 pub mod batches;
-#[cfg(feature = "scabbard-get-state")]
 pub mod state;
-#[cfg(feature = "scabbard-get-state")]
 pub mod state_address;
 pub mod ws_subscribe;

--- a/libsplinter/src/service/scabbard/rest_api/resources/mod.rs
+++ b/libsplinter/src/service/scabbard/rest_api/resources/mod.rs
@@ -14,5 +14,4 @@
 
 pub mod batch_statuses;
 pub mod batches;
-#[cfg(feature = "scabbard-get-state")]
 pub mod state;

--- a/libsplinter/src/service/scabbard/state.rs
+++ b/libsplinter/src/service/scabbard/state.rs
@@ -35,10 +35,8 @@ use transact::database::{
 use transact::families::command::CommandTransactionHandler;
 use transact::sawtooth::SawtoothToTransactHandlerAdapter;
 use transact::scheduler::{serial::SerialScheduler, BatchExecutionResult, Scheduler};
-#[cfg(feature = "scabbard-get-state")]
-use transact::state::merkle::StateDatabaseError;
 use transact::state::{
-    merkle::{MerkleRadixTree, MerkleState, INDEXES},
+    merkle::{MerkleRadixTree, MerkleState, StateDatabaseError, INDEXES},
     StateChange as TransactStateChange, Write,
 };
 use transact::{
@@ -62,7 +60,6 @@ const ITER_CACHE_SIZE: usize = 64;
 const COMPLETED_BATCH_INFO_ITER_RETRY_MILLIS: u64 = 100;
 const DEFAULT_BATCH_HISTORY_SIZE: usize = 100;
 
-#[cfg(feature = "scabbard-get-state")]
 /// Iterator over entries in a Scabbard service's state
 pub type StateIter = Box<dyn Iterator<Item = Result<(String, Vec<u8>), ScabbardStateError>>>;
 
@@ -189,7 +186,6 @@ impl ScabbardState {
         Ok(())
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Fetch the value at the given `address` in state. Returns `None` if the `address` is not set.
     pub fn get_state_at_address(
         &self,
@@ -201,7 +197,6 @@ impl ScabbardState {
         )
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Fetch a list of entries in state. If a `prefix` is provided, only return entries whose
     /// addresses are under the given address prefix. If no `prefix` is provided, return all state
     /// entries.
@@ -843,7 +838,6 @@ mod tests {
     use std::path::PathBuf;
 
     use tempdir::TempDir;
-    #[cfg(feature = "scabbard-get-state")]
     use transact::{
         families::command::make_command_transaction,
         protocol::{
@@ -921,7 +915,6 @@ mod tests {
         assert_eq!(some_event_ids, receipt_ids[1..].to_vec());
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Verify that the `ScabbardState::get_state_at_address` method works properly.
     ///
     /// 1. Initialize a new, empty `ScabbardState`.
@@ -979,7 +972,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "scabbard-get-state")]
     /// Verify that the `ScabbardState::get_state_with_prefix` method works properly.
     ///
     /// 1. Initialize a new, empty `ScabbardState`.

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -73,7 +73,6 @@ experimental = [
     "biome-credentials",
     "biome-key-management",
     "health",
-    "scabbard-get-state",
     "service-arg-validation",
     "ws-transport",
 ]
@@ -87,7 +86,6 @@ config-env-var = []
 config-toml = []
 database = ["splinter/postgres"]
 rest-api-cors = ["splinter/rest-api-cors"]
-scabbard-get-state = ["splinter/scabbard-get-state"]
 service-arg-validation = ["splinter/service-arg-validation"]
 ws-transport = ["splinter/ws-transport"]
 


### PR DESCRIPTION
Stabilize the `scabbard-get-state` feature by removing it as an
explicitly defined feature from the splinter library and splinterd.

Signed-off-by: Logan Seeley <seeley@bitwise.io>