### PR TITLE
Add missing serde decorator for BatchStatusResponse 

### DIFF
--- a/examples/gameroom/daemon/src/rest_api/routes/proposal.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/proposal.rs
@@ -216,7 +216,10 @@ pub async fn proposal_vote(
                 RestApiResponseError::BadRequest(err) => {
                     Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&err)))
                 }
-                _ => Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error())),
+                _ => {
+                    debug!("Internal Server Error: {}", err);
+                    Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()))
+                }
             },
             error::BlockingError::Canceled => {
                 debug!("Internal Server Error: {}", err);

--- a/examples/gameroom/daemon/src/rest_api/routes/submit.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/submit.rs
@@ -200,7 +200,10 @@ pub async fn submit_scabbard_payload(
             RestApiResponseError::BadRequest(message) => {
                 Ok(HttpResponse::BadRequest().json(ErrorResponse::bad_request(&message)))
             }
-            _ => Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error())),
+            _ => {
+                debug!("Internal Server Error: {}", err);
+                Ok(HttpResponse::InternalServerError().json(ErrorResponse::internal_error()))
+            }
         },
     }
 }

--- a/libsplinter/src/service/scabbard/client/mod.rs
+++ b/libsplinter/src/service/scabbard/client/mod.rs
@@ -422,6 +422,7 @@ struct BatchInfo {
 
 /// Used by `BatchInfo` for deserializing `GET /batch_status` responses.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "statusType", content = "message")]
 enum BatchStatus {
     Unknown,
     Pending,

--- a/libsplinter/src/service/scabbard/rest_api/resources/batch_statuses.rs
+++ b/libsplinter/src/service/scabbard/rest_api/resources/batch_statuses.rs
@@ -36,6 +36,7 @@ impl<'a> From<&'a BatchInfo> for BatchInfoResponse<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "statusType", content = "message")]
 pub enum BatchStatusResponse<'a> {
     Unknown,
     Pending,


### PR DESCRIPTION
The following decorator was missing from the local structs
used in the Scabbard RestAPI and ScabbardClient.

This decorator exists on the structs used in the scabbard
services. Without it, gameroom was showing an error toast
on submitting a XO transaction, even though the transaction
would be accepted and show up on the game board.

Also adds missing log messages to gameroomd when there is an InternalServerError.