### PR TITLE
Remove Connection Manager NotificationIter

### DIFF
--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::TryRecvError;
-
 use super::error::ConnectionManagerError;
 
 /// Messages that will be dispatched to all subscription handlers
@@ -41,97 +38,4 @@ pub enum ConnectionManagerNotification {
         endpoint: String,
         attempts: u64,
     },
-}
-
-/// An iterator over ConnectionManagerNotification values
-pub struct NotificationIter {
-    pub(super) recv: Receiver<ConnectionManagerNotification>,
-}
-
-impl NotificationIter {
-    /// Try to get the next notificaion, if it is available.
-    pub fn try_next(
-        &self,
-    ) -> Result<Option<ConnectionManagerNotification>, ConnectionManagerError> {
-        match self.recv.try_recv() {
-            Ok(notifications) => Ok(Some(notifications)),
-            Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Disconnected) => Err(ConnectionManagerError::SendMessageError(
-                "The connection manager is no longer running".into(),
-            )),
-        }
-    }
-}
-
-impl Iterator for NotificationIter {
-    type Item = ConnectionManagerNotification;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.recv.recv() {
-            Ok(notification) => Some(notification),
-            Err(_) => {
-                // This is expected if the connection manager shuts down before
-                // this end
-                None
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::sync::mpsc;
-    use std::thread;
-
-    #[test]
-    /// Tests that notifier iterator correctly exists when sender
-    /// is dropped.
-    ///
-    /// Procedure:
-    ///
-    /// The test creates a sync channel and a notifier, then it
-    /// creates a thread that send Connected notifications to
-    /// the notifier.
-    ///
-    /// Asserts:
-    ///
-    /// The notifications sent are received by the NotificationIter
-    /// correctly
-    ///
-    /// That the total number of notifications sent equals 5
-    fn test_notifications_handler_iterator() {
-        let (send, recv) = mpsc::channel();
-
-        let nh = NotificationIter { recv };
-
-        let join_handle = thread::spawn(move || {
-            for _ in 0..5 {
-                send.send(ConnectionManagerNotification::Connected {
-                    endpoint: "tcp://localhost:3030".to_string(),
-                    identity: "test".to_string(),
-                    connection_id: "test_connection_id".to_string(),
-                })
-                .unwrap();
-            }
-        });
-
-        let mut notifications_sent = 0;
-        for n in nh {
-            assert_eq!(
-                n,
-                ConnectionManagerNotification::Connected {
-                    endpoint: "tcp://localhost:3030".to_string(),
-                    identity: "test".to_string(),
-                    connection_id: "test_connection_id".to_string(),
-                }
-            );
-            notifications_sent += 1;
-        }
-
-        assert_eq!(notifications_sent, 5);
-
-        join_handle.join().unwrap();
-    }
 }

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -1442,12 +1442,14 @@ pub mod tests {
         let recv_connector = connector.clone();
         let jh = thread::spawn(move || {
             let connection = listener.accept().unwrap();
-            let mut subscriber = recv_connector
-                .subscription_iter()
+            let (subs_tx, subs_rx): (mpsc::Sender<ConnectionManagerNotification>, _) =
+                mpsc::channel();
+            let _ = recv_connector
+                .subscribe(subs_tx)
                 .expect("unable to get subscriber");
             recv_connector.add_inbound_connection(connection).unwrap();
             // wait for inbound connection notfication to come
-            subscriber.next().expect("unable to get notfication");
+            subs_rx.recv().expect("unable to get notfication");
         });
 
         let mut peer_manager = PeerManager::new(connector, None);


### PR DESCRIPTION
Remove the `NotificationIter`, as this struct is only used in tests, and has been supplanted by the `subscribe` function.  The iterator behavior can be easily recreated simply by using the receiving end of the channel.

This also removes the `connection-manager-notification-iter-try-next` feature, which is no longer needed with the removal of the iterator.
