### PR TITLE
Refinements on transport::matrix API doc

### DIFF
--- a/libsplinter/src/transport/matrix.rs
+++ b/libsplinter/src/transport/matrix.rs
@@ -12,19 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Traits that abstract specific functionality of a connection group.
+//! Traits for defining a connection matrix.
 //!
-//! A component that acts as a connection group peforms the following operations
-//!   - add: Adds a connection to the underlying connection group
-//!   - remove: Removes a connection from the connection group
-//!   - send: Send a message over a specific connection
-//!   - recv: Receive a message from any ready connection in the connection group
+//! A connection matrix is a collection containing [`Connection`] items, which allows sending to
+//! and receiving from those connections via a connection identifier.
 //!
-//! The following Matrix traits abstract out these different operations. For example,
-//! a networking component may only be interested in send and receiving messages. That component
-//! does not need to be given the methods to add or remove connection, only send and recv.
+//! A connection matrix must implement the following operations:
 //!
-//! Using these traits will also allow for replacing the backing connection group in the future.
+//!   - add: Add a connection to the connection matrix
+//!   - remove: Remove a connection from the connection matrix
+//!   - send: Send a message to a connection
+//!   - recv: Receive a message from any ready connection in the connection matrix
+//!
+//! Traits are defined in a granular manner which matches how a connection matrix is used. For
+//! example, lifecycle operations (add and remove) are performed in a different component than send
+//! and receive, and are thus handled via a separate trait.
+//!
+//! [`Connection`]: ../trait.Connection.html
 
 use std::time::Duration;
 
@@ -35,20 +39,29 @@ pub use super::error::{
     ConnectionMatrixRemoveError, ConnectionMatrixSendError,
 };
 
-/// Wrapper around a payload to include connection ID
+/// Contains a payload and the identifier for the connection on which the payload was received
 #[derive(Debug, Default, PartialEq)]
 pub struct ConnectionMatrixEnvelope {
+    /// The connection identifier
     id: String,
+    /// The message payload bytes
     payload: Vec<u8>,
 }
 
 impl ConnectionMatrixEnvelope {
-    /// Creates a new `ConnectionMatrixEnvelope` that will be sent over a connection
+    /// Creates a new `ConnectionMatrixEnvelope`
+    ///
+    /// This is used by the implementation of a [`ConnectionMatrixReceiver`] to create the envelope
+    /// returned by [`recv`] or [`recv_timeout`].
+    ///
+    /// [`ConnectionMatrixReceiver`]: trait.ConnectionMatrixReceiver.html
+    /// [`recv`]: trait.ConnectionMatrixReceiver.html#tymethod.recv
+    /// [`recv_timeout`]: trait.ConnectionMatrixReceiver.html#tymethod.recv_timeout
     pub fn new(id: String, payload: Vec<u8>) -> Self {
         ConnectionMatrixEnvelope { id, payload }
     }
 
-    /// Returns the connection ID of the recipient of the `ConnectionMatrixEnvelope`
+    /// Returns the connection identifier of the connection on which the payload was received
     pub fn id(&self) -> &str {
         &self.id
     }
@@ -58,21 +71,24 @@ impl ConnectionMatrixEnvelope {
         &self.payload
     }
 
-    /// Returns the payload from the message while consuming the the `ConnectionMatrixEnvelope`
+    /// Returns the bytes of the payload while consuming the `ConnectionMatrixEnvelope`
     pub fn take_payload(self) -> Vec<u8> {
         self.payload
     }
 }
 
