### PR TITLE
Acquire MeshState lock before adding the connection

### DIFF
--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -140,9 +140,9 @@ impl Mesh {
         connection: Box<dyn Connection>,
         unique_id: String,
     ) -> Result<usize, AddError> {
+        let mut state = self.state.write().map_err(|_| AddError::PoisonedLock)?;
         let outgoing = self.ctrl.add(connection)?;
         let mesh_id = outgoing.id();
-        let mut state = self.state.write().map_err(|_| AddError::PoisonedLock)?;
 
         state.outgoings.insert(mesh_id, outgoing);
         state.unique_ids.insert(unique_id, mesh_id);


### PR DESCRIPTION
This fixes a timing issue where a message would be
received before adding the unique id into mesh state.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>