### PR TITLE
Rename splinterd config bind -> rest_api_endpoint

### DIFF
--- a/docker/kubernetes/arcade.yaml
+++ b/docker/kubernetes/arcade.yaml
@@ -123,7 +123,7 @@ items:
                 fi && \
                 splinterd -vv \
                 --registries file:///config/registry/registry.yaml \
-                --bind $HOSTNAME:8085 \
+                --rest-api-endpoint $HOSTNAME:8085 \
                 --network-endpoints tcps://$HOSTNAME:8044 \
                 --node-id acme \
                 --service-endpoint tcp://$HOSTNAME:8043 \
@@ -287,7 +287,7 @@ items:
                 fi && \
                 splinterd -vv \
                 --registries file:///config/registry/registry.yaml \
-                --bind $HOSTNAME:8085 \
+                --rest-api-endpoint $HOSTNAME:8085 \
                 --network-endpoints tcps://$HOSTNAME:8044 \
                 --node-id bubba \
                 --service-endpoint tcp://$HOSTNAME:8043 \

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -152,7 +152,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-acme:8044 \
-              --bind 0.0.0.0:8085 \
+              --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome
@@ -253,7 +253,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-bubba:8044 \
-              --bind 0.0.0.0:8085 \
+              --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -182,7 +182,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-acme:8044 \
-              --bind 0.0.0.0:8085 \
+              --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome
@@ -305,7 +305,7 @@ services:
               --service-endpoint tcp://0.0.0.0:8043 \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-bubba:8044 \
-              --bind 0.0.0.0:8085 \
+              --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome

--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -33,4 +33,4 @@ peers = []
 storage = "yaml"
 
 # Rest api address.
-bind = "localhost:8085"
+rest_api_endpoint = "localhost:8085"

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -33,4 +33,4 @@ peers = []
 storage = "yaml"
 
 # Rest api address.
-bind = "localhost:8085"
+rest_api_endpoint = "localhost:8085"

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -112,7 +112,7 @@ services:
               --database postgres://admin:admin@splinterd-db-node:5432/splinter \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --bind 0.0.0.0:8085 \
+              --rest-api-endpoint 0.0.0.0:8085 \
               --tls-insecure \
               --enable-biome
       "

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -36,7 +36,7 @@ storage = "memory"
 transport = "tls"
 
 # Rest api address.
-bind = "0.0.0.0:8085"
+rest_api_endpoint = "0.0.0.0:8085"
 
 # Splinter Registry file
 registries = ["file:///project/tests/sample_registry.yaml"]

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -103,9 +103,6 @@ OPTIONS
   Specify multiple endpoints in a comma-separated list or with separate
   `--advertised-endpoint` options.
 
-`--bind BIND-ENDPOINT`
-: Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
-
 `-c`, `--config` `CONFIG-FILE`
 : Specifies the path and file name for a `splinterd` configuration file, which
   is a TOML file that contains `splinterd` settings. (The file name must end
@@ -166,6 +163,9 @@ OPTIONS
 `--registry-forced-refresh SECONDS`
 : Specifies how often, in seconds, to fetch remote node registry changes on
   read. (Default: 10 seconds.) Use 0 to turn off forced refreshes.
+
+`--rest-api-endpoint REST-API-ENDPOINT`
+: Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
 
 `--state-dir STATE-DIR`
 : Specifies the storage directory.

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -33,7 +33,7 @@ peers = []
 storage = "memory"
 
 # Rest api address.
-bind = "localhost:8085"
+rest_api_endpoint = "localhost:8085"
 
 # Splinter Registry file
 registries = ["file:///etc/splinter/registry.yaml"]

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -33,7 +33,7 @@ peers = []
 storage = "memory"
 
 # Rest api address.
-bind = "0.0.0.0:8080"
+rest_api_endpoint = "0.0.0.0:8080"
 
 # db address
 database = "postgres://splinter_admin:splinter_test@127.0.0.1:5432/splinter"

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -41,7 +41,7 @@ network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # Endpoint used for REST API communication
 # (default "127.0.0.1:8080")
-bind = "127.0.0.1:8080"
+rest_api_endpoint = "127.0.0.1:8080"
 
 # A list of splinter node endpoints the daemon will automatically
 # connect to on start up.

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -41,7 +41,7 @@ network_endpoints = ["tcps://127.0.0.1:8046"]
 
 # Endpoint used for REST API communication
 # (default "127.0.0.1:8080")
-bind = "127.0.0.1:8081"
+rest_api_endpoint = "127.0.0.1:8081"
 
 # A list of splinter nodes the daemon will automatically
 # connect to on start up.

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -194,14 +194,14 @@ impl ConfigBuilder {
                 Some(v) => Some((v, p.source())),
                 None => None,
             }),
