### PR TITLE
BACKPORT: Peer manager updates

### DIFF
--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -21,7 +21,7 @@ use super::error::{
     PeerRefRemoveError, PeerUnknownAddError,
 };
 use super::notification::PeerNotificationIter;
-use super::PeerRef;
+use super::{EndpointPeerRef, PeerRef};
 use super::{PeerManagerMessage, PeerManagerRequest};
 
 /// The PeerLookup trait provides an interface for looking up details about individual peer
@@ -104,8 +104,11 @@ impl PeerManagerConnector {
     ///
     /// * `endpoint` - The endpoint associated with the peer.
     ///
-    /// Returns Ok() if the unidentified peer was added
-    pub fn add_unidentified_peer(&self, endpoint: String) -> Result<(), PeerUnknownAddError> {
+    /// Returns Ok(EndpointPeerRef) if the unidentified peer was added
+    pub fn add_unidentified_peer(
+        &self,
+        endpoint: String,
+    ) -> Result<EndpointPeerRef, PeerUnknownAddError> {
         let (sender, recv) = channel();
 
         let message =

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -284,6 +284,27 @@ impl PeerRemover {
         recv.recv()
             .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
     }
+
+    pub fn remove_peer_ref_by_endpoint(&self, endpoint: &str) -> Result<(), PeerRefRemoveError> {
+        let (sender, recv) = channel();
+
+        let message = PeerManagerMessage::Request(PeerManagerRequest::RemovePeerByEndpoint {
+            endpoint: endpoint.to_string(),
+            sender,
+        });
+
+        match self.sender.send(message) {
+            Ok(()) => (),
+            Err(_) => {
+                return Err(PeerRefRemoveError::InternalError(
+                    "Unable to send message to PeerManager, receiver dropped".to_string(),
+                ))
+            }
+        };
+
+        recv.recv()
+            .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
+    }
 }
 
 impl PartialEq for PeerRemover {

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -24,21 +24,21 @@ use super::notification::PeerNotificationIter;
 use super::{EndpointPeerRef, PeerRef};
 use super::{PeerManagerMessage, PeerManagerRequest};
 
-/// The PeerLookup trait provides an interface for looking up details about individual peer
+/// The `PeerLookup` trait provides an interface for looking up details about individual peer
 /// connections.
 pub trait PeerLookup: Send {
-    /// Retrieves the connection id for a given peer id, if found.
+    /// Retrieves the connection ID for a given peer ID, if found.
     ///
     /// # Errors
     ///
-    /// Returns a PeerLookupError if the connection id cannot be retrieved.
+    /// Returns a `PeerLookupError` if the connection ID cannot be retrieved.
     fn connection_id(&self, peer_id: &str) -> Result<Option<String>, PeerLookupError>;
 
-    /// Retrieves the peer id for a given connection id, if found.
+    /// Retrieves the peer ID for a given connection ID, if found.
     ///
     /// # Errors
     ///
-    /// Returns a PeerLookupError if the peer id cannot be retrieved.
+    /// Returns a `PeerLookupError` if the peer ID cannot be retrieved.
     fn peer_id(&self, connection_id: &str) -> Result<Option<String>, PeerLookupError>;
 }
 
@@ -46,7 +46,7 @@ pub trait PeerLookupProvider {
     fn peer_lookup(&self) -> Box<dyn PeerLookup>;
 }
 
-/// The PeerManagerConnector will be used to make requests to the PeerManager.
+/// The `PeerManagerConnector` will be used to make requests to the `PeerManager`.
 ///
 /// The connector includes functions to add a new peer reference, update a peer and list the
 /// existing peers.
@@ -60,17 +60,17 @@ impl PeerManagerConnector {
         PeerManagerConnector { sender }
     }
 
-    /// Request that a peer is added to the PeerManager. If a peer already exists, the peer's ref
-    /// count will be incremented
+    /// Requests that a peer is added to the `PeerManager`. If a peer already exists, the peer's
+    /// reference count will be incremented
     ///
     /// # Arguments
     ///
-    /// * `peer_id` -  The unique id for the peer.
+    /// * `peer_id` -  The unique ID for the peer.
     /// * `endpoints` -  The list of endpoints associated with the peer. The list should be in
     ///     preference order, with the first endpoint being the first attempted.
     ///
-    /// Returns a PeerRef, that when dropped, will automatically send a removal request to the
-    /// PeerManager.
+    /// Returns a `PeerRef`, that when dropped, will automatically send a removal request to the
+    /// `PeerManager`.
     pub fn add_peer_ref(
         &self,
         peer_id: String,
@@ -97,14 +97,14 @@ impl PeerManagerConnector {
             .map_err(|err| PeerRefAddError::ReceiveError(format!("{:?}", err)))?
     }
 
-    /// Request that a peer is added to the PeerManager. This function should be used when the
-    /// peer id is unknown.
+    /// Requests that a peer is added to the `PeerManager`. This function should be used when the
+    /// peer ID is unknown.
     ///
     /// # Arguments
     ///
     /// * `endpoint` - The endpoint associated with the peer.
     ///
-    /// Returns Ok(EndpointPeerRef) if the unidentified peer was added
+    /// Returns `Ok(EndpointPeerRef)` if the unidentified peer was added
     pub fn add_unidentified_peer(
         &self,
         endpoint: String,
@@ -127,9 +127,9 @@ impl PeerManagerConnector {
             .map_err(|err| PeerUnknownAddError::ReceiveError(format!("{:?}", err)))?
     }
 
-    /// Request the list of currently connected peers.
+    /// Requests the list of currently connected peers.
     ///
-    /// Returns the list of peer ids.
+    /// Returns the list of peer IDs.
     pub fn list_peers(&self) -> Result<Vec<String>, PeerListError> {
         let (sender, recv) = channel();
         let message = PeerManagerMessage::Request(PeerManagerRequest::ListPeers { sender });
@@ -147,7 +147,7 @@ impl PeerManagerConnector {
             .map_err(|err| PeerListError::ReceiveError(format!("{:?}", err)))?
     }
 
-    /// Request the list of unreferenced peers.
+    /// Requests the list of unreferenced peers.
     ///
     /// Unreferenced peers are those peers that have successfully connected from a remote node, but
     /// have not yet be referenced by a circuit.  These peers are available to be promoted to fully
@@ -170,9 +170,9 @@ impl PeerManagerConnector {
             .map_err(|err| PeerListError::ReceiveError(format!("{:?}", err)))?
     }
 
-    /// Request the map of currently connected peers to connection id
+    /// Requests the map of currently connected peers to connection ID
     ///
-    /// Returns a map of peer id to connection id
+    /// Returns a map of peer ID to connection ID
     pub fn connection_ids(&self) -> Result<BiHashMap<String, String>, PeerConnectionIdError> {
         let (sender, recv) = channel();
         let message = PeerManagerMessage::Request(PeerManagerRequest::ConnectionIds { sender });
@@ -190,10 +190,10 @@ impl PeerManagerConnector {
             .map_err(|err| PeerConnectionIdError::ReceiveError(format!("{:?}", err)))?
     }
 
-    /// Subscribe to PeerManager notifications.
+    /// Subscribes to `PeerManager` notifications.
     ///
-    /// Returns a PeerNotificationIter that can be used to receive notifications about connected and
-    /// disconnected peers
+    /// Returns a `PeerNotificationIter` that can be used to receive notifications about connected
+    /// and disconnected peers
     pub fn subscribe(&self) -> Result<PeerNotificationIter, PeerManagerError> {
         let (send, recv) = channel();
         match self.sender.send(PeerManagerMessage::Subscribe(send)) {
@@ -253,8 +253,8 @@ impl PeerLookupProvider for PeerManagerConnector {
     }
 }
 
-/// The PeerRemover will be used in the PeerRef to decrement the reference count for a peer when
-/// the PeerRef is dropped.
+/// The `PeerRemover` will be used in the `PeerRef` to decrement the reference count for a peer when
+/// the `PeerRef` is dropped.
 #[derive(Clone, Debug)]
 pub(crate) struct PeerRemover {
     pub sender: Sender<PeerManagerMessage>,
@@ -263,10 +263,10 @@ pub(crate) struct PeerRemover {
 impl PeerRemover {
     /// This function will only be called when the PeerRef is dropped.
     ///
-    /// Sends a request to the PeerManager to remove a peer.
+    /// Sends a request to the `PeerManager` to remove a peer.
     ///
     /// # Arguments
-    /// * `peer_id` - the peer_id of the PeerRef that has been dropped
+    /// * `peer_id` - the peer ID of the `PeerRef` that has been dropped
     pub fn remove_peer_ref(&self, peer_id: &str) -> Result<(), PeerRefRemoveError> {
         let (sender, recv) = channel();
 
@@ -288,6 +288,12 @@ impl PeerRemover {
             .map_err(|err| PeerRefRemoveError::ReceiveError(format!("{:?}", err)))?
     }
 
+    /// Sends a request to the `PeerManager` to remove a peer.
+    ///
+    /// This function will only be called when the `EndpointPeerRef` is dropped.
+    ///
+    /// # Arguments
+    /// * `endpoint` - the endpoint of the `EndpointPeerRef` that has been dropped
     pub fn remove_peer_ref_by_endpoint(&self, endpoint: &str) -> Result<(), PeerRefRemoveError> {
         let (sender, recv) = channel();
 

--- a/libsplinter/src/peer/error.rs
+++ b/libsplinter/src/peer/error.rs
@@ -14,11 +14,13 @@
 
 use std::{error, fmt};
 
+/// Errors that could be raised by the `PeerManager`
 #[derive(Debug, PartialEq)]
 pub enum PeerManagerError {
+    /// `PeerManager` start up failed
     StartUpError(String),
+    /// Error raised when a message failed to send
     SendMessageError(String),
-    RetryEndpoints(String),
 }
 
 impl error::Error for PeerManagerError {}
@@ -28,19 +30,18 @@ impl fmt::Display for PeerManagerError {
         match self {
             PeerManagerError::StartUpError(msg) => write!(f, "{}", msg),
             PeerManagerError::SendMessageError(msg) => write!(f, "{}", msg),
-            PeerManagerError::RetryEndpoints(msg) => write!(
-                f,
-                "Error occured while trying to find new active endpoint: {}",
-                msg
-            ),
         }
     }
 }
 
+/// Errors that could be raised when requesting a peer is added
 #[derive(Debug, PartialEq)]
 pub enum PeerRefAddError {
+    /// Internal `PeerManager` error
     InternalError(String),
+    /// Unable to receive response
     ReceiveError(String),
+    /// Unable to add requested peer
     AddError(String),
 }
 
@@ -58,10 +59,14 @@ impl fmt::Display for PeerRefAddError {
     }
 }
 
+/// Errors that could be raised when requesting a peer is added without a peer ID
 #[derive(Debug, PartialEq)]
 pub enum PeerUnknownAddError {
+    /// Internal `PeerManager` error
     InternalError(String),
+    /// Unable to receive response
     ReceiveError(String),
+    /// Unable to add requested peer
     AddError(String),
 }
 
@@ -83,10 +88,14 @@ impl fmt::Display for PeerUnknownAddError {
     }
 }
 
+/// Errors that could be raised when requesting a peer is removed
 #[derive(Debug, PartialEq)]
 pub enum PeerRefRemoveError {
+    /// Internal `PeerManager` error
     InternalError(String),
+    /// Unable to receive response
     ReceiveError(String),
+    /// Unable to remove requested peer
     RemoveError(String),
 }
 
@@ -104,10 +113,14 @@ impl fmt::Display for PeerRefRemoveError {
     }
 }
 
+/// Errors that could be raised when requesting a list of peers
 #[derive(Debug, PartialEq)]
 pub enum PeerListError {
+    /// Internal `PeerManager`error
     InternalError(String),
+    /// Unable to receive response
     ReceiveError(String),
+    /// Unable to get current list of peers
     ListError(String),
 }
 
@@ -125,10 +138,14 @@ impl fmt::Display for PeerListError {
     }
 }
 
+/// Errors that could be raised when requesting a peer's connection ID
 #[derive(Debug, PartialEq)]
 pub enum PeerConnectionIdError {
+    /// Internal `PeerManager` error
     InternalError(String),
+    /// Unable to receive response
     ReceiveError(String),
+    /// Unable to get peer's connection ID
     ListError(String),
 }
 
@@ -150,6 +167,7 @@ impl fmt::Display for PeerConnectionIdError {
     }
 }
 
+/// Errors raised by trying to update a peer
 #[derive(Debug)]
 pub struct PeerUpdateError(pub String);
 
@@ -161,8 +179,10 @@ impl fmt::Display for PeerUpdateError {
     }
 }
 
+/// Errors that could be raised by `PeerInterconnect`
 #[derive(Debug, PartialEq)]
 pub enum PeerInterconnectError {
+    /// `PeerInterconnect` start up failed
     StartUpError(String),
 }
 
@@ -178,6 +198,7 @@ impl fmt::Display for PeerInterconnectError {
     }
 }
 
+/// Errors that could be raised when looking up a peer
 #[derive(Debug)]
 pub struct PeerLookupError(pub String);
 

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1013,7 +1013,7 @@ fn handle_inbound_connection(
             }
         }
     } else {
-        debug!("Adding unrefrenced peer for {}", identity);
+        debug!("Adding peer with id: {}", identity);
 
         if let Some(old_peer) = unreferenced_peers.peers.insert(
             identity,
@@ -1022,8 +1022,8 @@ fn handle_inbound_connection(
                 endpoint: endpoint.to_string(),
             },
         ) {
-            debug!("Removing old unreferenced peer connection");
             if old_peer.endpoint != endpoint {
+                debug!("Removing old peer connection for {}", old_peer.endpoint);
                 if let Err(err) = connector.remove_connection(&old_peer.endpoint) {
                     error!("Unable to clean up old connection: {}", err);
                 }
@@ -1172,8 +1172,8 @@ fn handle_connected(
                 endpoint: endpoint.to_string(),
             },
         ) {
-            debug!("Removing old unreferenced peer connection");
             if old_peer.endpoint != endpoint {
+                debug!("Removing old peer connection for {}", old_peer.endpoint);
                 if let Err(err) = connector.remove_connection(&old_peer.endpoint) {
                     error!("Unable to clean up old connection: {}", err);
                 }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -606,10 +606,12 @@ fn add_peer(
     let mut active_endpoint = match endpoints.get(0) {
         Some(endpoint) => endpoint.to_string(),
         None => {
+            // remove ref we just added
+            ref_map.remove_ref(&peer_id);
             return Err(PeerRefAddError::AddError(format!(
                 "No endpoints provided for peer {}",
                 peer_id
-            )))
+            )));
         }
     };
 

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -925,7 +925,7 @@ fn handle_disconnection(
         }
         subscribers.retain(|sender| sender.send(notification.clone()).is_ok());
     } else {
-        // check for unrefrenced peer and remove if it has disconnected
+        // check for unreferenced peer and remove if it has disconnected
         debug!("Removing disconnected peer: {}", identity);
         if let Some(unref_peer) = unreferenced_peers.peers.remove(&identity) {
             if let Err(err) = connector.remove_connection(&unref_peer.endpoint) {

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -690,7 +690,7 @@ fn remove_peer(
             ))
         })?;
 
-        // If the peer is pending or invalid there is no connection to remove
+        // If the peer is pending there is no connection to remove
         if peer_metadata.status == PeerStatus::Pending {
             return Ok(());
         }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -137,6 +137,40 @@ impl Drop for PeerRef {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct EndpointPeerRef {
+    endpoint: String,
+    peer_remover: PeerRemover,
+}
+
+impl EndpointPeerRef {
+    pub(super) fn new(endpoint: String, peer_remover: PeerRemover) -> Self {
+        EndpointPeerRef {
+            endpoint,
+            peer_remover,
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for EndpointPeerRef {
+    fn drop(&mut self) {
+        match self
+            .peer_remover
+            .remove_peer_ref_by_endpoint(&self.endpoint)
+        {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Unable to remove reference to peer with endpoint {} on drop: {}",
+                self.endpoint, err
+            ),
+        }
+    }
+}
+
 /// An entry of unreferenced peers, that may connected externally, but not yet requested locally.
 #[derive(Debug)]
 struct UnreferencedPeer {

--- a/libsplinter/src/peer/notification.rs
+++ b/libsplinter/src/peer/notification.rs
@@ -19,15 +19,18 @@ use std::sync::mpsc::{Receiver, TryRecvError};
 /// subscription handlers
 #[derive(Debug, PartialEq, Clone)]
 pub enum PeerManagerNotification {
+    /// Notifies subscribers that a peer is connected. Includes the peer ID of the connected peer.
     Connected { peer: String },
+    /// Notifies subscribers that a peer is disconnected. Include the peer ID of the disconnected
+    /// peer.
     Disconnected { peer: String },
 }
 
-/// PeerNotificationIter is used to receive notfications from the PeerManager. The notifications
+/// `PeerNotificationIter` is used to receive notfications from the `PeerManager`. The notifications
 /// include:
-/// - PeerManagerNotification::Disconnected: peer disconnected and reconnection
+/// - `PeerManagerNotification::Disconnected`: peer disconnected and reconnection
 ///     is being attempted.
-/// - PeerManagerNotification::Connected: reconnection to peer was successful
+/// - `PeerManagerNotification::Connected`: reconnection to peer was successful
 pub struct PeerNotificationIter {
     pub(super) recv: Receiver<PeerManagerNotification>,
 }

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -157,6 +157,10 @@ impl PeerMap {
             .iter()
             .filter(|(_id, peer_meta)| peer_meta.status == PeerStatus::Pending)
     }
+
+    pub fn contains_endpoint(&self, endpoint: &str) -> bool {
+        self.endpoints.contains_key(endpoint)
+    }
 }
 
 #[cfg(test)]

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -56,7 +56,7 @@ impl PeerMap {
         }
     }
 
-    /// Returns the current list of peer ids.
+    /// Returns the current list of peer IDs.
     pub fn peer_ids(&self) -> Vec<String> {
         self.peers
             .iter()
@@ -64,7 +64,7 @@ impl PeerMap {
             .collect()
     }
 
-    /// Returns the current map of peer ids to connection_ids
+    /// Returns the current map of peer IDs to connection_ids
     pub fn connection_ids(&self) -> BiHashMap<String, String> {
         let mut peer_to_connection_id = BiHashMap::new();
         for (peer, metadata) in self.peers.iter() {
@@ -74,7 +74,7 @@ impl PeerMap {
         peer_to_connection_id
     }
 
-    /// Insert a new peer id and endpoints
+    /// Insert a new peer ID and endpoints
     pub fn insert(
         &mut self,
         peer_id: String,
@@ -100,7 +100,7 @@ impl PeerMap {
         }
     }
 
-    /// Remove a peer id and its endpoint. Returns the PeerMetdata if the peer exists.
+    /// Remove a peer ID and its endpoint. Returns the PeerMetdata if the peer exists.
     pub fn remove(&mut self, peer_id: &str) -> Option<PeerMetadata> {
         if let Some(peer_metadata) = self.peers.remove(&peer_id.to_string()) {
             for endpoint in peer_metadata.endpoints.iter() {
@@ -133,7 +133,7 @@ impl PeerMap {
         }
     }
 
-    /// Returns the endpoint for the given peer id
+    /// Returns the endpoint for the given peer ID
     pub fn get_peer_from_endpoint(&self, endpoint: &str) -> Option<&PeerMetadata> {
         if let Some(peer) = self.endpoints.get(endpoint) {
             self.peers.get(peer)

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -364,9 +364,11 @@ impl SplinterDaemon {
             })
             .collect::<Vec<_>>();
 
+        // hold on to peer refs for the peers provided to ensure the connections are kept around
+        let mut peer_refs = vec![];
         for endpoint in self.initial_peers.iter() {
             match peer_connector.add_unidentified_peer(endpoint.into()) {
-                Ok(_) => (),
+                Ok(peer_ref) => peer_refs.push(peer_ref),
                 Err(err) => error!("Connect Error: {}", err),
             }
         }


### PR DESCRIPTION
This PR backports the changes introduced in https://github.com/Cargill/splinter/pull/851 and https://github.com/Cargill/splinter/pull/866