### PR TITLE
Clean up CORS log statements

### DIFF
--- a/libsplinter/src/rest_api/cors.rs
+++ b/libsplinter/src/rest_api/cors.rs
@@ -37,7 +37,6 @@ impl Cors {
 
     /// Initialize the CORS preflight check with "*" domains.
     pub fn new_allow_any() -> Self {
-        debug!("Creating CORS with whitelist: '*'");
         Cors::new(vec!["*".into()])
     }
 }


### PR DESCRIPTION
Removes a duplicate log statement from the REST API CORS module.

Signed-off-by: Shannyn Telander <telander@bitwise.io>