### PR TITLE
Config cleanup

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -168,6 +168,7 @@ impl AdminService {
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
         storage_type: &str,
+        storage_location: &str,
         // The coordinator timeout for the two-phase commit consensus engine; if `None`, the
         // default value will be used (30 seconds).
         coordinator_timeout: Option<Duration>,
@@ -191,6 +192,7 @@ impl AdminService {
                 key_verifier,
                 key_permission_manager,
                 storage_type,
+                storage_location,
             )?)),
             orchestrator,
             coordinator_timeout,
@@ -646,6 +648,8 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
+    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
+
     /// Test that a circuit creation creates the correct connections and sends the appropriate
     /// messages.
     #[test]
@@ -681,6 +685,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
             None,
         )
         .expect("Service should have been created correctly");

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -14,9 +14,7 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::env;
 use std::iter::FromIterator;
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -66,9 +64,6 @@ use super::{
     Events,
 };
 
-const DEFAULT_STATE_DIR: &str = "/var/lib/splinter/";
-const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
-const SPLINTER_HOME_ENV: &str = "SPLINTER_HOME";
 static VOTER_ROLE: &str = "voter";
 static PROPOSER_ROLE: &str = "proposer";
 
@@ -216,21 +211,8 @@ impl AdminServiceShared {
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
         storage_type: &str,
+        location: &str,
     ) -> Result<Self, ServiceError> {
-        let location = {
-            if let Ok(s) = env::var(STATE_DIR_ENV) {
-                s
-            } else if let Ok(s) = env::var(SPLINTER_HOME_ENV) {
-                Path::new(&s)
-                    .join("data")
-                    .to_str()
-                    .map(ToOwned::to_owned)
-                    .unwrap_or_else(|| String::from(DEFAULT_STATE_DIR))
-            } else {
-                DEFAULT_STATE_DIR.to_string()
-            }
-        };
-
         let storage_location = match storage_type {
             "yaml" => format!("{}{}", location, "/circuit_proposals.yaml"),
             "memory" => "memory".to_string(),
@@ -1829,6 +1811,8 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
+    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
+
     /// Test that the CircuitManagementPayload is moved to the pending payloads when the peers are
     /// fully authorized.
     #[test]
@@ -1859,6 +1843,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -1962,6 +1947,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -2041,6 +2027,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2070,6 +2057,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2099,6 +2087,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2134,6 +2123,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2169,6 +2159,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2207,6 +2198,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2242,6 +2234,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2277,6 +2270,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2317,6 +2311,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2346,6 +2341,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2377,6 +2373,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2412,6 +2409,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2454,6 +2452,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2496,6 +2495,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2526,6 +2526,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2556,6 +2557,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2594,6 +2596,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2632,6 +2635,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2670,6 +2674,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2700,6 +2705,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2730,6 +2736,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2760,6 +2767,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2790,6 +2798,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2820,6 +2829,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2851,6 +2861,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2881,6 +2892,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2911,6 +2923,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2949,6 +2962,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2982,6 +2996,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3030,6 +3045,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3080,6 +3096,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3132,6 +3149,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
+            STORAGE_LOCATION,
         )
         .unwrap();
 

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -167,6 +167,12 @@ OPTIONS
 : Specifies how often, in seconds, to fetch remote node registry changes on
   read. (Default: 10 seconds.) Use 0 to turn off forced refreshes.
 
+`--state-dir STATE-DIR`
+: Specifies the storage directory.
+  (Default: `/var/lib/splinter`.)
+
+  This option overrides the `SPLINTER_STATE_DIR` environment variable, if set.
+
 `--service-endpoint SERVICE-ENDPOINT`
 : Specifies the endpoint for service-to-daemon communication, using the format
   `tcp://ip:port`. (Default: `127.0.0.1:8043`.)

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -139,21 +139,6 @@ impl ConfigBuilder {
                 None => None,
             })
             .ok_or_else(|| ConfigError::MissingValue("network endpoints".to_string()))?;
-        let node_id = self.partial_configs.iter().find_map(|p| match p.node_id() {
-            Some(v) => Some((v, p.source())),
-            None => None,
-        });
-        let display_name = self
-            .partial_configs
-            .iter()
-            .find_map(|p| match p.display_name() {
-                Some(v) => Some((v, p.source())),
-                None => None,
-            })
-            .unwrap_or_else(|| match &node_id {
-                Some((id, _)) => (format!("Node {}", id), ConfigSource::Default),
-                None => (String::from("Node"), ConfigSource::Default),
-            });
         // Iterates over the list of `PartialConfig` objects to find the first config with a value
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
@@ -198,8 +183,17 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("peers".to_string()))?,
-            display_name,
-            node_id,
+            display_name: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.display_name() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }),
+            node_id: self.partial_configs.iter().find_map(|p| match p.node_id() {
+                Some(v) => Some((v, p.source())),
+                None => None,
+            }),
             bind: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -12,17 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `ConfigBuilder` implementation to construct a finalized `Config` object.
+//!
+//! Takes various `PartialConfig` objects and finalizes the config values sourced from the
+//! `PartialConfigs` to construct a `Config` object to be used to start up the Splinter daemon.
+
 use std::path::Path;
 
 use crate::config::error::ConfigError;
 use crate::config::{Config, ConfigSource, PartialConfig};
 
 pub trait PartialConfigBuilder {
-    /// Takes all values set in a config object to create a PartialConfig object.
+    /// Takes all values set in a config object to create a `PartialConfig` object.
     ///
     fn build(self) -> Result<PartialConfig, ConfigError>;
 }
 
