### PR TITLE
Connect/Disconnect handlers for Service Component Messages

### DIFF
--- a/libsplinter/protos/service.proto
+++ b/libsplinter/protos/service.proto
@@ -72,7 +72,7 @@ message SMDisconnectRequest {
 
 message SMDisconnectResponse {
     enum Status {
-        UNSET_ERROR = 0;
+        UNSET_STATUS = 0;
         OK = 1;
         ERROR_CIRCUIT_DOES_NOT_EXIST = 2;
         ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY = 3;

--- a/libsplinter/protos/service.proto
+++ b/libsplinter/protos/service.proto
@@ -55,6 +55,7 @@ message SMConnectResponse {
         ERROR_SERVICE_ALREADY_REGISTERED = 4;
         ERROR_NOT_AN_ALLOWED_NODE = 5;
         ERROR_QUEUE_FULL = 6;
+        ERROR_INTERNAL_ERROR = 7;
     }
 
     Status status = 1;
@@ -78,6 +79,7 @@ message SMDisconnectResponse {
         ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY = 3;
         ERROR_SERVICE_NOT_REGISTERED = 4;
         ERROR_QUEUE_FULL = 5;
+        ERROR_INTERNAL_ERROR = 6;
     }
 
     Status status = 1;

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! trait implementations to support service components.

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -13,3 +13,311 @@
 // limitations under the License.
 
 //! trait implementations to support service components.
+
+use crate::circuit::service::{Service, ServiceId, SplinterNode};
+use crate::circuit::{ServiceDefinition, SplinterState};
+use crate::service::network::handlers::{
+    ServiceAddInstanceError, ServiceInstances, ServiceRemoveInstanceError,
+};
+
+/// A collection of service instances, backed by `SplinterState`.
+pub struct SplinterStateServiceInstances {
+    splinter_node: SplinterNode,
+    state: SplinterState,
+}
+
+impl SplinterStateServiceInstances {
+    /// Construct a new instance with the given local node information and an instance of splinter
+    /// state.
+    ///
+    /// # Params
+    ///
+    /// - `splinter_node`: the local node information
+    /// - `state`: an instance of splinter state, that will be used to store the service instances
+    pub fn new(splinter_node: SplinterNode, state: SplinterState) -> Self {
+        Self {
+            splinter_node,
+            state,
+        }
+    }
+}
+
+impl ServiceInstances for SplinterStateServiceInstances {
+    fn add_service_instance(
+        &self,
+        service_id: ServiceId,
+        component_id: String,
+    ) -> Result<(), ServiceAddInstanceError> {
+        let has_service = self.state.has_service(&service_id).map_err(|err| {
+            ServiceAddInstanceError::InternalError {
+                context: format!(
+                    "unable to check if service {} is already registered",
+                    service_id
+                ),
+                source: Some(Box::new(err)),
+            }
+        })?;
+
+        if has_service {
+            return Err(ServiceAddInstanceError::AlreadyRegistered);
+        }
+
+        let unique_id = service_id.clone();
+        let (circuit_name, service_id) = service_id.into_parts();
+
+        let circuit = self
+            .state
+            .circuit(&circuit_name)
+            .map_err(|err| ServiceAddInstanceError::InternalError {
+                context: format!("unable to load circuit information for {}", unique_id),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or(ServiceAddInstanceError::CircuitDoesNotExist)?;
+
+        let service_def = if !service_id.starts_with("admin::") {
+            circuit
+                .roster()
+                .iter()
+                .find(|service| service.service_id == service_id)
+                .cloned()
+        } else {
+            Some(
+                ServiceDefinition::builder(service_id.clone(), "admin".into())
+                    .with_allowed_nodes(vec![self.splinter_node.id().to_string()])
+                    .build(),
+            )
+        };
+
+        if let Some(service_def) = service_def {
+            if !service_def
+                .allowed_nodes
+                .iter()
+                .any(|node_id| node_id == self.splinter_node.id())
+            {
+                return Err(ServiceAddInstanceError::NotAllowed);
+            }
+
+            let service = Service::new(
+                service_id.clone(),
+                Some(component_id),
+                self.splinter_node.clone(),
+            );
+
+            self.state.add_service(unique_id, service).map_err(|err| {
+                ServiceAddInstanceError::InternalError {
+                    context: format!("unable to add service {}", service_id),
+                    source: Some(Box::new(err)),
+                }
+            })?;
+        } else {
+            return Err(ServiceAddInstanceError::NotInCircuit);
+        }
+        Ok(())
+    }
+
+    fn remove_service_instance(
+        &self,
+        service_id: ServiceId,
+        _component_id: String,
+    ) -> Result<(), ServiceRemoveInstanceError> {
+        let has_service = !self.state.has_service(&service_id).map_err(|err| {
+            ServiceRemoveInstanceError::InternalError {
+                context: format!("unable to check if service {} is registered", service_id),
+                source: Some(Box::new(err)),
+            }
+        })?;
+
+        if has_service {
+            return Err(ServiceRemoveInstanceError::NotRegistered);
+        }
+
+        self.state
+            .remove_service(&service_id)
+            .map(|_| ())
+            .map_err(|err| ServiceRemoveInstanceError::InternalError {
+                context: format!("unable to remove service {}", service_id),
+                source: Some(Box::new(err)),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::circuit::directory::CircuitDirectory;
+    use crate::circuit::{AuthorizationType, Circuit, DurabilityType, PersistenceType, RouteType};
+
+    #[test]
+    // Test that if the circuit does not exist, a ServiceAddInstanceError::CircuitDoesNotExist
+    // error is returned.
+    fn test_add_service_instance_circuit_does_not_exist() {
+        let circuit_directory = CircuitDirectory::new();
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state);
+
+        let res = service_instances.add_service_instance(
+            ServiceId::new("alpha".into(), "abc".into()),
+            "my_component".into(),
+        );
+
+        assert!(matches!(
+            res,
+            Err(ServiceAddInstanceError::CircuitDoesNotExist)
+        ));
+    }
+
+    #[test]
+    // Test that if the service is not in circuit, a ServiceAddInstanceError::NotInCircuit error is
+    // returned.
+    fn test_add_service_instance_not_in_circuit() {
+        let circuit = build_circuit();
+
+        let mut circuit_directory = CircuitDirectory::new();
+        circuit_directory.add_circuit("alpha".into(), circuit);
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state);
+
+        let res = service_instances.add_service_instance(
+            ServiceId::new("alpha".into(), "BAD".into()),
+            "my_component".into(),
+        );
+
+        assert!(matches!(res, Err(ServiceAddInstanceError::NotInCircuit)));
+    }
+
+    #[test]
+    // Test that if the service is already registered, a ServiceAddInstanceError::AlreadyRegistered
+    // error is returned.
+    fn test_add_service_instance_already_registered() {
+        let circuit = build_circuit();
+
+        let mut circuit_directory = CircuitDirectory::new();
+        circuit_directory.add_circuit("alpha".into(), circuit);
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service = Service::new(
+            "abc".to_string(),
+            Some("abc_network".to_string()),
+            splinter_node.clone(),
+        );
+        let id = ServiceId::new("alpha".into(), "abc".into());
+        state.add_service(id.clone(), service).unwrap();
+
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state);
+
+        let res = service_instances.add_service_instance(
+            ServiceId::new("alpha".into(), "abc".into()),
+            "my_component".into(),
+        );
+
+        assert!(matches!(
+            res,
+            Err(ServiceAddInstanceError::AlreadyRegistered)
+        ));
+    }
+
+    #[test]
+    // Test that if the service is in a circuit and not connected, the service is accepted.
+    // This is the happy-path test
+    fn test_add_service_instance_accepted() {
+        let circuit = build_circuit();
+
+        let mut circuit_directory = CircuitDirectory::new();
+        circuit_directory.add_circuit("alpha".to_string(), circuit);
+
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state.clone());
+
+        let id = ServiceId::new("alpha".into(), "abc".into());
+        let res = service_instances.add_service_instance(id.clone(), "my_component".into());
+
+        assert!(matches!(res, Ok(())));
+        assert!(state
+            .has_service(&id)
+            .expect("cannot check if it has the service"));
+    }
+
+    #[test]
+    // Test that if the circuit is not registered, a ServiceRemoveInstanceError::NotRegistered
+    // should be returned.
+    fn test_remove_service_instance_not_registred() {
+        let circuit = build_circuit();
+
+        let mut circuit_directory = CircuitDirectory::new();
+        circuit_directory.add_circuit("alpha".into(), circuit);
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state);
+
+        let res = service_instances.remove_service_instance(
+            ServiceId::new("alpha".into(), "abc".into()),
+            "my_component".into(),
+        );
+
+        assert!(matches!(
+            res,
+            Err(ServiceRemoveInstanceError::NotRegistered)
+        ));
+    }
+
+    #[test]
+    fn test_remove_service_instance_accepted() {
+        let circuit = build_circuit();
+
+        let mut circuit_directory = CircuitDirectory::new();
+        circuit_directory.add_circuit("alpha".into(), circuit);
+        let state = SplinterState::new("memory".to_string(), circuit_directory);
+
+        let splinter_node = SplinterNode::new("123".into(), vec!["tcp://127.0.0.1:0".into()]);
+        let service = Service::new(
+            "abc".to_string(),
+            Some("abc_network".to_string()),
+            splinter_node.clone(),
+        );
+        let id = ServiceId::new("alpha".into(), "abc".into());
+        state.add_service(id.clone(), service).unwrap();
+
+        let service_instances = SplinterStateServiceInstances::new(splinter_node, state.clone());
+
+        let res = service_instances.remove_service_instance(id.clone(), "my_component".into());
+
+        assert!(matches!(res, Ok(())));
+
+        assert!(!state
+            .has_service(&id)
+            .expect("cannot check if it has the service"));
+    }
+
+    fn build_circuit() -> Circuit {
+        let service_abc = ServiceDefinition::builder("abc".into(), "test".into())
+            .with_allowed_nodes(vec!["123".to_string()])
+            .build();
+
+        let service_def = ServiceDefinition::builder("def".into(), "test".into())
+            .with_allowed_nodes(vec!["345".to_string()])
+            .build();
+
+        let circuit = Circuit::builder()
+            .with_id("alpha".into())
+            .with_auth(AuthorizationType::Trust)
+            .with_members(vec!["123".into(), "345".into()])
+            .with_roster(vec![service_abc, service_def])
+            .with_persistence(PersistenceType::Any)
+            .with_durability(DurabilityType::NoDurability)
+            .with_routes(RouteType::Any)
+            .with_circuit_management_type("service_connect_test_app".into())
+            .build()
+            .expect("Should have built a correct circuit");
+
+        circuit
+    }
+}

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "service-network")]
+pub mod component;
 pub mod directory;
 pub mod handlers;
 pub mod service;

--- a/libsplinter/src/circuit/service.rs
+++ b/libsplinter/src/circuit/service.rs
@@ -29,6 +29,14 @@ impl ServiceId {
             service_id,
         }
     }
