### PR TITLE
Add more error pages to Gameroom UI

### DIFF
--- a/examples/gameroom/gameroom-app/src/router.ts
+++ b/examples/gameroom/gameroom-app/src/router.ts
@@ -94,6 +94,11 @@ const router = new Router({
           name: 'not-found',
           component: () => import('@/views/NotFound.vue'),
         },
+        {
+          path: '/server-error',
+          name: 'server-error',
+          component: () => import('@/views/ServerError.vue'),
+        },
       ],
     },
   ],

--- a/examples/gameroom/gameroom-app/src/router.ts
+++ b/examples/gameroom/gameroom-app/src/router.ts
@@ -99,6 +99,11 @@ const router = new Router({
           name: 'server-error',
           component: () => import('@/views/ServerError.vue'),
         },
+        {
+          path: '/request-error',
+          name: 'request-error',
+          component: () => import('@/views/RequestError.vue'),
+        },
       ],
     },
   ],

--- a/examples/gameroom/gameroom-app/src/store/api.ts
+++ b/examples/gameroom/gameroom-app/src/store/api.ts
@@ -40,15 +40,17 @@ gameroomAPI.interceptors.response.use(
     if (error.response) {
       switch (error.response.status) {
         case 401:
-          throw new Error('Incorrect username or password.');
+          console.error('Incorrect username or password');
+          throw error;
         case 500:
-          throw new Error(
-            'The Gameroom server has encountered an error. Please contact the administrator.',
-          );
+          console.error('The Gameroom server is unavailable. Please contact the administrator.');
+          throw error;
         case 503:
-          throw new Error('The Gameroom server is unavailable. Please contact the administrator.');
+          console.error('The Gameroom server is unavailable. Please contact the administrator.');
+          throw error;
         default:
-          throw new Error(error.response.data.message);
+          console.error('Encountered an error.');
+          throw error;
       }
     }
   },

--- a/examples/gameroom/gameroom-app/src/views/GameDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameDetail.vue
@@ -94,8 +94,9 @@ function setSelectedGameroom(to: any, next: any) {
   });
 }
 
-function listGames(to: any, next: any) {
-  store.dispatch('games/listGames', to.params.id).then(() => {
+async function listGames(to: any, next: any) {
+  try {
+    await store.dispatch('games/listGames', to.params.id).then(() => {
       const selectedGame = store.getters['games/getGames'].find(
         (game: Game) => game.game_name_hash === to.params.gameNameHash);
       if (selectedGame) {
@@ -103,7 +104,17 @@ function listGames(to: any, next: any) {
       } else {
         next({ name: 'not-found' });
       }
-  });
+    });
+  } catch (e) {
+    store.commit('pageLoading/setPageLoadingComplete');
+    if (e.response.status === 404) {
+      next({ name: 'not-found' });
+    } else if (e.response.status >= 500 || e.response.status < 600) {
+      next({ name: 'server-error' });
+    } else {
+      next({ name: 'request-error' });
+    }
+  }
 }
 
 </script>

--- a/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
+++ b/examples/gameroom/gameroom-app/src/views/GameroomDetail.vue
@@ -132,7 +132,14 @@ import Loading from '@/components/Loading.vue';
           await store.dispatch('games/listGames', to.params.id);
           next();
         } catch (e) {
-          next({ name: 'not-found' });
+          store.commit('pageLoading/setPageLoadingComplete');
+          if (e.response.status === 404) {
+            next({ name: 'not-found' });
+          } else if (e.response.status >= 500 || e.response.status < 600) {
+            next({ name: 'server-error' });
+          } else {
+            next({ name: 'request-error' });
+          }
         }
       }
 
@@ -144,7 +151,14 @@ import Loading from '@/components/Loading.vue';
           await store.dispatch('games/listGames', to.params.id);
           next();
         } catch (e) {
-          next({ name: 'not-found' });
+          store.commit('pageLoading/setPageLoadingComplete');
+          if (e.response.status === 404) {
+            next({ name: 'not-found' });
+          } else if (e.response.status >= 500 || e.response.status < 600) {
+            next({ name: 'server-error' });
+          } else {
+            next({ name: 'request-error' });
+          }
         }
       }
 

--- a/examples/gameroom/gameroom-app/src/views/RequestError.vue
+++ b/examples/gameroom/gameroom-app/src/views/RequestError.vue
@@ -1,0 +1,56 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div class="request-error-container">
+    <h2>Request Error</h2>
+    <div class="message-containter">
+      <i class="material-icons error-icon"> error_outline </i>
+      <h3>Error encountered processing request</h3>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+@Component
+export default class RequestErrorPage extends Vue {}
+</script>
+
+<style lang="scss" scoped>
+  .request-error-container {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 4rem;
+    height: 100%;
+  }
+
+  .message-containter {
+    @include overlay(1);
+    @include rounded-border;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    margin-top: 2rem;
+    align-items: center;
+    justify-content: center;
+
+  }
+  .error-icon {
+    color: $color-text-primary;
+    font-size: 5rem;
+    margin: 1rem;
+  }
+
+</style>

--- a/examples/gameroom/gameroom-app/src/views/ServerError.vue
+++ b/examples/gameroom/gameroom-app/src/views/ServerError.vue
@@ -1,0 +1,56 @@
+<!--
+Copyright 2018-2020 Cargill Incorporated
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<template>
+  <div class="server-error-container">
+    <h2>Server Error</h2>
+    <div class="message-containter">
+      <i class="material-icons error-icon"> error_outline </i>
+      <h3>The Gameroom server encountered an error</h3>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+@Component
+export default class ServerErrorPage extends Vue {}
+</script>
+
+<style lang="scss" scoped>
+  .server-error-container {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 4rem;
+    height: 100%;
+  }
+
+  .message-containter {
+    @include overlay(1);
+    @include rounded-border;
+    display: flex;
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    margin-top: 2rem;
+    align-items: center;
+    justify-content: center;
+
+  }
+  .error-icon {
+    color: $color-text-primary;
+    font-size: 5rem;
+    margin: 1rem;
+  }
+
+</style>


### PR DESCRIPTION
This adds two more error landing pages to the Gameroom UI, a 'request error' and 'server error' page. This will now redirect to a more fitting error landing page than the catch-all 404 page previously used. 

In order to test, build either acme or bubba's UI, create a gameroom, create a game (for the purpose of having pages to attempt to navigate to, this doesn't affect any game-play functionality) and then run `docker container stop gameroomd-acme` or `-bubba`, doesn't matter. Then, try to navigate to a gameroom or click on a game if a gameroom page is already open for you. It does take a second to resolve the request, but after a few seconds the new error landing page should be displayed. It should have a `Server Error` header, if you are following these instructions to test. 