### PR TITLE
Await response from submit endpoint

### DIFF
--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -62,6 +62,7 @@ async function http(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest();
+    request.responseType = 'json';
     request.open(method, `/api${url}`);
     if (headerFn) {
       headerFn(request);
@@ -70,7 +71,7 @@ async function http(
       if (request.status >= 200 && request.status < 300) {
         resolve(request.response);
       } else {
-        console.error(request);
+        console.error(request.response.message);
         if (request.status >= 400 && request.status < 500) {
           reject('Failed to send request. Contact the administrator for help.');
         } else {

--- a/examples/gameroom/gameroom-app/src/views/Dashboard.vue
+++ b/examples/gameroom/gameroom-app/src/views/Dashboard.vue
@@ -151,7 +151,7 @@ export default class Dashboard extends Vue {
         this.submitting = true;
         const member = this.newGameroom.member ? this.newGameroom.member.identity : '';
         try {
-          this.$store.dispatch('gamerooms/proposeGameroom', {
+          await this.$store.dispatch('gamerooms/proposeGameroom', {
             alias: this.newGameroom.alias,
             members: [member],
           });


### PR DESCRIPTION
Waits for the response from the /submit endpoint to more accurately
display error messages that may occur.

To test: Run the gameroom example, then attempt submitting a gameroom proposal with the local node selected. (So, if you're on Acme's UI, select the 'Acme' node in the dropdown and vice-versa for bubba's UI) This should then display the error rather than a success message, as it previously did. 