### PR TITLE
Remove config-* features

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -66,10 +66,6 @@ default = [
     "biome",
     "biome-credentials",
     "biome-key-management",
-    "config-command-line",
-    "config-default",
-    "config-env-var",
-    "config-toml",
 ]
 
 stable = [
@@ -90,10 +86,6 @@ experimental = [
 biome = ["splinter/biome", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
 biome-key-management = ["splinter/biome-key-management", "biome"]
-config-default = []
-config-command-line = []
-config-env-var = []
-config-toml = []
 database = ["splinter/postgres"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -60,7 +60,6 @@ impl ConfigBuilder {
         }
     }
 
-    #[cfg(feature = "default")]
     /// Adds a `PartialConfig` to the `ConfigBuilder` object.
     ///
     /// # Arguments

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -14,7 +14,6 @@
 
 use std::error::Error;
 use std::fmt;
-#[cfg(feature = "config-env-var")]
 use std::io;
 
 use toml::de::Error as TomlError;
@@ -22,17 +21,11 @@ use toml::de::Error as TomlError;
 #[derive(Debug)]
 /// General error type used during `Config` contruction.
 pub enum ConfigError {
-    #[cfg(feature = "config-toml")]
-    ReadError {
-        file: String,
-        err: io::Error,
-    },
+    ReadError { file: String, err: io::Error },
     TomlParseError(TomlError),
     InvalidArgument(clap::Error),
     MissingValue(String),
-    #[cfg(feature = "config-toml")]
     InvalidVersion(String),
-    #[cfg(feature = "config-env-var")]
     StdError(io::Error),
 }
 
@@ -51,14 +44,11 @@ impl From<clap::Error> for ConfigError {
 impl Error for ConfigError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            #[cfg(feature = "config-toml")]
             ConfigError::ReadError { err, .. } => Some(err),
             ConfigError::TomlParseError(source) => Some(source),
             ConfigError::InvalidArgument(source) => Some(source),
             ConfigError::MissingValue(_) => None,
-            #[cfg(feature = "config-toml")]
             ConfigError::InvalidVersion(_) => None,
-            #[cfg(feature = "config-env-var")]
             ConfigError::StdError(source) => Some(source),
         }
     }
@@ -67,16 +57,13 @@ impl Error for ConfigError {
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            #[cfg(feature = "config-toml")]
             ConfigError::ReadError { file, err } => write!(f, "{}: {}", err, file),
             ConfigError::TomlParseError(source) => write!(f, "Invalid File Format: {}", source),
             ConfigError::InvalidArgument(source) => {
                 write!(f, "Unable to parse command line argument: {}", source)
             }
             ConfigError::MissingValue(msg) => write!(f, "Configuration value must be set: {}", msg),
-            #[cfg(feature = "config-toml")]
             ConfigError::InvalidVersion(msg) => write!(f, "{}", msg),
-            #[cfg(feature = "config-env-var")]
             ConfigError::StdError(source) => write!(f, "{}", source),
         }
     }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -19,26 +19,18 @@
 //! sources to be combined into a final `Config` object.
 
 mod builder;
-#[cfg(feature = "config-command-line")]
 mod clap;
-#[cfg(feature = "config-default")]
 mod default;
-#[cfg(feature = "config-env-var")]
 mod env;
 mod error;
 mod partial;
-#[cfg(feature = "config-toml")]
 mod toml;
 
 use std::time::Duration;
 
-#[cfg(feature = "config-command-line")]
 pub use crate::config::clap::ClapPartialConfigBuilder;
-#[cfg(feature = "config-default")]
 pub use crate::config::default::DefaultPartialConfigBuilder;
-#[cfg(feature = "config-env-var")]
 pub use crate::config::env::EnvPartialConfigBuilder;
-#[cfg(feature = "config-toml")]
 pub use crate::config::toml::TomlPartialConfigBuilder;
 pub use builder::{ConfigBuilder, PartialConfigBuilder};
 pub use error::ConfigError;
@@ -460,7 +452,6 @@ impl Config {
     }
 }
 
-#[cfg(feature = "default")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -215,7 +215,6 @@ impl PartialConfig {
         self.whitelist.clone()
     }
 
-    #[cfg(feature = "config-env-var")]
     /// Adds a `config_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -227,7 +226,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `storage` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -239,7 +237,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_cert_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -251,7 +248,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_ca_file` value to the  `PartialConfig` object.
     ///
     /// # Arguments
@@ -263,7 +259,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_client_cert` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -276,7 +271,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_client_key` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -288,7 +282,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_server_cert` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -301,7 +294,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_server_key` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -313,7 +305,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `service_endpoint` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -326,7 +317,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `network_endpoints` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -338,7 +328,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `advertised_endpoints` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -350,7 +339,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `peers` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -362,7 +350,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `node_id` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -374,7 +361,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `display_name` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -385,8 +371,6 @@ impl PartialConfig {
         self.display_name = display_name;
         self
     }
-
-    #[allow(dead_code)]
 
     /// Adds a `rest_api_endpoint` value to the PartialConfig object.
     ///
@@ -412,7 +396,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `registries` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -424,7 +407,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `registry_auto_refresh` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -437,7 +419,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `registry_forced_refresh` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -450,7 +431,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `heartbeat` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -462,7 +442,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `timeout` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -478,7 +457,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `state_dir` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -490,7 +468,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `tls_insecure` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -502,7 +479,6 @@ impl PartialConfig {
         self
     }
 
-    #[allow(dead_code)]
     /// Adds a `no-tls` value to the `PartialConfig` object.
     ///
     /// # Arguments


### PR DESCRIPTION
Removes the config-* features and guards related to the use of the
config modules in splinterd.

Signed-off-by: Shannyn Telander <telander@bitwise.io>