### PR TITLE
Pin moment dependency in gameroom-app

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -23,7 +23,7 @@
     "@types/sjcl": "^1.0.28",
     "axios": "^0.19.0",
     "core-js": "^2.6.5",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "protobufjs": "^6.8.8",
     "request": "^2.88.0",
     "sawtooth-sdk": "^1.0.5",


### PR DESCRIPTION
The moment 2.25 release did not include typescript bindings, which led
to gameroom app not being able to resolve the dependency. This commit
pins the version of moment to 2.24 which was working.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>