-            bind: self
+            rest_api_endpoint: self
                 .partial_configs
                 .iter()
-                .find_map(|p| match p.bind() {
+                .find_map(|p| match p.rest_api_endpoint() {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 })
-                .ok_or_else(|| ConfigError::MissingValue("bind".to_string()))?,
+                .ok_or_else(|| ConfigError::MissingValue("rest api endpoint".to_string()))?,
             #[cfg(feature = "database")]
             database: self
                 .partial_configs
@@ -359,7 +359,7 @@ mod tests {
             config.display_name(),
             Some(EXAMPLE_DISPLAY_NAME.to_string())
         );
-        assert_eq!(config.bind(), None);
+        assert_eq!(config.rest_api_endpoint(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), Some(vec![]));
@@ -394,7 +394,7 @@ mod tests {
             .with_peers(Some(vec![]))
             .with_node_id(Some(EXAMPLE_NODE_ID.to_string()))
             .with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()))
-            .with_bind(None)
+            .with_rest_api_endpoint(None)
             .with_registries(Some(vec![]))
             .with_heartbeat(None)
             .with_admin_timeout(None);

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -72,7 +72,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
             )
             .with_node_id(self.matches.value_of("node_id").map(String::from))
             .with_display_name(self.matches.value_of("display_name").map(String::from))
