### PR TITLE
Implement the ServiceProcessorMessage handler

### DIFF
--- a/libsplinter/protos/service.proto
+++ b/libsplinter/protos/service.proto
@@ -31,6 +31,8 @@ message ServiceMessage {
 enum ServiceMessageType {
     UNSET_SERVICE_MESSAGE_TYPE = 0;
 
+    SM_SERVICE_ERROR_MESSAGE = 1;
+
     // Registration-related messages
     SM_SERVICE_CONNECT_REQUEST = 100;
     SM_SERVICE_CONNECT_RESPONSE = 101;
@@ -103,4 +105,26 @@ message ServiceProcessorMessage {
 
     // ID used to correlate the response with this request (optional)
     string correlation_id = 4;
+}
+
+message ServiceErrorMessage {
+    enum Error {
+        UNSET_SERVICE_ERROR_TYPE = 0;
+
+        SM_ERROR_INTERNAL_ERROR = 1;
+        SM_ERROR_CIRCUIT_DOES_NOT_EXIST = 2;
+        SM_ERROR_RECIPIENT_NOT_IN_CIRCUIT_ROSTER = 3;
+        SM_ERROR_SENDER_NOT_IN_CIRCUIT_ROSTER = 4;
+        SM_ERROR_RECIPIENT_NOT_IN_DIRECTORY = 5;
+        SM_ERROR_SENDER_NOT_IN_DIRECTORY = 6;
+    }
+
+    // Kind of the service-related error that was encountered
+    Error error = 1;
+
+    // Explanation of the error
+    string error_message = 2;
+
+    // ID used to correlate the response with this request (optional)
+    string correlation_id = 3;
 }

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -16,7 +16,7 @@
 
 use crate::circuit::service::{Service, ServiceId, SplinterNode};
 use crate::circuit::{ServiceDefinition, SplinterState};
-use crate::service::network::handlers::{
+use crate::service::network::{
     ServiceAddInstanceError, ServiceInstances, ServiceRemoveInstanceError,
 };
 

--- a/libsplinter/src/network/dispatch/mod.rs
+++ b/libsplinter/src/network/dispatch/mod.rs
@@ -51,6 +51,12 @@ impl From<String> for PeerId {
     }
 }
 
+impl From<&String> for PeerId {
+    fn from(s: &String) -> PeerId {
+        PeerId(s.clone())
+    }
+}
+
 impl From<&str> for PeerId {
     fn from(s: &str) -> PeerId {
         PeerId(s.into())
@@ -86,6 +92,12 @@ impl std::ops::Deref for ConnectionId {
 impl From<String> for ConnectionId {
     fn from(s: String) -> ConnectionId {
         ConnectionId(s)
+    }
+}
+
+impl From<&String> for ConnectionId {
+    fn from(s: &String) -> ConnectionId {
+        ConnectionId(s.clone())
     }
 }
 

--- a/libsplinter/src/peer/component.rs
+++ b/libsplinter/src/peer/component.rs
@@ -13,3 +13,211 @@
 // limitations under the License.
 
 //! trait implementations to support messages that are sent from service components.
+
+use protobuf::Message;
+
+use crate::circuit::service::{ServiceId, SplinterNode};
+use crate::circuit::SplinterState;
+use crate::peer::interconnect::NetworkMessageSender;
+use crate::protocol::service::ServiceProcessorMessage;
+use crate::protos::circuit::{
+    AdminDirectMessage, CircuitDirectMessage, CircuitMessage, CircuitMessageType,
+};
+use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::service::network::{ForwardResult, ServiceForwardingError, ServiceMessageForwarder};
+
+const ADMIN_SERVICE_ID_PREFIX: &str = "admin::";
+
+///
+pub struct NetworkMessageForwarder {
+    splinter_node: SplinterNode,
+    network_sender: NetworkMessageSender,
+    state: SplinterState,
+}
+
+impl ServiceMessageForwarder for NetworkMessageForwarder {
+    fn forward(
+        &self,
+        service_id: &ServiceId,
+        service_msg: ServiceProcessorMessage,
+    ) -> Result<ForwardResult, ServiceForwardingError> {
+        if service_id.circuit() == "admim" {
+            self.forward_admin_message(service_id, service_msg)
+        } else {
+            self.forward_general_circuit_message(service_id, service_msg)
+        }
+    }
+}
+
+impl NetworkMessageForwarder {
+    fn forward_admin_message(
+        &self,
+        service_id: &ServiceId,
+        service_msg: ServiceProcessorMessage,
+    ) -> Result<ForwardResult, ServiceForwardingError> {
+        if !is_admin_service_id(service_id.service_id()) {
+            return Err(ServiceForwardingError::SenderNotInCircuit);
+        }
+
+        if !is_admin_service_id(&service_msg.recipient) {
+            return Err(ServiceForwardingError::RecipientNotInCircuit);
+        }
+
+        let target_node_id = (&service_msg.recipient[ADMIN_SERVICE_ID_PREFIX.len()..]).to_string();
+        let mut admin_direct_message = AdminDirectMessage::new();
+        admin_direct_message.set_circuit("admin".into());
+        admin_direct_message.set_sender(service_id.service_id().to_string());
+        admin_direct_message.set_recipient(service_msg.recipient);
+        admin_direct_message.set_payload(service_msg.payload);
+
+        if let Some(correlation_id) = service_msg.correlation_id {
+            admin_direct_message.set_correlation_id(correlation_id);
+        }
+
+        let bytes = admin_direct_message.write_to_bytes().map_err(|err| {
+            ServiceForwardingError::InternalError {
+                context: "unable to serialize admin direct message envelope".into(),
+                source: Some(Box::new(err)),
+            }
+        })?;
+
+        let msg =
+            create_message(bytes, CircuitMessageType::ADMIN_DIRECT_MESSAGE).map_err(|err| {
+                ServiceForwardingError::InternalError {
+                    context: "unable to create circuit/network envelope".into(),
+                    source: Some(Box::new(err)),
+                }
+            })?;
+
+        self.network_sender
+            .send(target_node_id, msg)
+            .map(|_| ForwardResult::Sent)
+            .map_err(|(target, _)| ServiceForwardingError::InternalError {
+                context: format!("unable to send admin direct message to {}", target),
+                source: None,
+            })
+    }
+
+    fn forward_general_circuit_message(
+        &self,
+        service_id: &ServiceId,
+        service_msg: ServiceProcessorMessage,
+    ) -> Result<ForwardResult, ServiceForwardingError> {
+        let circuit = self
+            .state
+            .circuit(service_id.circuit())
+            .map_err(|err| ServiceForwardingError::InternalError {
+                context: "unable to look up circuit".into(),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| ServiceForwardingError::CircuitDoesNotExist)?;
+
+        if !circuit.roster().contains(service_id.service_id()) {
+            return Err(ServiceForwardingError::SenderNotInCircuit);
+        }
+
+        if !circuit.roster().contains(&service_msg.recipient) {
+            return Err(ServiceForwardingError::RecipientNotInCircuit);
+        }
+
+        let recipient_id = ServiceId::new(
+            service_id.circuit().to_string(),
+            service_msg.recipient.clone(),
+        );
+
+        // validate that the services are in the directory
+        self.state
+            .get_service(service_id)
+            .map_err(|err| ServiceForwardingError::InternalError {
+                context: format!("unable to look up service {}", service_id),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| ServiceForwardingError::SenderNotRegistered)?;
+
+        let recipient_service = self
+            .state
+            .get_service(&recipient_id)
+            .map_err(|err| ServiceForwardingError::InternalError {
+                context: format!("unable to look up service {}", &recipient_id),
+                source: Some(Box::new(err)),
+            })?
+            .ok_or_else(|| ServiceForwardingError::RecipientNotRegistered)?;
+
+        if self.splinter_node.id() != recipient_service.node().id() {
+            // Construct a circuit direct message, and send it to the service peer:
+            let (circuit_name, recipient_id) = recipient_id.into_parts();
+            let mut direct_msg = CircuitDirectMessage::new();
+            direct_msg.set_circuit(circuit_name);
+            direct_msg.set_sender(service_id.service_id().to_string());
+            direct_msg.set_recipient(recipient_id);
+            direct_msg.set_payload(service_msg.payload);
+            if let Some(correlation_id) = service_msg.correlation_id {
+                direct_msg.set_correlation_id(correlation_id);
+            }
+
+            let bytes = direct_msg.write_to_bytes().map_err(|err| {
+                ServiceForwardingError::InternalError {
+                    context: "unable to serialize circuit direct message envelope".into(),
+                    source: Some(Box::new(err)),
+                }
+            })?;
+
+            let msg = create_message(bytes, CircuitMessageType::CIRCUIT_DIRECT_MESSAGE).map_err(
+                |err| ServiceForwardingError::InternalError {
+                    context: "unable to create circuit/network envelope".into(),
+                    source: Some(Box::new(err)),
+                },
+            )?;
+
+            self.network_sender
+                .send(recipient_service.node().id().into(), msg)
+                .map(|_| ForwardResult::Sent)
+                .map_err(|_| ServiceForwardingError::InternalError {
+                    context: format!(
+                        "unable to send admin direct message to {}",
+                        recipient_service.node().id()
+                    ),
+                    source: None,
+                })
+        } else if let Some(component_id) = recipient_service.peer_id() {
+            Ok(ForwardResult::LocalReReroute(
+                component_id.into(),
+                service_msg,
+            ))
+        } else {
+            Err(ServiceForwardingError::InternalError {
+                context: format!(
+                    "Service {} was registered without a component id",
+                    recipient_service.service_id()
+                ),
+                source: None,
+            })
+        }
+    }
+}
+
+/// Check if the service id is an admin service.
+fn is_admin_service_id(service_id: &str) -> bool {
+    service_id.starts_with(ADMIN_SERVICE_ID_PREFIX)
+}
+
+/// Helper function for creating a NetworkMessge with a Circuit message type
+///
+/// # Arguments
+///
+/// * `payload` - The payload in bytes that should be set in the Circuit message get_payload
+/// * `circuit_message_type` - The message type that should be set in teh Circuit message
+pub fn create_message(
+    payload: Vec<u8>,
+    circuit_message_type: CircuitMessageType,
+) -> Result<Vec<u8>, protobuf::error::ProtobufError> {
+    let mut circuit_msg = CircuitMessage::new();
+    circuit_msg.set_message_type(circuit_message_type);
+    circuit_msg.set_payload(payload);
+    let circuit_bytes = circuit_msg.write_to_bytes()?;
+
+    let mut network_msg = NetworkMessage::new();
+    network_msg.set_message_type(NetworkMessageType::CIRCUIT);
+    network_msg.set_payload(circuit_bytes);
+    network_msg.write_to_bytes()
+}

--- a/libsplinter/src/peer/component.rs
+++ b/libsplinter/src/peer/component.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! trait implementations to support messages that are sent from service components.

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "service-network")]
+pub mod component;
 mod connector;
 mod error;
 pub mod interconnect;

--- a/libsplinter/src/service/network/error.rs
+++ b/libsplinter/src/service/network/error.rs
@@ -135,3 +135,67 @@ impl fmt::Display for ServiceRemoveInstanceError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum ServiceForwardingError {
+    /// The sending service is not in the circuit.
+    SenderNotInCircuit,
+
+    /// The receiving service is not in the circuit.
+    RecipientNotInCircuit,
+
+    /// The sending service is not registered.
+    SenderNotRegistered,
+
+    /// The receiving service is not registered.
+    RecipientNotRegistered,
+
+    /// The specified circuit does not exist.
+    CircuitDoesNotExist,
+
+    /// An internal error has occurred while forwarding the message.
+    InternalError {
+        context: String,
+        source: Option<Box<dyn Error + Send>>,
+    },
+}
+
+impl Error for ServiceForwardingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ServiceForwardingError::InternalError {
+                source: Some(ref err),
+                ..
+            } => Some(&**err),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ServiceForwardingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ServiceForwardingError::CircuitDoesNotExist => f.write_str("circuit does not exist"),
+            ServiceForwardingError::SenderNotInCircuit => {
+                f.write_str("sending service is not in the circuit")
+            }
+            ServiceForwardingError::RecipientNotInCircuit => {
+                f.write_str("receiving service is not in the circuit")
+            }
+            ServiceForwardingError::SenderNotRegistered => {
+                f.write_str("sending service is not registered")
+            }
+            ServiceForwardingError::RecipientNotRegistered => {
+                f.write_str("receiving service is not registered")
+            }
+            ServiceForwardingError::InternalError {
+                context,
+                source: Some(ref err),
+            } => write!(f, "{}: {}", context, err),
+            ServiceForwardingError::InternalError {
+                context,
+                source: None,
+            } => f.write_str(&context),
+        }
+    }
+}

--- a/libsplinter/src/service/network/error.rs
+++ b/libsplinter/src/service/network/error.rs
@@ -36,3 +36,102 @@ impl fmt::Display for ServiceConnectionError {
         f.write_str(&self.0)
     }
 }
+
+/// Errors that may occur on registration.
+#[derive(Debug)]
+pub enum ServiceAddInstanceError {
+    /// The service is not allowed to register for the given circuit on this node.
+    NotAllowed,
+    /// The service is already registered.
+    AlreadyRegistered,
+    /// The service does not belong to the specified circuit.
+    NotInCircuit,
+    /// The specified circuit does not exist.
+    CircuitDoesNotExist,
+    /// An internal error has occurred while processing the service registration.
+    InternalError {
+        context: String,
+        source: Option<Box<dyn std::error::Error + Send>>,
+    },
+}
+
+impl Error for ServiceAddInstanceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ServiceAddInstanceError::InternalError {
+                source: Some(ref err),
+                ..
+            } => Some(&**err),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ServiceAddInstanceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ServiceAddInstanceError::NotAllowed => f.write_str("service not allowed on this node"),
+            ServiceAddInstanceError::AlreadyRegistered => f.write_str("service already registered"),
+            ServiceAddInstanceError::NotInCircuit => f.write_str("service is not in the circuit"),
+            ServiceAddInstanceError::CircuitDoesNotExist => f.write_str("circuit does not exist"),
+            ServiceAddInstanceError::InternalError {
+                context,
+                source: Some(ref err),
+            } => write!(f, "{}: {}", context, err),
+            ServiceAddInstanceError::InternalError {
+                context,
+                source: None,
+            } => f.write_str(&context),
+        }
+    }
+}
+
+/// Errors that may occur on deregistration.
+#[derive(Debug)]
+pub enum ServiceRemoveInstanceError {
+    /// The service is not currently registered with this node.
+    NotRegistered,
+    /// The service does not belong to the specified circuit.
+    NotInCircuit,
+    /// The specified circuit does not exist.
+    CircuitDoesNotExist,
+    /// An internal error has occurred while processing the service deregistration.
+    InternalError {
+        context: String,
+        source: Option<Box<dyn std::error::Error + Send>>,
+    },
+}
+
+impl Error for ServiceRemoveInstanceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ServiceRemoveInstanceError::InternalError {
+                source: Some(ref err),
+                ..
+            } => Some(&**err),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ServiceRemoveInstanceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ServiceRemoveInstanceError::NotRegistered => f.write_str("service is not registered"),
+            ServiceRemoveInstanceError::NotInCircuit => {
+                f.write_str("service is not in the circuit")
+            }
+            ServiceRemoveInstanceError::CircuitDoesNotExist => {
+                f.write_str("circuit does not exist")
+            }
+            ServiceRemoveInstanceError::InternalError {
+                context,
+                source: Some(ref err),
+            } => write!(f, "{}: {}", context, err),
+            ServiceRemoveInstanceError::InternalError {
+                context,
+                source: None,
+            } => f.write_str(&context),
+        }
+    }
+}

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -28,6 +28,7 @@ use crate::protos::prelude::*;
 use crate::protos::service;
 
 use super::error::{ServiceAddInstanceError, ServiceRemoveInstanceError};
