### PR TITLE
Use advertised endpoints for gameroom node info

### DIFF
--- a/examples/gameroom/daemon/src/config.rs
+++ b/examples/gameroom/daemon/src/config.rs
@@ -138,6 +138,6 @@ pub fn get_node(splinterd_url: &str) -> Result<NodeInfo, GetNodeError> {
 pub struct NodeInfo {
     #[serde(alias = "node_id")]
     pub identity: String,
-    #[serde(alias = "network_endpoints")]
+    #[serde(alias = "advertised_endpoints")]
     pub endpoints: Vec<String>,
 }


### PR DESCRIPTION
Updates gameroomd to use the local splinter node's
`advertised_endpoints` instead of `network_endpoints` field from the
`/status` request. The advertised endpoints are intended to accurately
represent the endpoints available on the network; network endpoints may
not be available publicly.

Signed-off-by: Logan Seeley <seeley@bitwise.io>