### PR TITLE
Update man page licenses to Creative Commons

### DIFF
--- a/cli/man/TEMPLATE.1.md.example
+++ b/cli/man/TEMPLATE.1.md.example
@@ -1,18 +1,8 @@
 % COMMAND(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 <!--

--- a/cli/man/splinter-cert-generate.1.md
+++ b/cli/man/splinter-cert-generate.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CERT-GENERATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-cert.1.md
+++ b/cli/man/splinter-cert.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CERT(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-LIST(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-PROPOSALS(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-PROPOSE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-SHOW(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-template-arguments.1.md
+++ b/cli/man/splinter-circuit-template-arguments.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-TEMPLATE-ARGUMENTS(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-template-list.1.md
+++ b/cli/man/splinter-circuit-template-list.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-TEMPLATE-LIST(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-template-show.1.md
+++ b/cli/man/splinter-circuit-template-show.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-TEMPLATE-SHOW(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-template.1.md
+++ b/cli/man/splinter-circuit-template.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-TEMPLATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit-vote.1.md
+++ b/cli/man/splinter-circuit-vote.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT-VOTE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-circuit.1.md
+++ b/cli/man/splinter-circuit.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-CIRCUIT(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-database-migrate.1.md
+++ b/cli/man/splinter-database-migrate.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-DATABASE-MIGRATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-database.1.md
+++ b/cli/man/splinter-database.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-DATABASE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-health-status.1.md
+++ b/cli/man/splinter-health-status.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-HEALTH-STATUS(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-health.1.md
+++ b/cli/man/splinter-health.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-HEALTH(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -1,18 +1,8 @@
 % SPLINTER-KEYGEN(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/cli/man/splinter.1.md
+++ b/cli/man/splinter.1.md
@@ -1,18 +1,8 @@
 % SPLINTER(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-contract-list.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-list.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CONTRACT-LIST(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-contract-show.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-show.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CONTRACT-SHOW(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-contract-upload.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-upload.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CONTRACT-UPLOAD(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-contract.1.md
+++ b/services/scabbard/cli/man/scabbard-contract.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CONTRACT(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-cr-create.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-create.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CR-CREATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-cr-delete.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-delete.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CR-DELETE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-cr-update.1.md
+++ b/services/scabbard/cli/man/scabbard-cr-update.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CR-UPDATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-cr.1.md
+++ b/services/scabbard/cli/man/scabbard-cr.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-CR(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-exec.1.md
+++ b/services/scabbard/cli/man/scabbard-exec.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-EXEC(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-ns-create.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-create.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-NS-CREATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-ns-delete.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-delete.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-NS-DELETE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-ns-update.1.md
+++ b/services/scabbard/cli/man/scabbard-ns-update.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-NS-UPDATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-ns.1.md
+++ b/services/scabbard/cli/man/scabbard-ns.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-NS(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-perm.1.md
+++ b/services/scabbard/cli/man/scabbard-perm.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-PERM(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-sp-create.1.md
+++ b/services/scabbard/cli/man/scabbard-sp-create.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-SP-CREATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-sp-delete.1.md
+++ b/services/scabbard/cli/man/scabbard-sp-delete.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-SP-DELETE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-sp-update.1.md
+++ b/services/scabbard/cli/man/scabbard-sp-update.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-SP-UPDATE(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard-sp.1.md
+++ b/services/scabbard/cli/man/scabbard-sp.1.md
@@ -1,18 +1,8 @@
 % SCABBARD-SP(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/services/scabbard/cli/man/scabbard.1.md
+++ b/services/scabbard/cli/man/scabbard.1.md
@@ -1,18 +1,8 @@
 % SCABBARD(1) Cargill, Incorporated | Splinter Commands
 <!--
   Copyright 2018-2020 Cargill Incorporated
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
 -->
 
 NAME

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -1,4 +1,9 @@
 % SPLINTERD(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
 
 NAME
 ====


### PR DESCRIPTION
The man pages should be licensed under Creative Commons, not Apache.

Signed-off-by: Logan Seeley <seeley@bitwise.io>