+use super::ServiceInstances;
 
 /// Dispatch handler for the service message envelope.
 pub struct ServiceMessageHandler {
@@ -75,36 +76,6 @@ impl Handler for ServiceMessageHandler {
                 ))
             })
     }
-}
-
-/// A mapping of service instances and the component responsible for it.  This can be used to add
-/// or remove service connection information.
-pub trait ServiceInstances {
-    /// Add a service instance.
-    ///
-    /// This method should create an association of the service with the given component id.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `ServiceAddInstanceError` if the service cannot be added.
-    fn add_service_instance(
-        &self,
-        service_id: ServiceId,
-        component_id: String,
-    ) -> Result<(), ServiceAddInstanceError>;
-
-    /// Remove a service instance.
-    ///
-    /// This method should remove the association of the service with the given component id.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `ServiceRemoveInstanceError` if the service cannot be removed.
-    fn remove_service_instance(
-        &self,
-        service_id: ServiceId,
-        component_id: String,
-    ) -> Result<(), ServiceRemoveInstanceError>;
 }
 
 /// Dispatch handler for `ServiceConnectRequest` messages.

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -27,6 +27,8 @@ use crate::protos::component;
 use crate::protos::prelude::*;
 use crate::protos::service;
 
+use super::error::{ServiceAddInstanceError, ServiceRemoveInstanceError};
+
 /// Dispatch handler for the service message envelope.
 pub struct ServiceMessageHandler {
     sender: DispatchMessageSender<service::ServiceMessageType, ConnectionId>,
@@ -103,105 +105,6 @@ pub trait ServiceInstances {
         service_id: ServiceId,
         component_id: String,
     ) -> Result<(), ServiceRemoveInstanceError>;
-}
-
-/// Errors that may occur on registration.
-#[derive(Debug)]
-pub enum ServiceAddInstanceError {
-    /// The service is not allowed to register for the given circuit on this node.
-    NotAllowed,
-    /// The service is already registered.
-    AlreadyRegistered,
-    /// The service does not belong to the specified circuit.
-    NotInCircuit,
-    /// The specified circuit does not exist.
-    CircuitDoesNotExist,
-    /// An internal error has occurred while processing the service registration.
-    InternalError {
-        context: String,
-        source: Option<Box<dyn std::error::Error + Send>>,
-    },
-}
-
-impl std::error::Error for ServiceAddInstanceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ServiceAddInstanceError::InternalError {
-                source: Some(ref err),
-                ..
-            } => Some(&**err),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for ServiceAddInstanceError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            ServiceAddInstanceError::NotAllowed => f.write_str("service not allowed on this node"),
-            ServiceAddInstanceError::AlreadyRegistered => f.write_str("service already registered"),
-            ServiceAddInstanceError::NotInCircuit => f.write_str("service is not in the circuit"),
-            ServiceAddInstanceError::CircuitDoesNotExist => f.write_str("circuit does not exist"),
-            ServiceAddInstanceError::InternalError {
-                context,
-                source: Some(ref err),
-            } => write!(f, "{}: {}", context, err),
-            ServiceAddInstanceError::InternalError {
-                context,
-                source: None,
-            } => f.write_str(&context),
-        }
-    }
-}
-
-/// Errors that may occur on deregistration.
-#[derive(Debug)]
-pub enum ServiceRemoveInstanceError {
-    /// The service is not currently registered with this node.
-    NotRegistered,
-    /// The service does not belong to the specified circuit.
-    NotInCircuit,
-    /// The specified circuit does not exist.
-    CircuitDoesNotExist,
-    /// An internal error has occurred while processing the service deregistration.
-    InternalError {
-        context: String,
-        source: Option<Box<dyn std::error::Error + Send>>,
-    },
-}
-
-impl std::error::Error for ServiceRemoveInstanceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ServiceRemoveInstanceError::InternalError {
-                source: Some(ref err),
-                ..
-            } => Some(&**err),
-            _ => None,
-        }
-    }
-}
-
-impl std::fmt::Display for ServiceRemoveInstanceError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            ServiceRemoveInstanceError::NotRegistered => f.write_str("service is not registered"),
-            ServiceRemoveInstanceError::NotInCircuit => {
-                f.write_str("service is not in the circuit")
-            }
-            ServiceRemoveInstanceError::CircuitDoesNotExist => {
-                f.write_str("circuit does not exist")
-            }
-            ServiceRemoveInstanceError::InternalError {
-                context,
-                source: Some(ref err),
-            } => write!(f, "{}: {}", context, err),
-            ServiceRemoveInstanceError::InternalError {
-                context,
-                source: None,
-            } => f.write_str(&context),
-        }
-    }
 }
 
 /// Dispatch handler for `ServiceConnectRequest` messages.

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -23,6 +23,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
+use crate::circuit::service::ServiceId;
 use crate::network::connection_manager::{ConnectionManagerNotification, Connector};
 
 use self::error::ServiceConnectionAgentError;
