### PR TITLE
Stabilize biome features in splinterd

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -54,6 +54,9 @@ features = [
 
 [features]
 default = [
+    "biome",
+    "biome-credentials",
+    "biome-key-management",
     "config-command-line",
     "config-default",
     "config-env-var",
@@ -69,9 +72,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "biome",
-    "biome-credentials",
-    "biome-key-management",
     "health",
     "service-arg-validation",
     "ws-transport",


### PR DESCRIPTION
Move biome, biome-key-management, and biome-credentials into splinterd's
default features list. This is so gameroom can use them without needing
the experimental containers from dockerhub. Additionally this was
erroneously left out the biome stabilization effort.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>