### PR TITLE
Set low level crates to log level Warn

### DIFF
--- a/services/scabbard/cli/src/main.rs
+++ b/services/scabbard/cli/src/main.rs
@@ -1380,6 +1380,10 @@ fn run() -> Result<(), CliError> {
 fn setup_logging(log_level: log::LevelFilter) -> Result<(), CliError> {
     let mut log_spec_builder = LogSpecBuilder::new();
     log_spec_builder.default(log_level);
+    log_spec_builder.module("reqwest", log::LevelFilter::Warn);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("mio", log::LevelFilter::Warn);
+    log_spec_builder.module("want", log::LevelFilter::Warn);
 
     Logger::with(log_spec_builder.build())
         .format(log_format)


### PR DESCRIPTION
This is done in the splinter cli as well. This reduces the noisy
logs when adding a lot of -vvv.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>