-/// `ConnectionMatrixLifeCycle` trait abstracts out adding and removing connections to a connection
-/// group without requiring knowledge about sending or receiving messges.
+/// Defines connection lifecycle operations (addition and removal of a `Connection`)
+///
+/// This trait is distinct from the sender/receiver traits because the lifecycle operations
+/// typically occur in a separate component. Thus, we can expose this trait only where the
+/// lifecycle operations are performed and nowhere else in the system.
 pub trait ConnectionMatrixLifeCycle: Clone + Send {
-    /// Adds a connection to the connection group with a connection ID
+    /// Adds a connection to the connection matrix
     ///
     /// # Arguments
     ///
-    /// * `connection` - A boxed connection that will be passed to the connection group.
-    /// * `id` - a unique connection ID that will be used to send messages over a connection.
+    /// * `connection` - Connection being added to the connection matrix
+    /// * `id` - Connection identifier; must be unique within the connection matrix
     ///
     /// If the add failed, a `ConnectionMatrixAddError` will be returned.
     fn add(
@@ -81,60 +97,58 @@ pub trait ConnectionMatrixLifeCycle: Clone + Send {
         id: String,
     ) -> Result<usize, ConnectionMatrixAddError>;
 
-    /// Removes a connection from the connection group with a connection ID.
+    /// Removes a connection from the connection matrix
     ///
     /// # Arguments
     ///
-    /// * `id` - the unique connection ID for the connection that should be removed
+    /// * `id` - the connection identifier for the connection being removed
     ///
     /// If the remove failed, a `ConnectionMatrixRemoveError` will be returned.
     fn remove(&self, id: &str) -> Result<Box<dyn Connection>, ConnectionMatrixRemoveError>;
 }
 
-/// `ConnectionMatrixSender` trait abstracts out sending messages through a connection group
-/// without requiring knowledge about adding and removing connections.
+/// Defines a function to send a message using a connection identifier
 pub trait ConnectionMatrixSender: Clone + Send {
     /// Sends a message over the specified connection.
     ///
     /// # Arguments
     ///
-    /// * `id` - the unique connection ID the message should be sent over
+    /// * `id` - the identifier of the connection on which the message should be sent
     /// * `message` - the bytes of the message
     ///
     /// If the send failed, a `ConnectionMatrixSendError` will be returned.
     fn send(&self, id: String, message: Vec<u8>) -> Result<(), ConnectionMatrixSendError>;
 }
 
-/// `ConnectionMatrixReceiver` trait abstracts out receiving messages from a connection group without
-/// requiring knowledge about adding and removing connections.
+/// Defines functions to receive messages from connections within the connection matrix
 pub trait ConnectionMatrixReceiver: Clone + Send {
-    /// Attempts to receive a message from the connection group. This function will block until
-    /// there is a `ConnectionMatrixEnvelope` to receive. The message will come from the first ready connection
+    /// Attempts to receive a message. The envelope returned contains both the payload (message)
+    /// and the identifier of the connection on which it was received. This function will block
+    /// until there is a message to receive. The message will come from the first ready connection
     /// detected.
     ///
-    /// If successful, returns an `ConnectionMatrixEnvelope` containing the payload and the connection ID of the
-    /// the sender. Otherwise, returns a `ConnectionMatrixRecvError`.
+    /// If the receive failed, a `ConnectionMatrixRecvError` is returned.
     fn recv(&self) -> Result<ConnectionMatrixEnvelope, ConnectionMatrixRecvError>;
 
-    /// Attempts to receive a message from the connection group. This function will block until
-    /// there is a `ConnectionMatrixEnvelope` to receive or the timeout expires
+    /// Attempts to receive a message, with a timeout. The envelope returned contains both the
+    /// payload (message) and the identifier of the connection on which it was received. This
+    /// function will block until there is a message to receive or the specified timeout expires.
+    /// The message will come from the first ready connection detected.
     ///
     /// # Arguments
     ///
-    /// * `timeout` - a Duration for the amount of time the function should block waiting on an
-    ///     envelope to arrive.
+    /// * `timeout` - `Duration` for the amount of time the function should block waiting on an
+    ///   envelope to arrive
     ///
-    /// If successful, returns an `ConnectionMatrixEnvelope` containing the payload and the connection ID of the
-    /// the sender. Otherwise, returns a `ConnectionMatrixRecvTimeoutError`.
+    /// If the receive failed or timed out, a `ConnectionMatrixRecvTimeoutError` is returned.
     fn recv_timeout(
         &self,
         timeout: Duration,
     ) -> Result<ConnectionMatrixEnvelope, ConnectionMatrixRecvTimeoutError>;
 }
 
-/// `ConnectionMatrixShutdown` trait abstracts out shutting down a connection group without
-/// requiring knowledge of the other connection group operations.
+/// Defines a function to shutdown the connection matrix
 pub trait ConnectionMatrixShutdown: Clone + Send {
-    /// Notifies the underlying connection group to shutdown
+    /// Notifies the underlying connection matrix to shutdown
     fn shutdown(&self);
 }


### PR DESCRIPTION
Removes 'connection group' terminology. A few other stylistic changes
are also made in an attempt refine the resulting output to be more
consistent with other rust doc.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>