### PR TITLE
Fix splinterd postinst error

### DIFF
--- a/splinterd/packaging/ubuntu/postinst
+++ b/splinterd/packaging/ubuntu/postinst
@@ -40,7 +40,6 @@ case "$1" in
         chmod 755 /etc/splinter
         chmod 640 /etc/splinter/*.toml*
         chmod 640 /etc/splinter/*.yaml*
-        chmod 660 /etc/splinter/nodes.yaml.example
         chown root:$group /etc/splinter/*.toml*
         chown root:$group /etc/splinter/*.yaml*
         chown -R root:$group /etc/splinter/certs


### PR DESCRIPTION
The nodes.yaml was renamed to resgitry.yaml as part of the unified registry
change. This file is no longer written to by splinterd so permissions don't
need to be modified.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>