### PR TITLE
Set CLI default REST API port to 8080

### DIFF
--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -34,7 +34,7 @@ use clap::ArgMatches;
 
 use super::error::CliError;
 
-const DEFAULT_SPLINTER_REST_API_URL: &str = "http://127.0.0.1:8085";
+const DEFAULT_SPLINTER_REST_API_URL: &str = "http://127.0.0.1:8080";
 const SPLINTER_REST_API_URL_ENV: &str = "SPLINTER_REST_API_URL";
 
 /// A CLI Command Action.


### PR DESCRIPTION
The default REST API port which is used if no URL is specified was set
to 8085.  This value is an older default and does not match the default
value set by splinterd.

This commit corrects the port to 8080.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>