### PR TITLE
Move scabbard version update for crates publishing

### DIFF
--- a/ci/publish-crates
+++ b/ci/publish-crates
@@ -19,5 +19,9 @@ export VERSION=AUTO_STRICT
 export REPO_VERSION=$($top_dir/bin/get_version)
 
 docker build -f ci/publish-splinter-crates -t publish-splinter-crates ci/
-sed -i'' -e "s/splinter = {.*$/splinter\ =\ \"$REPO_VERSION\"/" services/scabbard/libscabbard/Cargo.toml
-docker run --rm -v $(pwd):/project/splinter -e CARGO_CRED=$CARGO_TOKEN publish-splinter-crates
+docker run \
+  --rm \
+  -v $(pwd):/project/splinter \
+  -e REPO_VERSION=$REPO_VERSION \
+  -e CARGO_CRED=$CARGO_TOKEN \
+  publish-splinter-crates

--- a/ci/publish-splinter-crates
+++ b/ci/publish-splinter-crates
@@ -52,6 +52,7 @@ CMD cargo login $CARGO_CRED \
  && cargo test \
  && cargo publish \
  && cd /project/splinter/services/scabbard/libscabbard \
+ && sed -i'' -e "s/splinter = {.*$/splinter\ =\ \"$REPO_VERSION\"/" Cargo.toml \
  && rm -f ../../../Cargo.lock ./Cargo.lock \
  && cargo clean \
  && cargo test \


### PR DESCRIPTION
Changing scabbard's splinter path dependency to a version number prior to
publishing splinter causes compile problems due to the workspace Cargo.toml.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>