### PR TITLE
 Move Pacemaker to crate::threading 

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -82,6 +82,8 @@ pub mod rest_api;
 pub mod service;
 pub mod signing;
 pub mod storage;
+#[cfg(feature = "connection-manager")]
+mod threading;
 pub mod transport;
 
 #[cfg(feature = "rest-api")]

--- a/libsplinter/src/threading/error.rs
+++ b/libsplinter/src/threading/error.rs
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module will contain components that will be used to support different threading models
+use std::{error, fmt};
 
-pub mod error;
-pub mod pacemaker;
+#[derive(Clone, Debug, PartialEq)]
+pub struct PacemakerStartError(pub String);
+
+impl error::Error for PacemakerStartError {}
+
+impl fmt::Display for PacemakerStartError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Pacemaker was unable to start: {}", self.0)
+    }
+}

--- a/libsplinter/src/threading/mod.rs
+++ b/libsplinter/src/threading/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module will contain components that will be used to support different threading models


### PR DESCRIPTION
The pacemaker functionality will be useful in more places
then just the ConnectionManger, for example the PeerManager
needs to periodically try pending peers.