### PR TITLE
Several auth2 cleanup commits 

### DIFF
--- a/libsplinter/src/network/auth2/connection_manager.rs
+++ b/libsplinter/src/network/auth2/connection_manager.rs
@@ -17,9 +17,9 @@ use crate::network::connection_manager::{
 };
 use crate::transport::Connection;
 
-use super::{AuthorizationPoolError, ConnectionAuthorizationState, PoolAuthorizer};
+use super::{AuthorizationConnector, AuthorizationManagerError, ConnectionAuthorizationState};
 
-impl Authorizer for PoolAuthorizer {
+impl Authorizer for AuthorizationConnector {
     fn authorize_connection(
         &self,
         connection_id: String,
@@ -59,8 +59,8 @@ impl From<ConnectionAuthorizationState> for AuthorizationResult {
     }
 }
 
-impl From<AuthorizationPoolError> for AuthorizerError {
-    fn from(err: AuthorizationPoolError) -> Self {
+impl From<AuthorizationManagerError> for AuthorizerError {
+    fn from(err: AuthorizationManagerError) -> Self {
         AuthorizerError(err.to_string())
     }
 }

--- a/libsplinter/src/network/auth2/handlers.rs
+++ b/libsplinter/src/network/auth2/handlers.rs
@@ -26,7 +26,7 @@ use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::protos::prelude::*;
 
 use super::{
-    AuthorizationAction, AuthorizationMessageSender, AuthorizationPoolStateMachine,
+    AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessageSender,
     AuthorizationState,
 };
 
@@ -39,7 +39,7 @@ use super::{
 /// The identity provided is sent to connections for Trust authorizations.
 pub fn create_authorization_dispatcher(
     identity: String,
-    auth_manager: AuthorizationPoolStateMachine,
+    auth_manager: AuthorizationManagerStateMachine,
     auth_msg_sender: impl MessageSender<ConnectionId> + Clone + 'static,
 ) -> Dispatcher<NetworkMessageType, ConnectionId> {
     let mut auth_dispatcher = Dispatcher::new(Box::new(auth_msg_sender.clone()));
@@ -127,11 +127,11 @@ impl Handler for AuthorizedHandler {
 ///
 /// Handler for the Connect Request Authorization Message Type
 struct ConnectRequestHandler {
-    auth_manager: AuthorizationPoolStateMachine,
+    auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl ConnectRequestHandler {
-    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         ConnectRequestHandler { auth_manager }
     }
 }
@@ -273,11 +273,11 @@ impl Handler for ConnectResponseHandler {
 
 /// Handler for the TrustRequest Authorization Message Type
 struct TrustRequestHandler {
-    auth_manager: AuthorizationPoolStateMachine,
+    auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl TrustRequestHandler {
-    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         TrustRequestHandler { auth_manager }
     }
 }
@@ -334,11 +334,11 @@ impl Handler for TrustRequestHandler {
 
 /// Handler for the Authorization Error Message Type
 struct AuthorizationErrorHandler {
-    auth_manager: AuthorizationPoolStateMachine,
+    auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl AuthorizationErrorHandler {
-    fn new(auth_manager: AuthorizationPoolStateMachine) -> Self {
+    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         AuthorizationErrorHandler { auth_manager }
     }
 }
@@ -416,7 +416,7 @@ mod tests {
     ///    response.
     #[test]
     fn connect_request_dispatch() {
-        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
         let dispatcher =
@@ -475,7 +475,7 @@ mod tests {
     /// 2) the trust request includes the local identity
     #[test]
     fn connect_response_dispatch() {
-        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
         let dispatcher =
@@ -519,7 +519,7 @@ mod tests {
     /// 3). receiving an Authorize message, which is the result of successful authorization
     #[test]
     fn trust_request_dispatch() {
-        let auth_mgr = AuthorizationPoolStateMachine::default();
+        let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
         let dispatcher =

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -96,31 +96,31 @@ impl fmt::Display for AuthorizationActionError {
 }
 
 #[derive(Debug)]
-pub struct AuthorizationPoolError(pub String);
+pub struct AuthorizationManagerError(pub String);
 
-impl std::error::Error for AuthorizationPoolError {}
+impl std::error::Error for AuthorizationManagerError {}
 
-impl fmt::Display for AuthorizationPoolError {
+impl fmt::Display for AuthorizationManagerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&self.0)
     }
 }
 
 /// Manages authorization states for connections on a network.
-pub struct AuthorizationPool {
+pub struct AuthorizationManager {
     local_identity: String,
     thread_pool: ThreadPool,
     shared: Arc<Mutex<ManagedAuthorizations>>,
 }
 
-impl AuthorizationPool {
-    /// Constructs an AuthorizationPool
-    pub fn new(local_identity: String) -> Result<Self, AuthorizationPoolError> {
+impl AuthorizationManager {
+    /// Constructs an AuthorizationManager
+    pub fn new(local_identity: String) -> Result<Self, AuthorizationManagerError> {
         let thread_pool = ThreadPoolBuilder::new()
             .with_size(AUTHORIZATION_THREAD_POOL_SIZE)
-            .with_prefix("AuthorizationPool-".into())
+            .with_prefix("AuthorizationManager-".into())
             .build()
-            .map_err(|err| AuthorizationPoolError(err.to_string()))?;
+            .map_err(|err| AuthorizationManagerError(err.to_string()))?;
 
         let shared = Arc::new(Mutex::new(ManagedAuthorizations::new()));
 
@@ -141,8 +141,8 @@ impl AuthorizationPool {
         self.thread_pool.join_all()
     }
 
-    pub fn pool_authorizer(&self) -> PoolAuthorizer {
-        PoolAuthorizer {
+    pub fn authorization_connector(&self) -> AuthorizationConnector {
+        AuthorizationConnector {
             local_identity: self.local_identity.clone(),
             shared: Arc::clone(&self.shared),
             executor: self.thread_pool.executor(),
@@ -163,24 +163,24 @@ impl ShutdownSignaler {
 type Callback =
     Box<dyn Fn(ConnectionAuthorizationState) -> Result<(), Box<dyn std::error::Error>> + Send>;
 
-pub struct PoolAuthorizer {
+pub struct AuthorizationConnector {
     local_identity: String,
     shared: Arc<Mutex<ManagedAuthorizations>>,
     executor: pool::JobExecutor,
 }
 
-impl PoolAuthorizer {
+impl AuthorizationConnector {
     pub fn add_connection(
         &self,
         connection_id: String,
         connection: Box<dyn Connection>,
         on_complete_callback: Callback,
-    ) -> Result<(), AuthorizationPoolError> {
+    ) -> Result<(), AuthorizationManagerError> {
         let mut connection = connection;
 
         let (tx, rx) = mpsc::channel();
         let connection_shared = Arc::clone(&self.shared);
-        let state_machine = AuthorizationPoolStateMachine {
+        let state_machine = AuthorizationManagerStateMachine {
             shared: Arc::clone(&self.shared),
         };
         let msg_sender = AuthorizationMessageSender { sender: tx };
@@ -290,20 +290,20 @@ impl PoolAuthorizer {
     }
 }
 
-fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationPoolError> {
+fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationManagerError> {
     let mut network_msg = NetworkMessage::new();
     network_msg.set_message_type(NetworkMessageType::AUTHORIZATION);
 
     let connect_msg = AuthorizationMessage::ConnectRequest(ConnectRequest::Bidirectional);
     network_msg.set_payload(
         IntoBytes::<authorization::AuthorizationMessage>::into_bytes(connect_msg).map_err(
-            |err| AuthorizationPoolError(format!("Unable to send connect request: {}", err)),
+            |err| AuthorizationManagerError(format!("Unable to send connect request: {}", err)),
         )?,
     );
 
-    network_msg
-        .write_to_bytes()
-        .map_err(|err| AuthorizationPoolError(format!("Unable to send connect request: {}", err)))
+    network_msg.write_to_bytes().map_err(|err| {
+        AuthorizationManagerError(format!("Unable to send connect request: {}", err))
+    })
 }
 
 #[derive(Clone)]
@@ -318,11 +318,11 @@ impl AuthorizationMessageSender {
 }
 
 #[derive(Clone, Default)]
-pub struct AuthorizationPoolStateMachine {
+pub struct AuthorizationManagerStateMachine {
     shared: Arc<Mutex<ManagedAuthorizations>>,
 }
 
-impl AuthorizationPoolStateMachine {
+impl AuthorizationManagerStateMachine {
     /// Transitions from one authorization state to another
     ///
     /// Errors
@@ -449,7 +449,7 @@ pub(in crate::network) mod tests {
     use crate::protos::authorization;
     use crate::protos::network::{NetworkMessage, NetworkMessageType};
 
-    impl AuthorizationPool {
+    impl AuthorizationManager {
         /// A test friendly shutdown and wait method.
         pub fn shutdown_and_await(self) {
             self.shutdown_signaler().shutdown();

--- a/libsplinter/src/network/auth2/mod.rs
+++ b/libsplinter/src/network/auth2/mod.rs
@@ -78,7 +78,7 @@ impl fmt::Display for AuthorizationAction {
 pub(crate) enum AuthorizationActionError {
     AlreadyConnecting,
     InvalidMessageOrder(AuthorizationState, AuthorizationAction),
-    SystemFailure(String),
+    InternalError(String),
 }
 
 impl fmt::Display for AuthorizationActionError {
@@ -90,7 +90,7 @@ impl fmt::Display for AuthorizationActionError {
             AuthorizationActionError::InvalidMessageOrder(start, action) => {
                 write!(f, "Attempting to transition from {} via {}.", start, action)
             }
-            AuthorizationActionError::SystemFailure(msg) => f.write_str(&msg),
+            AuthorizationActionError::InternalError(msg) => f.write_str(&msg),
         }
     }
 }
@@ -334,7 +334,7 @@ impl AuthorizationPoolStateMachine {
         action: AuthorizationAction,
     ) -> Result<AuthorizationState, AuthorizationActionError> {
         let mut shared = self.shared.lock().map_err(|_| {
-            AuthorizationActionError::SystemFailure("Authorization pool lock was poisoned".into())
+            AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
         })?;
 
         let cur_state = shared

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -1049,7 +1049,7 @@ mod tests {
 
     use crate::mesh::Mesh;
     use crate::network::auth2::tests::negotiation_connection_auth;
-    use crate::network::auth2::AuthorizationPool;
+    use crate::network::auth2::AuthorizationManager;
     use crate::transport::inproc::InprocTransport;
     use crate::transport::socket::TcpTransport;
 
@@ -1206,10 +1206,10 @@ mod tests {
             mesh.shutdown_signaler().shutdown();
         });
 
-        let authorization_pool = AuthorizationPool::new("test_identity".into())
+        let authorization_pool = AuthorizationManager::new("test_identity".into())
             .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::new(
-            Box::new(authorization_pool.pool_authorizer()),
+            Box::new(authorization_pool.authorization_connector()),
             mesh.get_life_cycle(),
             mesh.get_sender(),
             transport,
@@ -1252,10 +1252,10 @@ mod tests {
             mesh.shutdown_signaler().shutdown();
         });
 
-        let authorization_pool = AuthorizationPool::new("test_identity".into())
+        let authorization_pool = AuthorizationManager::new("test_identity".into())
             .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::new(
-            Box::new(authorization_pool.pool_authorizer()),
+            Box::new(authorization_pool.authorization_connector()),
             mesh.get_life_cycle(),
             mesh.get_sender(),
             transport,
@@ -1368,10 +1368,10 @@ mod tests {
             mesh2.shutdown_signaler().shutdown();
         });
 
-        let authorization_pool = AuthorizationPool::new("test_identity".into())
+        let authorization_pool = AuthorizationManager::new("test_identity".into())
             .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::new(
-            Box::new(authorization_pool.pool_authorizer()),
+            Box::new(authorization_pool.authorization_connector()),
             mesh1.get_life_cycle(),
             mesh1.get_sender(),
             transport,
@@ -1500,10 +1500,10 @@ mod tests {
         let endpoint = listener.endpoint();
 
         let mesh = Mesh::new(512, 128);
-        let authorization_pool = AuthorizationPool::new("test_identity".into())
+        let authorization_pool = AuthorizationManager::new("test_identity".into())
             .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::new(
-            Box::new(authorization_pool.pool_authorizer()),
+            Box::new(authorization_pool.authorization_connector()),
             mesh.get_life_cycle(),
             mesh.get_sender(),
             // The transport on this end doesn't matter for this test

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -130,9 +130,9 @@ impl ServiceConnectionManager {
     /// # let transport = InprocTransport::default();
     /// # let mesh = Mesh::new(1, 1);
     /// # let authorization_pool = AuthorizationManager::new("test_identity".into()).unwrap();
-    /// # let authorizer: Box<dyn Authorizer> = Box::new(authorization_pool.authorization_connector());
+    /// # let authorizer = Box::new(authorization_pool.authorization_connector());
     /// let mut cm = ConnectionManager::new(
-    ///     Box::new(authorization_pool.authorization_connector()),
+    ///     authorizer,
     ///     mesh.get_life_cycle(),
     ///     mesh.get_sender(),
     ///     Box::new(transport),

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -123,16 +123,16 @@ impl ServiceConnectionManager {
     ///
     /// ```no_run
     /// # use splinter::mesh::Mesh;
-    /// # use splinter::network::auth2::AuthorizationPool;
+    /// # use splinter::network::auth2::AuthorizationManager;
     /// # use splinter::network::connection_manager::{Authorizer, ConnectionManager};
     /// # use splinter::service::network::ServiceConnectionManager;
     /// # use splinter::transport::inproc::InprocTransport;
     /// # let transport = InprocTransport::default();
     /// # let mesh = Mesh::new(1, 1);
-    /// # let authorization_pool = AuthorizationPool::new("test_identity".into()).unwrap();
-    /// # let authorizer: Box<dyn Authorizer> = Box::new(authorization_pool.pool_authorizer());
+    /// # let authorization_pool = AuthorizationManager::new("test_identity".into()).unwrap();
+    /// # let authorizer: Box<dyn Authorizer> = Box::new(authorization_pool.authorization_connector());
     /// let mut cm = ConnectionManager::new(
-    ///     Box::new(authorization_pool.pool_authorizer()),
+    ///     Box::new(authorization_pool.authorization_connector()),
     ///     mesh.get_life_cycle(),
     ///     mesh.get_sender(),
     ///     Box::new(transport),


### PR DESCRIPTION
- Renames SystemFailure error variant
- Renames AuthorizationPool and PoolAuthorizer
- fixes a doc test to remove the visible use of the AuthorizatonManager