### PR TITLE
Fix reconnection in the PeerManager

### DIFF
--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -338,8 +338,27 @@ where
 
         // if peer exists, send message over the network
         if let Some(connection_id) = connection_id {
-            if let Err(err) = message_sender.send(connection_id, payload) {
-                error!("Unable to send message to {}: {}", recipient, err);
+            // If connection is missing, check with peer manager to see if connection id has
+            // changed and try to resend message. Otherwise remove cached connection_id.
+            if let Err(err) = message_sender.send(connection_id.to_string(), payload.to_vec()) {
+                if let Some(new_connection_id) =
+                    peer_connector.connection_id(&recipient).map_err(|err| {
+                        format!("Unable to get connection id for {}: {}", recipient, err)
+                    })?
+                {
+                    // if connection_id has changed replace it and try to send again
+                    if new_connection_id != connection_id {
+                        peer_id_to_connection_id
+                            .insert(recipient.clone(), new_connection_id.clone());
+                        if let Err(err) = message_sender.send(new_connection_id, payload) {
+                            error!("Unable to send message to {}: {}", recipient, err);
+                        }
+                    }
+                } else {
+                    error!("Unable to send message to {}: {}", recipient, err);
+                    // remove cached connection id, peer has gone away
+                    peer_id_to_connection_id.remove(&recipient);
+                }
             }
         } else {
             error!("Cannot send message, unknown peer: {}", recipient);

--- a/libsplinter/src/network/peer_manager/interconnect.rs
+++ b/libsplinter/src/network/peer_manager/interconnect.rs
@@ -294,7 +294,10 @@ where
                 }
             }
         } else {
-            error!("Received message from unknown peer");
+            error!(
+                "Received message from unknown peer with connection_id {}",
+                connection_id
+            );
         }
     }
 }

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -442,7 +442,13 @@ fn add_peer(
         endpoint,
     }) = unreferenced_peers.remove(&peer_id)
     {
-        peers.insert(peer_id.clone(), connection_id, endpoints, endpoint);
+        peers.insert(
+            peer_id.clone(),
+            connection_id,
+            endpoints,
+            endpoint,
+            PeerStatus::Connected,
+        );
 
         let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
         return Ok(peer_ref);
@@ -479,6 +485,7 @@ fn add_peer(
         connection_id,
         endpoints.to_vec(),
         active_endpoint,
+        PeerStatus::Pending,
     );
     let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
     Ok(peer_ref)

--- a/libsplinter/src/network/peer_manager/mod.rs
+++ b/libsplinter/src/network/peer_manager/mod.rs
@@ -615,13 +615,34 @@ fn handle_notifications(
                 "Received peer connection from {} (remote endpoint: {})",
                 identity, endpoint
             );
-            unreferenced_peers.insert(
-                identity,
-                UnreferencedPeer {
-                    connection_id,
-                    endpoint,
-                },
-            );
+
+            // If we got an inbound counnection for an existing peer, replace old connection with
+            // this new one.
+            if let Some(mut peer_metadata) = peers.get_by_peer_id(&identity).cloned() {
+                peer_metadata.status = PeerStatus::Connected;
+                peer_metadata.connection_id = connection_id;
+
+                if let Err(err) = connector.remove_connection(&peer_metadata.active_endpoint) {
+                    error!("Unable to clean up old connection: {}", err);
+                }
+                let notification = PeerManagerNotification::Connected {
+                    peer: peer_metadata.id.to_string(),
+                };
+                subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
+
+                peer_metadata.active_endpoint = endpoint;
+                if let Err(err) = peers.update_peer(peer_metadata) {
+                    error!("Unable to update peer: {}", err);
+                }
+            } else {
+                unreferenced_peers.insert(
+                    identity,
+                    UnreferencedPeer {
+                        connection_id,
+                        endpoint,
+                    },
+                );
+            }
         }
         ConnectionManagerNotification::Connected {
             endpoint,

--- a/libsplinter/src/network/peer_manager/peer_map.rs
+++ b/libsplinter/src/network/peer_manager/peer_map.rs
@@ -82,12 +82,13 @@ impl PeerMap {
         connection_id: String,
         endpoints: Vec<String>,
         active_endpoint: String,
+        status: PeerStatus,
     ) {
         let peer_metadata = PeerMetadata {
             id: peer_id.clone(),
             endpoints: endpoints.clone(),
             active_endpoint,
-            status: PeerStatus::Pending,
+            status,
             connection_id,
             last_connection_attempt: Instant::now(),
             retry_frequency: INITIAL_RETRY_FREQUENCY,
@@ -179,6 +180,7 @@ pub mod tests {
             "connection_id_1".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Connected,
         );
 
         peer_map.insert(
@@ -186,6 +188,7 @@ pub mod tests {
             "connection_id_2".to_string(),
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
+            PeerStatus::Connected,
         );
 
         let mut peers = peer_map.peer_ids();
@@ -211,6 +214,7 @@ pub mod tests {
             "connection_id_1".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Connected,
         );
 
         peer_map.insert(
@@ -218,6 +222,7 @@ pub mod tests {
             "connection_id_2".to_string(),
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
+            PeerStatus::Connected,
         );
 
         let peers = peer_map.connection_ids();
@@ -249,6 +254,7 @@ pub mod tests {
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Pending,
         );
 
         let peer_metadata = peer_map
@@ -282,6 +288,7 @@ pub mod tests {
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Pending,
         );
         assert!(peer_map.peers.contains_key("test_peer"));
 
@@ -315,6 +322,7 @@ pub mod tests {
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Pending,
         );
         assert!(peer_map.peers.contains_key("test_peer"));
 
@@ -353,6 +361,7 @@ pub mod tests {
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
+            PeerStatus::Connected,
         );
         assert!(peer_map.peers.contains_key("test_peer"));
 


### PR DESCRIPTION
In gameroom (docker-compose) with an existing circuit, when downing one splinterd and upping it again. The two splinterds would reconnect but were left with an orphaned connection that could not send messages over.

Now when handling a new InboundConnection, check to see if there is already a promoted peer for the identity. If there is replace the connection_id and active endpoint for the connection. Also notify subscribers of connection.

PeerInterconnect will also handle the case where a peer's connection id has changed.
