### PR TITLE
Add tooling for getting scabbard's state root hash 

### DIFF
--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -249,7 +249,7 @@ impl Internal {
         // If the last attempt to refresh the cache wasn't successful, try again
         if !self.last_refresh_successful {
             match self.refresh_cache() {
-                Ok(_) => debug!("Successfully refreshed remote registy '{}'", self.url),
+                Ok(_) => debug!("Successfully refreshed remote registry '{}'", self.url),
                 // Last attempt also failed, so just log with DEBUG to keep the WARN logs clean
                 Err(err) => debug!("Failed to refresh remote registry '{}': {}", self.url, err),
             }
@@ -261,7 +261,10 @@ impl Internal {
             .unwrap_or(false)
         {
             match self.refresh_cache() {
-                Ok(_) => debug!("Forced refresh of remote registy '{}' successful", self.url),
+                Ok(_) => debug!(
+                    "Forced refresh of remote registry '{}' successful",
+                    self.url
+                ),
                 // Already checked that the previous attempt was successful (previous branch of the
                 // if/else), so log as WARN to indicate that something's changed
                 Err(err) => warn!(
@@ -353,7 +356,7 @@ fn automatic_refresh_loop(
         let previous_refresh_successful = internal.last_refresh_successful;
 
         match internal.refresh_cache() {
-            Ok(_) => debug!("Automatic refresh of remote registy '{}' successful", url),
+            Ok(_) => debug!("Automatic refresh of remote registry '{}' successful", url),
             Err(err) => {
                 // If the previous attempt was successful, log with WARN because
                 // something changed; if the previous attempt also failed, just log

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -57,6 +57,7 @@ experimental = [
   "namespace",
   "namespace-permission",
   "smart-permissions",
+  "state",
 ]
 
 contract = []
@@ -65,6 +66,7 @@ execute = []
 namespace = []
 namespace-permission = []
 smart-permissions = []
+state = []
 
 [package.metadata.deb]
 maintainer = "The Splinter Team"

--- a/services/scabbard/libscabbard/src/client/mod.rs
+++ b/services/scabbard/libscabbard/src/client/mod.rs
@@ -85,7 +85,7 @@ impl ScabbardClient {
         }
     }
 
-    /// Get the value at the given `address` in state for the Scabbard instance with the given
+    /// Get the value at the given `address` in state for the scabbard instance with the given
     /// `service_id`. Returns `None` if there is no entry at the given address.
     ///
     /// # Errors
@@ -142,7 +142,7 @@ impl ScabbardClient {
         }
     }
 
-    /// Get all entries under the given address `prefix` in state for the Scabbard instance with
+    /// Get all entries under the given address `prefix` in state for the scabbard instance with
     /// the given `service_id`.
     ///
     /// # Errors

--- a/services/scabbard/libscabbard/src/protocol.rs
+++ b/services/scabbard/libscabbard/src/protocol.rs
@@ -24,3 +24,5 @@ pub(crate) const SCABBARD_BATCH_STATUSES_PROTOCOL_MIN: u32 = 1;
 pub(crate) const SCABBARD_GET_STATE_PROTOCOL_MIN: u32 = 1;
 #[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
 pub(crate) const SCABBARD_LIST_STATE_PROTOCOL_MIN: u32 = 1;
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+pub(crate) const SCABBARD_STATE_ROOT_PROTOCOL_MIN: u32 = 1;

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -187,6 +187,7 @@ impl ServiceFactory for ScabbardFactory {
     /// * `GET /ws/subscribe` - Subscribe to Scabbard state-delta events
     /// * `GET /state/{address}` - Get a value from Scabbard's state
     /// * `GET /state` - Get multiple Scabbard state entries
+    /// * `GET /state_root` - Get the current state root hash of scabbard's state
     ///
     /// These endpoints are only available if the following REST API backend feature is enabled:
     ///
@@ -208,6 +209,7 @@ impl ServiceFactory for ScabbardFactory {
                 actix::batch_statuses::make_get_batch_status_endpoint(),
                 actix::state_address::make_get_state_at_address_endpoint(),
                 actix::state::make_get_state_with_prefix_endpoint(),
+                actix::state_root::make_get_state_root_endpoint(),
             ])
         }
 

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -182,11 +182,11 @@ impl ServiceFactory for ScabbardFactory {
     /// The `Scabbard` services created by the `ScabbardFactory` provide the following REST API
     /// endpoints as [`ServiceEndpoint`]s:
     ///
-    /// * `POST /batches` - Add one or more batches to Scabbard's queue
+    /// * `POST /batches` - Add one or more batches to scabbard's queue
     /// * `GET /batch_statuses` - Get the status of one or more batches
-    /// * `GET /ws/subscribe` - Subscribe to Scabbard state-delta events
-    /// * `GET /state/{address}` - Get a value from Scabbard's state
-    /// * `GET /state` - Get multiple Scabbard state entries
+    /// * `GET /ws/subscribe` - Subscribe to scabbard state-delta events
+    /// * `GET /state/{address}` - Get a value from scabbard's state
+    /// * `GET /state` - Get multiple scabbard state entries
     /// * `GET /state_root` - Get the current state root hash of scabbard's state
     ///
     /// These endpoints are only available if the following REST API backend feature is enabled:

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -142,6 +142,16 @@ impl Scabbard {
             .get_state_with_prefix(prefix)?)
     }
 
+    /// Get the current state root hash of the scabbard service's state.
+    pub fn get_current_state_root(&self) -> Result<String, ScabbardError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| ScabbardError::LockPoisoned)?
+            .current_state_root()
+            .to_string())
+    }
+
     pub fn add_batches(&self, batches: Vec<BatchPair>) -> Result<Option<String>, ScabbardError> {
         let mut shared = self
             .shared

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -121,7 +121,7 @@ impl Scabbard {
         })
     }
 
-    /// Fetch the value at the given `address` in the Scabbard service's state. Returns `None` if
+    /// Fetch the value at the given `address` in the scabbard service's state. Returns `None` if
     /// the `address` is not set.
     pub fn get_state_at_address(&self, address: &str) -> Result<Option<Vec<u8>>, ScabbardError> {
         Ok(self
@@ -131,7 +131,7 @@ impl Scabbard {
             .get_state_at_address(address)?)
     }
 
-    /// Fetch a list of entries in the Scabbard service's state. If a `prefix` is provided, only
+    /// Fetch a list of entries in the scabbard service's state. If a `prefix` is provided, only
     /// return entries whose addresses are under the given address prefix. If no `prefix` is
     /// provided, return all state entries.
     pub fn get_state_with_prefix(&self, prefix: Option<&str>) -> Result<StateIter, ScabbardError> {

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/mod.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/mod.rs
@@ -16,4 +16,5 @@ pub mod batch_statuses;
 pub mod batches;
 pub mod state;
 pub mod state_address;
+pub mod state_root;
 pub mod ws_subscribe;

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -1,0 +1,245 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use actix_web::HttpResponse;
+use futures::IntoFuture;
+use splinter::{
+    rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard},
+    service::rest_api::ServiceEndpoint,
+};
+
+use crate::protocol;
+use crate::service::{Scabbard, SERVICE_TYPE};
+
+pub fn make_get_state_root_endpoint() -> ServiceEndpoint {
+    ServiceEndpoint {
+        service_type: SERVICE_TYPE.into(),
+        route: "/state_root".into(),
+        method: Method::Get,
+        handler: Arc::new(move |_, _, service| {
+            let scabbard = match service.as_any().downcast_ref::<Scabbard>() {
+                Some(s) => s,
+                None => {
+                    error!("Failed to downcast to scabbard service");
+                    return Box::new(
+                        HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future(),
+                    );
+                }
+            };
+
+            Box::new(match scabbard.get_current_state_root() {
+                Ok(state_root) => HttpResponse::Ok().json(state_root).into_future(),
+                Err(err) => {
+                    error!("Failed to get current state root: {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            })
+        }),
+        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+            protocol::SCABBARD_STATE_ROOT_PROTOCOL_MIN,
+            protocol::SCABBARD_PROTOCOL_VERSION,
+        ))],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use reqwest::{blocking::Client, StatusCode, Url};
+    use tempdir::TempDir;
+    use transact::{
+        families::command::make_command_transaction,
+        protocol::{
+            batch::BatchBuilder,
+            command::{BytesEntry, Command, SetState},
+        },
+        signing::hash::HashSigner,
+    };
+
+    use splinter::{
+        rest_api::{Resource, RestApiBuilder, RestApiServerError, RestApiShutdownHandle},
+        service::Service,
+        signing::hash::HashVerifier,
+    };
+
+    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard};
+
+    const MOCK_CIRCUIT_ID: &str = "abcde-01234";
+    const MOCK_SERVICE_ID: &str = "ABCD";
+    const TEMP_DB_SIZE: usize = 1 << 30; // 1024 ** 3
+
+    /// Verify that the `GET /state_root` endpoint works properly.
+    ///
+    /// 1. Initialize a temporary instance of `ScabbardState`, set some values in state, and get
+    ///    the resulting state root hash.
+    /// 2. Initialize an instance of the `Scabbard` service that's backed by the same underlying
+    ///    state that was set in the previous step.
+    /// 3. Setup the REST API with the `GET /state_root` endpoint exposed.
+    /// 3. Make a request to the endpoint, verify that the response code is 200, and check that the
+    ///    body of the response contains the same state root hash that was reported in step (1).
+    #[test]
+    fn state_root() {
+        let paths = StatePaths::new("state_root");
+
+        // Initialize a temporary scabbard state and set some values to pre-populate the DBs, then
+        // get the resulting state root hash.
+        let expected_state_root = {
+            let mut state = ScabbardState::new(
+                &paths.state_db_path,
+                TEMP_DB_SIZE,
+                &paths.receipt_db_path,
+                TEMP_DB_SIZE,
+                vec![],
+            )
+            .expect("Failed to initialize state");
+
+            let signer = HashSigner::default();
+            let batch = BatchBuilder::new()
+                .with_transactions(vec![
+                    make_command_transaction(&[Command::SetState(SetState::new(vec![
+                        BytesEntry::new("abcdef".into(), b"value1".to_vec()),
+                        BytesEntry::new("012345".into(), b"value2".to_vec()),
+                    ]))])
+                    .take()
+                    .0,
+                ])
+                .build_pair(&signer)
+                .expect("Failed to build batch");
+            state
+                .prepare_change(batch)
+                .expect("Failed to prepare change");
+            state.commit().expect("Failed to commit change");
+            state.current_state_root().to_string()
+        };
+
+        // Initialize scabbard
+        let scabbard = Scabbard::new(
+            MOCK_SERVICE_ID.into(),
+            MOCK_CIRCUIT_ID,
+            Default::default(),
+            paths.temp_dir.path(),
+            TEMP_DB_SIZE,
+            paths.temp_dir.path(),
+            TEMP_DB_SIZE,
+            Box::new(HashVerifier),
+            vec![],
+            None,
+        )
+        .expect("Failed to create scabbard");
+
+        // Setup the REST API
+        let (shutdown_handle, join_handle, bind_url) =
+            run_rest_api_on_open_port(vec![resource_from_service_endpoint(
+                make_get_state_root_endpoint(),
+                Arc::new(Mutex::new(scabbard)),
+            )]);
+
+        // Verify that a request is successful and the correct state root hash is returned
+        let url =
+            Url::parse(&format!("http://{}/state_root", bind_url)).expect("Failed to parse URL");
+        let resp = Client::new()
+            .get(url)
+            .header(
+                "SplinterProtocolVersion",
+                protocol::SCABBARD_PROTOCOL_VERSION,
+            )
+            .send()
+            .expect("Failed to perform request");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let response_state_root: String = resp.json().expect("Failed to deserialize body");
+        assert_eq!(response_state_root, expected_state_root);
+
+        shutdown_handle
+            .shutdown()
+            .expect("Unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
+    }
+
+    struct StatePaths {
+        pub temp_dir: TempDir,
+        pub state_db_path: PathBuf,
+        pub receipt_db_path: PathBuf,
+    }
+
+    impl StatePaths {
+        fn new(prefix: &str) -> Self {
+            let temp_dir = TempDir::new(prefix).expect("Failed to create temp dir");
+            // This computes the paths such that they're the same ones that will be used by
+            // scabbard when it's initialized
+            let (state_db_path, receipt_db_path) = compute_db_paths(
+                MOCK_SERVICE_ID,
+                MOCK_CIRCUIT_ID,
+                temp_dir.path(),
+                temp_dir.path(),
+            )
+            .expect("Failed to compute DB paths");
+            Self {
+                temp_dir,
+                state_db_path,
+                receipt_db_path,
+            }
+        }
+    }
+
+    fn resource_from_service_endpoint(
+        service_endpoint: ServiceEndpoint,
+        service: Arc<Mutex<dyn Service>>,
+    ) -> Resource {
+        let mut resource = Resource::build(&service_endpoint.route);
+        for request_guard in service_endpoint.request_guards.into_iter() {
+            resource = resource.add_request_guard(request_guard);
+        }
+        let handler = service_endpoint.handler;
+        resource.add_method(service_endpoint.method, move |request, payload| {
+            (handler)(
+                request,
+                payload,
+                &*service.lock().expect("Service lock poisoned"),
+            )
+        })
+    }
+
+    fn run_rest_api_on_open_port(
+        resources: Vec<Resource>,
+    ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
+        (10000..20000)
+            .find_map(|port| {
+                let bind_url = format!("127.0.0.1:{}", port);
+                let result = RestApiBuilder::new()
+                    .with_bind(&bind_url)
+                    .add_resources(resources.clone())
+                    .build()
+                    .expect("Failed to build REST API")
+                    .run();
+                match result {
+                    Ok((shutdown_handle, join_handle)) => {
+                        Some((shutdown_handle, join_handle, bind_url))
+                    }
+                    Err(RestApiServerError::BindError(_)) => None,
+                    Err(err) => panic!("Failed to run REST API: {}", err),
+                }
+            })
+            .expect("No port available")
+    }
+}

--- a/services/scabbard/libscabbard/src/service/state.rs
+++ b/services/scabbard/libscabbard/src/service/state.rs
@@ -216,6 +216,11 @@ impl ScabbardState {
         ))
     }
 
+    /// Get the current state root hash.
+    pub fn current_state_root(&self) -> &str {
+        &self.current_state_root
+    }
+
     pub fn prepare_change(&mut self, batch: BatchPair) -> Result<String, ScabbardStateError> {
         // Setup the transact scheduler
         let (result_tx, result_rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
Adds the following to support checking a scabbard service's current
state root hash:
- `ScabbardState::current_state_root` method
- `Scabbard::get_current_state_root` method
- `GET /state_root` REST API endpoint
- `ScabbardClient::get_current_state_root` method
- `scabbard state root` CLI subcommand

Signed-off-by: Logan Seeley <seeley@bitwise.io>

To test:
1. Sartup gameroom
2. Create a new room between acme and bubba
3. Navigate to the scabbard CLI directory (`cd services/scabbard/cli` from the root repo directory)
4. Run `cargo run --features=state -- state root --url http://localhost:8088 --service-id <circuit_id>::<acme_service_id>`
5. Run `cargo run --features=state -- state root --url http://localhost:8089 --service-id <circuit_id>::<bubba_service_id>`
6. Verify that the result of (4) and (5) is the same