### PR TITLE
Implement Vec::from for ConnectionMatrixEnvelope

### DIFF
--- a/libsplinter/src/mesh/mod.rs
+++ b/libsplinter/src/mesh/mod.rs
@@ -169,13 +169,13 @@ impl Mesh {
     /// Send the envelope on the mesh.
     ///
     /// This is a convenience function and is equivalent to
-    /// `mesh.outgoing(envelope.id()).send(envelope.take_payload())`.
+    /// `mesh.outgoing(envelope.id()).send(Vec::from(envelope))`.
     pub fn send(&self, envelope: Envelope) -> Result<(), SendError> {
         let state = &self.state.read().map_err(|_| SendError::PoisonedLock)?;
         let id = envelope.id().to_string();
         if let Some(mesh_id) = state.unique_ids.get_by_key(&id) {
             match state.outgoings.get(mesh_id) {
-                Some(ref outgoing) => match outgoing.send(envelope.take_payload()) {
+                Some(ref outgoing) => match outgoing.send(Vec::from(envelope)) {
                     Ok(()) => Ok(()),
                     Err(err) => Err(SendError::from_outgoing_send_error(err, id)),
                 },

--- a/libsplinter/src/network/network.rs
+++ b/libsplinter/src/network/network.rs
@@ -330,7 +330,7 @@ impl Network {
             }
         };
 
-        Ok(NetworkMessageWrapper::new(peer_id, envelope.take_payload()))
+        Ok(NetworkMessageWrapper::new(peer_id, Vec::from(envelope)))
     }
 
     pub fn recv_timeout(
@@ -348,7 +348,7 @@ impl Network {
             }
         };
 
-        Ok(NetworkMessageWrapper::new(peer_id, envelope.take_payload()))
+        Ok(NetworkMessageWrapper::new(peer_id, Vec::from(envelope)))
     }
 
     pub fn shutdown_signaler(&self) -> MeshShutdownSignaler {

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -337,7 +337,7 @@ pub fn run_incoming_loop(
     while incoming_running.load(Ordering::SeqCst) {
         let timeout = Duration::from_secs(TIMEOUT_SEC);
         let message_bytes = match incoming_mesh.recv_timeout(timeout) {
-            Ok(envelope) => envelope.take_payload(),
+            Ok(envelope) => Vec::from(envelope),
             Err(MeshRecvTimeoutError::Timeout) => continue,
             Err(MeshRecvTimeoutError::Disconnected) => {
                 error!("Mesh Disconnected");

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -188,7 +188,7 @@ impl ServiceProcessor {
                     while incoming_running.load(Ordering::SeqCst) {
                         let timeout = Duration::from_secs(TIMEOUT_SEC);
                         let message_bytes = match incoming_mesh.recv_timeout(timeout) {
-                            Ok(envelope) => envelope.take_payload(),
+                            Ok(envelope) => Vec::from(envelope),
                             Err(MeshRecvTimeoutError::Timeout) => continue,
                             Err(MeshRecvTimeoutError::Disconnected) => {
                                 error!("Mesh Disconnected");

--- a/libsplinter/src/transport/matrix.rs
+++ b/libsplinter/src/transport/matrix.rs
@@ -72,8 +72,13 @@ impl ConnectionMatrixEnvelope {
     }
 
     /// Returns the bytes of the payload while consuming the `ConnectionMatrixEnvelope`
-    #[deprecated(since = "0.3.19", note = "Please use Vec::from instead")]
+    #[deprecated(since = "0.3.19", note = "Please use into_inner() instead")]
     pub fn take_payload(self) -> Vec<u8> {
+        self.payload
+    }
+
+    /// Returns the payload and consumes the ConnectionMatrixEnvelope
+    pub fn into_inner(self) -> Vec<u8> {
         self.payload
     }
 }

--- a/libsplinter/src/transport/matrix.rs
+++ b/libsplinter/src/transport/matrix.rs
@@ -72,8 +72,15 @@ impl ConnectionMatrixEnvelope {
     }
 
     /// Returns the bytes of the payload while consuming the `ConnectionMatrixEnvelope`
+    #[deprecated(since = "0.3.19", note = "Please use Vec::from instead")]
     pub fn take_payload(self) -> Vec<u8> {
         self.payload
+    }
+}
+
+impl From<ConnectionMatrixEnvelope> for Vec<u8> {
+    fn from(envelope: ConnectionMatrixEnvelope) -> Self {
+        envelope.payload.to_vec()
     }
 }
 


### PR DESCRIPTION
This commit also deprecates ConnectionMatrixEnvelope
take_payload() because it is similar to From implementation
but From is cleaner.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>