### PR TITLE
Fix state_dir handling and reduce use of "storage_location"

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -168,7 +168,7 @@ impl AdminService {
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
         storage_type: &str,
-        storage_location: &str,
+        state_dir: &str,
         // The coordinator timeout for the two-phase commit consensus engine; if `None`, the
         // default value will be used (30 seconds).
         coordinator_timeout: Option<Duration>,
@@ -192,7 +192,7 @@ impl AdminService {
                 key_verifier,
                 key_permission_manager,
                 storage_type,
-                storage_location,
+                state_dir,
             )?)),
             orchestrator,
             coordinator_timeout,
@@ -648,7 +648,7 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
-    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
+    const STATE_DIR: &str = "/var/lib/splinter/";
 
     /// Test that a circuit creation creates the correct connections and sends the appropriate
     /// messages.
@@ -685,7 +685,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
             None,
         )
         .expect("Service should have been created correctly");

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -15,6 +15,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -211,10 +212,14 @@ impl AdminServiceShared {
         key_verifier: Box<dyn AdminKeyVerifier>,
         key_permission_manager: Box<dyn KeyPermissionManager>,
         storage_type: &str,
-        location: &str,
+        state_dir: &str,
     ) -> Result<Self, ServiceError> {
         let storage_location = match storage_type {
-            "yaml" => format!("{}{}", location, "/circuit_proposals.yaml"),
+            "yaml" => Path::new(state_dir)
+                .join("circuit_proposals.yaml")
+                .to_str()
+                .expect("'state_dir' is not a valid UTF-8 string")
+                .to_string(),
             "memory" => "memory".to_string(),
             _ => panic!("Storage type is not supported: {}", storage_type),
         };
@@ -1811,7 +1816,7 @@ mod tests {
         25, 26, 27, 28, 29, 30, 31, 32,
     ];
 
-    const STORAGE_LOCATION: &str = "/var/lib/splinter/";
+    const STATE_DIR: &str = "/var/lib/splinter/";
 
     /// Test that the CircuitManagementPayload is moved to the pending payloads when the peers are
     /// fully authorized.
@@ -1843,7 +1848,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 
@@ -1947,7 +1952,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 
@@ -2027,7 +2032,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2057,7 +2062,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2087,7 +2092,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2123,7 +2128,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2159,7 +2164,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2198,7 +2203,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2234,7 +2239,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2270,7 +2275,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2311,7 +2316,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2341,7 +2346,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2373,7 +2378,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2409,7 +2414,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2452,7 +2457,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2495,7 +2500,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2526,7 +2531,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2557,7 +2562,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2596,7 +2601,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2635,7 +2640,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2674,7 +2679,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2705,7 +2710,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2736,7 +2741,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2767,7 +2772,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2798,7 +2803,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let mut circuit = setup_test_circuit();
@@ -2829,7 +2834,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2861,7 +2866,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::new(false)),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2892,7 +2897,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2923,7 +2928,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2962,7 +2967,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
         let circuit = setup_test_circuit();
@@ -2996,7 +3001,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 
@@ -3045,7 +3050,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 
@@ -3096,7 +3101,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 
@@ -3149,7 +3154,7 @@ mod tests {
             Box::new(MockAdminKeyVerifier::default()),
             Box::new(AllowAllKeyPermissionManager),
             "memory",
-            STORAGE_LOCATION,
+            STATE_DIR,
         )
         .unwrap();
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -385,32 +385,6 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     let transport = build_transport(&config)?;
 
-    let state_dir = Path::new(config.state_dir());
-
-    let storage_location = match &config.storage() as &str {
-        "yaml" => state_dir
-            .join("circuits.yaml")
-            .to_str()
-            .ok_or_else(|| {
-                UserError::InvalidArgument("'state_dir' is not a valid UTF-8 string".into())
-            })?
-            .to_string(),
-        "memory" => "memory".to_string(),
-        _ => {
-            return Err(UserError::InvalidArgument(format!(
-                "storage type is not supported: {}",
-                config.storage()
-            )))
-        }
-    };
-
-    let registry_directory = state_dir
-        .to_str()
-        .ok_or_else(|| {
-            UserError::InvalidArgument("'state_dir' is not a valid UTF-8 string".into())
-        })?
-        .to_string();
-
     let rest_api_endpoint = config.bind();
 
     #[cfg(feature = "database")]
@@ -429,8 +403,7 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
     let mut daemon_builder = SplinterDaemonBuilder::new();
 
     daemon_builder = daemon_builder
-        .with_storage_location(storage_location)
-        .with_registry_directory(registry_directory)
+        .with_state_dir(config.state_dir().to_string())
         .with_network_endpoints(config.network_endpoints().to_vec())
         .with_advertised_endpoints(config.advertised_endpoints().to_vec())
         .with_service_endpoint(String::from(config.service_endpoint()))


### PR DESCRIPTION
This reduces the use of "storage_location" and "location" by replacing
it with state_dir where it was really used as state_dir.

Also pushes state_dir into the daemon code, removing the separate
concept of registry directory and storage location as configurable
options. Registry directory remains largely the same, but circuits.yaml
path is now constructed in the daemon.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>