### PR TITLE
Update peers created by only an endpoint, to be treated like a normal peer

### DIFF
--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -21,7 +21,7 @@ use super::error::{
     PeerRefRemoveError, PeerUnknownAddError,
 };
 use super::notification::PeerNotificationIter;
-use super::PeerRef;
+use super::{EndpointPeerRef, PeerRef};
 use super::{PeerManagerMessage, PeerManagerRequest};
 
 /// The PeerLookup trait provides an interface for looking up details about individual peer
@@ -104,8 +104,11 @@ impl PeerManagerConnector {
     ///
     /// * `endpoint` - The endpoint associated with the peer.
     ///
-    /// Returns Ok() if the unidentified peer was added
-    pub fn add_unidentified_peer(&self, endpoint: String) -> Result<(), PeerUnknownAddError> {
+    /// Returns Ok(EndpointPeerRef) if the unidentified peer was added
+    pub fn add_unidentified_peer(
+        &self,
+        endpoint: String,
+    ) -> Result<EndpointPeerRef, PeerUnknownAddError> {
         let (sender, recv) = channel();
 
         let message =

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -284,6 +284,27 @@ impl PeerRemover {
         recv.recv()
             .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
     }
+
+    pub fn remove_peer_ref_by_endpoint(&self, endpoint: &str) -> Result<(), PeerRefRemoveError> {
+        let (sender, recv) = channel();
+
+        let message = PeerManagerMessage::Request(PeerManagerRequest::RemovePeerByEndpoint {
+            endpoint: endpoint.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerRefRemoveError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
+    }
 }
 
 impl PartialEq for PeerRemover {

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1013,7 +1013,7 @@ fn handle_inbound_connection(
             }
         }
     } else {
-        debug!("Adding unrefrenced peer for {}", identity);
+        debug!("Adding peer with id: {}", identity);
 
         if let Some(old_peer) = unreferenced_peers.peers.insert(
             identity,
@@ -1022,8 +1022,8 @@ fn handle_inbound_connection(
                 endpoint: endpoint.to_string(),
             },
         ) {
-            debug!("Removing old unreferenced peer connection");
             if old_peer.endpoint != endpoint {
+                debug!("Removing old peer connection for {}", old_peer.endpoint);
                 if let Err(err) = connector.remove_connection(&old_peer.endpoint) {
                     error!("Unable to clean up old connection: {}", err);
                 }
@@ -1172,8 +1172,8 @@ fn handle_connected(
                 endpoint: endpoint.to_string(),
             },
         ) {
-            debug!("Removing old unreferenced peer connection");
             if old_peer.endpoint != endpoint {
+                debug!("Removing old peer connection for {}", old_peer.endpoint);
                 if let Err(err) = connector.remove_connection(&old_peer.endpoint) {
                     error!("Unable to clean up old connection: {}", err);
                 }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -606,10 +606,12 @@ fn add_peer(
     let mut active_endpoint = match endpoints.get(0) {
         Some(endpoint) => endpoint.to_string(),
         None => {
+            // remove ref we just added
+            ref_map.remove_ref(&peer_id);
             return Err(PeerRefAddError::AddError(format!(
                 "No endpoints provided for peer {}",
                 peer_id
-            )))
+            )));
         }
     };
 

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -925,7 +925,7 @@ fn handle_disconnection(
         }
         subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
     } else {
-        // check for unrefrenced peer and remove if it has disconnected
+        // check for unreferenced peer and remove if it has disconnected
         debug!("Removing disconnected peer: {}", identity);
         if let Some(unref_peer) = unreferenced_peers.peers.remove(&identity) {
             if let Err(err) = connector.remove_connection(&unref_peer.endpoint) {

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -690,7 +690,7 @@ fn remove_peer(
             ))
         })?;
 
-        // If the peer is pending or invalid there is no connection to remove
+        // If the peer is pending there is no connection to remove
         if peer_metadata.status == PeerStatus::Pending {
             return Ok(());
         }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -137,6 +137,40 @@ impl Drop for PeerRef {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct EndpointPeerRef {
+    endpoint: String,
+    peer_remover: PeerRemover,
+}
+
+impl EndpointPeerRef {
+    pub(super) fn new(endpoint: String, peer_remover: PeerRemover) -> Self {
+        EndpointPeerRef {
+            endpoint,
+            peer_remover,
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for EndpointPeerRef {
+    fn drop(&mut self) {
+        match self
+            .peer_remover
+            .remove_peer_ref_by_endpoint(&self.endpoint)
+        {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Unable to remove reference to peer with endpoint {} on drop: {}",
+                self.endpoint, err
+            ),
+        }
+    }
+}
+
 /// An entry of unreferenced peers, that may connected externally, but not yet requested locally.
 #[derive(Debug)]
 struct UnreferencedPeer {

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -157,6 +157,10 @@ impl PeerMap {
             .iter()
             .filter(|(_id, peer_meta)| peer_meta.status == PeerStatus::Pending)
     }
+
+    pub fn contains_endpoint(&self, endpoint: &str) -> bool {
+        self.endpoints.contains_key(endpoint)
+    }
 }
 
 #[cfg(test)]

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -364,9 +364,11 @@ impl SplinterDaemon {
             })
             .collect::<Vec<_>>();
 
+        // hold on to peer refs for the peers provided to ensure the connections are kept around
+        let mut peer_refs = vec![];
         for endpoint in self.initial_peers.iter() {
             match peer_connector.add_unidentified_peer(endpoint.into()) {
-                Ok(_) => (),
+                Ok(peer_ref) => peer_refs.push(peer_ref),
                 Err(err) => error!("Connect Error: {}", err),
             }
         }


### PR DESCRIPTION
add_unidentified_peer now returns an EndpointPeerRef that will act like a normal PeerRef, sending a remove request on drop. On successful connection the peer is added to the peer map and treated like a normal peer. 