### PR TITLE
Modify authorization state machine

### DIFF
--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -26,8 +26,8 @@ use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::protos::prelude::*;
 
 use super::{
-    AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessageSender,
-    AuthorizationState,
+    AuthorizationAction, AuthorizationActionError, AuthorizationManagerStateMachine,
+    AuthorizationMessageSender, AuthorizationState,
 };
 
 /// Create a Dispatcher for Authorization messages
@@ -137,7 +137,7 @@ impl Handler for AuthorizedHandler {
             AuthorizationAction::RemoteAuthorizing,
         ) {
             Err(err) => {
-                debug!(
+                warn!(
                     "Ignoring authorize message from {}: {}",
                     context.source_connection_id(),
                     err
@@ -185,9 +185,15 @@ impl Handler for ConnectRequestHandler {
             context.source_connection_id(),
             AuthorizationAction::Connecting,
         ) {
-            Err(err) => {
+            Err(AuthorizationActionError::AlreadyConnecting) => {
                 debug!(
-                    "Ignoring duplicate connect message from {}: {}",
+                    "Ignoring duplicate connect request from {}",
+                    context.source_connection_id(),
+                );
+            }
+            Err(err) => {
+                warn!(
+                    "Ignoring connect message from {}: {}",
                     context.source_connection_id(),
                     err
                 );
@@ -332,7 +338,7 @@ impl Handler for TrustRequestHandler {
             AuthorizationAction::TrustIdentifying(trust_request.identity),
         ) {
             Err(err) => {
-                debug!(
+                warn!(
                     "Ignoring trust request message from connection {}: {}",
                     context.source_connection_id(),
                     err

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -50,7 +50,7 @@ pub fn create_authorization_dispatcher(
 
     auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
 
-    auth_dispatcher.set_handler(Box::new(AuthorizedHandler));
+    auth_dispatcher.set_handler(Box::new(AuthorizedHandler::new(auth_manager.clone())));
 
     auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
 
@@ -103,7 +103,15 @@ impl Handler for AuthorizationMessageHandler {
     }
 }
 
-pub struct AuthorizedHandler;
+pub struct AuthorizedHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+impl AuthorizedHandler {
+    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
+    }
+}
 
 impl Handler for AuthorizedHandler {
     type Source = ConnectionId;
@@ -120,10 +128,31 @@ impl Handler for AuthorizedHandler {
         context: &MessageContext<Self::Source, Self::MessageType>,
         _sender: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
-        debug!("Connection {} authorized", context.source_connection_id());
+        debug!(
+            "Received authorize message from {}",
+            context.source_connection_id()
+        );
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::RemoteAuthorizing,
+        ) {
+            Err(err) => {
+                debug!(
+                    "Ignoring authorize message from {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+
+            Ok(_) => {
+                debug!("Authorized by {}", context.source_connection_id());
+            }
+        }
+
         Ok(())
     }
 }
+
 ///
 /// Handler for the Connect Request Authorization Message Type
 struct ConnectRequestHandler {
@@ -309,10 +338,12 @@ impl Handler for TrustRequestHandler {
                     err
                 );
             }
-            Ok(AuthorizationState::Authorized) => {
+            Ok(AuthorizationState::RemoteIdentified(identity))
+            | Ok(AuthorizationState::Authorized(identity)) => {
                 debug!(
-                    "Sending Authorized message to connection {}",
-                    context.source_connection_id()
+                    "Sending Authorized message to connection {} after receiving identity {}",
+                    context.source_connection_id(),
+                    identity,
                 );
                 let auth_msg = AuthorizationMessage::Authorized(Authorized);
                 let mut msg = NetworkMessage::new();

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -456,6 +456,26 @@ pub enum ConnectionAuthorizationState {
     },
 }
 
+impl std::fmt::Debug for ConnectionAuthorizationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ConnectionAuthorizationState::Authorized {
+                connection_id,
+                identity,
+                ..
+            } => f
+                .debug_struct("Authorized")
+                .field("connection_id", connection_id)
+                .field("identity", identity)
+                .finish(),
+            ConnectionAuthorizationState::Unauthorized { connection_id, .. } => f
+                .debug_struct("Unauthorized")
+                .field("connection_id", connection_id)
+                .finish(),
+        }
+    }
+}
+
 #[cfg(test)]
 pub(in crate::network) mod tests {
     use super::*;

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -38,7 +38,9 @@ const AUTHORIZATION_THREAD_POOL_SIZE: usize = 8;
 pub(crate) enum AuthorizationState {
     Unknown,
     Connecting,
-    Authorized,
+    RemoteIdentified(String),
+    RemoteAccepted,
+    Authorized(String),
     Unauthorized,
 }
 
@@ -47,7 +49,9 @@ impl fmt::Display for AuthorizationState {
         f.write_str(match self {
             AuthorizationState::Unknown => "Unknown",
             AuthorizationState::Connecting => "Connecting",
-            AuthorizationState::Authorized => "Authorized",
+            AuthorizationState::RemoteIdentified(_) => "Remote Identified",
+            AuthorizationState::RemoteAccepted => "Remote Accepted",
+            AuthorizationState::Authorized(_) => "Authorized",
             AuthorizationState::Unauthorized => "Unauthorized",
         })
     }
@@ -61,6 +65,7 @@ pub(crate) enum AuthorizationAction {
     Connecting,
     TrustIdentifying(Identity),
     Unauthorizing,
+    RemoteAuthorizing,
 }
 
 impl fmt::Display for AuthorizationAction {
@@ -69,6 +74,7 @@ impl fmt::Display for AuthorizationAction {
             AuthorizationAction::Connecting => f.write_str("Connecting"),
             AuthorizationAction::TrustIdentifying(_) => f.write_str("TrustIdentifying"),
             AuthorizationAction::Unauthorizing => f.write_str("Unauthorizing"),
+            AuthorizationAction::RemoteAuthorizing => f.write_str("RemoteAuthorizing"),
         }
     }
 }
@@ -264,8 +270,8 @@ impl AuthorizationConnector {
                     }
                 };
 
-                if shared.is_complete(&connection_id).is_some() {
-                    break 'main shared.cleanup_connection_state(&connection_id);
+                if let Some(true) = shared.is_complete(&connection_id) {
+                    break 'main shared.take_connection_identity(&connection_id);
                 }
             };
 
@@ -281,6 +287,7 @@ impl AuthorizationConnector {
                     connection,
                 }
             };
+
             if let Err(err) = on_complete_callback(auth_state) {
                 error!("unable to pass auth result to callback: {}", err);
             }
@@ -339,20 +346,19 @@ impl AuthorizationManagerStateMachine {
 
         let cur_state = shared
             .states
-            .get(connection_id)
-            .unwrap_or(&AuthorizationState::Unknown);
-        match *cur_state {
+            .entry(connection_id.to_string())
+            .or_insert(AuthorizationState::Unknown);
+
+        if action == AuthorizationAction::Unauthorizing {
+            *cur_state = AuthorizationState::Unauthorized;
+            return Ok(AuthorizationState::Unauthorized);
+        }
+
+        match &*cur_state {
             AuthorizationState::Unknown => match action {
                 AuthorizationAction::Connecting => {
-                    // Here the decision for Challenges will be made.
-                    shared
-                        .states
-                        .insert(connection_id.to_string(), AuthorizationState::Connecting);
+                    *cur_state = AuthorizationState::Connecting;
                     Ok(AuthorizationState::Connecting)
-                }
-                AuthorizationAction::Unauthorizing => {
-                    shared.mark_complete(connection_id, None);
-                    Ok(AuthorizationState::Unauthorized)
                 }
                 _ => Err(AuthorizationActionError::InvalidMessageOrder(
                     AuthorizationState::Unknown,
@@ -362,24 +368,39 @@ impl AuthorizationManagerStateMachine {
             AuthorizationState::Connecting => match action {
                 AuthorizationAction::Connecting => Err(AuthorizationActionError::AlreadyConnecting),
                 AuthorizationAction::TrustIdentifying(identity) => {
+                    let new_state = AuthorizationState::RemoteIdentified(identity);
+                    *cur_state = new_state.clone();
                     // Verify pub key allowed
-                    shared.mark_complete(connection_id, Some(identity));
-                    Ok(AuthorizationState::Authorized)
+                    Ok(new_state)
                 }
-                AuthorizationAction::Unauthorizing => {
-                    shared.mark_complete(connection_id, None);
-
-                    Ok(AuthorizationState::Unauthorized)
-                }
-            },
-            AuthorizationState::Authorized => match action {
-                AuthorizationAction::Unauthorizing => {
-                    shared.mark_complete(connection_id, None);
-
-                    Ok(AuthorizationState::Unauthorized)
+                AuthorizationAction::RemoteAuthorizing => {
+                    *cur_state = AuthorizationState::RemoteAccepted;
+                    Ok(AuthorizationState::RemoteAccepted)
                 }
                 _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Authorized,
+                    AuthorizationState::Connecting,
+                    action,
+                )),
+            },
+            AuthorizationState::RemoteIdentified(identity) => match action {
+                AuthorizationAction::RemoteAuthorizing => {
+                    let new_state = AuthorizationState::Authorized(identity.clone());
+                    *cur_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::RemoteIdentified(identity.clone()),
+                    action,
+                )),
+            },
+            AuthorizationState::RemoteAccepted => match action {
+                AuthorizationAction::TrustIdentifying(identity) => {
+                    let new_state = AuthorizationState::Authorized(identity);
+                    *cur_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::RemoteAccepted,
                     action,
                 )),
             },
@@ -394,32 +415,32 @@ impl AuthorizationManagerStateMachine {
 #[derive(Default)]
 struct ManagedAuthorizations {
     states: HashMap<String, AuthorizationState>,
-    complete_and_authorized: HashMap<String, Option<String>>,
 }
 
 impl ManagedAuthorizations {
     fn new() -> Self {
         Self {
             states: HashMap::new(),
-            complete_and_authorized: HashMap::new(),
         }
     }
 
-    fn cleanup_connection_state(&mut self, connection_id: &str) -> Option<String> {
-        self.states.remove(connection_id);
-        self.complete_and_authorized.remove(connection_id).flatten()
-    }
-
-    // Mark complete with an optional identity
-    fn mark_complete(&mut self, connection_id: &str, authorized_identity: Option<String>) {
-        self.complete_and_authorized
-            .insert(connection_id.to_string(), authorized_identity);
+    fn take_connection_identity(&mut self, connection_id: &str) -> Option<String> {
+        self.states
+            .remove(connection_id)
+            .and_then(|state| match state {
+                AuthorizationState::Authorized(identity) => Some(identity),
+                _ => None,
+            })
     }
 
     fn is_complete(&self, connection_id: &str) -> Option<bool> {
-        self.complete_and_authorized
+        self.states
             .get(connection_id)
-            .map(|ident| ident.is_some())
+            .and_then(|state| match state {
+                AuthorizationState::Authorized(_) => Some(true),
+                AuthorizationState::Unauthorized => Some(true),
+                _ => Some(false),
+            })
     }
 }
 

--- a/libsplinter/src/network/auth/pool.rs
+++ b/libsplinter/src/network/auth/pool.rs
@@ -198,7 +198,7 @@ impl Worker {
 
                     match msg {
                         Message::NewJob(job) => {
-                            debug!("Worker {} received job; executing.", id);
+                            trace!("Worker {} received job; executing.", id);
                             job.call_box();
                         }
                         Message::Terminate => {


### PR DESCRIPTION
This change require tracking the states more closely. The states of remote acceptance and remote identified have been added, so that these states can be properly transitioned through to the final Authorized state.  

It also allows for the use of the state value to indicate whether or not authorization is complete, as well as hold the identity.