@@ -83,6 +84,36 @@ pub enum ServiceConnectionNotification {
         service_id: String,
         endpoint: String,
     },
+}
+
+/// A mapping of service instances and the component responsible for it.  This can be used to add
+/// or remove service connection information.
+pub trait ServiceInstances {
+    /// Add a service instance.
+    ///
+    /// This method should create an association of the service with the given component id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ServiceAddInstanceError` if the service cannot be added.
+    fn add_service_instance(
+        &self,
+        service_id: ServiceId,
+        component_id: String,
+    ) -> Result<(), ServiceAddInstanceError>;
+
+    /// Remove a service instance.
+    ///
+    /// This method should remove the association of the service with the given component id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ServiceRemoveInstanceError` if the service cannot be removed.
+    fn remove_service_instance(
+        &self,
+        service_id: ServiceId,
+        component_id: String,
+    ) -> Result<(), ServiceRemoveInstanceError>;
 }
 
 /// Constructs new ServiceConnectionManager structs.

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -27,6 +27,7 @@ use crate::network::connection_manager::{ConnectionManagerNotification, Connecto
 
 use self::error::ServiceConnectionAgentError;
 pub use self::error::ServiceConnectionError;
+pub use self::error::{ServiceAddInstanceError, ServiceRemoveInstanceError};
 
 pub type SubscriberId = usize;
 type Subscriber =


### PR DESCRIPTION
This PR implements a dispatch handler for `ServiceProcessorMessage` instances.  This handler receives messages from a service component and forwards them via a `ServiceMessageForwarder` trait, or sends them to another local component.

It implements this trait for the peer interconnect network sender and `SplinterState`, translating the service processor messages into the appropriate type of direct message.

Also,
- Moves the traits up to `splinter::service::network`
- Adds a missing `correlation_id` to the `ServiceProcessMessage`protocol (i.e. native) struct
- Adds a ServiceErrorMessage to the suite of service messages
- implements several handy std library traits for several items.