### PR TITLE
Parse response into JSON to extract error message

### DIFF
--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -62,7 +62,6 @@ async function http(
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest();
-    request.responseType = 'json';
     request.open(method, `/api${url}`);
     if (headerFn) {
       headerFn(request);
@@ -71,7 +70,8 @@ async function http(
       if (request.status >= 200 && request.status < 300) {
         resolve(request.response);
       } else {
-        console.error(request.response.message);
+        const responseBody = JSON.parse(request.responseText);
+        console.error(responseBody.message);
         if (request.status >= 400 && request.status < 500) {
           reject('Failed to send request. Contact the administrator for help.');
         } else {


### PR DESCRIPTION
This fixes an error which was parsing the response to extract the error message, but then later handling of the response also tried to parse (leading to an error). 

Now, this just parses the response text into a JSON object if we need to extract the error message, and logs that error message rather than just the request/ response itself. 