### PR TITLE
Remove extra --tls-insecure flag gameroom dockerhub compose file

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -154,7 +154,6 @@ services:
               --advertised-endpoints tcps://splinterd-node-acme:8044 \
               --bind 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
-              --tls-insecure
               --tls-insecure \
               --enable-biome
         "


### PR DESCRIPTION
The extra flag without line continuation prevents biome from being enabled.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>