### PR TITLE
Add CI linting for scabbard

### DIFF
--- a/docker/compose/run-lint.yaml
+++ b/docker/compose/run-lint.yaml
@@ -47,7 +47,9 @@ services:
          echo \"Running clippy on experimental features...\" && \
          (cd libsplinter && cargo clippy --features experimental -- -D warnings) && \
          (cd splinterd && cargo clippy --features experimental -- -D warnings) && \
-         (cd cli && cargo clippy --features experimental -- -D warnings)
+         (cd cli && cargo clippy --features experimental -- -D warnings) && \
+         (cd services/scabbard/cli && cargo clippy --features experimental -- -D warnings) && \
+         (cd services/scabbard/libscabbard && cargo clippy --features experimental -- -D warnings)
       "
 
   lint-gameroom-client:


### PR DESCRIPTION
Lint the scabbard CLI and libscabbard crates with experimental features
as part of CI.

Signed-off-by: Logan Seeley <seeley@bitwise.io>