### PR TITLE
Change RefMap so it returns an Result instead of panic!ing

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -797,7 +797,8 @@ mod tests {
             .start()
             .expect("Unable to start Connection Manager");
         let connector = cm.connector();
-        let mut peer_manager = PeerManager::new(connector, None, Some(1), "test-node".to_string());
+        let mut peer_manager =
+            PeerManager::new(connector, None, Some(1), "test-node".to_string(), true);
         let peer_connector = peer_manager.start().expect("Cannot start PeerManager");
 
         let mut storage = get_storage("memory", CircuitDirectory::new).unwrap();

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3471,7 +3471,7 @@ mod tests {
             .start()
             .expect("Unable to start Connection Manager");
         let connector = cm.connector();
-        let mut pm = PeerManager::new(connector, None, Some(1), "my_id".to_string());
+        let mut pm = PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
         let peer_connector = pm.start().expect("Cannot start PeerManager");
         (mesh, cm, pm, peer_connector)
     }

--- a/libsplinter/src/collections/error.rs
+++ b/libsplinter/src/collections/error.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Collections used within this crate.
+#[derive(Debug, PartialEq)]
+pub struct RefMapRemoveError(pub String);
 
-mod bi_hash_map;
-mod error;
-mod ref_map;
+impl std::error::Error for RefMapRemoveError {}
 
-pub(crate) use bi_hash_map::BiHashMap;
-pub(crate) use ref_map::RefMap;
+impl std::fmt::Display for RefMapRemoveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -529,7 +529,8 @@ pub mod tests {
             .expect("Unable to start Connection Manager");
 
         let connector = cm.connector();
-        let mut peer_manager = PeerManager::new(connector, None, Some(1), "my_id".to_string());
+        let mut peer_manager =
+            PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
         let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
         let (send, recv) = channel();
 
@@ -607,7 +608,8 @@ pub mod tests {
             .expect("Unable to start Connection Manager");
 
         let connector = cm.connector();
-        let mut peer_manager = PeerManager::new(connector, None, Some(1), "my_id".to_string());
+        let mut peer_manager =
+            PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
         let peer_connector = peer_manager.start().expect("Cannot start PeerManager");
         let (dispatcher_sender, _dispatched_receiver) = dispatch_channel();
         let interconnect = PeerInterconnectBuilder::new()

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -564,7 +564,13 @@ fn add_peer(
                         })?
                     } else {
                         // remove ref we just added
-                        ref_map.remove_ref(&peer_id);
+                        if let Err(err) = ref_map.remove_ref(&peer_id) {
+                            error!(
+                                "Unable to remove ref that was just added for peer {}: {}",
+                                peer_id, err
+                            );
+                        };
+
                         return Err(PeerRefAddError::AddError(format!(
                             "Mismatch betwen existing and requested peer endpoints: {:?} does not \
                             contain {}",
@@ -623,7 +629,12 @@ fn add_peer(
         Some(endpoint) => endpoint.to_string(),
         None => {
             // remove ref we just added
-            ref_map.remove_ref(&peer_id);
+            if let Err(err) = ref_map.remove_ref(&peer_id) {
+                error!(
+                    "Unable to remove ref that was just added for peer {}: {}",
+                    peer_id, err
+                );
+            };
             return Err(PeerRefAddError::AddError(format!(
                 "No endpoints provided for peer {}",
                 peer_id
@@ -697,7 +708,14 @@ fn remove_peer(
     unreferenced_peers.peers.remove(&peer_id);
 
     // remove the reference
-    let removed_peer = ref_map.remove_ref(&peer_id);
+    let removed_peer = match ref_map.remove_ref(&peer_id) {
+        Ok(removed_peer) => removed_peer,
+        Err(err) => return Err(PeerRefRemoveError::RemoveError(format!(
+            "Failed to remove ref for peer {} from ref map: {}",
+            peer_id, err
+        )))
+    };
+
     if let Some(removed_peer) = removed_peer {
         let peer_metadata = peers.remove(&removed_peer).ok_or_else(|| {
             PeerRefRemoveError::RemoveError(format!(
@@ -750,7 +768,13 @@ fn remove_peer_by_endpoint(
         peer_metadata.id, endpoint
     );
     // remove the reference
-    let removed_peer = ref_map.remove_ref(&peer_metadata.id);
+    let removed_peer = match ref_map.remove_ref(&peer_metadata.id) {
+        Ok(removed_peer) => removed_peer,
+        Err(err) => return Err(PeerRefRemoveError::RemoveError(format!(
+            "Failed to remove ref for peer {} from ref map: {}",
+            peer_metadata.id, err
+        )))
+    };
     if let Some(removed_peer) = removed_peer {
         let peer_metadata = peers.remove(&removed_peer).ok_or_else(|| {
             PeerRefRemoveError::RemoveError(format!(

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -314,6 +314,13 @@ ENVIRONMENT VARIABLES
   set to `yaml`. (See `--storage`.) By default, this file is stored in
   `/var/lib/splinter`.
 
+**SPLINTER_STRICT_REF_COUNT**
+: Turns on strict peer reference counting. If `SPLINTER_STRICT_REF_COUNT`is set
+  to `true` and the peer manager tries to remove a peer reference that does not
+  exist, the Splinter daemon will panic. By default, the daemon does not panic
+  and instead logs an error. This environment variable is intended for
+  development and testing.
+
 FILES
 =====
 

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -299,6 +299,14 @@ impl ConfigBuilder {
                     Some(v) => Some((v, p.source())),
                     None => None,
                 }),
+            strict_ref_counts: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.strict_ref_counts() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                })
+                .ok_or_else(|| ConfigError::MissingValue("strict_ref_counts".to_string()))?,
         })
     }
 }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -72,7 +72,8 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_admin_timeout(Some(ADMIN_TIMEOUT))
             .with_state_dir(Some(String::from(STATE_DIR)))
             .with_tls_insecure(Some(false))
-            .with_no_tls(Some(false));
+            .with_no_tls(Some(false))
+            .with_strict_ref_counts(Some(false));
 
         #[cfg(feature = "service-endpoint")]
         {

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -24,6 +24,7 @@ const CONFIG_DIR_ENV: &str = "SPLINTER_CONFIG_DIR";
 const STATE_DIR_ENV: &str = "SPLINTER_STATE_DIR";
 const CERT_DIR_ENV: &str = "SPLINTER_CERT_DIR";
 const SPLINTER_HOME_ENV: &str = "SPLINTER_HOME";
+const SPLINTER_STRICT_REF_COUNT_ENV: &str = "SPLINTER_STRICT_REF_COUNT";
 
 pub struct EnvPartialConfigBuilder;
 
@@ -79,10 +80,20 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
             }
             _ => None,
         };
+
+        let strict_ref_counts = match env::var(SPLINTER_STRICT_REF_COUNT_ENV).ok() {
+            Some(value) => {
+                let t: bool = value.parse().unwrap_or(false);
+                Some(t)
+            }
+            None => Some(false),
+        };
+
         Ok(PartialConfig::new(ConfigSource::Environment)
             .with_config_dir(config_dir_env)
             .with_tls_cert_dir(tls_cert_dir_env)
-            .with_state_dir(state_dir_env))
+            .with_state_dir(state_dir_env)
+            .with_strict_ref_counts(strict_ref_counts))
     }
 }
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -70,6 +70,7 @@ pub struct Config {
     enable_biome: (bool, ConfigSource),
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<(Vec<String>, ConfigSource)>,
+    strict_ref_counts: (bool, ConfigSource),
 }
 
 impl Config {
@@ -193,6 +194,10 @@ impl Config {
         }
     }
 
+    pub fn strict_ref_counts(&self) -> bool {
+        self.strict_ref_counts.0
+    }
+
     pub fn config_dir_source(&self) -> &ConfigSource {
         &self.config_dir.1
     }
@@ -311,6 +316,10 @@ impl Config {
         } else {
             None
         }
+    }
+
+    fn strict_ref_counts_source(&self) -> &ConfigSource {
+        &self.strict_ref_counts.1
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -442,6 +451,11 @@ impl Config {
         );
         #[cfg(feature = "rest-api-cors")]
         self.log_whitelist();
+        debug!(
+            "Config: strict_ref_counts: {:?} (source: {:?})",
+            self.strict_ref_counts(),
+            self.strict_ref_counts_source()
+        );
     }
 
     #[cfg(feature = "rest-api-cors")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -63,6 +63,7 @@ pub struct PartialConfig {
     enable_biome: Option<bool>,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
+    strict_ref_counts: Option<bool>,
 }
 
 impl PartialConfig {
@@ -100,6 +101,7 @@ impl PartialConfig {
             enable_biome: None,
             #[cfg(feature = "rest-api-cors")]
             whitelist: None,
+            strict_ref_counts: None,
         }
     }
 
@@ -213,6 +215,10 @@ impl PartialConfig {
     #[cfg(feature = "rest-api-cors")]
     pub fn whitelist(&self) -> Option<Vec<String>> {
         self.whitelist.clone()
+    }
+
+    pub fn strict_ref_counts(&self) -> Option<bool> {
+        self.strict_ref_counts
     }
 
     /// Adds a `config_dir` value to the `PartialConfig` object.
@@ -511,6 +517,17 @@ impl PartialConfig {
     ///
     pub fn with_whitelist(mut self, whitelist: Option<Vec<String>>) -> Self {
         self.whitelist = whitelist;
+        self
+    }
+
+    /// Adds a `strict_ref_counts` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `strict_ref_counts` - Turns on panics if peer reference counting fails
+    ///
+    pub fn with_strict_ref_counts(mut self, strict_ref_counts: Option<bool>) -> Self {
+        self.strict_ref_counts = strict_ref_counts;
         self
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -235,6 +235,7 @@ impl SplinterDaemon {
             None,
             None,
             self.node_id.to_string(),
+            false,
         );
         let peer_connector = peer_manager.start().map_err(|err| {
             StartError::NetworkError(format!("Unable to start peer manager: {}", err))

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -121,6 +121,7 @@ pub struct SplinterDaemon {
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
     heartbeat: u64,
+    strict_ref_counts: bool,
 }
 
 impl SplinterDaemon {
@@ -235,7 +236,7 @@ impl SplinterDaemon {
             None,
             None,
             self.node_id.to_string(),
-            false,
+            self.strict_ref_counts,
         );
         let peer_connector = peer_manager.start().map_err(|err| {
             StartError::NetworkError(format!("Unable to start peer manager: {}", err))
@@ -732,6 +733,7 @@ pub struct SplinterDaemonBuilder {
     admin_timeout: Duration,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
+    strict_ref_counts: Option<bool>,
 }
 
 impl SplinterDaemonBuilder {
@@ -828,6 +830,11 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    pub fn with_strict_ref_counts(mut self, strict_ref_counts: bool) -> Self {
+        self.strict_ref_counts = Some(strict_ref_counts);
+        self
+    }
+
     pub fn build(self) -> Result<SplinterDaemon, CreateError> {
         let heartbeat = self.heartbeat.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: heartbeat".to_string())
@@ -892,6 +899,10 @@ impl SplinterDaemonBuilder {
             CreateError::MissingRequiredField("Missing field: storage_type".to_string())
         })?;
 
+        let strict_ref_counts = self.strict_ref_counts.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: strict_ref_counts".to_string())
+        })?;
+
         Ok(SplinterDaemon {
             state_dir,
             #[cfg(feature = "service-endpoint")]
@@ -915,6 +926,7 @@ impl SplinterDaemonBuilder {
             #[cfg(feature = "rest-api-cors")]
             whitelist: self.whitelist,
             heartbeat,
+            strict_ref_counts,
         })
     }
 }

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -412,7 +412,8 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_registry_auto_refresh(config.registry_auto_refresh())
         .with_registry_forced_refresh(config.registry_forced_refresh())
         .with_heartbeat(config.heartbeat())
-        .with_admin_timeout(admin_timeout);
+        .with_admin_timeout(admin_timeout)
+        .with_strict_ref_counts(config.strict_ref_counts());
 
     #[cfg(feature = "service-endpoint")]
     {


### PR DESCRIPTION
Also makes PeerManager configurable to either return an error if refmap error or panic if strict_ref_map is set. Also adds env variable to splinterd to configure the PeerManager, SPLINTER_STRICT_REF_COUNT.