### PR TITLE
Remove experimental feature matrix

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -102,7 +102,6 @@ experimental = [
     "circuit-template",
     "connection-manager",
     "connection-manager-notification-iter-try-next",
-    "matrix",
     "network-peer-manager",
     "network-ref-map",
     "service-arg-validation",
@@ -117,10 +116,9 @@ biome-key-management = ["biome"]
 biome-notifications = ["biome"]
 biome-user = ["biome"]
 circuit-template = []
-connection-manager = ["matrix"]
+connection-manager = []
 connection-manager-notification-iter-try-next = ["connection-manager"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
-matrix = []
 network-peer-manager = ["connection-manager", "network-ref-map"]
 network-ref-map = []
 postgres = ["diesel/postgres", "diesel_migrations"]

--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -51,7 +51,6 @@
 
 mod control;
 mod incoming;
-#[cfg(feature = "matrix")]
 mod matrix;
 mod outgoing;
 mod pool;
@@ -66,12 +65,10 @@ use std::time::Duration;
 use crate::mesh::control::Control;
 pub use crate::mesh::control::{AddError, RemoveError};
 use crate::mesh::incoming::Incoming;
-#[cfg(feature = "matrix")]
 pub use crate::mesh::matrix::{
     MeshLifeCycle, MeshMatrixReceiver, MeshMatrixSender, MeshMatrixShutdown,
 };
 use crate::mesh::outgoing::Outgoing;
-#[cfg(feature = "matrix")]
 pub use crate::transport::matrix::ConnectionMatrixEnvelope as Envelope;
 
 pub use crate::collections::BiHashMap;
@@ -83,33 +80,6 @@ use crate::transport::Connection;
 pub(in crate::mesh) enum InternalEnvelope {
     Message { id: usize, payload: Vec<u8> },
     Shutdown,
-}
-
-#[cfg(not(feature = "matrix"))]
-/// Wrapper around payload to include connection id
-#[derive(Debug, Default, PartialEq)]
-pub struct Envelope {
-    id: String,
-    payload: Vec<u8>,
-}
-
-#[cfg(not(feature = "matrix"))]
-impl Envelope {
-    pub fn new(id: String, payload: Vec<u8>) -> Self {
-        Envelope { id, payload }
-    }
-
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    pub fn payload(&self) -> &[u8] {
-        &self.payload
-    }
-
-    pub fn take_payload(self) -> Vec<u8> {
-        self.payload
-    }
 }
 
 struct MeshState {
@@ -265,28 +235,24 @@ impl Mesh {
         }
     }
 
-    #[cfg(feature = "matrix")]
     /// Creates a MeshLifeCycle that can be used to add and remove connection from this Mesh
     pub fn get_life_cycle(&self) -> MeshLifeCycle {
         let mesh = self.clone();
         MeshLifeCycle::new(mesh)
     }
 
-    #[cfg(feature = "matrix")]
     /// Creates a MeshMatrixSender that can be used to send messages over through this Mesh
     pub fn get_sender(&self) -> MeshMatrixSender {
         let mesh = self.clone();
         MeshMatrixSender::new(mesh)
     }
 
-    #[cfg(feature = "matrix")]
     /// Creates a MeshMatrixReceiver that can be used to receives message from this Mesh
     pub fn get_receiver(&self) -> MeshMatrixReceiver {
         let mesh = self.clone();
         MeshMatrixReceiver::new(mesh)
     }
 
-    #[cfg(feature = "matrix")]
     /// Creates a MeshMatrixShutdown to shutdown this Mesh instance
     pub fn get_matrix_shutdown(&self) -> MeshMatrixShutdown {
         MeshMatrixShutdown::new(self.shutdown_signaler())

--- a/libsplinter/src/transport/error.rs
+++ b/libsplinter/src/transport/error.rs
@@ -218,21 +218,18 @@ impl From<io::Error> for SendError {
     }
 }
 
-#[cfg(feature = "matrix")]
 #[derive(Debug)]
 pub struct ConnectionMatrixAddError {
     pub context: String,
     pub source: Option<Box<dyn Error + Send>>,
 }
 
-#[cfg(feature = "matrix")]
 impl ConnectionMatrixAddError {
     pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
         Self { context, source }
     }
 }
 
-#[cfg(feature = "matrix")]
 impl Error for ConnectionMatrixAddError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         if let Some(ref err) = self.source {
@@ -243,7 +240,6 @@ impl Error for ConnectionMatrixAddError {
     }
 }
 
-#[cfg(feature = "matrix")]
 impl std::fmt::Display for ConnectionMatrixAddError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Some(ref err) = self.source {
@@ -254,21 +250,18 @@ impl std::fmt::Display for ConnectionMatrixAddError {
     }
 }
 
-#[cfg(feature = "matrix")]
 #[derive(Debug)]
 pub struct ConnectionMatrixRemoveError {
     pub context: String,
     pub source: Option<Box<dyn Error + Send>>,
 }
 
-#[cfg(feature = "matrix")]
 impl ConnectionMatrixRemoveError {
     pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
         Self { context, source }
     }
 }
 
