### PR TITLE
Ignore test_environment_var_set_config and test_final_config_precedence

### DIFF
--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -102,6 +102,10 @@ mod tests {
     use super::*;
 
     #[test]
+    // This test intermittently fails due to interaction with other tests that set the environment
+    // variables used within. It also fails to reset the environment variables to their original
+    // values.
+    #[ignore]
     /// This test verifies that a `PartialConfig` object, constructed from the
     /// `EnvPartialConfigBuilder` module, contains the correct values using the following steps:
     ///

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -689,6 +689,9 @@ mod tests {
     }
 
     #[test]
+    // This test potentially interactions with other tests that set the environment variables used
+    // within. It also fails to reset the environment variables to their original values.
+    #[ignore]
     /// This test verifies that a `Config` object, constructed from multiple config modules, contains
     /// the correct values, giving `ClapPartialConfigBuilder` values ultimate precedence, using the
     /// following steps:


### PR DESCRIPTION
These tests interacts poorly with other tests which set the env variables
which they use. They also fail to properly clean up.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>