### PR TITLE
BACKPORT: Add PeerManagerBuilder for PeerManager 

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -797,9 +797,15 @@ mod tests {
             .start()
             .expect("Unable to start Connection Manager");
         let connector = cm.connector();
-        let mut peer_manager =
-            PeerManager::new(connector, None, Some(1), "test-node".to_string(), true);
-        let peer_connector = peer_manager.start().expect("Cannot start PeerManager");
+
+        let peer_manager = PeerManager::builder()
+            .with_connector(connector)
+            .with_retry_interval(1)
+            .with_identity("test-node".to_string())
+            .with_strict_ref_counts(true)
+            .start()
+            .expect("Cannot start peer_manager");
+        let peer_connector = peer_manager.connector();
 
         let mut storage = get_storage("memory", CircuitDirectory::new).unwrap();
 

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3471,8 +3471,15 @@ mod tests {
             .start()
             .expect("Unable to start Connection Manager");
         let connector = cm.connector();
-        let mut pm = PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
-        let peer_connector = pm.start().expect("Cannot start PeerManager");
+
+        let pm = PeerManager::builder()
+            .with_connector(connector)
+            .with_retry_interval(1)
+            .with_identity("my_id".to_string())
+            .with_strict_ref_counts(true)
+            .start()
+            .expect("Cannot start peer_manager");
+        let peer_connector = pm.connector();
         (mesh, cm, pm, peer_connector)
     }
 

--- a/libsplinter/src/peer/builder.rs
+++ b/libsplinter/src/peer/builder.rs
@@ -1,0 +1,122 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data structures for building a `PeerManager` instance.
+//!
+//! The public interface includes the structs [`PeerManagerBuilder`]
+
+use crate::network::connection_manager::Connector;
+
+use super::error::PeerManagerError;
+use super::PeerManager;
+
+// Default value of how often the Pacemaker should send RetryPending message
+const DEFAULT_PACEMAKER_INTERVAL: u64 = 10;
+// The number of retry attempts for an active endpoint before the PeerManager will try other
+// endpoints associated with a peer
+const DEFAULT_MAXIMUM_RETRY_ATTEMPTS: u64 = 5;
+
+#[derive(Default)]
+pub struct PeerManagerBuilder {
+    connector: Option<Connector>,
+    max_retry_attempts: Option<u64>,
+    retry_interval: Option<u64>,
+    identity: Option<String>,
+    strict_ref_counts: Option<bool>,
+}
+
+/// Constructs new `PeerManager` instances.
+///
+/// This builder is used to construct new `PeerManager` instances. The `PeerManager` requires
+/// a `Connector` to request connections from the `ConnectionManageer` and the unique ID of the
+/// node this `PeerManager` is for.  It also has several optional configuration values, such as
+/// max_retry_attempts and retry_interval.
+impl PeerManagerBuilder {
+    /// Construct a new builder.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set the connector instance to use with the resulting `PeerManager`.
+    ///
+    /// This is the `Connector` to the `ConnectionManager` that will handle the connections
+    /// requested by the `PeerManager`.
+    pub fn with_connector(mut self, connector: Connector) -> Self {
+        self.connector = Some(connector);
+        self
+    }
+
+    /// Set the max_retry_attempts instance to use with the resulting `PeerManager`.
+    ///
+    /// The number of retry attempts for an active endpoint before the
+    /// `PeerManager` will try other endpoints associated with a peer
+    pub fn with_max_retry_attempts(mut self, max_retry_attempts: u64) -> Self {
+        self.max_retry_attempts = Some(max_retry_attempts);
+        self
+    }
+
+    /// Set the retry_interval to use with the resulting `PeerManager`.
+    ///
+    /// How often (in seconds) the `Pacemaker` should notify the `PeerManager`
+    /// to retry pending peers.
+    pub fn with_retry_interval(mut self, retry_interval: u64) -> Self {
+        self.retry_interval = Some(retry_interval);
+        self
+    }
+
+    /// Set the identity to use with the resulting `PeerManager`.
+    ///
+    /// The unique ID of the node this `PeerManager` belongs to.
+    pub fn with_identity(mut self, identity: String) -> Self {
+        self.identity = Some(identity);
+        self
+    }
+
+    /// Set strict_ref_counts in the the resulting `PeerManager`.
+    ///
+    /// Determines whether or not to panic when attempting to remove a
+    /// reference to a peer that is not referenced.
+    pub fn with_strict_ref_counts(mut self, strict_ref_counts: bool) -> Self {
+        self.strict_ref_counts = Some(strict_ref_counts);
+        self
+    }
+
+    /// Starts the `PeerManager`
+    ///
+    /// Starts up a thread that will handle incoming requests to add, remove and get peers. Also
+    /// handles notifications from the `ConnectionManager`.
+    ///
+    /// Returns a `PeerManagerConnector` that can be used to send requests to the `PeerManager`.
+    pub fn start(&mut self) -> Result<PeerManager, PeerManagerError> {
+        let retry_interval = self.retry_interval.unwrap_or(DEFAULT_PACEMAKER_INTERVAL);
+        let max_retry_attempts = self
+            .max_retry_attempts
+            .unwrap_or(DEFAULT_MAXIMUM_RETRY_ATTEMPTS);
+        let strict_ref_counts = self.strict_ref_counts.unwrap_or(false);
+        let identity = self.identity.take().ok_or_else(|| {
+            PeerManagerError::StartUpError("Missing required value `identity`".to_string())
+        })?;
+        let connector = self.connector.take().ok_or_else(|| {
+            PeerManagerError::StartUpError("Missing required value `connector`".to_string())
+        })?;
+
+        PeerManager::build(
+            retry_interval,
+            max_retry_attempts,
+            strict_ref_counts,
+            identity,
+            connector,
+        )
+    }
+}

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -543,9 +543,16 @@ pub mod tests {
             .expect("Unable to start Connection Manager");
 
         let connector = cm.connector();
-        let mut peer_manager =
-            PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
-        let peer_connector = peer_manager.start().expect("Cannot start peer_manager");
+
+        let peer_manager = PeerManager::builder()
+            .with_connector(connector)
+            .with_retry_interval(1)
+            .with_identity("my_id".to_string())
+            .with_strict_ref_counts(true)
+            .start()
+            .expect("Cannot start peer_manager");
+        let peer_connector = peer_manager.connector();
+
         let (send, recv) = channel();
 
         let (dispatcher_sender, dispatcher_receiver) = dispatch_channel();
@@ -578,7 +585,7 @@ pub mod tests {
             .add_peer_ref("test_peer".to_string(), vec!["test".to_string()])
             .expect("Unable to add peer");
 
-        assert_eq!(peer_ref.peer_id, "test_peer");
+        assert_eq!(peer_ref.peer_id(), "test_peer");
 
         let notification = subscriber.next().expect("Unable to get notification");
         assert_eq!(
@@ -622,9 +629,14 @@ pub mod tests {
             .expect("Unable to start Connection Manager");
 
         let connector = cm.connector();
-        let mut peer_manager =
-            PeerManager::new(connector, None, Some(1), "my_id".to_string(), true);
-        let peer_connector = peer_manager.start().expect("Cannot start PeerManager");
+        let peer_manager = PeerManager::builder()
+            .with_connector(connector)
+            .with_retry_interval(1)
+            .with_identity("my_id".to_string())
+            .with_strict_ref_counts(true)
+            .start()
+            .expect("Cannot start peer_manager");
+        let peer_connector = peer_manager.connector();
         let (dispatcher_sender, _dispatched_receiver) = dispatch_channel();
         let interconnect = PeerInterconnectBuilder::new()
             .with_peer_connector(peer_connector)

--- a/libsplinter/src/peer/peer_ref.rs
+++ b/libsplinter/src/peer/peer_ref.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data structures for building a `PeerManager` instance.
+//!
+//! The public interface includes the structs [`PeerRef`] and [`EndpointPeerRef`]
+
+use crate::peer::connector::PeerRemover;
+
+/// Used to keep track of peer references. When dropped, the `PeerRef` will send a request to the
+/// `PeerManager` to remove a reference to the peer, thus removing the peer if no more references
+/// exist.
+#[derive(Debug, PartialEq)]
+pub struct PeerRef {
+    peer_id: String,
+    peer_remover: PeerRemover,
+}
+
+impl PeerRef {
+    /// Creates a new `PeerRef`
+    pub(super) fn new(peer_id: String, peer_remover: PeerRemover) -> Self {
+        PeerRef {
+            peer_id,
+            peer_remover,
+        }
+    }
+
+    /// Returns the peer ID this reference is for
+    pub fn peer_id(&self) -> &str {
+        &self.peer_id
+    }
+}
+
+impl Drop for PeerRef {
+    fn drop(&mut self) {
+        match self.peer_remover.remove_peer_ref(&self.peer_id) {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Unable to remove reference to {} on drop: {}",
+                self.peer_id, err
+            ),
+        }
+    }
+}
+
+/// Used to keep track of peer references that are created only with an endpoint. When dropped, a
+/// request is sent to the `PeerManager` to remove a reference to the peer, thus removing the peer
+/// if no more references exist.
+#[derive(Debug, PartialEq)]
+pub struct EndpointPeerRef {
+    endpoint: String,
+    peer_remover: PeerRemover,
+}
+
+impl EndpointPeerRef {
+    /// Creates a new `EndpointPeerRef`
+    pub(super) fn new(endpoint: String, peer_remover: PeerRemover) -> Self {
+        EndpointPeerRef {
+            endpoint,
+            peer_remover,
+        }
+    }
+
+    /// Returns the endpoint of the peer this reference is for
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for EndpointPeerRef {
+    fn drop(&mut self) {
+        match self
+            .peer_remover
+            .remove_peer_ref_by_endpoint(&self.endpoint)
+        {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Unable to remove reference to peer with endpoint {} on drop: {}",
+                self.endpoint, err
+            ),
+        }
+    }
+}

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -230,16 +230,16 @@ impl SplinterDaemon {
         let connection_connector = connection_manager.connector();
         let connection_manager_shutdown = connection_manager.shutdown_signaler();
 
-        let mut peer_manager = PeerManager::new(
-            connection_connector.clone(),
-            None,
-            None,
-            self.node_id.to_string(),
-            self.strict_ref_counts,
-        );
-        let peer_connector = peer_manager.start().map_err(|err| {
-            StartError::NetworkError(format!("Unable to start peer manager: {}", err))
-        })?;
+        let peer_manager = PeerManager::builder()
+            .with_connector(connection_connector.clone())
+            .with_identity(self.node_id.to_string())
+            .with_strict_ref_counts(self.strict_ref_counts)
+            .start()
+            .map_err(|err| {
+                StartError::NetworkError(format!("Unable to start peer manager: {}", err))
+            })?;
+
+        let peer_connector = peer_manager.connector();
         let peer_manager_shutdown = peer_manager.shutdown_handle();
 
         // Listen for services


### PR DESCRIPTION
Backport changes in #896 

Note: the builder commit differs slightly because of the different version number listed in the deprecation notification