### PR TITLE
Remove `service_endpoint` from CLI status response

### DIFF
--- a/cli/src/action/api.rs
+++ b/cli/src/action/api.rs
@@ -74,7 +74,6 @@ pub struct ServerError {
 pub struct NodeStatus {
     pub node_id: String,
     pub display_name: String,
-    pub service_endpoint: String,
     pub network_endpoints: Vec<String>,
     pub advertised_endpoints: Vec<String>,
     pub version: String,


### PR DESCRIPTION
Remove the `service_endpoint` field from the `NodeStatus` struct in the
CLI, which is used to parse the response from a `GET /status` request
made to splinterd. This field was recently moved behind an experimental
feature, so it is not included in the response by default. This field is
not currently required by the CLI, so it can be removed.

Signed-off-by: Logan Seeley <seeley@bitwise.io>