-            .with_bind(self.matches.value_of("bind").map(String::from))
+            .with_rest_api_endpoint(self.matches.value_of("rest_api_endpoint").map(String::from))
             .with_registries(
                 self.matches
                     .values_of("registries")
@@ -180,7 +180,7 @@ mod tests {
             config.display_name(),
             Some(EXAMPLE_DISPLAY_NAME.to_string())
         );
-        assert_eq!(config.bind(), None);
+        assert_eq!(config.rest_api_endpoint(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
@@ -212,7 +212,7 @@ mod tests {
             (@arg tls_server_cert: --("tls-server-cert") +takes_value)
             (@arg tls_server_key:  --("tls-server-key") +takes_value)
             (@arg tls_client_key:  --("tls-client-key") +takes_value)
-            (@arg bind: --("bind") +takes_value)
+            (@arg rest_api_endpoint: --("rest-api-endpoint") +takes_value)
             (@arg tls_insecure: --("tls-insecure"))
             (@arg no_tls: --("no-tls"))
             (@arg state_dir: --("state-dir") + takes_value))

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -28,7 +28,7 @@ const TLS_SERVER_CERT: &str = "server.crt";
 const TLS_SERVER_KEY: &str = "private/server.key";
 const TLS_CA_FILE: &str = "ca.pem";
 
-const BIND: &str = "127.0.0.1:8080";
+const REST_API_ENDPOINT: &str = "127.0.0.1:8080";
 const SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
 const NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
 #[cfg(feature = "database")]
@@ -64,7 +64,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_service_endpoint(Some(String::from(SERVICE_ENDPOINT)))
             .with_network_endpoints(Some(vec![String::from(NETWORK_ENDPOINT)]))
             .with_peers(Some(vec![]))
-            .with_bind(Some(String::from(BIND)))
+            .with_rest_api_endpoint(Some(String::from(REST_API_ENDPOINT)))
             .with_registries(Some(vec![]))
             .with_registry_auto_refresh(Some(REGISTRY_AUTO_REFRESH))
             .with_registry_forced_refresh(Some(REGISTRY_FORCED_REFRESH))
@@ -120,7 +120,10 @@ mod tests {
         assert_eq!(config.peers(), Some(vec![]));
         assert_eq!(config.node_id(), None);
         assert_eq!(config.display_name(), None);
-        assert_eq!(config.bind(), Some(String::from(BIND)));
+        assert_eq!(
+            config.rest_api_endpoint(),
+            Some(String::from(REST_API_ENDPOINT))
+        );
         #[cfg(feature = "database")]
         assert_eq!(config.database(), Some(String::from(DATABASE)));
         assert_eq!(config.registries(), Some(vec![]));

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -62,7 +62,7 @@ pub struct Config {
     peers: (Vec<String>, ConfigSource),
     node_id: Option<(String, ConfigSource)>,
     display_name: Option<(String, ConfigSource)>,
-    bind: (String, ConfigSource),
+    rest_api_endpoint: (String, ConfigSource),
     #[cfg(feature = "database")]
     database: (String, ConfigSource),
     registries: (Vec<String>, ConfigSource),
@@ -144,8 +144,8 @@ impl Config {
         }
     }
 
-    pub fn bind(&self) -> &str {
-        &self.bind.0
+    pub fn rest_api_endpoint(&self) -> &str {
+        &self.rest_api_endpoint.0
     }
 
     #[cfg(feature = "database")]
@@ -263,8 +263,8 @@ impl Config {
         }
     }
 
-    fn bind_source(&self) -> &ConfigSource {
-        &self.bind.1
+    fn rest_api_endpoint_source(&self) -> &ConfigSource {
+        &self.rest_api_endpoint.1
     }
 
     #[cfg(feature = "database")]
@@ -388,9 +388,9 @@ impl Config {
             debug!("Config: display_name: {} (source: {:?})", name, source,);
         }
         debug!(
-            "Config: bind: {} (source: {:?})",
-            self.bind(),
-            self.bind_source()
+            "Config: rest_api_endpoint: {} (source: {:?})",
+            self.rest_api_endpoint(),
+            self.rest_api_endpoint_source()
         );
         debug!(
             "Config: registries: {:?} (source: {:?})",
@@ -546,7 +546,7 @@ mod tests {
         (@arg tls_server_cert: --("tls-server-cert") +takes_value)
         (@arg tls_server_key:  --("tls-server-key") +takes_value)
         (@arg tls_client_key:  --("tls-client-key") +takes_value)
-        (@arg bind: --("bind") +takes_value)
+        (@arg rest_api_endpoint: --("rest-api-endpoint") +takes_value)
         (@arg tls_insecure: --("tls-insecure"))
         (@arg no_tls: --("no-tls"))
         (@arg enable_biome: --("enable-biome")))
@@ -913,10 +913,13 @@ mod tests {
             ),
             (Some("Node 1"), Some(&ConfigSource::CommandLine))
         );
-        // The `DefaultPartialConfigBuilder` is the only config with a value for `bind` (source
-        // should be `Default`).
+        // The DefaultPartialConfigBuilder is the only config with a value for `rest_api_endpoint`
+        // (source should be Default).
         assert_eq!(
-            (final_config.bind(), final_config.bind_source()),
+            (
+                final_config.rest_api_endpoint(),
+                final_config.rest_api_endpoint_source()
+            ),
             ("127.0.0.1:8080", &ConfigSource::Default)
         );
         #[cfg(feature = "database")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -47,7 +47,7 @@ pub struct PartialConfig {
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     display_name: Option<String>,
-    bind: Option<String>,
+    rest_api_endpoint: Option<String>,
     #[cfg(feature = "database")]
     database: Option<String>,
     registries: Option<Vec<String>>,
@@ -83,7 +83,7 @@ impl PartialConfig {
             peers: None,
             node_id: None,
             display_name: None,
-            bind: None,
+            rest_api_endpoint: None,
             #[cfg(feature = "database")]
             database: None,
             registries: None,
@@ -161,8 +161,8 @@ impl PartialConfig {
         self.display_name.clone()
     }
 
-    pub fn bind(&self) -> Option<String> {
-        self.bind.clone()
+    pub fn rest_api_endpoint(&self) -> Option<String> {
+        self.rest_api_endpoint.clone()
     }
 
     #[cfg(feature = "database")]
@@ -383,14 +383,15 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `bind` value to the `PartialConfig` object.
+
+    /// Adds a `rest_api_endpoint` value to the PartialConfig object.
     ///
     /// # Arguments
     ///
-    /// * `bind` - Connection endpoint for REST API.
+    /// * `rest_api_endpoint` - Connection endpoint for REST API.
     ///
-    pub fn with_bind(mut self, bind: Option<String>) -> Self {
-        self.bind = bind;
+    pub fn with_rest_api_endpoint(mut self, rest_api_endpoint: Option<String>) -> Self {
+        self.rest_api_endpoint = rest_api_endpoint;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -41,7 +41,7 @@ struct TomlConfig {
     peers: Option<Vec<String>>,
     node_id: Option<String>,
     display_name: Option<String>,
-    bind: Option<String>,
+    rest_api_endpoint: Option<String>,
     #[cfg(feature = "database")]
     database: Option<String>,
     registries: Option<Vec<String>>,
@@ -64,6 +64,7 @@ struct TomlConfig {
     registry_auto_refresh_interval: Option<u64>,
     registry_forced_refresh_interval: Option<u64>,
     admin_service_coordinator_timeout: Option<u64>,
+    bind: Option<String>,
 }
 
 /// `PartialConfig` builder which holds values defined in a toml file.
@@ -126,7 +127,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_peers(self.toml_config.peers)
             .with_node_id(self.toml_config.node_id)
             .with_display_name(self.toml_config.display_name)
-            .with_bind(self.toml_config.bind)
+            .with_rest_api_endpoint(self.toml_config.rest_api_endpoint)
             .with_registries(self.toml_config.registries)
             .with_registry_auto_refresh(self.toml_config.registry_auto_refresh)
             .with_registry_forced_refresh(self.toml_config.registry_forced_refresh)
@@ -176,6 +177,9 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         if partial_config.admin_timeout().is_none() {
             partial_config = partial_config
                 .with_admin_timeout(self.toml_config.admin_service_coordinator_timeout)
+        }
+        if partial_config.rest_api_endpoint().is_none() {
+            partial_config = partial_config.with_rest_api_endpoint(self.toml_config.bind)
         }
 
         Ok(partial_config)
@@ -312,7 +316,7 @@ mod tests {
             config.display_name(),
             Some(EXAMPLE_DISPLAY_NAME.to_string())
         );
-        assert_eq!(config.bind(), None);
+        assert_eq!(config.rest_api_endpoint(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);
@@ -349,7 +353,7 @@ mod tests {
         assert_eq!(config.peers(), None);
         assert_eq!(config.node_id(), None);
         assert_eq!(config.display_name(), None);
-        assert_eq!(config.bind(), None);
+        assert_eq!(config.rest_api_endpoint(), None);
         #[cfg(feature = "database")]
         assert_eq!(config.database(), None);
         assert_eq!(config.registries(), None);

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -198,8 +198,6 @@ fn main() {
         (@arg service_endpoint: --("service-endpoint") +takes_value
           "Endpoint that service will connect to, tcp://ip:port")
         (@arg no_tls:  --("no-tls") "Turn off tls configuration")
-        (@arg bind: --("bind") +takes_value
-          "Connection endpoint for REST API")
         (@arg registry_auto_refresh: --("registry-auto-refresh") +takes_value
             "How often remote Splinter registries should attempt to fetch upstream changes in the \
              background (in seconds); default is 600 (10 minutes), 0 means off")
@@ -246,6 +244,13 @@ fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .alias("network-endpoint"),
+        )
+        .arg(
+            Arg::with_name("rest_api_endpoint")
+                .long("rest-api-endpoint")
+                .help("Connection endpoint for REST API")
+                .takes_value(true)
+                .alias("bind"),
         )
         .arg(
             Arg::with_name("peers")
@@ -385,7 +390,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     let transport = build_transport(&config)?;
 
-    let rest_api_endpoint = config.bind();
+    let rest_api_endpoint = config.rest_api_endpoint();
 
     #[cfg(feature = "database")]
     let db_url = config.database();


### PR DESCRIPTION
Renames the `bind` configuration option for splinterd to
`rest_api_endpoint`. The corresponding CLI option is now
`--rest-api-endpoint`. This change makes the option's intent more clear.

Signed-off-by: Logan Seeley <seeley@bitwise.io>