+// Constructs the tls config file paths by checking whether the file is an absolute or relative
+// path, otherwise if only a file name is provided, the `cert_dir` option will be appended to the
+// file name.
 fn get_tls_file_path(cert_dir: &str, file: &str) -> String {
     let file_path = Path::new(file);
     if file_path.is_absolute() || file_path.starts_with("../") || file_path.starts_with("./") {
@@ -39,8 +47,8 @@ fn get_tls_file_path(cert_dir: &str, file: &str) -> String {
     }
 }
 
-/// ConfigBuilder collects PartialConfig objects from various sources to be used to generate a
-/// Config object.
+/// ConfigBuilder collects `PartialConfig` objects from various sources to be used to generate a
+/// `Config` object.
 pub struct ConfigBuilder {
     partial_configs: Vec<PartialConfig>,
 }
@@ -53,18 +61,18 @@ impl ConfigBuilder {
     }
 
     #[cfg(feature = "default")]
-    /// Adds a PartialConfig to the ConfigBuilder object.
+    /// Adds a `PartialConfig` to the `ConfigBuilder` object.
     ///
     /// # Arguments
     ///
-    /// * `partial` - A PartialConfig object generated from any of the config modules.
+    /// * `partial` - A `PartialConfig` object generated from any of the config modules.
     ///
     pub fn with_partial_config(mut self, partial: PartialConfig) -> Self {
         self.partial_configs.push(partial);
         self
     }
 
-    /// Builds a Config object by incorporating the values from each PartialConfig object.
+    /// Builds a `Config` object by incorporating the values from each `PartialConfig` object.
     ///
     pub fn build(self) -> Result<Config, ConfigError> {
         let config_dir = self
@@ -146,7 +154,7 @@ impl ConfigBuilder {
                 Some((id, _)) => (format!("Node {}", id), ConfigSource::Default),
                 None => (String::from("Node"), ConfigSource::Default),
             });
-        // Iterates over the list of PartialConfig objects to find the first config with a value
+        // Iterates over the list of `PartialConfig` objects to find the first config with a value
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
             config_dir,
@@ -366,18 +374,18 @@ mod tests {
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object is accurately constructed by chaining the
-    /// PartialConfigBuilder methods. The following steps are performed:
+    /// This test verifies that a `PartialConfig` object is accurately constructed by chaining the
+    /// `PartialConfigBuilder` methods. The following steps are performed:
     ///
-    /// 1. An empty PartialConfig object is constructed.
-    /// 2. The fields of the PartialConfig object are populated by chaining the builder methods.
+    /// 1. An empty `PartialConfig` object is constructed.
+    /// 2. The fields of the `PartialConfig` object are populated by chaining the builder methods.
     ///
-    /// This test then verifies the PartialConfig object built from chaining the builder methods
+    /// This test then verifies the `PartialConfig` object built from chaining the builder methods
     /// contains the correct values by asserting each expected value.
     fn test_builder_chain() {
-        // Create an empty PartialConfig object.
+        // Create an empty `PartialConfig` object.
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
-        // Populate the PartialConfig fields by chaining the builder methods.
+        // Populate the `PartialConfig` fields by chaining the builder methods.
         partial_config = partial_config
             .with_storage(Some(EXAMPLE_STORAGE.to_string()))
             .with_tls_cert_dir(None)
@@ -396,24 +404,24 @@ mod tests {
             .with_registries(Some(vec![]))
             .with_heartbeat(None)
             .with_admin_timeout(None);
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_config_values(partial_config);
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object is accurately constructed by separately
+    /// This test verifies that a `PartialConfig` object is accurately constructed by separately
     /// applying the builder methods. The following steps are performed:
     ///
-    /// 1. An empty PartialConfig object is constructed.
-    /// 2. The fields of the PartialConfig object are populated by separately applying the builder
+    /// 1. An empty `PartialConfig` object is constructed.
+    /// 2. The fields of the `PartialConfig` object are populated by separately applying the builder
     ///    methods.
     ///
-    /// This test then verifies the PartialConfig object built from separately applying the builder
+    /// This test then verifies the `PartialConfig` object built from separately applying the builder
     /// methods contains the correct values by asserting each expected value.
     fn test_builder_separate() {
-        // Create a new PartialConfig object.
+        // Create a new `PartialConfig` object.
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
-        // Populate the PartialConfig fields by separately applying the builder methods.
+        // Populate the `PartialConfig` fields by separately applying the builder methods.
         partial_config = partial_config.with_storage(Some(EXAMPLE_STORAGE.to_string()));
         partial_config = partial_config.with_tls_ca_file(Some(EXAMPLE_CA_CERTS.to_string()));
         partial_config = partial_config.with_tls_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()));
@@ -431,7 +439,7 @@ mod tests {
         partial_config = partial_config.with_display_name(Some(EXAMPLE_DISPLAY_NAME.to_string()));
         partial_config = partial_config.with_admin_timeout(None);
         partial_config = partial_config.with_registries(Some(vec![]));
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_config_values(partial_config);
     }
 }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -85,7 +85,8 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 Some(true)
             } else {
                 None
-            });
+            })
+            .with_state_dir(self.matches.value_of("state_dir").map(String::from));
 
         #[cfg(feature = "biome")]
         {
@@ -133,6 +134,7 @@ mod tests {
     static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
     static EXAMPLE_DISPLAY_NAME: &str = "Node 1";
+    static EXAMPLE_STATE_DIR: &str = "/var/lib/splinter/";
 
     /// Asserts config values based on the example values.
     fn assert_config_values(config: PartialConfig) {
@@ -183,6 +185,7 @@ mod tests {
         assert_eq!(config.admin_timeout(), None);
         assert_eq!(config.tls_insecure(), Some(true));
         assert_eq!(config.no_tls(), Some(true));
+        assert_eq!(config.state_dir(), Some(EXAMPLE_STATE_DIR.to_string()));
     }
 
     /// Creates an ArgMatches object to be used to construct a ClapPartialConfigBuilder object.
@@ -206,7 +209,8 @@ mod tests {
             (@arg tls_client_key:  --("tls-client-key") +takes_value)
             (@arg bind: --("bind") +takes_value)
             (@arg tls_insecure: --("tls-insecure"))
-            (@arg no_tls: --("no-tls")))
+            (@arg no_tls: --("no-tls"))
+            (@arg state_dir: --("state-dir") + takes_value))
         .get_matches_from(args)
     }
 
@@ -249,6 +253,8 @@ mod tests {
             EXAMPLE_SERVER_KEY,
             "--tls-insecure",
             "--no-tls",
+            "--state-dir",
+            EXAMPLE_STATE_DIR,
         ];
         // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
         let matches = create_arg_matches(args);

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `PartialConfig` builder using values from splinterd command line arguments.
+
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 use clap::{ArgMatches, ErrorKind};
 
-/// Holds configuration values from command line arguments, represented by clap ArgMatches.
+/// `PartialConfig` builder which holds command line arguments, represented as clap `ArgMatches`.
 pub struct ClapPartialConfigBuilder<'a> {
     matches: ArgMatches<'a>,
 }
 
