### PR TITLE
BACKPORT: Scabbard man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@
 
 /examples/gameroom/gameroom-app/src/compiled_protos.json
 
+/services/scabbard/cli/packaging/man/*.1
+
 /tests/Cargo.lock
 /tests/target
 

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -59,4 +59,8 @@ smart-permissions = []
 [package.metadata.deb]
 maintainer = "The Splinter Team"
 depends = "$auto"
+assets = [
+    ["packaging/man/*.1", "/usr/share/man/man1", "644"],
+    ["target/release/scabbard", "/usr/bin/scabbard", "755"]
+]
 maintainer-scripts = "packaging/ubuntu"

--- a/services/scabbard/cli/Dockerfile-installed-bionic
+++ b/services/scabbard/cli/Dockerfile-installed-bionic
@@ -65,6 +65,9 @@ COPY --from=builder /build/target/debian/scabbard-cli_*.deb /tmp
 COPY --from=builder /commit-hash /commit-hash
 
 RUN apt-get update \
- && apt-get install -y curl \
+ && apt-get install -y \
+    curl \
+    man \
+ && mandb \
  && dpkg --unpack /tmp/scabbard-cli_*.deb \
  && apt-get -f -y install

--- a/services/scabbard/cli/build.rs
+++ b/services/scabbard/cli/build.rs
@@ -1,0 +1,157 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::process::Command;
+
+const FORCE_PANDOC: &str = "SPLINTER_FORCE_PANDOC";
+const PATH: &str = "PATH";
+
+/// This build script will take the markdown files in the /man directory and convert them to
+/// man pages stored in packaging/man. This build script will check if pandoc is installed locally
+/// and skip generating the manpages if it is not. If the build should fail if man pages cannot be
+/// generated set environment variable SPLINTER_FORCE_PANDOC=true
+fn main() -> Result<(), BuildError> {
+    let paths = env::var(PATH)
+        .map_err(|_| BuildError("Unable to read PATH environment variable".into()))?;
+    let mut pandoc_exist = false;
+    for path in paths.split(':') {
+        let entries = match fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                // skip a directory in the path that cannot be read.
+                println!("Unable to read path entry {}: {}", path, err);
+                continue;
+            }
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    // skip an entry in the path that cannot be read.
+                    println!("Unable to read entry in {}: {}", path, err);
+                    continue;
+                }
+            };
+
+            let path = entry.path();
+            if path.ends_with("pandoc") {
+                pandoc_exist = true;
+                break;
+            }
+        }
+    }
+
+    if !pandoc_exist {
+        if let Ok(var) = env::var(FORCE_PANDOC) {
+            let map_to_build_err = move |_| {
+                BuildError("Unable to read SPLINTER_FORCE_PANDOC environment variable".into())
+            };
+            if var.parse().map_err(map_to_build_err)? {
+                return Err(BuildError(
+                    "Cannot generate man pages, pandoc is not installed".into(),
+                ));
+            }
+        } else {
+            println!("Skip generating man pages");
+            return Ok(());
+        }
+    }
+
+    let entries = match fs::read_dir("man/") {
+        Ok(entries) => {
+            match entries
+                .map(|res| res.map(|e| e.path()))
+                .collect::<Result<Vec<_>, io::Error>>()
+            {
+                Ok(entries) => entries,
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to retrieve entries for man pages: {}",
+                        err
+                    )))
+                }
+            }
+        }
+        Err(err) => {
+            return Err(BuildError(format!(
+                "Unable to read man pages directory: {}",
+                err
+            )))
+        }
+    };
+
+    println!("Markdown files found {:?}", entries);
+
+    for entry in entries {
+        // This conversion would only fail if the filename is not valid UTF-8
+        let markdown = &entry
+            .to_str()
+            .ok_or_else(|| BuildError("Cannot get markdown file path".into()))?
+            .to_string();
+
+        let file = entry
+            .file_stem()
+            .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?;
+        let manpage = &format!(
+            "packaging/man/{}",
+            file.to_str()
+                .ok_or_else(|| BuildError("Cannot get markdown file name".into()))?
+        );
+
+        if markdown.ends_with(".md") {
+            match Command::new("pandoc")
+                .args(&["--standalone", "--to", "man", &markdown, "-o", &manpage])
+                .status()
+            {
+                Ok(status) => {
+                    if status.success() {
+                        println!("Generated man page: {}", manpage);
+                    } else {
+                        println!("Unable to generate man page {} status {}", manpage, status);
+                    }
+                }
+                Err(err) => {
+                    return Err(BuildError(format!(
+                        "Unable to generate man page: {} {}",
+                        manpage, err
+                    )))
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub struct BuildError(String);
+
+impl Error for BuildError {}
+
+// This is the output that will be used for print errors returned from main
+impl fmt::Debug for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/services/scabbard/cli/man/scabbard-contract-list.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-list.1.md
@@ -1,0 +1,76 @@
+% SCABBARD-CONTRACT-LIST(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-contract-list** — Displays a scabbard service's smart contracts
+
+SYNOPSIS
+========
+
+**scabbard contract list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command allows users to list all smart contracts that have been uploaded to
+a particular scabbard service. The smart contract details are displayed in three
+columns: `NAME`, `VERSIONS`, and `OWNERS`. This command can be used to verify
+that one or more contracts have been uploaded, or to discover what contracts are
+available on the given scabbard service. Because scabbard services share state
+with each other, all services on the same circuit will have the same contracts.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-f`, `--format` FORMAT
+: Specifies the output format of the listed smart contracts. (default `human`).
+  Possible values for formatting are `human` and `csv`, where `human` displays
+  information in a table.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+EXAMPLES
+========
+The following command lists the smart contracts uploaded to a scabbard service
+on circuit `01234-ABCDE` with service ID `abcd`, running on the node with the
+REST API endpoint `http://localhost:8088`.
+
+```
+$ scabbard contract list \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd
+NAME VERSIONS OWNERS
+xo   0.3.3    0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a
+```
+
+The next command displays the smart contracts from the same service, but
+the output is formatted as CSV.
+
+```
+$ scabbard contract list \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --format csv
+NAME,VERSIONS,OWNERS
+xo,0.3.3,0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a
+```
+
+SEE ALSO
+========
+| `scabbard-contract-show(1)`
+| `scabbard-contract-upload(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-contract-show.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-show.1.md
@@ -1,0 +1,67 @@
+% SCABBARD-CONTRACT-SHOW(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-contract-show** — Displays the details of a scabbard smart contract
+
+SYNOPSIS
+========
+
+**scabbard contract show** \[**FLAGS**\] \[**OPTIONS**\] CONTRACT
+
+DESCRIPTION
+===========
+This command shows the details of a specific smart contract that has been
+uploaded to a scabbard service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+ARGUMENTS
+=========
+`CONTRACT`
+: Specifies the contract to display, using the format `NAME:VERSION`. The name
+  and version must exactly match the name and version of the smart contract.
+
+EXAMPLES
+========
+The following command displays the details of the `0.3.3` version of the smart
+contract named `xo`. This smart contract has been uploaded to the scabbard
+service on circuit `01234-ABCDE` with service ID `abcd`, which is running on the
+node with the REST API endpoint `http://localhost:8088`.
+
+```
+$ scabbard contract show \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  xo:0.3.3
+xo 0.3.3
+  inputs:
+  - 5b7349
+  outputs:
+  - 5b7349
+  creator: 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a
+```
+
+SEE ALSO
+========
+| `scabbard-contract-list(1)`
+| `scabbard-contract-upload(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-contract-upload.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-upload.1.md
@@ -1,0 +1,121 @@
+% SCABBARD-CONTRACT-UPLOAD(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-contract-upload** — Uploads a smart contract to scabbard
+
+SYNOPSIS
+========
+
+**scabbard contract upload** \[**FLAGS**\] \[**OPTIONS**\] SCAR
+
+DESCRIPTION
+===========
+This command takes a sabre contract archive (scar) file and uploads its smart
+contract to a scabbard service. The scar file is specified using a name, version
+requirement, and a list of paths. The file to upload is dynamically determined
+by searching the specified paths for a scar file matching the given name and
+version requirement. If multiple scar files are found that match the
+name/version, the file with the latest version will be used.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`-p`, `--path` PATH
+: Specifies the directory path(s) to use when searching for the scar file to
+  upload. This option can be specified multiple times to provide multiple
+  directories to search. If this option is not provided, the `$SCAR_PATH`
+  environment variable will be checked. If the environment variable has not been
+  set, the default path `/usr/share/scar` will be used.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`SCAR`
+: Specifies the name and version requirements of the scar file to upload, using
+  the format `NAME:VERSION_REQ`. The name must not include underscores (`_`),
+  since these are invalid in scar file names. The version requirement can be any
+  valid semantic versioning requirement string (for details on semantic
+  versioning, visit https://semver.org/).
+
+ENVIRONMENT VARIABLES
+=====================
+**SCAR_PATH_ENV_VAR**
+: List of directories to use when searching for the scar file to upload. (See
+  `-p`, `--path`.)
+
+EXAMPLES
+========
+The following command uploads the smart contract from a scar file located at
+`/usr/share/scar/xo_0.3.3.scar`. It uploads the contract to a scabbard service
+on circuit `01234-ABCDE` with service ID `abcd`, running on the node with the
+REST API endpoint `http://localhost:8088`.
+
+```
+$ scabbard contract upload \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  xo:0.3.3
+```
+
+For the next command, there are two scar files in the `~/scar` directory:
+`intkey_0.1.0.scar` and `intkey_0.1.1.scar`. This command uploads the smart
+contract from `intkey_0.1.1.scar`, since it specifies a minimum version
+requirement of `0.1`, and `0.1.1` is later than `0.1.0`.
+
+```
+$ scabbard contract upload \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --path ~/scar \
+  xo:0.1
+```
+
+The next example uploads the contract from the same `intkey_0.1.1.scar` file to
+he same scabbard service, but it uses a wildcard to match any version. It also
+specifies a key in the `$HOME/.splinter/keys` directory by name and waits up to
+10 seconds for the contract upload batch to commit.
+
+```
+$ scabbard contract upload \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --wait 10 \
+  --path ~/scar \
+  xo:*
+```
+
+SEE ALSO
+========
+| `scabbard-contract-list(1)`
+| `scabbard-contract-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-contract.1.md
+++ b/services/scabbard/cli/man/scabbard-contract.1.md
@@ -1,0 +1,44 @@
+% SCABBARD-CONTRACT(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-contract** — Provides contract management functionality
+
+SYNOPSIS
+========
+
+**scabbard contract** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command allows users to upload and view Sabre contracts for a scabbard
+service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+SUBCOMMANDS
+===========
+`list`
+: Displays contracts that have already been uploaded to a scabbard service.
+
+`show`
+: Shows details about a specific smart contract that was uploaded to a scabbard
+  service.
+
+`upload`
+: Uploads a smart contract to a scabbard service.
+
+SEE ALSO
+========
+| `scabbard-contract-list(1)`
+| `scabbard-contract-show(1)`
+| `scabbard-contract-upload(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-cr-create.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-create.1.md
@@ -1,0 +1,94 @@
+% SCABBARD-CR-CREATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-cr-create** — Creates a Sabre contract registry.
+
+SYNOPSIS
+========
+
+**scabbard cr create** \[**FLAGS**\] \[**OPTIONS**\] NAME
+
+DESCRIPTION
+===========
+This command allows users to create a new Sabre contract registry in state for
+the targeted scabbard service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`-O`, `--owners` KEY
+: Includes the given public keys as owners of the new contract registry. The
+  contract registry must have one or more owners.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAME`
+: Provides the name of the contract registry to create.
+
+EXAMPLES
+========
+The following command adds the `xo` contract registry to a scabbard service on
+circuit `01234-ABCDE` with service ID `abcd`, running on the node with the
+REST API endpoint `http://localhost:8088`. The new contract registry has one
+owner, and the transaction will be signed with the key located in the file
+`~/user.priv`.
+
+```
+$ scabbard cr create \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  xo
+```
+
+The next command adds the `intkey_multiply` contract registry to the same
+scabbard service, but adds multiple owners and specifies a key in the
+`$HOME/.splinter/keys` directory by name. It also waits up to 10 seconds for the
+contract registry creation batch to commit.
+
+```
+$ scabbard cr create \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  --owner 7b6c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118 \
+  --owner 02381b606ac2bbe3bd374654cb7cb467ffb0225eb46038a5ec37b43e0c2f085dcb \
+  --wait 10 \
+  intkey_multiply
+```
+
+SEE ALSO
+========
+| `scabbard-cr-delete(1)`
+| `scabbard-cr-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-cr-delete.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-delete.1.md
@@ -1,0 +1,85 @@
+% SCABBARD-CR-DELETE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-cr-delete** — Deletes a Sabre contract registry.
+
+SYNOPSIS
+========
+
+**scabbard cr delete** \[**FLAGS**\] \[**OPTIONS**\] NAME
+
+DESCRIPTION
+===========
+This command allows users to delete a Sabre contract registry from the targeted
+scabbard service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAME`
+: Provides the name of the contract registry to delete.
+
+EXAMPLES
+========
+The following command removes the `xo` contract registry from a scabbard service
+on circuit `01234-ABCDE` with service ID `abcd`, running on the node with the
+REST API endpoint `http://localhost:8088`. The transaction will be signed with
+the key located in the file `~/user.priv`.
+
+```
+$ scabbard cr delete \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  xo
+```
+
+The next command removes the `intkey_multiply` contract registry from the same
+scabbard service, but specifies a key in the `$HOME/.splinter/keys` directory by
+name. It also waits up to 10 seconds for the contract registry deletion batch to
+commit.
+
+```
+$ scabbard cr delete \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --wait 10 \
+  intkey_multiply
+```
+
+SEE ALSO
+========
+| `scabbard-cr-create(1)`
+| `scabbard-cr-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-cr-update.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-update.1.md
@@ -1,0 +1,95 @@
+% SCABBARD-CR-UPDATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-cr-update** — Updates the owners of a Sabre contract registry.
+
+SYNOPSIS
+========
+
+**scabbard cr update** \[**FLAGS**\] \[**OPTIONS**\] NAME
+
+DESCRIPTION
+===========
+This command allows users to update the owners of an existing Sabre contract
+registry in state for the targeted scabbard service. All of the existing owners
+will be replaced by the owners provided with this command.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`-O`, `--owners` KEY
+: Includes the given public keys as owners of the contract registry. The
+  contract registry must have one or more owners.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAME`
+: Provides the name of the contract registry to update.
+
+EXAMPLES
+========
+The following command updates the owners of the `xo` contract registry for a
+scabbard service on circuit `01234-ABCDE` with service ID `abcd`, running on the
+node with the REST API endpoint `http://localhost:8088`. The contract registry
+will be updated to have just one owner, and the transaction will be signed with
+the key located in the file `~/user.priv`.
+
+```
+$ scabbard cr update \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  xo
+```
+
+The next command updates the owners of the `intkey_multiply` contract registry
+for the same scabbard service, but includes multiple owners and specifies a key
+in the `$HOME/.splinter/keys` directory by name. It also waits up to 10 seconds
+for the contract registry update batch to commit.
+
+```
+$ scabbard cr update \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  --owner 7b6c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118 \
+  --owner 02381b606ac2bbe3bd374654cb7cb467ffb0225eb46038a5ec37b43e0c2f085dcb \
+  --wait 10 \
+  intkey_multiply
+```
+
+SEE ALSO
+========
+| `scabbard-cr-create(1)`
+| `scabbard-cr-delete(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-cr.1.md
+++ b/services/scabbard/cli/man/scabbard-cr.1.md
@@ -1,0 +1,44 @@
+% SCABBARD-CR(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-cr** — Provides management of the Sabre contract registry.
+
+SYNOPSIS
+========
+
+**scabbard cr** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command provides management functionality for the Sabre contract registry
+of a scabbard service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+SUBCOMMANDS
+===========
+`create`
+: Creates a contract registry in a scabbard service's state.
+
+`delete`
+: Deletes a contract registry from a scabbard service's state.
+
+`update`
+: Updates the owner(s) of an existing contract registry in a scabbard service's
+  state.
+
+SEE ALSO
+========
+| `scabbard-cr-create(1)`
+| `scabbard-cr-delete(1)`
+| `scabbard-cr-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-exec.1.md
+++ b/services/scabbard/cli/man/scabbard-exec.1.md
@@ -1,0 +1,116 @@
+% SCABBARD-EXEC(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-exec** — Executes a Sabre smart contract.
+
+SYNOPSIS
+========
+
+**scabbard exec** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command executes a smart contract on the targeted scabbard service.
+The name and version of the contract must be provided, and they must match a
+registered smart contract in the targeted scabbard service. A payload file
+provides the data for the smart contract execution, and one or more input/output
+addresses must be specified for the transaction.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-C`, `--contract` CONTRACT
+: Specifies the smart contract to execute, using the format `NAME:VERSION`. The
+  given name and version must exactly match a smart contract that has been
+  uploaded and registered in the scabbard service's state. This option is
+  required.
+
+`--inputs` ADDRESS
+: Specifies an input address for the execution of the smart contract. Inputs are
+  state addresses that this transaction is allowed to read from; the smart
+  contract must have read permissions for the namespace of each input. This
+  option may be provided multiple times to specify multiple input addresses. One
+  or more input addresses must be provided.
+
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`--outputs` ADDRESS
+: Specifies an output address for the execution of the smart contract. Outputs
+  are state addresses that this transaction is allowed to write to; the smart
+  contract must have write permissions for the namespace of each output. This
+  option may be provided multiple times to specify multiple output addresses.
+  One or more output addresses must be provided.
+
+`-p`, `--payload` FILE
+: Provides the payload in the file to the smart contract for execution. This
+  option is required.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+EXAMPLES
+========
+The following command executes version `0.1.0` of the `xo` smart contract in a
+scabbard service on circuit `01234-ABCDE` with service ID `abcd`, running on the
+node with the REST API endpoint `http://localhost:8088`. The transaction will be
+signed with the key located in the file `~/user.priv`. Three addresses are
+provided as both inputs and outputs, and the payload file at `~/xo-payload-1`
+will be used.
+
+```
+$ scabbard exec \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --contract xo:0.1.0 \
+  --inputs 00ec03 \
+  --inputs cad11d \
+  --inputs 5b7349 \
+  --outputs 00ec03 \
+  --outputs cad11d \
+  --outputs 5b7349 \
+  --payload ~/xo-payload-1
+```
+
+The next command executes version `0.1.2` of the `intkey_multiply` contract in
+the same scabbard service, but specifies a key in the `$HOME/.splinter/keys`
+directory by name. It also waits up to 10 seconds for the contract execution
+batch to commit.
+
+```
+$ scabbard exec \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --wait 10 \
+  --contract intkey_multiply:0.1.2 \
+  --inputs abcdef \
+  --outputs abcdef \
+  --payload ~/intkey-multiply-payload-1
+```
+
+SEE ALSO
+========
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-ns-create.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-create.1.md
@@ -1,0 +1,98 @@
+% SCABBARD-NS-CREATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-ns-create** — Creates a Sabre namespace.
+
+SYNOPSIS
+========
+
+**scabbard ns create** \[**FLAGS**\] \[**OPTIONS**\] NAMESPACE
+
+DESCRIPTION
+===========
+This command allows users to create a new Sabre namespace in state for the
+targeted scabbard service. A Sabre namespace is a reserved portion of state that
+can be written to and read by one or more smart contracts. A contract must be
+given permission to read or write to a namespace (see `scabbard-perm(1)` for
+setting namespace permissions).
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`-O`, `--owners` KEY
+: Includes the given public keys as owners of the new namespace. The namespace
+  must have one or more owners.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAMESPACE`
+: Provides the state address prefix to reserve for the new namespace.
+
+EXAMPLES
+========
+The following command creates a new namespace for the `abcdef` address prefix in
+a scabbard service on circuit `01234-ABCDE` with service ID `abcd`, running on
+the node with the REST API endpoint `http://localhost:8088`. The new namespace
+has one owner, and the transaction will be signed with the key located in the
+file `~/user.priv`.
+
+```
+$ scabbard ns create \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  abcdef
+```
+
+The next command creates a new namespace for the `012345` address prefix in the
+same scabbard service, but adds multiple owners and specifies a key in the
+`$HOME/.splinter/keys` directory by name. It also waits up to 10 seconds for the
+namespace creation batch to commit.
+
+```
+$ scabbard ns create \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  --owner 7b6c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118 \
+  --owner 02381b606ac2bbe3bd374654cb7cb467ffb0225eb46038a5ec37b43e0c2f085dcb \
+  --wait 10 \
+  012345
+```
+
+SEE ALSO
+========
+| `scabbard-ns-delete(1)`
+| `scabbard-ns-update(1)`
+| `scabbard-perm(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-ns-delete.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-delete.1.md
@@ -1,0 +1,84 @@
+% SCABBARD-NS-DELETE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-ns-delete** — Deletes a Sabre namespace.
+
+SYNOPSIS
+========
+
+**scabbard ns delete** \[**FLAGS**\] \[**OPTIONS**\] NAMESPACE
+
+DESCRIPTION
+===========
+This command allows users to delete a Sabre namespace from the targeted scabbard
+service.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAMESPACE`
+: Provides the state address prefix of the namespace to delete.
+
+EXAMPLES
+========
+The following command removes the `abcdef` namespace from a scabbard service on
+circuit `01234-ABCDE` with service ID `abcd`, running on the node with the REST
+API endpoint `http://localhost:8088`. The transaction will be signed with the
+key located in the file `~/user.priv`.
+
+```
+$ scabbard ns delete \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  abcdef
+```
+
+The next command removes the `012345` namespace from the same scabbard service,
+but specifies a key in the `$HOME/.splinter/keys` directory by name. It also
+waits up to 10 seconds for the namespace deletion batch to commit.
+
+```
+$ scabbard ns delete \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --wait 10 \
+  012345
+```
+
+SEE ALSO
+========
+| `scabbard-ns-create(1)`
+| `scabbard-ns-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-ns-update.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-update.1.md
@@ -1,0 +1,96 @@
+% SCABBARD-NS-UPDATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-ns-update** — Updates the owners of a Sabre namespace.
+
+SYNOPSIS
+========
+
+**scabbard ns update** \[**FLAGS**\] \[**OPTIONS**\] NAMESPACE
+
+DESCRIPTION
+===========
+This command allows users to update the owners of an existing Sabre namespace in
+state for the targeted scabbard service. All of the existing owners will be
+replaced by the owners provided with this command.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`-O`, `--owners` KEY
+: Includes the given public keys as owners of the namespace. The namespace must
+  have one or more owners.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAMESPACE`
+: Provides the state address prefix of the namespace to update.
+
+EXAMPLES
+========
+The following command updates the owners of the `abcdef` namespace in a scabbard
+service on circuit `01234-ABCDE` with service ID `abcd`, running on the node
+with the REST API endpoint `http://localhost:8088`. The namespace will be
+updated to have just one owner, and the transaction will be signed with the key
+located in the file `~/user.priv`.
+
+```
+$ scabbard ns update \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  abcdef
+```
+
+The next command updates the owners of the `012345` namespace in the same
+scabbard service, but includes multiple owners and specifies a key in the
+`$HOME/.splinter/keys` directory by name. It also waits up to 10 seconds for the
+namespace update batch to commit.
+
+```
+$ scabbard ns update \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --owner 0385d50a3512f1ef324c9fc86798998d4e3ad2a4e189ceb9ca49aacdcad30a595a \
+  --owner 7b6c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118 \
+  --owner 02381b606ac2bbe3bd374654cb7cb467ffb0225eb46038a5ec37b43e0c2f085dcb \
+  --wait 10 \
+  012345
+```
+
+SEE ALSO
+========
+| `scabbard-ns-create(1)`
+| `scabbard-ns-delete(1)`
+| `scabbard-perm(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-ns.1.md
+++ b/services/scabbard/cli/man/scabbard-ns.1.md
@@ -1,0 +1,47 @@
+% SCABBARD-NS(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-ns** — Provides management of Sabre namespaces.
+
+SYNOPSIS
+========
+
+**scabbard ns** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command provides management functionality for the Sabre namespaces of a
+scabbard service. A Sabre namespace is a reserved portion of state that
+can be written to and read by one or more smart contracts. A contract must be
+given permission to read or write to a namespace (see `scabbard-perm(1)` for
+setting namespace permissions).
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+SUBCOMMANDS
+===========
+`create`
+: Creates a namespace in a scabbard service's state.
+
+`delete`
+: Deletes a namespace from a scabbard service's state.
+
+`update`
+: Updates the owner(s) of an existing namespace in a scabbard service's state.
+
+SEE ALSO
+========
+| `scabbard-ns-create(1)`
+| `scabbard-ns-delete(1)`
+| `scabbard-ns-update(1)`
+| `scabbard-perm(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard-perm.1.md
+++ b/services/scabbard/cli/man/scabbard-perm.1.md
@@ -1,0 +1,125 @@
+% SCABBARD-PERM(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard-perm** — Sets or deletes a Sabre namespace permission.
+
+SYNOPSIS
+========
+
+**scabbard perm** \[**FLAGS**\] \[**OPTIONS**\] NAMESPACE CONTRACT
+
+DESCRIPTION
+===========
+This command allows users to set or delete permissions for Sabre namespaces in
+state for the targeted scabbard service. Setting a permission requires the
+namespace's state address prefix, the name of the smart contract to set
+permissions for, and the `-r`/`--read` and/or `-w`/`--write` flags to indicate
+the permissions to set. Deleting a permission requires the namespace's state
+address prefix and the `--delete` flag; this deletes all contracts' permissions
+for the namespace.
+
+FLAGS
+=====
+`-d`, `--delete`
+: Deletes all permissions for the namespace.
+
+`-h`, `--help`
+: Prints help information.
+
+`-r`, `--read`
+: Adds namespace read permissions for the contract. This flag conflicts with the
+  `-d`/`--delete` flag.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+`-w`, `--write`
+: Adds namespace write permissions for the contract. This flag conflicts with
+  the `-d`/`--delete` flag.
+
+OPTIONS
+=======
+`-k`, `--key` FILE
+: Indicates the key file to use for signing scabbard transactions. The `FILE`
+  can be a relative or absolute file path, or it can be the name of a .priv file
+  in the `$HOME/.splinter/keys` directory. The target file must contain a valid
+  secp256k1 private key. This option is required.
+
+`--service-id` ID
+: Specifies the fully-qualified service ID of the targeted scabbard service,
+  using the format `CIRCUIT_ID::SERVICE_ID`. This option is required.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API that is running the targeted
+  scabbard service. (default `http://localhost:8080`) This option is required.
+
+`--wait` SECONDS
+: If provided, waits the given number of seconds for the batch to commit.
+  Displays an error message if the batch does not commit in time.
+
+ARGUMENTS
+=========
+`NAMESPACE`
+: Provides the state address prefix of the namespace to set permissions for.
+
+`CONTRACT`
+: Specifies the name of the contract to give permissions to for the namespace.
+  This argument conflicts with the `-d`/`--delete` flag.
+
+EXAMPLES
+========
+The following command gives read permissions for the `abcdef` namespace to the
+`xo` smart contract in a scabbard service on circuit `01234-ABCDE` with service
+ID `abcd`, running on the node with the REST API endpoint
+`http://localhost:8088`. The transaction will be signed with the key located in
+the file `~/user.priv`.
+
+```
+$ scabbard perm \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --read \
+  abcdef \
+  xo
+```
+
+The next command gives both read and write permissions for the `012345`
+namespace to the `intkey_multiply` smart contract in the same scabbard service.
+It also specifies a key in the `$HOME/.splinter/keys` directory by name and
+waits up to 10 seconds for the namespace permission batch to commit.
+
+```
+$ scabbard perm \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key user \
+  --wait 10 \
+  --read \
+  --write \
+  012345 \
+  intkey_multiply
+```
+
+This example deletes all permissions for the `012abc` namespace in the same
+scabbard service as the previous examples.
+
+
+```
+$ scabbard perm \
+  --url http://localhost:8088 \
+  --service-id 01234-ABCDE::abcd \
+  --key ~/user.priv \
+  --delete \
+  012abc
+```
+
+SEE ALSO
+========
+| `scabbard-ns-create(1)`
+| `scabbard-ns-delete(1)`
+| `scabbard-ns-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/man/scabbard.1.md
+++ b/services/scabbard/cli/man/scabbard.1.md
@@ -1,0 +1,68 @@
+% SCABBARD(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**scabbard** — Command-line interface for scabbard
+
+SYNOPSIS
+========
+
+**scabbard** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+The `scabbard` utility is the command-line interface for scabbard, a Splinter
+service that runs Sawtooth Sabre smart contracts on Hyperledger Transact. This
+CLI is a convenient tool for uploading, viewing, and executing smart contracts.
+
+* Run `scabbard *SUBCOMMAND* --help` to see information about a specific
+  subcommand (for example, `scabbard contract upload --help`).
+
+* To view the man page for a scabbard subcommand, use the "dashed form" of the
+  name, where each space is replaced with a hyphen. For example, run
+  `man scabbard-contract-show` to see the man page for `scabbard contract show`.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+SUBCOMMANDS
+===========
+
+`contract`
+: Provides commands to upload, list, and show Sabre smart contracts.
+
+`cr`
+: Provides commands to create, update, and delete a Sabre contract registry.
+
+`exec`
+: Executes a Sabre smart contract.
+
+`ns`
+: Provides commands to create, update, and delete Sabre namespaces.
+
+`perm`
+: Sets or deletes a Sabre namespace permission.
+
+SEE ALSO
+========
+| `scabbard-contract-list(1)`
+| `scabbard-contract-show(1)`
+| `scabbard-contract-upload(1)`
+| `scabbard-cr-create(1)`
+| `scabbard-cr-delete(1)`
+| `scabbard-cr-update(1)`
+| `scabbard-exec(1)`
+| `scabbard-ns-create(1)`
+| `scabbard-ns-delete(1)`
+| `scabbard-ns-update(1)`
+| `scabbard-perm(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/

--- a/services/scabbard/cli/packaging/man/README.md
+++ b/services/scabbard/cli/packaging/man/README.md
@@ -1,0 +1,2 @@
+This is the directory where the generated man pages for `scabbard` will be
+located.


### PR DESCRIPTION
Backport of #889

This backport differs from the original PR in that it doesn't include the man pages for the `scabbard sp` subcommand, which is not stable.