+
+    pub fn circuit(&self) -> &str {
+        &self.circuit_name
+    }
+
+    pub fn service_id(&self) -> &str {
+        &self.service_id
+    }
 }
 
 impl fmt::Display for ServiceId {

--- a/libsplinter/src/circuit/service.rs
+++ b/libsplinter/src/circuit/service.rs
@@ -37,6 +37,11 @@ impl ServiceId {
     pub fn service_id(&self) -> &str {
         &self.service_id
     }
+
+    /// Decompose this ServiceId into a tuple of (<circuit name>, <service id>).
+    pub fn into_parts(self) -> (String, String) {
+        (self.circuit_name, self.service_id)
+    }
 }
 
 impl fmt::Display for ServiceId {

--- a/libsplinter/src/network/dispatch/mod.rs
+++ b/libsplinter/src/network/dispatch/mod.rs
@@ -34,7 +34,7 @@ pub use r#loop::{
 /// A wrapper for a PeerId.
 ///
 /// This type constrains a dispatcher to peer-specific messages
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct PeerId(String);
 
 impl std::ops::Deref for PeerId {
@@ -72,7 +72,7 @@ impl fmt::Display for PeerId {
 /// A wrapper for Connection Id
 ///
 /// The type constrains a dispatcher to connection-specific messages
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ConnectionId(String);
 
 impl std::ops::Deref for ConnectionId {

--- a/libsplinter/src/protocol/component.rs
+++ b/libsplinter/src/protocol/component.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Protocol structs for splinter component messages
+//!
+//! These structs are used to operate on the messages that are transmitted between components and a
+//! splinter node.
+
+use protobuf::Message;
+
+use crate::protocol::service::ServiceMessage;
+use crate::protos::component;
+use crate::protos::prelude::*;
+use crate::protos::service;
+
+/// The component message envelope.  All message sent to local components will be wrapped in one of
+/// these.
+pub enum ComponentMessage {
+    /// A message to/from service components.
+    Service(ServiceMessage),
+    /// A keep-alive message.
+    Heartbeat,
+}
+
+impl FromProto<component::ComponentMessage> for ComponentMessage {
+    fn from_proto(msg: component::ComponentMessage) -> Result<Self, ProtoConversionError> {
+        use component::ComponentMessageType::*;
+        match msg.get_message_type() {
+            SERVICE => Ok(ComponentMessage::Service(FromBytes::<
+                service::ServiceMessage,
+            >::from_bytes(
+                msg.get_payload()
+            )?)),
+            COMPONENT_HEARTBEAT => Ok(ComponentMessage::Heartbeat),
+            UNSET_COMPONENT_MESSAGE_TYPE => Err(ProtoConversionError::InvalidTypeError(
+                "message type not set".into(),
+            )),
+        }
+    }
+}
+
+impl FromNative<ComponentMessage> for component::ComponentMessage {
+    fn from_native(msg: ComponentMessage) -> Result<Self, ProtoConversionError> {
+        let mut proto_msg = component::ComponentMessage::new();
+        use component::ComponentMessageType::*;
+        match msg {
+            ComponentMessage::Service(service_msg) => {
+                proto_msg.set_message_type(SERVICE);
+                proto_msg.set_payload(IntoBytes::<service::ServiceMessage>::into_bytes(
+                    service_msg,
+                )?);
+            }
+            ComponentMessage::Heartbeat => {
+                proto_msg.set_message_type(COMPONENT_HEARTBEAT);
+                proto_msg.set_payload(
+                    component::ComponentHeartbeat::new()
+                        .write_to_bytes()
+                        .map_err(|err| ProtoConversionError::SerializationError(err.to_string()))?,
+                );
+            }
+        }
+
+        Ok(proto_msg)
+    }
+}

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -15,6 +15,7 @@
 //! Protocol versions for various endpoints provided by splinter.
 
 pub mod authorization;
+pub mod component;
 pub mod service;
 
 pub const ADMIN_PROTOCOL_VERSION: u32 = 1;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -15,6 +15,7 @@
 //! Protocol versions for various endpoints provided by splinter.
 
 pub mod authorization;
+pub mod service;
 
 pub const ADMIN_PROTOCOL_VERSION: u32 = 1;
 

--- a/libsplinter/src/protocol/service.rs
+++ b/libsplinter/src/protocol/service.rs
@@ -1,0 +1,349 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Protocol structs for splinter service component messages
+//!
+//! These structs are used to operate on the messages that are transmitted between service
+//! components and a splinter node.
+
+use crate::protos::prelude::*;
+use crate::protos::service;
+
+/// A message envelope for messages either sent or received from service components.
+pub struct ServiceMessage {
+    /// The name of the circuit the message is meant for
+    pub circuit: String,
+    /// The unique ID of the service that is connecting to the circuit
+    pub service_id: String,
+    /// The message envelope contents
+    pub payload: ServiceMessagePayload,
+}
+
+/// The payload of a service message.
+pub enum ServiceMessagePayload {
+    ConnectRequest(ServiceConnectRequest),
+    ConnectResponse(ServiceConnectResponse),
+    DisconnectRequest(ServiceDisconnectRequest),
+    DisconnectResponse(ServiceDisconnectResponse),
+    ServiceProcessorMessage(ServiceProcessorMessage),
+}
+
+/// This message is sent by a service processor component to connect to a splinter node.
+pub struct ServiceConnectRequest {
+    /// ID used to correlate the response with this request
+    pub correlation_id: String,
+}
+
+/// This message is sent to a service processor component from a splinter node in response to its
+/// connection request.
+pub struct ServiceConnectResponse {
+    /// ID used to correlate the response with this request
+    pub correlation_id: String,
+    /// The response status.
+    pub status: ConnectResponseStatus,
+}
+
+pub enum ConnectResponseStatus {
+    Ok,
+    CircuitDoesNotExist(String),
+    ServiceNotInCircuitRegistry(String),
+    ServiceAlreadyRegistered(String),
+    NotAnAllowedNode(String),
+    QueueFull,
+}
+
+/// This message is sent by a service processor component to disconnect from a splinter node.
+pub struct ServiceDisconnectRequest {
+    /// ID used to correlate the response with this request
+    pub correlation_id: String,
+}
+
+/// This message is sent to a service processor component from a splinter node in response to its
+/// disconnect request.
+pub struct ServiceDisconnectResponse {
+    /// ID used to correlate the response with this request
+    pub correlation_id: String,
+    /// The response status.
+    pub status: DisconnectResponseStatus,
+}
+
+pub enum DisconnectResponseStatus {
+    Ok,
+    CircuitDoesNotExist(String),
+    ServiceNotInCircuitRegistry(String),
+    ServiceNotRegistered(String),
+    QueueFull,
+}
+
+/// Opaque messages that are sent to or received from a service processor.
+pub struct ServiceProcessorMessage {
+    /// The sending node
+    pub sender: String,
+    /// The target node
+    pub recipient: String,
+    /// The opaque payload.
+    pub payload: Vec<u8>,
+}
+
+impl FromProto<service::SMConnectRequest> for ServiceConnectRequest {
+    fn from_proto(mut req: service::SMConnectRequest) -> Result<Self, ProtoConversionError> {
+        Ok(Self {
+            correlation_id: req.take_correlation_id(),
+        })
+    }
+}
+
+impl FromNative<ServiceConnectRequest> for service::SMConnectRequest {
+    fn from_native(req: ServiceConnectRequest) -> Result<Self, ProtoConversionError> {
+        let mut proto_req = service::SMConnectRequest::new();
+        proto_req.set_correlation_id(req.correlation_id);
+
+        Ok(proto_req)
+    }
+}
+
+impl FromProto<service::SMConnectResponse> for ServiceConnectResponse {
+    fn from_proto(mut res: service::SMConnectResponse) -> Result<Self, ProtoConversionError> {
+        use service::SMConnectResponse_Status::*;
+
+        Ok(Self {
+            correlation_id: res.take_correlation_id(),
+            status: match res.get_status() {
+                OK => ConnectResponseStatus::Ok,
+                ERROR_CIRCUIT_DOES_NOT_EXIST => {
+                    ConnectResponseStatus::CircuitDoesNotExist(res.take_error_message())
+                }
+                ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY => {
+                    ConnectResponseStatus::ServiceNotInCircuitRegistry(res.take_error_message())
+                }
+                ERROR_SERVICE_ALREADY_REGISTERED => {
+                    ConnectResponseStatus::ServiceAlreadyRegistered(res.take_error_message())
+                }
+                ERROR_NOT_AN_ALLOWED_NODE => {
+                    ConnectResponseStatus::NotAnAllowedNode(res.take_error_message())
+                }
+                ERROR_QUEUE_FULL => ConnectResponseStatus::QueueFull,
+                UNSET_STATUS => {
+                    return Err(ProtoConversionError::InvalidTypeError(
+                        "no status was set".into(),
+                    ))
+                }
+            },
+        })
+    }
+}
+
+impl FromNative<ServiceConnectResponse> for service::SMConnectResponse {
+    fn from_native(res: ServiceConnectResponse) -> Result<Self, ProtoConversionError> {
+        let mut proto_res = service::SMConnectResponse::new();
+        proto_res.set_correlation_id(res.correlation_id);
+
+        use service::SMConnectResponse_Status::*;
+        match res.status {
+            ConnectResponseStatus::Ok => proto_res.set_status(OK),
+            ConnectResponseStatus::CircuitDoesNotExist(msg) => {
+                proto_res.set_status(ERROR_CIRCUIT_DOES_NOT_EXIST);
+                proto_res.set_error_message(msg);
+            }
+            ConnectResponseStatus::ServiceNotInCircuitRegistry(msg) => {
+                proto_res.set_status(ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY);
+                proto_res.set_error_message(msg);
+            }
+            ConnectResponseStatus::ServiceAlreadyRegistered(msg) => {
+                proto_res.set_status(ERROR_SERVICE_ALREADY_REGISTERED);
+                proto_res.set_error_message(msg);
+            }
+            ConnectResponseStatus::NotAnAllowedNode(msg) => {
+                proto_res.set_status(ERROR_NOT_AN_ALLOWED_NODE);
+                proto_res.set_error_message(msg);
+            }
+            ConnectResponseStatus::QueueFull => proto_res.set_status(ERROR_QUEUE_FULL),
+        }
+        Ok(proto_res)
+    }
+}
+
+impl FromProto<service::SMDisconnectRequest> for ServiceDisconnectRequest {
+    fn from_proto(mut req: service::SMDisconnectRequest) -> Result<Self, ProtoConversionError> {
+        Ok(Self {
+            correlation_id: req.take_correlation_id(),
+        })
+    }
+}
+
+impl FromNative<ServiceDisconnectRequest> for service::SMDisconnectRequest {
+    fn from_native(req: ServiceDisconnectRequest) -> Result<Self, ProtoConversionError> {
+        let mut proto_req = service::SMDisconnectRequest::new();
+        proto_req.set_correlation_id(req.correlation_id);
+
+        Ok(proto_req)
+    }
+}
+
+impl FromProto<service::SMDisconnectResponse> for ServiceDisconnectResponse {
+    fn from_proto(mut res: service::SMDisconnectResponse) -> Result<Self, ProtoConversionError> {
+        use service::SMDisconnectResponse_Status::*;
+
+        Ok(Self {
+            correlation_id: res.take_correlation_id(),
+            status: match res.get_status() {
+                OK => DisconnectResponseStatus::Ok,
+                ERROR_CIRCUIT_DOES_NOT_EXIST => {
+                    DisconnectResponseStatus::CircuitDoesNotExist(res.take_error_message())
+                }
+                ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY => {
+                    DisconnectResponseStatus::ServiceNotInCircuitRegistry(res.take_error_message())
+                }
+                ERROR_SERVICE_NOT_REGISTERED => {
+                    DisconnectResponseStatus::ServiceNotRegistered(res.take_error_message())
+                }
+                ERROR_QUEUE_FULL => DisconnectResponseStatus::QueueFull,
+                UNSET_STATUS => {
+                    return Err(ProtoConversionError::InvalidTypeError(
+                        "no status was set".into(),
+                    ))
+                }
+            },
+        })
+    }
+}
+
+impl FromNative<ServiceDisconnectResponse> for service::SMDisconnectResponse {
+    fn from_native(res: ServiceDisconnectResponse) -> Result<Self, ProtoConversionError> {
+        let mut proto_res = service::SMDisconnectResponse::new();
+        proto_res.set_correlation_id(res.correlation_id);
+
+        use service::SMDisconnectResponse_Status::*;
+        match res.status {
+            DisconnectResponseStatus::Ok => proto_res.set_status(OK),
+            DisconnectResponseStatus::CircuitDoesNotExist(msg) => {
+                proto_res.set_status(ERROR_CIRCUIT_DOES_NOT_EXIST);
+                proto_res.set_error_message(msg);
+            }
+            DisconnectResponseStatus::ServiceNotInCircuitRegistry(msg) => {
+                proto_res.set_status(ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY);
+                proto_res.set_error_message(msg);
+            }
+            DisconnectResponseStatus::ServiceNotRegistered(msg) => {
+                proto_res.set_status(ERROR_SERVICE_NOT_REGISTERED);
+                proto_res.set_error_message(msg);
+            }
+            DisconnectResponseStatus::QueueFull => proto_res.set_status(ERROR_QUEUE_FULL),
+        }
+        Ok(proto_res)
+    }
+}
+
+impl FromProto<service::ServiceProcessorMessage> for ServiceProcessorMessage {
+    fn from_proto(mut msg: service::ServiceProcessorMessage) -> Result<Self, ProtoConversionError> {
+        Ok(Self {
+            sender: msg.take_sender(),
+            recipient: msg.take_recipient(),
+            payload: msg.take_payload(),
+        })
+    }
+}
+
+impl FromNative<ServiceProcessorMessage> for service::ServiceProcessorMessage {
+    fn from_native(msg: ServiceProcessorMessage) -> Result<Self, ProtoConversionError> {
+        let mut proto_msg = service::ServiceProcessorMessage::new();
+        proto_msg.set_sender(msg.sender);
+        proto_msg.set_recipient(msg.recipient);
+        proto_msg.set_payload(msg.payload);
+
+        Ok(proto_msg)
+    }
+}
+
+impl FromProto<service::ServiceMessage> for ServiceMessage {
+    fn from_proto(mut msg: service::ServiceMessage) -> Result<Self, ProtoConversionError> {
+        let circuit = msg.take_circuit();
+        let service_id = msg.take_service_id();
+
+        use service::ServiceMessageType::*;
+        let bytes = msg.get_payload();
+        let payload = match msg.get_message_type() {
+            SM_SERVICE_CONNECT_REQUEST => {
+                ServiceMessagePayload::ConnectRequest(
+                    FromBytes::<service::SMConnectRequest>::from_bytes(bytes)?,
+                )
+            }
+            SM_SERVICE_CONNECT_RESPONSE => {
+                ServiceMessagePayload::ConnectResponse(
+                    FromBytes::<service::SMConnectResponse>::from_bytes(bytes)?,
+                )
+            }
+            SM_SERVICE_DISCONNECT_REQUEST => {
+                ServiceMessagePayload::DisconnectRequest(
+                    FromBytes::<service::SMDisconnectRequest>::from_bytes(bytes)?,
+                )
+            }
+            SM_SERVICE_DISCONNECT_RESPONSE => ServiceMessagePayload::DisconnectResponse(
+                FromBytes::<service::SMDisconnectResponse>::from_bytes(bytes)?,
+            ),
+            SM_SERVICE_PROCESSOR_MESSAGE => {
+                ServiceMessagePayload::ServiceProcessorMessage(FromBytes::<
+                    service::ServiceProcessorMessage,
+                >::from_bytes(bytes)?)
+            }
+            UNSET_SERVICE_MESSAGE_TYPE => {
+                return Err(ProtoConversionError::InvalidTypeError(
+                    "missing message type".into(),
+                ));
+            }
+        };
+
+        Ok(Self {
+            circuit,
+            service_id,
+            payload,
+        })
+    }
+}
+
+impl FromNative<ServiceMessage> for service::ServiceMessage {
+    fn from_native(msg: ServiceMessage) -> Result<Self, ProtoConversionError> {
+        let mut proto_msg = service::ServiceMessage::new();
+        proto_msg.set_circuit(msg.circuit);
+        proto_msg.set_service_id(msg.service_id);
+
+        use service::ServiceMessageType::*;
+        match msg.payload {
+            ServiceMessagePayload::ConnectRequest(req) => {
+                proto_msg.set_message_type(SM_SERVICE_CONNECT_REQUEST);
+                proto_msg.set_payload(IntoBytes::<service::SMConnectRequest>::into_bytes(req)?);
+            }
+            ServiceMessagePayload::ConnectResponse(req) => {
+                proto_msg.set_message_type(SM_SERVICE_CONNECT_RESPONSE);
+                proto_msg.set_payload(IntoBytes::<service::SMConnectResponse>::into_bytes(req)?);
+            }
+            ServiceMessagePayload::DisconnectRequest(req) => {
+                proto_msg.set_message_type(SM_SERVICE_DISCONNECT_REQUEST);
+                proto_msg.set_payload(IntoBytes::<service::SMDisconnectRequest>::into_bytes(req)?);
+            }
+            ServiceMessagePayload::DisconnectResponse(req) => {
+                proto_msg.set_message_type(SM_SERVICE_DISCONNECT_RESPONSE);
+                proto_msg.set_payload(IntoBytes::<service::SMDisconnectResponse>::into_bytes(req)?);
+            }
+            ServiceMessagePayload::ServiceProcessorMessage(msg) => {
+                proto_msg.set_message_type(SM_SERVICE_PROCESSOR_MESSAGE);
+                proto_msg.set_payload(IntoBytes::<service::ServiceProcessorMessage>::into_bytes(
+                    msg,
+                )?);
+            }
+        }
+
+        Ok(proto_msg)
+    }
+}

--- a/libsplinter/src/protocol/service.rs
+++ b/libsplinter/src/protocol/service.rs
@@ -60,6 +60,7 @@ pub enum ConnectResponseStatus {
     ServiceNotInCircuitRegistry(String),
     ServiceAlreadyRegistered(String),
     NotAnAllowedNode(String),
+    InternalError(String),
     QueueFull,
 }
 
@@ -84,6 +85,7 @@ pub enum DisconnectResponseStatus {
     ServiceNotInCircuitRegistry(String),
     ServiceNotRegistered(String),
     QueueFull,
+    InternalError(String),
 }
 
 /// Opaque messages that are sent to or received from a service processor.
@@ -134,6 +136,9 @@ impl FromProto<service::SMConnectResponse> for ServiceConnectResponse {
                     ConnectResponseStatus::NotAnAllowedNode(res.take_error_message())
                 }
                 ERROR_QUEUE_FULL => ConnectResponseStatus::QueueFull,
+                ERROR_INTERNAL_ERROR => {
+                    ConnectResponseStatus::InternalError(res.take_error_message())
+                }
                 UNSET_STATUS => {
                     return Err(ProtoConversionError::InvalidTypeError(
                         "no status was set".into(),
@@ -166,6 +171,10 @@ impl FromNative<ServiceConnectResponse> for service::SMConnectResponse {
             }
             ConnectResponseStatus::NotAnAllowedNode(msg) => {
                 proto_res.set_status(ERROR_NOT_AN_ALLOWED_NODE);
+                proto_res.set_error_message(msg);
+            }
+            ConnectResponseStatus::InternalError(msg) => {
+                proto_res.set_status(ERROR_INTERNAL_ERROR);
                 proto_res.set_error_message(msg);
             }
             ConnectResponseStatus::QueueFull => proto_res.set_status(ERROR_QUEUE_FULL),
@@ -208,6 +217,9 @@ impl FromProto<service::SMDisconnectResponse> for ServiceDisconnectResponse {
                 ERROR_SERVICE_NOT_REGISTERED => {
                     DisconnectResponseStatus::ServiceNotRegistered(res.take_error_message())
                 }
+                ERROR_INTERNAL_ERROR => {
+                    DisconnectResponseStatus::InternalError(res.take_error_message())
+                }
                 ERROR_QUEUE_FULL => DisconnectResponseStatus::QueueFull,
                 UNSET_STATUS => {
                     return Err(ProtoConversionError::InvalidTypeError(
@@ -237,6 +249,10 @@ impl FromNative<ServiceDisconnectResponse> for service::SMDisconnectResponse {
             }
             DisconnectResponseStatus::ServiceNotRegistered(msg) => {
                 proto_res.set_status(ERROR_SERVICE_NOT_REGISTERED);
+                proto_res.set_error_message(msg);
+            }
+            DisconnectResponseStatus::InternalError(msg) => {
+                proto_res.set_status(ERROR_INTERNAL_ERROR);
                 proto_res.set_error_message(msg);
             }
             DisconnectResponseStatus::QueueFull => proto_res.set_status(ERROR_QUEUE_FULL),

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -13,3 +13,58 @@
 // limitations under the License.
 
 //! Dispatch handlers for service component messages.
+
+use crate::circuit::service::ServiceId;
+use crate::network::dispatch::{
+    ConnectionId, DispatchError, DispatchMessageSender, Handler, MessageContext, MessageSender,
+};
+use crate::protos::component;
+use crate::protos::service;
+
+/// Dispatch handler for the service message envelope.
+pub struct ServiceMessageHandler {
+    sender: DispatchMessageSender<service::ServiceMessageType, ConnectionId>,
+}
+
+impl ServiceMessageHandler {
+    /// Construct a new `ServiceMessageHandler` with a `DispatchMessageSender` for the contents of
+    /// the envelope.
+    pub fn new(sender: DispatchMessageSender<service::ServiceMessageType, ConnectionId>) -> Self {
+        Self { sender }
+    }
+}
+
+impl Handler for ServiceMessageHandler {
+    type Source = ConnectionId;
+    type MessageType = component::ComponentMessageType;
+    type Message = service::ServiceMessage;
+
+    fn match_type(&self) -> Self::MessageType {
+        component::ComponentMessageType::SERVICE
+    }
+
+    fn handle(
+        &self,
+        mut msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let msg_type = msg.get_message_type();
+        let payload = msg.take_payload();
+        let circuit = msg.take_circuit();
+        let service_id = msg.take_service_id();
+        self.sender
+            .send_with_parent_context(
+                msg_type,
+                payload,
+                context.source_id().clone(),
+                Box::new(ServiceId::new(circuit, service_id)),
+            )
+            .map_err(|_| {
+                DispatchError::NetworkSendError((
+                    context.source_connection_id().to_string(),
+                    msg.payload,
+                ))
+            })
+    }
+}

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Dispatch handlers for service component messages.

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -18,7 +18,12 @@ use crate::circuit::service::ServiceId;
 use crate::network::dispatch::{
     ConnectionId, DispatchError, DispatchMessageSender, Handler, MessageContext, MessageSender,
 };
+use crate::protocol::component::ComponentMessage;
+use crate::protocol::service::{
+    ConnectResponseStatus, ServiceConnectResponse, ServiceMessage, ServiceMessagePayload,
+};
 use crate::protos::component;
+use crate::protos::prelude::*;
 use crate::protos::service;
 
 /// Dispatch handler for the service message envelope.
@@ -195,5 +200,483 @@ impl std::fmt::Display for ServiceRemoveInstanceError {
                 source: None,
             } => f.write_str(&context),
         }
+    }
+}
+
+/// Dispatch handler for `ServiceConnectRequest` messages.
+///
+/// This handler processes an incoming `ServiceConnectRequest` and sends a reply with the
+/// appropriate status.
+pub struct ServiceConnectRequestHandler {
+    service_instances: Box<dyn ServiceInstances + Send>,
+}
+
+impl ServiceConnectRequestHandler {
+    /// Construct a new handler with a given service instances implementation.
+    pub fn new(service_instances: Box<dyn ServiceInstances + Send>) -> Self {
+        Self { service_instances }
+    }
+}
+
+impl Handler for ServiceConnectRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = service::ServiceMessageType;
+    type Message = service::SMConnectRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST
+    }
+
+    fn handle(
+        &self,
+        mut msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let service_id: &ServiceId = context.get_parent_context().ok_or_else(|| {
+            DispatchError::HandleError(
+                "Service Connect Request not provided with service ID from envelope.".into(),
+            )
+        })?;
+
+        let status = match self
+            .service_instances
+            .add_service_instance(service_id.clone(), context.source_connection_id().into())
+        {
+            Ok(()) => ConnectResponseStatus::Ok,
+            Err(ServiceAddInstanceError::NotAllowed) => ConnectResponseStatus::NotAnAllowedNode(
+                format!("Service {} is not allowed on this node", service_id),
+            ),
+            Err(ServiceAddInstanceError::AlreadyRegistered) => {
+                ConnectResponseStatus::ServiceAlreadyRegistered(format!(
+                    "Service {} is already registered",
+                    service_id
+                ))
+            }
+            Err(ServiceAddInstanceError::NotInCircuit) => {
+                ConnectResponseStatus::ServiceNotInCircuitRegistry(format!(
+                    "Service {} is not allowed in circuit {}",
+                    service_id.service_id(),
+                    service_id.circuit()
+                ))
+            }
+            Err(ServiceAddInstanceError::CircuitDoesNotExist) => {
+                ConnectResponseStatus::CircuitDoesNotExist(format!(
+                    "Circuit {} does not exist",
+                    service_id.circuit()
+                ))
+            }
+            Err(err @ ServiceAddInstanceError::InternalError { .. }) => {
+                error!("Unable to register service {}: {}", service_id, err);
+                ConnectResponseStatus::InternalError("An internal error has occurred".into())
+            }
+        };
+
+        let response = ComponentMessage::Service(ServiceMessage {
+            circuit: service_id.circuit().to_string(),
+            service_id: service_id.service_id().to_string(),
+            payload: ServiceMessagePayload::ConnectResponse(ServiceConnectResponse {
+                correlation_id: msg.take_correlation_id(),
+                status,
+            }),
+        });
+
+        sender
+            .send(
+                context.source_connection_id().into(),
+                IntoBytes::<component::ComponentMessage>::into_bytes(response)?,
+            )
+            .map_err(|(recipient, msg)| DispatchError::NetworkSendError((recipient.into(), msg)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Arc, Mutex};
+
+    use protobuf::Message;
+
+    use crate::network::dispatch::Dispatcher;
+
+    // Test that service connection request is properly handled and sends a response with an OK
+    // status, if the registration is successful.
+    #[test]
+    fn test_connect_request_ok() {
+        let mock_instances = MockServiceInstances::new().with_add_result(Ok(()));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        mock_instances.assert_service_link(
+            ServiceId::new("some-circuit".into(), "test-service".into()),
+            "service-component".into(),
+        );
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(service::SMConnectResponse_Status::OK, msg.get_status());
+                assert!(msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    // Test that the service connection request is properly handled and sends a response with an
+    // ERROR_NOT_AN_ALLOWED_NODE, if the registration returns the error NotAllowed.
+    #[test]
+    fn test_connect_request_not_allowed() {
+        let mock_instances =
+            MockServiceInstances::new().with_add_result(Err(ServiceAddInstanceError::NotAllowed));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(
+                    service::SMConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE,
+                    msg.get_status()
+                );
+                assert!(!msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    // Test that the service connection request is properly handled and sends a response with an
+    // ERROR_SERVICE_ALREADY_REGISTERED, if the registration returns the error AlreadyRegistered.
+    #[test]
+    fn test_connect_request_already_registered() {
+        let mock_instances = MockServiceInstances::new()
+            .with_add_result(Err(ServiceAddInstanceError::AlreadyRegistered));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(
+                    service::SMConnectResponse_Status::ERROR_SERVICE_ALREADY_REGISTERED,
+                    msg.get_status()
+                );
+                assert!(!msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    // Test that the service connection request is properly handled and sends a response with an
+    // ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY, if the registration returns the error NotInCircuit.
+    #[test]
+    fn test_connect_request_not_in_circuit() {
+        let mock_instances =
+            MockServiceInstances::new().with_add_result(Err(ServiceAddInstanceError::NotInCircuit));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(
+                    service::SMConnectResponse_Status::ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY,
+                    msg.get_status()
+                );
+                assert!(!msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    // Test that the service connection request is properly handled and sends a response with an
+    // ERROR_SERVICE_NOT_IN_CIRCUIT_REGISTRY, if the registration returns the error NotInCircuit.
+    #[test]
+    fn test_connect_request_circuit_does_not_exist() {
+        let mock_instances = MockServiceInstances::new()
+            .with_add_result(Err(ServiceAddInstanceError::CircuitDoesNotExist));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(
+                    service::SMConnectResponse_Status::ERROR_CIRCUIT_DOES_NOT_EXIST,
+                    msg.get_status()
+                );
+                assert!(!msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    // Test that the service connection request is properly handled and sends a response with an
+    // ERROR_INTERNAL_ERROR, if the registration returns the error InternalError.
+    #[test]
+    fn test_connect_request_internal_error() {
+        let mock_instances = MockServiceInstances::new().with_add_result(Err(
+            ServiceAddInstanceError::InternalError {
+                context: "Some error".into(),
+                source: None,
+            },
+        ));
+
+        let mock_sender = MockMessageSender::default();
+        let mut dispatcher = Dispatcher::new(Box::new(mock_sender.clone()));
+        let connect_request_handler =
+            ServiceConnectRequestHandler::new(Box::new(mock_instances.clone()));
+        dispatcher.set_handler(Box::new(connect_request_handler));
+
+        let mut connect_req = service::SMConnectRequest::new();
+        connect_req.set_correlation_id("test-correlation-id".into());
+
+        dispatcher
+            .dispatch_with_parent_context(
+                "service-component".into(),
+                &service::ServiceMessageType::SM_SERVICE_CONNECT_REQUEST,
+                connect_req.write_to_bytes().unwrap(),
+                Box::new(ServiceId::new("some-circuit".into(), "test-service".into())),
+            )
+            .expect("unable to dispatch message");
+
+        let (connection_id, msg_bytes) = mock_sender
+            .pop_sent()
+            .expect("A message should have been sent");
+
+        assert_eq!(ConnectionId::from("service-component"), connection_id);
+        assert_service_msg(
+            &msg_bytes,
+            service::ServiceMessageType::SM_SERVICE_CONNECT_RESPONSE,
+            |msg: service::SMConnectResponse| {
+                assert_eq!("test-correlation-id", msg.get_correlation_id());
+                assert_eq!(
+                    service::SMConnectResponse_Status::ERROR_INTERNAL_ERROR,
+                    msg.get_status()
+                );
+                assert!(!msg.get_error_message().is_empty());
+            },
+        );
+    }
+
+    #[derive(Clone, Default)]
+    struct MockServiceInstances {
+        add_result: Arc<Mutex<Option<Result<(), ServiceAddInstanceError>>>>,
+        instances: Arc<Mutex<HashMap<ServiceId, String>>>,
+    }
+
+    impl MockServiceInstances {
+        fn new() -> Self {
+            MockServiceInstances::default()
+        }
+
+        fn with_add_result(self, result: Result<(), ServiceAddInstanceError>) -> Self {
+            self.add_result
+                .lock()
+                .expect("test lock was poisoned")
+                .replace(result);
+
+            self
+        }
+
+        fn assert_service_link(&self, service_id: ServiceId, component_id: String) {
+            assert_eq!(
+                Some(&component_id),
+                self.instances
+                    .lock()
+                    .expect("test lock was poisoned")
+                    .get(&service_id)
+            )
+        }
+    }
+
+    impl ServiceInstances for MockServiceInstances {
+        fn add_service_instance(
+            &self,
+            service_id: ServiceId,
+            component_id: String,
+        ) -> Result<(), ServiceAddInstanceError> {
+            let res = self
+                .add_result
+                .lock()
+                .expect("test lock was poisoned")
+                .take()
+                .expect(
+                    "Unexpected second call to add_service_instance without resetting the result",
+                );
+
+            if res.is_ok() {
+                self.instances
+                    .lock()
+                    .expect("test lock was poisoned")
+                    .insert(service_id, component_id);
+            }
+
+            res
+        }
+
+        fn remove_service_instance(
+            &self,
+            _service_id: ServiceId,
+            _component_id: String,
+        ) -> Result<(), ServiceRemoveInstanceError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct MockMessageSender {
+        messages: Arc<Mutex<VecDeque<(ConnectionId, Vec<u8>)>>>,
+    }
+
+    impl MockMessageSender {
+        fn pop_sent(&self) -> Option<(ConnectionId, Vec<u8>)> {
+            self.messages
+                .lock()
+                .expect("test sender lock was poisoned")
+                .pop_front()
+        }
+    }
+
+    impl MessageSender<ConnectionId> for MockMessageSender {
+        fn send(
+            &self,
+            recipient: ConnectionId,
+            message: Vec<u8>,
+        ) -> Result<(), (ConnectionId, Vec<u8>)> {
+            self.messages
+                .lock()
+                .expect("test sender lock was poisoned")
+                .push_back((recipient, message));
+
+            Ok(())
+        }
+    }
+
+    fn assert_service_msg<M: protobuf::Message, F: Fn(M)>(
+        msg_bytes: &[u8],
+        expected_service_msg_type: service::ServiceMessageType,
+        detail_assertions: F,
+    ) {
+        let component_message: component::ComponentMessage =
+            protobuf::parse_from_bytes(msg_bytes).unwrap();
+        let service_msg: service::ServiceMessage =
+            protobuf::parse_from_bytes(component_message.get_payload()).unwrap();
+        assert_eq!(expected_service_msg_type, service_msg.get_message_type(),);
+        let service_msg_paylaod: M = protobuf::parse_from_bytes(service_msg.get_payload()).unwrap();
+
+        detail_assertions(service_msg_paylaod);
     }
 }

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -16,6 +16,7 @@
 //! with services processors over connections.
 
 mod error;
+pub mod handlers;
 pub mod interconnect;
 
 use std::collections::{BTreeMap, HashMap};


### PR DESCRIPTION
This PR includes the handlers for the base component `ServiceMessage` envelope, as well as the connect (`SMConnectRequest`) and disconnect (`SMDisconnectRequest`).  The actual operations are abstracted behind a `ServiceInstances` trait.  This will remove the tight coupling between the handlers and `SplinterState` (as the previous "network" version of these message handlers were).

Additionally, 

- Adds native protocol structs for the component and service protobuf messages.
- Adds getters to the ServiceId struct
- Adds PartialEq to the PeerId/ConnectionId structs

Notes:

- Handlers for the `ServiceProcessMessage` will be added in a future PR
- ~Implementation of the `ServiceInstances` will be added in a future PR~