### PR TITLE
Explicitly set verify mode for TLS

### DIFF
--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -74,6 +74,8 @@ impl TlsTransport {
                 let ca_cert_path = Path::new(&ca_cert);
                 acceptor.set_ca_file(ca_cert_path)?;
                 connector.set_ca_file(ca_cert_path)?;
+                connector.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+                acceptor.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
                 let connector = connector.build();
                 let acceptor = acceptor.build();
                 (acceptor, connector)


### PR DESCRIPTION
The defaults are not always sufficient for rejecting
connection with a peer who has self signed certs. This
commit sets the verify mode of the TLS acceptor and
connector to SslVerifyMode::PEER and
SslVerifyMode::FAIL_IF_NO_PEER_CERT. For information
see https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_verify.html

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>