-#[cfg(feature = "matrix")]
 impl Error for ConnectionMatrixRemoveError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         if let Some(ref err) = self.source {
@@ -279,7 +272,6 @@ impl Error for ConnectionMatrixRemoveError {
     }
 }
 
-#[cfg(feature = "matrix")]
 impl std::fmt::Display for ConnectionMatrixRemoveError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Some(ref err) = self.source {
@@ -290,21 +282,18 @@ impl std::fmt::Display for ConnectionMatrixRemoveError {
     }
 }
 
-#[cfg(feature = "matrix")]
 #[derive(Debug)]
 pub struct ConnectionMatrixSendError {
     pub context: String,
     pub source: Option<Box<dyn Error + Send>>,
 }
 
-#[cfg(feature = "matrix")]
 impl ConnectionMatrixSendError {
     pub fn new(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
         Self { context, source }
     }
 }
 
-#[cfg(feature = "matrix")]
 impl Error for ConnectionMatrixSendError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         if let Some(ref err) = self.source {
@@ -315,7 +304,6 @@ impl Error for ConnectionMatrixSendError {
     }
 }
 
-#[cfg(feature = "matrix")]
 impl std::fmt::Display for ConnectionMatrixSendError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if let Some(ref err) = self.source {
@@ -326,7 +314,6 @@ impl std::fmt::Display for ConnectionMatrixSendError {
     }
 }
 
-#[cfg(feature = "matrix")]
 #[derive(Debug)]
 pub enum ConnectionMatrixRecvError {
     Disconnected,
@@ -337,14 +324,12 @@ pub enum ConnectionMatrixRecvError {
     Shutdown,
 }
 
-#[cfg(feature = "matrix")]
 impl ConnectionMatrixRecvError {
     pub fn new_internal_error(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
         ConnectionMatrixRecvError::InternalError { context, source }
     }
 }
 
-#[cfg(feature = "matrix")]
 impl Error for ConnectionMatrixRecvError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -361,7 +346,6 @@ impl Error for ConnectionMatrixRecvError {
     }
 }
 
-#[cfg(feature = "matrix")]
 impl std::fmt::Display for ConnectionMatrixRecvError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -382,7 +366,6 @@ impl std::fmt::Display for ConnectionMatrixRecvError {
     }
 }
 
-#[cfg(feature = "matrix")]
 #[derive(Debug)]
 pub enum ConnectionMatrixRecvTimeoutError {
     Timeout,
@@ -394,14 +377,12 @@ pub enum ConnectionMatrixRecvTimeoutError {
     Shutdown,
 }
 
-#[cfg(feature = "matrix")]
 impl ConnectionMatrixRecvTimeoutError {
     pub fn new_internal_error(context: String, source: Option<Box<dyn Error + Send>>) -> Self {
         ConnectionMatrixRecvTimeoutError::InternalError { context, source }
     }
 }
 
-#[cfg(feature = "matrix")]
 impl Error for ConnectionMatrixRecvTimeoutError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -419,7 +400,6 @@ impl Error for ConnectionMatrixRecvTimeoutError {
     }
 }
 
-#[cfg(feature = "matrix")]
 impl std::fmt::Display for ConnectionMatrixRecvTimeoutError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {

--- a/libsplinter/src/transport/mod.rs
+++ b/libsplinter/src/transport/mod.rs
@@ -37,7 +37,6 @@
 
 mod error;
 pub mod inproc;
-#[cfg(feature = "matrix")]
 pub(crate) mod matrix;
 pub mod multi;
 #[deprecated(since = "0.3.14", note = "please use splinter::transport::socket")]


### PR DESCRIPTION
Remove the experimental feature for matrix, making
the matrix traits available within the crate.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>