### PR TITLE
Remove db table volumes in gameroom compose files

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -83,7 +83,6 @@ services:
         POSTGRES_PASSWORD: gameroom_example
         POSTGRES_DB: gameroom
       volumes:
-        - "./database/tables:/docker-entrypoint-initdb.d"
         - acme-db:/var/lib/postgresql/data/
 
     gameroom-app-acme:
@@ -184,7 +183,6 @@ services:
         POSTGRES_PASSWORD: gameroom_example
         POSTGRES_DB: gameroom
       volumes:
-        - "./database/tables:/docker-entrypoint-initdb.d"
         - bubba-db:/var/lib/postgresql/data/
 
     gameroom-app-bubba:
@@ -271,4 +269,3 @@ services:
         POSTGRES_USER: admin
         POSTGRES_PASSWORD: admin
         POSTGRES_DB: splinter
-

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -95,8 +95,6 @@ services:
         POSTGRES_USER: gameroom
         POSTGRES_PASSWORD: gameroom_example
         POSTGRES_DB: gameroom
-      volumes:
-        - "./database/tables:/docker-entrypoint-initdb.d"
 
     gameroom-app-acme:
       build:
@@ -323,4 +321,3 @@ services:
         POSTGRES_USER: admin
         POSTGRES_PASSWORD: admin
         POSTGRES_DB: splinter
-


### PR DESCRIPTION
The removal of these volumes was missed in PR #743. Also removes extra
newlines at the end of both gameroom docker compose files.

Signed-off-by: Logan Seeley <seeley@bitwise.io>