### PR TITLE
Enhance log message when frame protocol version is incorrect

### DIFF
--- a/libsplinter/src/transport/socket/frame.rs
+++ b/libsplinter/src/transport/socket/frame.rs
@@ -70,6 +70,12 @@ pub enum FrameVersion {
     V1 = 1,
 }
 
+impl std::fmt::Display for FrameVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "v{}", *self as u32)
+    }
+}
+
 /// A complete Frame of transmitted data.
 ///
 /// This struct owns the data that has been transmitted.  It is essentially a receiving frame.

--- a/libsplinter/src/transport/socket/tcp.rs
+++ b/libsplinter/src/transport/socket/tcp.rs
@@ -97,9 +97,11 @@ impl Listener for TcpListener {
         let frame_version = FrameNegotiation::inbound(FrameVersion::V1)
             .negotiate(&mut stream)
             .map_err(|err| match err {
-                FrameError::UnsupportedVersion => AcceptError::ProtocolError(
-                    "Unable to connect; local version not supported by remote".into(),
-                ),
+                FrameError::UnsupportedVersion => AcceptError::ProtocolError(format!(
+                    "Local {} protocol version {} not supported by remote",
+                    PROTOCOL_PREFIX,
+                    FrameVersion::V1
+                )),
                 FrameError::IoError(err) => AcceptError::from(err),
                 err => AcceptError::ProtocolError(format!("Unexpected protocol error: {}", err)),
             })?;

--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -188,9 +188,11 @@ impl Listener for TlsListener {
         let frame_version = FrameNegotiation::inbound(FrameVersion::V1)
             .negotiate(&mut tls_stream)
             .map_err(|err| match err {
-                FrameError::UnsupportedVersion => AcceptError::ProtocolError(
-                    "Unable to connect; local version not supported by remote".into(),
-                ),
+                FrameError::UnsupportedVersion => AcceptError::ProtocolError(format!(
+                    "Local {} protocol version {} not supported by remote",
+                    PROTOCOL_PREFIX,
+                    FrameVersion::V1
+                )),
                 FrameError::IoError(err) => AcceptError::from(err),
                 err => AcceptError::ProtocolError(format!("Unexpected protocol error: {}", err)),
             })?;

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -322,11 +322,12 @@ impl SplinterDaemon {
             .map(|mut network_listener| {
                 let connection_connector_clone = connection_connector.clone();
                 thread::spawn(move || {
+                    let endpoint = network_listener.endpoint();
                     for connection_result in network_listener.incoming() {
                         let connection = match connection_result {
                             Ok(connection) => connection,
                             Err(AcceptError::ProtocolError(msg)) => {
-                                warn!("Failed to accept connection due to {}", msg);
+                                warn!("Failed to accept connection on {}: {}", endpoint, msg);
                                 continue;
                             }
                             Err(AcceptError::IoError(err)) => {


### PR DESCRIPTION
Prior to this change, a generic log message was printed with very little
useful information. After this change, the local endpoint and frame
version information is printed in the log message, making it much
clearer what happened. After this change, it is also possible to tell
the difference between endpoints in the log message, which is useful
when binding to multiple endpoints.

To test, startup a node like this:

```
export SPLINTER_HOME=$(pwd)/home/node1
cargo run \
    --manifest-path cli/Cargo.toml \
    cert generate \
    --skip
cargo run \
    --manifest-path splinterd/Cargo.toml \
    -- \
    -vv \
    --network-endpoints tcp://127.0.0.1:8044 \
    --network-endpoints tcps://127.0.0.1:8045 \
    --tls-insecure
```

Then:

```
openssl s_client -connect 127.0.0.1:8044
openssl s_client -connect 127.0.0.1:8045
```

Type garbage into openssl s_client (necessary for the TLS case) until it disconnects.

You will see something like this in the log output:

```
[2020-05-12 17:20:02.093] T["<unnamed>"] WARN [splinterd::daemon] Failed to accept connection on tcp://127.0.0.1:8044: Local tcp:// protocol version v1 not supported by remote
[2020-05-12 17:20:09.682] T["<unnamed>"] WARN [splinterd::daemon] Failed to accept connection on tcps://127.0.0.1:8045: Local tcps:// protocol version v1 not supported by remote
```