+// Parses a u64 value from a clap argument.
 fn parse_value(matches: &ArgMatches, arg: &str) -> Result<Option<u64>, ConfigError> {
     match value_t!(matches.value_of(arg), u64) {
         Ok(v) => Ok(Some(v)),
@@ -36,6 +39,8 @@ impl<'a> ClapPartialConfigBuilder<'a> {
     }
 }
 
+/// Implementation of the `PartialConfigBuilder` trait to create a `PartialConfig` object from the
+/// command line config options.
 impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         let mut partial_config = PartialConfig::new(ConfigSource::CommandLine);
@@ -188,7 +193,7 @@ mod tests {
         assert_eq!(config.state_dir(), Some(EXAMPLE_STATE_DIR.to_string()));
     }
 
-    /// Creates an ArgMatches object to be used to construct a ClapPartialConfigBuilder object.
+    /// Creates an `ArgMatches` object to be used to construct a `ClapPartialConfigBuilder` object.
     fn create_arg_matches(args: Vec<&str>) -> ArgMatches<'static> {
         clap_app!(configtest =>
             (version: crate_version!())
@@ -215,16 +220,16 @@ mod tests {
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object, constructed from the
-    /// ClapPartialConfigBuilder module, contains the correct values using the following steps:
+    /// This test verifies that a `PartialConfig` object, constructed from the
+    /// `ClapPartialConfigBuilder` module, contains the correct values using the following steps:
     ///
-    /// 1. An example ArgMatches object is created using `create_arg_matches`.
-    /// 2. A ClapPartialConfigBuilder object is constructed by passing in the example ArgMatches
+    /// 1. An example `ArgMatches` object is created using `create_arg_matches`.
+    /// 2. A `ClapPartialConfigBuilder` object is constructed by passing in the example `ArgMatches`
     ///    created in the previous step.
-    /// 3. The ClapPartialConfigBuilder object is transformed to a PartialConfig object using the
+    /// 3. The `ClapPartialConfigBuilder` object is transformed to a `PartialConfig` object using
     ///    `build`.
     ///
-    /// This test then verifies the PartialConfig object built from the ClapPartialConfigBuilder
+    /// This test then verifies the `PartialConfig` object built from the `ClapPartialConfigBuilder`
     /// object by asserting each expected value.
     fn test_command_line_config() {
         let args = vec![
@@ -256,17 +261,17 @@ mod tests {
             "--state-dir",
             EXAMPLE_STATE_DIR,
         ];
-        // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
+        // Create an example ArgMatches object to initialize the `ClapPartialConfigBuilder`.
         let matches = create_arg_matches(args);
-        // Create a new CommandLine object from the arg matches.
+        // Create a new `ClapPartialConfigBuilder` object from the arg matches.
         let command_config = ClapPartialConfigBuilder::new(matches);
-        // Build a PartialConfig from the ClapPartialConfigBuilder object created.
+        // Build a `PartialConfig` from the `ClapPartialConfigBuilder` object created.
         let built_config = command_config
             .build()
             .expect("Unable to build ClapPartialConfigBuilder");
-        // Assert the source is correctly identified for this PartialConfig object.
+        // Assert the source is correctly identified for this `PartialConfig` object.
         assert_eq!(built_config.source(), ConfigSource::CommandLine);
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_config_values(built_config);
     }
 }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `PartialConfig` builder using default values.
+
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 
 const STORAGE: &str = "yaml";
@@ -37,7 +39,6 @@ const REGISTRY_FORCED_REFRESH: u64 = 10; // 10 seconds
 const HEARTBEAT: u64 = 30; // 30 seconds
 const ADMIN_TIMEOUT: u64 = 30; // 30 seconds
 
-/// Holds the default configuration values.
 pub struct DefaultPartialConfigBuilder;
 
 impl DefaultPartialConfigBuilder {
@@ -46,6 +47,7 @@ impl DefaultPartialConfigBuilder {
     }
 }
 
+/// Constructs a `PartialConfig` object from the `DefaultPartialConfigBuilder`.
 impl PartialConfigBuilder for DefaultPartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
@@ -137,31 +139,31 @@ mod tests {
         assert_eq!(config.no_tls(), Some(false));
         #[cfg(feature = "biome")]
         assert_eq!(config.enable_biome(), Some(false));
-        // Assert the source is correctly identified for this PartialConfig object.
+        // Assert the source is correctly identified for this `PartialConfig` object.
         assert_eq!(config.source(), ConfigSource::Default);
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object is accurately constructed by using the
-    /// `build` method implemented by the DefaultPartialConfigBuilder module. The following steps
+    /// This test verifies that a `PartialConfig` object is accurately constructed by using the
+    /// `build` method implemented by the `DefaultPartialConfigBuilder` module. The following steps
     /// are performed:
     ///
-    /// 1. An empty DefaultPartialConfigBuilder object is constructed, which implements the
-    ///    PartialConfigBuilder trait.
-    /// 2. A PartialConfig object is created by calling the `build` method of the
-    ///    DefaultPartialConfigBuilder object.
+    /// 1. An empty `DefaultPartialConfigBuilder` object is constructed, which implements the
+    ///    `PartialConfigBuilder` trait.
+    /// 2. A `PartialConfig` object is created by calling the `build` method of the
+    ///    `DefaultPartialConfigBuilder` object.
     ///
-    /// This test then verifies the PartialConfig object built from the DefaulConfig object has
-    /// the correct values by asserting each expected value.
+    /// This test then verifies the `PartialConfig` object built from the
+    /// `DefaultPartialConfigBuilder` has the correct values by asserting each expected value.
     fn test_default_builder() {
         // Create a new DefaultPartialConfigBuilder object, which implements the
         // PartialConfigBuilder trait.
         let default_config = DefaultPartialConfigBuilder::new();
-        // Create a PartialConfig object using the `build` method.
+        // Create a `PartialConfig` object using the `build` method.
         let partial_config = default_config
             .build()
             .expect("Unable to build DefaultPartialConfigBuilder");
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_default_values(partial_config);
     }
 }

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `PartialConfig` builder using values from environment variables.
+
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -23,7 +25,6 @@ const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
 const SPLINTER_HOME_ENV: &str = "SPLINTER_HOME";
 
-/// Holds configuration values defined as environment variables.
 pub struct EnvPartialConfigBuilder;
 
 impl EnvPartialConfigBuilder {
@@ -32,6 +33,8 @@ impl EnvPartialConfigBuilder {
     }
 }
 
+/// Implementatiion of the `PartialConfigBuilder` trait to create a `PartialConfig` object from the
+/// environment variable config options.
 impl PartialConfigBuilder for EnvPartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         let config_dir_env = match (
@@ -88,22 +91,22 @@ mod tests {
     use super::*;
 
     #[test]
-    /// This test verifies that a PartialConfig object, constructed from the
-    /// EnvPartialConfigBuilder module, contains the correct values using the following steps:
+    /// This test verifies that a `PartialConfig` object, constructed from the
+    /// `EnvPartialConfigBuilder` module, contains the correct values using the following steps:
     ///
     /// 1. Remove any existing environment variables which may be set.
-    /// 2. A new EnvPartialConfigBuilder object is created.
-    /// 3. The EnvPartialConfigBuilder object is transformed to a PartialConfig object using the
+    /// 2. A new `EnvPartialConfigBuilder` object is created.
+    /// 3. The `EnvPartialConfigBuilder` object is transformed to a `PartialConfig` object using
     ///    `build`.
     /// 4. Set the environment variables for both the state and cert directories.
-    /// 5. A new EnvPartialConfigBuilder object is created.
-    /// 6. The EnvPartialConfigBuilder object is transformed to a PartialConfig object using the
+    /// 5. A new `EnvPartialConfigBuilder` object is created.
+    /// 6. The `EnvPartialConfigBuilder` object is transformed to a `PartialConfig` object using
     ///    `build`.
     ///
-    /// This test verifies each PartialConfig object built from the EnvPartialConfigBuilder module
+    /// This test verifies each `PartialConfig` object built from the `EnvPartialConfigBuilder` module
     /// by asserting each expected value. As the environment variables were initially unset, the
-    /// first PartialConfig should not contain any values. After the environment variables were
-    /// set, the new PartialConfig configuration values should reflect those values.
+    /// first `PartialConfig` should not contain any values. After the environment variables were
+    /// set, the new `PartialConfig` configuration values should reflect those values.
     fn test_environment_var_set_config() {
         // Remove any existing environment variables.
         env::remove_var(STATE_DIR_ENV);
@@ -111,12 +114,12 @@ mod tests {
 
         // Create a new EnvPartialConfigBuilder object.
         let env_var_config = EnvPartialConfigBuilder::new();
-        // Build a PartialConfig from the EnvPartialConfigBuilder object created.
+        // Build a `PartialConfig` from the `EnvPartialConfigBuilder` object created.
         let unset_config = env_var_config
             .build()
             .expect("Unable to build EnvPartialConfigBuilder");
         assert_eq!(unset_config.source(), ConfigSource::Environment);
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_eq!(unset_config.state_dir(), None);
         assert_eq!(unset_config.tls_cert_dir(), None);
 
@@ -125,12 +128,12 @@ mod tests {
         env::set_var(CERT_DIR_ENV, "cert/test/config");
         // Create a new EnvPartialConfigBuilder object.
         let env_var_config = EnvPartialConfigBuilder::new();
-        // Build a PartialConfig from the EnvPartialConfigBuilder object created.
+        // Build a `PartialConfig` from the `EnvPartialConfigBuilder` object created.
         let set_config = env_var_config
             .build()
             .expect("Unable to build EnvPartialConfigBuilder");
         assert_eq!(set_config.source(), ConfigSource::Environment);
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_eq!(
             set_config.state_dir(),
             Some(String::from("state/test/config"))

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -19,6 +19,7 @@ use std::io;
 use toml::de::Error as TomlError;
 
 #[derive(Debug)]
+/// General error type used during `Config` contruction.
 pub enum ConfigError {
     #[cfg(feature = "config-toml")]
     ReadError {

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -14,6 +14,7 @@
 
 use std::error::Error;
 use std::fmt;
+#[cfg(feature = "config-env-var")]
 use std::io;
 
 use toml::de::Error as TomlError;
@@ -31,6 +32,7 @@ pub enum ConfigError {
     MissingValue(String),
     #[cfg(feature = "config-toml")]
     InvalidVersion(String),
+    #[cfg(feature = "config-env-var")]
     StdError(io::Error),
 }
 
@@ -56,6 +58,7 @@ impl Error for ConfigError {
             ConfigError::MissingValue(_) => None,
             #[cfg(feature = "config-toml")]
             ConfigError::InvalidVersion(_) => None,
+            #[cfg(feature = "config-env-var")]
             ConfigError::StdError(source) => Some(source),
         }
     }
@@ -73,6 +76,7 @@ impl fmt::Display for ConfigError {
             ConfigError::MissingValue(msg) => write!(f, "Configuration value must be set: {}", msg),
             #[cfg(feature = "config-toml")]
             ConfigError::InvalidVersion(msg) => write!(f, "{}", msg),
+            #[cfg(feature = "config-env-var")]
             ConfigError::StdError(source) => write!(f, "{}", source),
         }
     }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Configuration to provide the necessary values to start up the Splinter daemon.
+//!
+//! These values may be sourced from a toml file, command line arguments, environment variables
+//! or pre-defined defaults. This module allows for configuration values from each of these
+//! sources to be combined into a final `Config` object.
+
 mod builder;
 #[cfg(feature = "config-command-line")]
 mod clap;
@@ -38,8 +44,8 @@ pub use builder::{ConfigBuilder, PartialConfigBuilder};
 pub use error::ConfigError;
 pub use partial::{ConfigSource, PartialConfig};
 
-/// Config is the final representation of configuration values. This final config object assembles
-/// values from PartialConfig objects generated from various sources.
+/// `Config` is the final representation of configuration values. This final config object assembles
+/// values from `PartialConfig` builder objects generated from various sources.
 #[derive(Debug)]
 pub struct Config {
     config_dir: (String, ConfigSource),
@@ -492,7 +498,7 @@ mod tests {
     static DEFAULT_SERVER_KEY: &str = "private/server.key";
     static DEFAULT_CA_CERT: &str = "ca.pem";
 
-    /// Converts a list of tuples to a toml Table Value used to write a toml file.
+    /// Converts a list of tuples to a toml `Table` `Value` used to write a toml file.
     pub fn get_toml_value() -> Value {
         let values = vec![
             ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
@@ -523,7 +529,7 @@ mod tests {
         Value::Table(config_values)
     }
 
-    /// Creates an ArgMatches object to be used to construct a ClapPartialConfigBuilder object.
+    /// Creates an `ArgMatches` object to be used to construct a `ClapPartialConfigBuilder` object.
     fn create_arg_matches(args: Vec<&str>) -> ArgMatches<'static> {
         clap_app!(configtest =>
         (version: crate_version!())
@@ -550,81 +556,82 @@ mod tests {
     }
 
     #[test]
-    /// This test verifies that a finalized Config object may be constructed from just
-    /// a DefaultPartialConfigBuilder object, in the following steps:
+    /// This test verifies that a finalized `Config` object may be constructed from just
+    /// a `DefaultPartialConfigBuilder` object, in the following steps:
     ///
-    /// 1. An empty ConfigBuilder object is created.
-    /// 2. A PartialConfig built from a DefaultPartialConfigBuilder is added to the ConfigBuilder.
+    /// 1. An empty `ConfigBuilder` object is created.
+    /// 2. A `PartialConfig` built from a `DefaultPartialConfigBuilder` is added to the
+    ///    `ConfigBuilder`.
     ///
-    /// This test then verifies the final Config object built from the ConfigBuilder object has
-    /// resulted in a default Config object, as the node_id is not required.
+    /// This test then verifies the final `Config` object built from the `ConfigBuilder` object has
+    /// resulted in a default `Config` object, as the node_id is not required.
     fn test_default_final_config() {
-        // Create a new ConfigBuilder object.
+        // Create a new `ConfigBuilder` object.
         let mut builder = ConfigBuilder::new();
-        // Add a PartialConfig built from a DefaultPartialConfigBuilder object to the
-        // ConfigBuilder.
+        // Add a `PartialConfig` built from a `DefaultPartialConfigBuilder` object to the
+        // `ConfigBuilder`.
         builder = builder.with_partial_config(
             DefaultPartialConfigBuilder::new()
                 .build()
                 .expect("Unable to build DefaultPartialConfigBuilder"),
         );
-        // Build the final Config object.
+        // Build the final `Config` object.
         let final_config = builder.build();
-        // Asserts the final Config was successfully built.
+        // Asserts the final `Config` was successfully built.
         assert!(final_config.is_ok());
     }
 
     #[test]
-    /// This test verifies that a finalized Config object constructed from just
-    /// a TomlPartialConfigBuilder object will be unsuccessful because of the missing values, in
+    /// This test verifies that a finalized `Config` object constructed from just
+    /// a `TomlPartialConfigBuilder` object will be unsuccessful because of the missing values, in
     /// the following steps:
     ///
-    /// 1. An empty ConfigBuilder object is created.
+    /// 1. An empty `ConfigBuilder` object is created.
     /// 2. The example config toml, TEST_TOML, is created, read and converted to a string.
-    /// 3. A TomlPartialConfigBuilder object is constructed by passing in the toml string created
+    /// 3. A `TomlPartialConfigBuilder` object is constructed by passing in the toml string created
     ///    in the previous step.
-    /// 4. The TomlPartialConfigBuilder object is added to the ConfigBuilder.
+    /// 4. The `TomlPartialConfigBuilder` object is added to the `ConfigBuilder`.
     ///
-    /// This test then verifies the final Config object built from the ConfigBuilder object has
+    /// This test then verifies the final `Config` object built from the `ConfigBuilder` object has
     /// resulted in an error because of the missing values.
     fn test_final_config_toml_err() {
-        // Create a new ConfigBuilder object.
+        // Create a new `ConfigBuilder` object.
         let mut builder = ConfigBuilder::new();
         // Create an example toml string.
         let toml_string = to_string(&get_toml_value()).expect("Could not encode TOML value");
-        // Create a TomlPartialConfigBuilder object from the toml string.
+        // Create a `TomlPartialConfigBuilder` object from the toml string.
         let toml_builder = TomlPartialConfigBuilder::new(toml_string, TEST_TOML.to_string())
             .expect(&format!(
                 "Unable to create TomlPartialConfigBuilder from: {}",
                 TEST_TOML
             ));
-        // Add a PartialConfig built from a DefaultPartialConfigBuilder object to the
-        // ConfigBuilder.
+        // Add a `PartialConfig` built from a `DefaultPartialConfigBuilder` object to the
+        // `ConfigBuilder`.
         builder = builder.with_partial_config(
             toml_builder
                 .build()
                 .expect("Unable to build TomlPartialConfigBuilder"),
         );
-        // Build the final Config object.
+        // Build the final `Config` object.
         let final_config = builder.build();
-        // Asserts the final Config was not successfully built.
+        // Asserts the final `Config` was not successfully built.
         assert!(final_config.is_err());
     }
 
     #[test]
-    /// This test verifies that a Config object, constructed from just a ClapPartialConfigBuilder
+    /// This test verifies that a `Config` object, constructed from just a `ClapPartialConfigBuilder`
     /// object, is unsuccessful because of the missing values, in the following steps:
     ///
-    /// 1. An empty ConfigBuilder object is created.
-    /// 2. An example ArgMatches object is created using `create_arg_matches`.
-    /// 3. A ClapPartialConfigBuilder object is constructed by passing in the example ArgMatches
+    /// 1. An empty `ConfigBuilder` object is created.
+    /// 2. An example `ArgMatches` object is created using `create_arg_matches`.
+    /// 3. A `ClapPartialConfigBuilder` object is constructed by passing in the example `ArgMatches`
     ///    created in the previous step.
-    /// 4. A PartialConfig built from the ClapPartialConfigBuilder is added to the ConfigBuilder.
+    /// 4. A `PartialConfig` built from the `ClapPartialConfigBuilder` is added to the `ConfigBuilder`.
     ///
-    /// This test then verifies the Config object built from the ClapPartialConfigBuilder has
+    /// This test then verifies the `Config` object built from the `ClapPartialConfigBuilder` has
     /// resulted in an error because of the missing values.
     fn test_clap_final_config_err() {
-        // Create a new ConfigBuilder object.
+        // Create a new `ConfigBuilder` object.
         let mut builder = ConfigBuilder::new();
         let args = vec![
             "configtest",
@@ -654,47 +661,47 @@ mod tests {
             "--no-tls",
             "--enable-biome",
         ];
-        // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
+        // Create an example `ArgMatches` object to initialize the `ClapPartialConfigBuilder`.
         let matches = create_arg_matches(args);
-        // Create a new CommandLiine object from the arg matches.
+        // Create a new `CommandLine` object from the arg matches.
         let command_config = ClapPartialConfigBuilder::new(matches);
-        // Add a PartialConfig built from a DefaultPartialConfigBuilder object to the
-        // ConfigBuilder.
+        // Add a `PartialConfig` built from a `DefaultPartialConfigBuilder` object to the
+        // `ConfigBuilder`.
         builder = builder.with_partial_config(
             command_config
                 .build()
                 .expect("Unable to build ClapPartialConfigBuilder"),
         );
         let final_config = builder.build();
-        // Assert the Config object was not successfully built.
+        // Assert the `Config` object was not successfully built.
         assert!(final_config.is_err());
     }
 
     #[test]
-    /// This test verifies that a Config object, constructed from multiple config modules, contains
-    /// the correct values, giving ClapPartialConfigBuilder values ultimate precedence, using the
+    /// This test verifies that a `Config` object, constructed from multiple config modules, contains
+    /// the correct values, giving `ClapPartialConfigBuilder` values ultimate precedence, using the
     /// following steps:
     ///
-    /// 1. An empty ConfigBuilder object is created.
-    /// 2. A PartialConfig is created from the EnvPartialConfigBuilder module.
-    /// 3. A PartialConfig is created from the DefaultPartialConfigBuilder module.
-    /// 4. A PartialConfig is created from the TomlPartialConfigBuilder module, using the TEST_TOML
-    ///    string.
-    /// 5. An example ArgMatches object is created using `create_arg_matches`.
-    /// 6. A ClapPartialConfigBuilder object is constructed by passing in the example ArgMatches
+    /// 1. An empty `ConfigBuilder` object is created.
+    /// 2. A `PartialConfig` is created from the `EnvPartialConfigBuilder` module.
+    /// 3. A `PartialConfig` is created from the `DefaultPartialConfigBuilder` module.
+    /// 4. A `PartialConfig` is created from the `TomlPartialConfigBuilder` module, using the
+    ///    TEST_TOML string.
+    /// 5. An example `ArgMatches` object is created using `create_arg_matches`.
+    /// 6. A `ClapPartialConfigBuilder` object is constructed by passing in the example `ArgMatches`
     ///    created in the previous step.
-    /// 7. All PartialConfig objects are added to the ConfigBuilder and the final Config object is
-    ///    built.
+    /// 7. All `PartialConfig` objects are added to the `ConfigBuilder` and the final `Config`
+    ///    object is built.
     ///
-    /// This test then verifies the Config object built from the ConfigBuilder object by
+    /// This test then verifies the `Config` object built from the `ConfigBuilder` object by
     /// asserting each expected value.
     fn test_final_config_precedence() {
-        // Set the environment variables to populate the EnvPartialConfigBuilder object.
+        // Set the environment variables to populate the `EnvPartialConfigBuilder` object.
         env::set_var("SPLINTER_STATE_DIR", "test/state/");
         env::set_var("SPLINTER_CERT_DIR", "test/certs/");
-        // Create a new ConfigBuilder object.
+        // Create a new `ConfigBuilder` object.
         let builder = ConfigBuilder::new();
-        // Arguments to be used to create a ClapPartialConfigBuilder object.
+        // Arguments to be used to create a `ClapPartialConfigBuilder` object.
         let args = vec![
             "configtest",
             "--node-id",
@@ -703,16 +710,16 @@ mod tests {
             "Node 1",
             "--no-tls",
         ];
-        // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
+        // Create an example `ArgMatches` object to initialize the `ClapPartialConfigBuilder`.
         let matches = create_arg_matches(args);
-        // Create a new CommandLine object from the arg matches.
+        // Create a new `CommandLine` object from the arg matches.
         let command_config = ClapPartialConfigBuilder::new(matches)
             .build()
             .expect("Unable to build ClapPartialConfigBuilder");
 
         // Create an example toml string.
         let toml_string = to_string(&get_toml_value()).expect("Could not encode TOML value");
-        // Create a TomlPartialConfigBuilder object from the toml string.
+        // Create a `TomlPartialConfigBuilder` object from the toml string.
         let toml_config = TomlPartialConfigBuilder::new(toml_string, TEST_TOML.to_string())
             .expect(&format!(
                 "Unable to create TomlPartialConfigBuilder from: {}",
@@ -721,17 +728,17 @@ mod tests {
             .build()
             .expect("Unable to build TomlPartialConfigBuilder");
 
-        // Create a PartialConfig from the EnvPartialConfigBuilder module.
+        // Create a `PartialConfig` from the `EnvPartialConfigBuilder` module.
         let env_config = EnvPartialConfigBuilder::new()
             .build()
             .expect("Unable to build EnvPartialConfigBuilder");
 
-        // Create a PartialConfig from the DefaultPartialConfigBuilder module.
+        // Create a `PartialConfig` from the `DefaultPartialConfigBuilder` module.
         let default_config = DefaultPartialConfigBuilder::new()
             .build()
             .expect("Unable to build DefaultPartialConfigBuilder");
 
-        // Add the PartialConfigs to the final ConfigBuilder in the order of precedence.
+        // Add the `PartialConfigs` to the final `ConfigBuilder` in the order of precedence.
         let final_config = builder
             .with_partial_config(command_config)
             .with_partial_config(toml_config)
@@ -741,9 +748,9 @@ mod tests {
             .expect("Unable to build final Config.");
 
         // Assert the final configuration values.
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `storage`, but the TomlPartialConfigBuilder value should have precedence (source should
-        // be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `storage`, but the `TomlPartialConfigBuilder` value should have precedence (source should
+        // be `Toml`).
         assert_eq!(
             (final_config.storage(), final_config.storage_source()),
             (
@@ -754,17 +761,17 @@ mod tests {
             )
         );
 
-        // Both the DefaultPartialConfigBuilder and  ClapPartialConfigBuilder had values for
-        // `no-tls`, but the  ClapPartialConfigBuilder value should have precedence (source
-        // should be ).
+        // Both the `DefaultPartialConfigBuilder` and `ClapPartialConfigBuilder` had values for
+        // `no-tls`, but the `ClapPartialConfigBuilder` value should have precedence (source
+        // should be `CommandLine`).
         assert_eq!(
             (final_config.no_tls(), final_config.no_tls_source()),
             (true, &ConfigSource::CommandLine)
         );
 
-        // The DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for
-        // `tls_cert_dir`, but the EnvPartialConfigBuilder value should have precedence (source
-        // should be Environment).
+        // The `DefaultPartialConfigBuilder` and `EnvPartialConfigBuilder` had values for
+        // `tls_cert_dir`, but the `EnvPartialConfigBuilder` value should have precedence (source
+        // should be `Environment`).
         assert_eq!(
             (
                 final_config.tls_cert_dir(),
@@ -772,9 +779,9 @@ mod tests {
             ),
             ("test/certs/", &ConfigSource::Environment)
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `tls_ca_file`, but the TomlPartialConfigBuilder value should have precedence (source
-        // should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `tls_ca_file`, but the `TomlPartialConfigBuilder `value should have precedence (source
+        // should be `Toml`).
         assert_eq!(
             (
                 final_config.tls_ca_file(),
@@ -787,9 +794,9 @@ mod tests {
                 },
             )
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `tls_client_cert`, but the TomlPartialConfigBuilder value should have precedence (source
-        // should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `tls_client_cert`, but the `TomlPartialConfigBuilder` value should have precedence
+        // (source should be `Toml`).
         assert_eq!(
             (
                 final_config.tls_client_cert(),
@@ -802,9 +809,9 @@ mod tests {
                 }
             )
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `tls_client_key`, but the TomlPartialConfigBuilder value should have precedence (source
-        // should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `tls_client_key`, but the `TomlPartialConfigBuilder` value should have precedence (source
+        // should be `Toml`).
         assert_eq!(
             (
                 final_config.tls_client_key(),
@@ -817,9 +824,9 @@ mod tests {
                 },
             )
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `tls_server_cert`, but the TomlPartialConfigBuilder value should have precedence (source
-        // should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `tls_server_cert`, but the `TomlPartialConfigBuilder` value should have precedence
+        // (source should be `Toml`).
         assert_eq!(
             (
                 final_config.tls_server_cert(),
@@ -832,9 +839,9 @@ mod tests {
                 }
             )
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `tls_server_key`, but the TomlPartialConfigBuilder value should have precedence (source
-        // should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `tls_server_key`, but the `TomlPartialConfigBuilder` value should have precedence (source
+        // should be `Toml`).
         assert_eq!(
             (
                 final_config.tls_server_key(),
@@ -847,9 +854,9 @@ mod tests {
                 }
             )
         );
-        // Both the DefaultPartialConfigBuilder and TomlPartialConfigBuilder had values for
-        // `service_endpoint`, but the TomlPartialConfigBuilder value should have precedence
-        // (source should be Toml).
+        // Both the `DefaultPartialConfigBuilder` and `TomlPartialConfigBuilder` had values for
+        // `service_endpoint`, but the `TomlPartialConfigBuilder` value should have precedence
+        // (source should be `Toml`).
         assert_eq!(
             (
                 final_config.service_endpoint(),
@@ -862,8 +869,8 @@ mod tests {
                 }
             )
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `network_endpoints`
-        // (source should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for `network_endpoints`
+        // (source should be `Default`).
         assert_eq!(
             (
                 final_config.network_endpoints(),
@@ -874,7 +881,7 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // `advertised_endpoints` defaults to `network_endpoints` (source should be Default).
+        // `advertised_endpoints` defaults to `network_endpoints` (source should be `Default`).
         assert_eq!(
             (
                 final_config.advertised_endpoints(),
@@ -885,22 +892,22 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `peers` (source
-        // should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for `peers` (source
+        // should be `Default`).
         assert_eq!(
             (final_config.peers(), final_config.peers_source()),
             (&[] as &[String], &ConfigSource::Default,)
         );
-        // Both the TomlPartialConfigBuilder and ClapPartialConfigBuilder had values for `node_id`,
-        // but the ClapPartialConfigBuilder value should have precedence (source should be
-        // CommandLine).
+        // Both the `TomlPartialConfigBuilder` and `ClapPartialConfigBuilder` had values for `node_id`,
+        // but the `ClapPartialConfigBuilder` value should have precedence (source should be
+        // `CommandLine`).
         assert_eq!(
             (final_config.node_id(), final_config.node_id_source()),
             (Some("123"), Some(&ConfigSource::CommandLine))
         );
-        // The TomlPartialConfigBuilder and ClapPartialConfigBuilder had values for `display_name`,
-        // but the ClapPartialConfigBuilder value should have precedence (source should be
-        // CommandLine).
+        // The `TomlPartialConfigBuilder` and `ClapPartialConfigBuilder` had values for `display_name`,
+        // but the `ClapPartialConfigBuilder` value should have precedence (source should be
+        // `CommandLine`).
         assert_eq!(
             (
                 final_config.display_name(),
@@ -908,21 +915,21 @@ mod tests {
             ),
             ("Node 1", &ConfigSource::CommandLine)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `bind` (source
-        // should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for `bind` (source
+        // should be `Default`).
         assert_eq!(
             (final_config.bind(), final_config.bind_source()),
             ("127.0.0.1:8080", &ConfigSource::Default)
         );
         #[cfg(feature = "database")]
-        // The DefaultPartialConfigBuilder is the only config with a value for `database` (source
-        // should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for `database` (source
+        // should be `Default`).
         assert_eq!(
             (final_config.database(), final_config.database_source()),
             ("127.0.0.1:5432", &ConfigSource::Default)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for
-        // `registry_auto_refresh` (source should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for
+        // `registry_auto_refresh` (source should be `Default`).
         assert_eq!(
             (
                 final_config.registry_auto_refresh(),
@@ -930,8 +937,8 @@ mod tests {
             ),
             (600, &ConfigSource::Default)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for
-        // `registry_forced_refresh` (source should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for
+        // `registry_forced_refresh` (source should be `Default`).
         assert_eq!(
             (
                 final_config.registry_forced_refresh(),
@@ -939,14 +946,14 @@ mod tests {
             ),
             (10, &ConfigSource::Default)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for `heartbeat`
-        // (source should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for `heartbeat`
+        // (source should be `Default`).
         assert_eq!(
             (final_config.heartbeat(), final_config.heartbeat_source()),
             (30, &ConfigSource::Default)
         );
-        // The DefaultPartialConfigBuilder is the only config with a value for
-        // `admin_timeout` (source should be Default).
+        // The `DefaultPartialConfigBuilder` is the only config with a value for
+        // `admin_timeout` (source should be `Default`).
         assert_eq!(
             (
                 final_config.admin_timeout(),
@@ -954,9 +961,9 @@ mod tests {
             ),
             (Duration::from_secs(30), &ConfigSource::Default)
         );
-        // Both the DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for
-        // `state_dir`, but the EnvPartialConfigBuilder value should have precedence (source should
-        // be EnvVarConfig).
+        // Both the `DefaultPartialConfigBuilder` and `EnvPartialConfigBuilder` had values for
+        // `state_dir`, but the `EnvPartialConfigBuilder` value should have precedence (source
+        // should be `Environment`).
         assert_eq!(
             (final_config.state_dir(), final_config.state_dir_source()),
             ("test/state/", &ConfigSource::Environment)
@@ -964,24 +971,24 @@ mod tests {
     }
 
     #[test]
-    /// This test verifies that a Config object, created from a DefaultPartialConfigBuilder and
-    /// ClapPartialConfigBuilder object holds the correct file paths, using the following steps:
+    /// This test verifies that a `Config` object, created from a `DefaultPartialConfigBuilder` and
+    /// `ClapPartialConfigBuilder` object holds the correct file paths, using the following steps:
     ///
-    /// 1. An empty ConfigBuilder object is created.
-    /// 2. A PartialConfig is created from the DefaultPartialConfigBuilder module.
-    /// 3. An example ArgMatches object is created using `create_arg_matches`.
-    /// 4. A ClapPartialConfigBuilder object is constructed by passing in the example ArgMatches
+    /// 1. An empty `ConfigBuilder` object is created.
+    /// 2. A `PartialConfig` is created from the `DefaultPartialConfigBuilder` module.
+    /// 3. An example `ArgMatches` object is created using `create_arg_matches`.
+    /// 4. A `ClapPartialConfigBuilder` object is constructed by passing in the example `ArgMatches`
     ///    created in the previous step.
-    /// 5. All PartialConfig objects are added to the ConfigBuilder and the final Config object is
-    ///    built.
+    /// 5. All `PartialConfig` objects are added to the `ConfigBuilder` and the final `Config`
+    ///    object is built.
     ///
-    /// This test then verifies the Config object built holds the correct file paths. The cert_dir
-    /// value passed into the ClapPartialConfigBuilder object should be appended to the default
+    /// This test then verifies the `Config` object built holds the correct file paths. The `cert_dir`
+    /// value passed into the `ClapPartialConfigBuilder` object should be appended to the default
     /// file names for the certificate files.
     fn test_final_config_file_paths() {
-        // Create a new ConfigBuilder object.
+        // Create a new `ConfigBuilder` object.
         let builder = ConfigBuilder::new();
-        // Arguments to be used to create a ClapPartialConfigBuilder object, passing in a cert_dir.
+        // Arguments to be used to create a C`lapPartialConfigBuilder` object, passing in a `cert_dir`.
         let args = vec![
             "configtest",
             "--node-id",
@@ -991,28 +998,28 @@ mod tests {
             "--tls-cert-dir",
             "/my_files/",
         ];
-        // Create an example ArgMatches object to initialize the ClapPartialConfigBuilder.
+        // Create an example `ArgMatches` object to initialize the `ClapPartialConfigBuilder`.
         let matches = create_arg_matches(args);
-        // Create a new CommandLine object from the arg matches.
+        // Create a new `CommandLine` object from the arg matches.
         let command_config = ClapPartialConfigBuilder::new(matches)
             .build()
             .expect("Unable to build ClapPartialConfigBuilder");
 
-        // Create a PartialConfig from the DefaultPartialConfigBuilder module.
+        // Create a `PartialConfig` from the `DefaultPartialConfigBuilder` module.
         let default_config = DefaultPartialConfigBuilder::new()
             .build()
             .expect("Unable to build DefaultPartialConfigBuilder");
 
-        // Add the PartialConfigs to the final ConfigBuilder in the order of precedence.
+        // Add the `PartialConfigs` to the final `ConfigBuilder` in the order of precedence.
         let final_config = builder
             .with_partial_config(command_config)
             .with_partial_config(default_config)
             .build()
             .expect("Unable to build final Config.");
 
-        // The DefaultPartialConfigBuilder and EnvPartialConfigBuilder had values for `cert_dir`,
-        // but the EnvPartialConfigBuilder value should have precedence (source should be
-        // Environment).
+        // The `DefaultPartialConfigBuilder` and `EnvPartialConfigBuilder` had values for `cert_dir`,
+        // but the `EnvPartialConfigBuilder` value should have precedence (source should be
+        // `Environment`).
         assert_eq!(
             (
                 final_config.tls_cert_dir(),
@@ -1020,8 +1027,8 @@ mod tests {
             ),
             ("/my_files/", &ConfigSource::CommandLine)
         );
-        // The DefaultPartialConfigBuilder had a value for the ca_file, and since the cert_dir
-        // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
+        // The `DefaultPartialConfigBuilder` had a value for the `ca_file`, and since the `cert_dir`
+        // value was provided to the `ClapPartialConfigBuilder`, the `cert_dir` value should be
         // appended to the default file name.
         assert_eq!(
             (
@@ -1033,8 +1040,8 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder had a value for the client_cert, and since the cert_dir
-        // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
+        // The `DefaultPartialConfigBuilder had a value for the client_cert, and since the `cert_dir`
+        // value was provided to the `ClapPartialConfigBuilder`, the `cert_dir` value should be
         // appended to the default file name.
         assert_eq!(
             (
@@ -1046,8 +1053,8 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder had a value for the client_key, and since the cert_dir
-        // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
+        // The `DefaultPartialConfigBuilder` had a value for the `client_key`, and since the `cert_dir`
+        // value was provided to the `ClapPartialConfigBuilder`, the `cert_dir` value should be
         // appended to the default file name.
         assert_eq!(
             (
@@ -1059,9 +1066,9 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder had a value for the server_cert, and since the cert_dir
-        // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
-        // appended to the default file name.
+        // The `DefaultPartialConfigBuilder` had a value for the `server_cert`, and since the
+        // `cert_dir` value was provided to the `ClapPartialConfigBuilder`, the `cert_dir` value
+        // should be appended to the default file name.
         assert_eq!(
             (
                 final_config.tls_server_cert(),
@@ -1072,9 +1079,9 @@ mod tests {
                 &ConfigSource::Default,
             )
         );
-        // The DefaultPartialConfigBuilder had a value for the server_key, and since the cert_dir
-        // value was provided to the ClapPartialConfigBuilder, the cert_dir value should be
-        // appended to the default file name.
+        // The `DefaultPartialConfigBuilder` had a value for the `server_key`, and since the
+        // `cert_dir` value was provided to the `ClapPartialConfigBuilder`, the `cert_dir` value
+        // should be appended to the default file name.
         assert_eq!(
             (
                 final_config.tls_server_key(),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -381,15 +381,11 @@ impl Config {
             self.peers(),
             self.peers_source()
         );
-        if let Some(id) = self.node_id() {
-            debug!(
-                "Config: node_id: {:?} (source: {:?})",
-                id,
-                self.node_id_source()
-            );
+        if let (Some(id), Some(source)) = (self.node_id(), self.node_id_source()) {
+            debug!("Config: node_id: {} (source: {:?})", id, source,);
         }
         if let (Some(name), Some(source)) = (self.display_name(), self.display_name_source()) {
-            debug!("Config: display_name: {:?} (source: {:?})", name, source,);
+            debug!("Config: display_name: {} (source: {:?})", name, source,);
         }
         debug!(
             "Config: bind: {} (source: {:?})",
@@ -454,12 +450,8 @@ impl Config {
 
     #[cfg(feature = "rest-api-cors")]
     fn log_whitelist(&self) {
-        if let Some(list) = self.whitelist() {
-            debug!(
-                "Config: whitelist: {:?} (source: {:?})",
-                list,
-                self.whitelist_source()
-            );
+        if let (Some(list), Some(source)) = (self.whitelist(), self.whitelist_source()) {
+            debug!("Config: whitelist: {:?} (source: {:?})", list, source,);
         }
     }
 }
@@ -919,7 +911,7 @@ mod tests {
                 final_config.display_name(),
                 final_config.display_name_source()
             ),
-            ("Node 1", &ConfigSource::CommandLine)
+            (Some("Node 1"), Some(&ConfigSource::CommandLine))
         );
         // The `DefaultPartialConfigBuilder` is the only config with a value for `bind` (source
         // should be `Default`).

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -61,7 +61,7 @@ pub struct Config {
     advertised_endpoints: (Vec<String>, ConfigSource),
     peers: (Vec<String>, ConfigSource),
     node_id: Option<(String, ConfigSource)>,
-    display_name: (String, ConfigSource),
+    display_name: Option<(String, ConfigSource)>,
     bind: (String, ConfigSource),
     #[cfg(feature = "database")]
     database: (String, ConfigSource),
@@ -136,8 +136,12 @@ impl Config {
         }
     }
 
-    pub fn display_name(&self) -> &str {
-        &self.display_name.0
+    pub fn display_name(&self) -> Option<&str> {
+        if let Some((name, _)) = &self.display_name {
+            Some(name)
+        } else {
+            None
+        }
     }
 
     pub fn bind(&self) -> &str {
@@ -251,8 +255,12 @@ impl Config {
         }
     }
 
-    fn display_name_source(&self) -> &ConfigSource {
-        &self.display_name.1
+    fn display_name_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.display_name {
+            Some(source)
+        } else {
+            None
+        }
     }
 
     fn bind_source(&self) -> &ConfigSource {
@@ -380,11 +388,9 @@ impl Config {
                 self.node_id_source()
             );
         }
-        debug!(
-            "Config: display_name: {} (source: {:?})",
-            self.display_name(),
-            self.display_name_source()
-        );
+        if let (Some(name), Some(source)) = (self.display_name(), self.display_name_source()) {
+            debug!("Config: display_name: {:?} (source: {:?})", name, source,);
+        }
         debug!(
             "Config: bind: {} (source: {:?})",
             self.bind(),

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -212,6 +212,7 @@ impl PartialConfig {
         self.whitelist.clone()
     }
 
+    #[cfg(feature = "config-env-var")]
     /// Adds a `config_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! An intermediate representation of the configuration values, used to take the
+//! configuration values from different sources into a common representation.
+
 use std::time::Duration;
 
-/// ConfigSource displays the source of configuration values, used to identify which of the various
-/// config modules were used to create a particular PartialConfig object.
+/// `ConfigSource` displays the source of configuration values, used to identify which of the various
+/// config modules were used to create a particular `PartialConfig` object.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub enum ConfigSource {
     Toml { file: String },
@@ -24,8 +27,8 @@ pub enum ConfigSource {
     CommandLine,
 }
 
-/// PartialConfig is an intermediate representation of configuration values, used when combining
-/// several sources. As such, all values of the PartialConfig are options as it is not necessary
+/// `PartialConfig` is an intermediate representation of configuration values, used when combining
+/// several sources. As such, all values of the `PartialConfig` are options as it is not necessary
 /// to provide all values from a single source.
 #[derive(Deserialize, Debug)]
 pub struct PartialConfig {
@@ -209,7 +212,7 @@ impl PartialConfig {
         self.whitelist.clone()
     }
 
-    /// Adds a `config_dir` value to the PartialConfig object.
+    /// Adds a `config_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -221,7 +224,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `storage` value to the PartialConfig object.
+    /// Adds a `storage` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -233,7 +236,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_cert_dir` value to the PartialConfig object.
+    /// Adds a `tls_cert_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -245,7 +248,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_ca_file` value to the  PartialConfig object.
+    /// Adds a `tls_ca_file` value to the  `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -257,7 +260,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_client_cert` value to the PartialConfig object.
+    /// Adds a `tls_client_cert` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -270,7 +273,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_client_key` value to the PartialConfig object.
+    /// Adds a `tls_client_key` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -282,7 +285,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_server_cert` value to the PartialConfig object.
+    /// Adds a `tls_server_cert` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -295,7 +298,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_server_key` value to the PartialConfig object.
+    /// Adds a `tls_server_key` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -307,7 +310,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `service_endpoint` value to the PartialConfig object.
+    /// Adds a `service_endpoint` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -319,7 +322,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `network_endpoints` value to the PartialConfig object.
+    /// Adds a `network_endpoints` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -331,7 +334,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `advertised_endpoints` value to the PartialConfig object.
+    /// Adds a `advertised_endpoints` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -343,7 +346,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `peers` value to the PartialConfig object.
+    /// Adds a `peers` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -355,7 +358,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `node_id` value to the PartialConfig object.
+    /// Adds a `node_id` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -367,7 +370,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `display_name` value to the PartialConfig object.
+    /// Adds a `display_name` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -379,7 +382,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `bind` value to the PartialConfig object.
+    /// Adds a `bind` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -391,7 +394,7 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "database")]
-    /// Adds a `database` value to the PartialConfig object, when the `database`
+    /// Adds a `database` value to the `PartialConfig` object, when the `database`
     /// feature flag is used.
     ///
     /// # Arguments
@@ -404,7 +407,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `registries` value to the PartialConfig object.
+    /// Adds a `registries` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -416,7 +419,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `registry_auto_refresh` value to the PartialConfig object.
+    /// Adds a `registry_auto_refresh` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -429,7 +432,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `registry_forced_refresh` value to the PartialConfig object.
+    /// Adds a `registry_forced_refresh` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -442,7 +445,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `heartbeat` value to the PartialConfig object.
+    /// Adds a `heartbeat` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -454,7 +457,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `timeout` value to the PartialConfig object.
+    /// Adds a `timeout` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -470,7 +473,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `state_dir` value to the PartialConfig object.
+    /// Adds a `state_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -482,7 +485,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `tls_insecure` value to the PartialConfig object.
+    /// Adds a `tls_insecure` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -494,7 +497,7 @@ impl PartialConfig {
     }
 
     #[allow(dead_code)]
-    /// Adds a `no-tls` value to the PartialConfig object.
+    /// Adds a `no-tls` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -506,7 +509,7 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "biome")]
-    /// Adds a `enable_biome` value to the PartialConfig object.
+    /// Adds a `enable_biome` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
@@ -518,7 +521,7 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "rest-api-cors")]
-    /// Adds a `whitelist` value to the PartialConfig object.
+    /// Adds a `whitelist` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `PartialConfig` builder using values from a toml config file.
+
 use crate::config::PartialConfigBuilder;
 use crate::config::{ConfigError, ConfigSource, PartialConfig};
 
 use serde_derive::Deserialize;
 
+/// `TOML_VERSION` represents the version of the toml config file.
+/// The version determines the most current valid toml config entries.
 const TOML_VERSION: &str = "1";
 
-/// Holds configuration values defined in a toml file. This struct must be
+/// `TomlConfig` object which holds values defined in a toml file. This struct must be
 /// treated as part of the external API of splinter because changes here
 /// will impact the valid format of the config file.
 #[derive(Deserialize, Default, Debug)]
@@ -62,11 +66,14 @@ struct TomlConfig {
     admin_service_coordinator_timeout: Option<u64>,
 }
 
+/// `PartialConfig` builder which holds values defined in a toml file.
 pub struct TomlPartialConfigBuilder {
     source: Option<ConfigSource>,
     toml_config: TomlConfig,
 }
 
+/// Takes a toml file, represented as a string, and the path to the toml file to
+/// construct a `TomlPartialConfigBuilder`.
 impl TomlPartialConfigBuilder {
     pub fn new(toml: String, toml_path: String) -> Result<TomlPartialConfigBuilder, ConfigError> {
         Ok(TomlPartialConfigBuilder {
@@ -76,6 +83,8 @@ impl TomlPartialConfigBuilder {
     }
 }
 
+/// Implementation of the `PartialConfigBuilder` trait to create a `PartialConfig` object from the
+/// toml config file entries.
 impl PartialConfigBuilder for TomlPartialConfigBuilder {
     fn build(self) -> Result<PartialConfig, ConfigError> {
         let source = match self.source {
@@ -200,7 +209,7 @@ mod tests {
     static EXAMPLE_REGISTRY_FORCE: u64 = 18;
     static EXAMPLE_ADMIN_TIMEOUT: u64 = 17;
 
-    /// Converts a list of tuples to a toml Table Value used to write a toml file.
+    /// Converts a list of tuples to a toml `Table` `Value` used to write a toml file.
     fn get_toml_value() -> Value {
         let values = vec![
             ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
@@ -231,7 +240,7 @@ mod tests {
         Value::Table(config_values)
     }
 
-    /// Converts a list of tuples to a toml Table Value used to write a toml file.
+    /// Converts a list of tuples to a toml `Table` `Value` used to write a toml file.
     fn get_deprecated_toml_value() -> Value {
         let values = vec![
             ("cert_dir".to_string(), EXAMPLE_CERT_DIR.to_string()),
@@ -351,61 +360,61 @@ mod tests {
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object, constructed from the
-    /// TomlPartialConfigBuilder module, contains the correct values using the following steps:
+    /// This test verifies that a `PartialConfig `object, constructed from the
+    /// `TomlPartialConfigBuilder` module, contains the correct values using the following steps:
     ///
     /// 1. An example config toml is string is created.
-    /// 2. A TomlPartialConfigBuilder object is constructed by passing in the toml string created
+    /// 2. A `TomlPartialConfigBuilder` object is constructed by passing in the toml string created
     ///    in the previous step.
-    /// 3. The TomlPartialConfigBuilder object is transformed to a PartialConfig object using the
-    ///    `build` method.
+    /// 3. The `TomlPartialConfigBuilder` object is transformed to a `PartialConfig` object using
+    ///    `build`.
     ///
-    /// This test then verifies the PartialConfig object built from the TomlPartialConfigBuilder
+    /// This test then verifies the `PartialConfig` object built from the `TomlPartialConfigBuilder`
     /// object by asserting each expected value.
     fn test_toml_build() {
         // Create an example toml string.
         let toml_string = toml::to_string(&get_toml_value()).expect("Could not encode TOML value");
-        // Create a TomlPartialConfigBuilder object from the toml string.
+        // Create a `TomlPartialConfigBuilder` object from the toml string.
         let toml_builder = TomlPartialConfigBuilder::new(toml_string, TEST_TOML.to_string())
             .expect(&format!(
                 "Unable to create TomlPartialConfigBuilder from: {}",
                 TEST_TOML
             ));
-        // Build a PartialConfig from the TomlPartialConfigBuilder object created.
+        // Build a `PartialConfig` from the `TomlPartialConfigBuilder `object created.
         let built_config = toml_builder
             .build()
             .expect("Unable to build TomlPartialConfigBuilder");
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_config_values(built_config);
     }
 
     #[test]
-    /// This test verifies that a PartialConfig object, constructed from the
-    /// TomlPartialConfigBuilder module, contains the correct values when using deprecated values:
+    /// This test verifies that a `PartialConfig` object, constructed from the
+    /// `TomlPartialConfigBuilder` module, contains the correct values when using deprecated values:
     ///
     /// 1. An example config toml string is created that is only made up of deprecated tls values
-    /// 2. A TomlPartialConfigBuilder object is constructed by passing in the toml string created
+    /// 2. A `TomlPartialConfigBuilder` object is constructed by passing in the toml string created
     ///    in the previous step.
-    /// 3. The TomlPartialConfigBuilder object is transformed to a PartialConfig object using the
-    ///    `build` method.
+    /// 3. The `TomlPartialConfigBuilder` object is transformed to a `PartialConfig` object using
+    ///    `build`.
     ///
-    /// This test then verifies the PartialConfig object built from the TomlPartialConfigBuilder
+    /// This test then verifies the `PartialConfig` object built from the `TomlPartialConfigBuilder`
     /// object by asserting each expected tls value was properly set from deprecated values
     fn test_deprecated_toml_build() {
         // Create an example toml string.
         let toml_string =
             toml::to_string(&get_deprecated_toml_value()).expect("Could not encode TOML value");
-        // Create a TomlPartialConfigBuilder object from the toml string.
+        // Create a `TomlPartialConfigBuilder` object from the toml string.
         let toml_builder = TomlPartialConfigBuilder::new(toml_string, TEST_TOML.to_string())
             .expect(&format!(
                 "Unable to create TomlPartialConfigBuilder from: {}",
                 TEST_TOML
             ));
-        // Build a PartialConfig from the TomlPartialConfigBuilder object created.
+        // Build a `PartialConfig` from the `TomlPartialConfigBuilder` object created.
         let built_config = toml_builder
             .build()
             .expect("Unable to build TomlPartialConfigBuilder");
-        // Compare the generated PartialConfig object against the expected values.
+        // Compare the generated `PartialConfig` object against the expected values.
         assert_deprecated_config_values(built_config);
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -414,6 +414,7 @@ impl SplinterDaemon {
             Box::new(registry.clone_box_as_reader()),
             Box::new(AllowAllKeyPermissionManager),
             &self.storage_type,
+            &self.storage_location,
             Some(self.admin_timeout),
         )
         .map_err(|err| {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -310,6 +310,12 @@ fn main() {
                 .long("tls-insecure")
                 .help("If set to tls, should accept all peer certificates")
                 .alias("insecure"),
+        )
+        .arg(
+            Arg::with_name("state_dir")
+                .long("state-dir")
+                .help("Storage directory when storage is YAML")
+                .takes_value(true),
         );
 
     #[cfg(feature = "database")]

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -421,6 +421,10 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     config.log_as_debug();
 
     let node_id = find_node_id(&config)?;
+    let display_name = config
+        .display_name()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("Node {}", &node_id));
 
     let mut daemon_builder = SplinterDaemonBuilder::new();
 
@@ -432,7 +436,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_service_endpoint(String::from(config.service_endpoint()))
         .with_initial_peers(config.peers().to_vec())
         .with_node_id(node_id)
-        .with_display_name(String::from(config.display_name()))
+        .with_display_name(display_name)
         .with_rest_api_endpoint(String::from(rest_api_endpoint))
         .with_storage_type(String::from(config.storage()))
         .with_registries(config.registries().to_vec())


### PR DESCRIPTION
A few cleanup tasks surrounding the splinterd config, including adding a `state_dir` option to the splinterd CLI, as well as using this value for the AdminService.

Also adds some documentation. And adds a check for the default node diplay name to incorporate the randomly generated node_id, if neither the node_id nor display_name are set. 