### PR TITLE
Remove storage_type and use storage location in AdminService

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -167,7 +167,6 @@ impl AdminService {
         signature_verifier: Box<dyn SignatureVerifier + Send>,
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
-        storage_type: &str,
         storage_location: &str,
         // The coordinator timeout for the two-phase commit consensus engine; if `None`, the
         // default value will be used (30 seconds).
@@ -191,7 +190,6 @@ impl AdminService {
                 signature_verifier,
                 key_verifier,
                 key_permission_manager,
-                storage_type,
                 storage_location,
             )?)),
             orchestrator,
@@ -648,8 +646,6 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
-    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
-
     /// Test that a circuit creation creates the correct connections and sends the appropriate
     /// messages.
     #[test]
@@ -685,7 +681,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
             None,
         )
         .expect("Service should have been created correctly");

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -210,16 +210,9 @@ impl AdminServiceShared {
         signature_verifier: Box<dyn SignatureVerifier + Send>,
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
-        storage_type: &str,
         location: &str,
     ) -> Result<Self, ServiceError> {
-        let storage_location = match storage_type {
-            "yaml" => format!("{}{}", location, "/circuit_proposals.yaml"),
-            "memory" => "memory".to_string(),
-            _ => panic!("Storage type is not supported: {}", storage_type),
-        };
-
-        let open_proposals = OpenProposals::new(storage_location)
+        let open_proposals = OpenProposals::new(location.to_string())
             .map_err(|err| ServiceError::UnableToCreate(Box::new(err)))?;
 
         let event_mailbox = Mailbox::new(DurableBTreeSet::new_boxed_with_bound(
@@ -1811,8 +1804,6 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
-    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
-
     /// Test that the CircuitManagementPayload is moved to the pending payloads when the peers are
     /// fully authorized.
     #[test]
@@ -1843,7 +1834,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -1947,7 +1937,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -2027,7 +2016,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2057,7 +2045,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2087,7 +2074,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2123,7 +2109,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2159,7 +2144,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2198,7 +2182,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2234,7 +2217,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2270,7 +2252,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2311,7 +2292,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2341,7 +2321,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2373,7 +2352,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2409,7 +2387,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2452,7 +2429,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2495,7 +2471,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2526,7 +2501,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2557,7 +2531,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2596,7 +2569,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2635,7 +2607,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2674,7 +2645,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2705,7 +2675,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2736,7 +2705,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2767,7 +2735,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2798,7 +2765,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2829,7 +2795,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2861,7 +2826,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2892,7 +2856,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2923,7 +2886,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2962,7 +2924,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2996,7 +2957,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3045,7 +3005,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3096,7 +3055,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 
@@ -3149,7 +3107,6 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
         )
         .unwrap();
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -404,6 +404,23 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         }
     };
 
+    let proposals_location = match &config.storage() as &str {
+        "yaml" => state_dir
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .ok_or_else(|| {
+                UserError::InvalidArgument("'state_dir' is not a valid UTF-8 string".into())
+            })?
+            .to_string(),
+        "memory" => "memory".to_string(),
+        _ => {
+            return Err(UserError::InvalidArgument(format!(
+                "storage type is not supported: {}",
+                config.storage()
+            )))
+        }
+    };
+
     let registry_directory = state_dir
         .to_str()
         .ok_or_else(|| {
@@ -430,6 +447,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     daemon_builder = daemon_builder
         .with_storage_location(storage_location)
+        .with_proposals_location(proposals_location)
         .with_registry_directory(registry_directory)
         .with_network_endpoints(config.network_endpoints().to_vec())
         .with_advertised_endpoints(config.advertised_endpoints().to_vec())
@@ -438,7 +456,6 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_node_id(node_id)
         .with_display_name(display_name)
         .with_rest_api_endpoint(String::from(rest_api_endpoint))
-        .with_storage_type(String::from(config.storage()))
         .with_registries(config.registries().to_vec())
         .with_registry_auto_refresh(config.registry_auto_refresh())
         .with_registry_forced_refresh(config.registry_forced_refresh())


### PR DESCRIPTION
The AdminService will now take the path to proposals
location directly, instead of configuring it based
an storage locations.

Storage locations are now configured in only 1 place
instead of passing around storage type and locations.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>