### PR TITLE
Make tcps (TLS) the default network endpoint

### DIFF
--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -135,7 +135,8 @@ OPTIONS
 
 `-n`, `--network-endpoints` `NETWORK-ENDPOINT`
 : Specifies the endpoint for daemon-to-daemon communication between Splinter
-  nodes, using the format `tcp://ip:port`. (Default: 127.0.0.1:8044.)
+  nodes, using the format `protocol_prefix://ip:port`.
+  (Default: tcps://127.0.0.1:8044.)
 
   Specify multiple endpoints in a comma-separated list or with separate
   `-n` or `--network-endpoint` options.
@@ -175,7 +176,7 @@ OPTIONS
 
 `--service-endpoint SERVICE-ENDPOINT`
 : Specifies the endpoint for service-to-daemon communication, using the format
-  `tcp://ip:port`. (Default: `127.0.0.1:8043`.)
+  `tcp://ip:port`. (Default: `tcp://127.0.0.1:8043`.)
 
 `--storage STORAGE-TYPE`
 : Specifies whether to store circuit state in memory or in a local YAML file.

--- a/splinterd/sample_configs/splinterd-node-0-docker.toml
+++ b/splinterd/sample_configs/splinterd-node-0-docker.toml
@@ -19,7 +19,7 @@ version = "1"
 node_id =  "012"
 
 # Endpoint used for service to daemon communication.
-service_endpoint = "127.0.0.1:8043"
+service_endpoint = "tcp://127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
 network_endpoints = ["tcps://127.0.0.1:8044"]

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -30,13 +30,13 @@ display_name = "node-012"
 # Endpoint used for service to daemon communication.
 # Use a protocol prefix to enforce the connection type, using the format
 # `protocol_prefix://ip:port`
-# (default "127.0.0.1:8043")
+# (default "tcp://127.0.0.1:8043")
 service_endpoint = "127.0.0.1:8043"
 
 # Endpoints used for daemon to daemon communication.
 # Use a protocol prefix to enforce the connection type, using the format
 # `protocol_prefix://ip:port`
-# (default ["127.0.0.1:8044"])
+# (default ["tcps://127.0.0.1:8044"])
 network_endpoints = ["tcps://127.0.0.1:8044"]
 
 # Endpoint used for REST API communication

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -30,13 +30,13 @@ display_name = "node_345"
 # Endpoint used for service to daemon communication.
 # Use a protocol prefix to enforce the connection type, using the format
 # `protocol_prefix://ip:port`
-# (default "127.0.0.1:8043")
+# (default "tcp://127.0.0.1:8043")
 service_endpoint = "127.0.0.1:8045"
 
 # Endpoints used for daemon to daemon communication.
 # Use a protocol prefix to enforce the connection type, using the format
 # `protocol_prefix://ip:port`
-# (default ["127.0.0.1:8044"])
+# (default ["tcps://127.0.0.1:8044"])
 network_endpoints = ["tcps://127.0.0.1:8046"]
 
 # Endpoint used for REST API communication

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -29,8 +29,8 @@ const TLS_SERVER_KEY: &str = "private/server.key";
 const TLS_CA_FILE: &str = "ca.pem";
 
 const REST_API_ENDPOINT: &str = "127.0.0.1:8080";
-const SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
-const NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+const SERVICE_ENDPOINT: &str = "tcp://127.0.0.1:8043";
+const NETWORK_ENDPOINT: &str = "tcps://127.0.0.1:8044";
 #[cfg(feature = "database")]
 const DATABASE: &str = "127.0.0.1:5432";
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -484,8 +484,8 @@ mod tests {
     static EXAMPLE_CLIENT_KEY: &str = "private/client.key";
     static EXAMPLE_SERVER_CERT: &str = "server.crt";
     static EXAMPLE_SERVER_KEY: &str = "private/server.key";
-    static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
-    static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
+    static EXAMPLE_SERVICE_ENDPOINT: &str = "tcp://127.0.0.1:8043";
+    static EXAMPLE_NETWORK_ENDPOINT: &str = "tcps://127.0.0.1:8044";
     static EXAMPLE_ADVERTISED_ENDPOINT: &str = "localhost:8044";
     static EXAMPLE_NODE_ID: &str = "012";
     static EXAMPLE_DISPLAY_NAME: &str = "Node 1";

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -388,6 +388,17 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     let config = create_config(config_file_path, matches.clone())?;
 
+    if config.no_tls() {
+        for network_endpoint in config.network_endpoints() {
+            if network_endpoint.starts_with("tcps://") {
+                return Err(UserError::InvalidArgument(format!(
+                    "TLS is disabled, thus endpoint {} is invalid",
+                    network_endpoint,
+                )));
+            }
+        }
+    }
+
     let transport = build_transport(&config)?;
 
     let rest_api_endpoint = config.rest_api_endpoint();


### PR DESCRIPTION
This commit changes the default endpoint from TCP
to TLS. It also now required that if using --no-tls,
a valid tcp:// endpoint is provided otherwise the
following error is returned.

Failed to start daemon, required argument is invalid:
TLS is disabled, thus endpoint tcps://127.0.0.1:8044 is invalid

Also clarifies that service endpoint defaults to tcp://

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>