### PR TITLE
Add a context string to ListenError::IoError

### DIFF
--- a/libsplinter/src/transport/error.rs
+++ b/libsplinter/src/transport/error.rs
@@ -110,14 +110,14 @@ impl From<io::Error> for DisconnectError {
 
 #[derive(Debug)]
 pub enum ListenError {
-    IoError(io::Error),
+    IoError(String, io::Error),
     ProtocolError(String),
 }
 
 impl Error for ListenError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            ListenError::IoError(err) => Some(err),
+            ListenError::IoError(_, err) => Some(err),
             ListenError::ProtocolError(_) => None,
         }
     }
@@ -126,15 +126,9 @@ impl Error for ListenError {
 impl std::fmt::Display for ListenError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ListenError::IoError(err) => write!(f, "io error occurred: {}", err),
+            ListenError::IoError(msg, err) => write!(f, "io error occurred: {}: {}", msg, err),
             ListenError::ProtocolError(err) => write!(f, "protocol error occurred: {}", err),
         }
-    }
-}
-
-impl From<io::Error> for ListenError {
-    fn from(io_error: io::Error) -> Self {
-        ListenError::IoError(io_error)
     }
 }
 

--- a/libsplinter/src/transport/socket/tcp.rs
+++ b/libsplinter/src/transport/socket/tcp.rs
@@ -81,7 +81,9 @@ impl Transport for TcpTransport {
         };
 
         Ok(Box::new(TcpListener {
-            listener: StdTcpListener::bind(address)?,
+            listener: StdTcpListener::bind(address).map_err(|err| {
+                ListenError::IoError(format!("Failed to bind to {}", address), err)
+            })?,
         }))
     }
 }

--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -169,7 +169,9 @@ impl Transport for TlsTransport {
         };
 
         Ok(Box::new(TlsListener {
-            listener: TcpListener::bind(address)?,
+            listener: TcpListener::bind(address).map_err(|err| {
+                ListenError::IoError(format!("Failed to bind to {}", address), err)
+            })?,
             acceptor: self.acceptor.clone(),
         }))
     }

--- a/libsplinter/src/transport/ws/transport.rs
+++ b/libsplinter/src/transport/ws/transport.rs
@@ -126,8 +126,14 @@ impl Transport for WsTransport {
             bind
         };
 
-        let server: Server<NoTlsAcceptor> = Server::bind(address)?;
-        let local_endpoint = format!("ws://{}", server.local_addr()?);
+        let server: Server<NoTlsAcceptor> = Server::bind(address)
+            .map_err(|err| ListenError::IoError(format!("Failed to bind to {}", address), err))?;
+        let local_endpoint = format!(
+            "ws://{}",
+            server.local_addr().map_err(|err| {
+                ListenError::IoError("Failed to get local address".into(), err)
+            })?
+        );
 
         Ok(Box::new(WsListener::new(server, local_endpoint)))
     }


### PR DESCRIPTION
Adds a context string to transport's `ListenError::IoError` variant.
This string provides more information about the error that occurred,
like the address the transport was attempting to listen to. Before this
change, there was no context to provide clues about why the error
occurred.

Signed-off-by: Logan Seeley <seeley@bitwise.io>