### PR TITLE
Move database and database-migrate-biome to default

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,10 +50,12 @@ gag = "0.1"
 serial_test = "0.3"
 
 [features]
-default = []
+default = [
+    "database",
+    "database-migrate-biome",
+]
 
 stable = [
-    "database-migrate-biome",
     "default"
 ]
 
@@ -63,7 +65,6 @@ experimental = [
     # The following features are experimental:
     "circuit-template",
     "health",
-    "database",
     "postgres",
     "circuit-auth-type",
 ]


### PR DESCRIPTION
Moves the database feature and the database-migrate-biome feature to the
default features list. We are moving database-migrate-biome into default
because we don't expect users to recompile the cli binary with the
stable feature flag. Additionally, we are moving database into stable
because its corresponding libsplinter feature, postgres, was recently
stabilized.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>