### PR TITLE
BACKPORT: Add 10s sleep during crates publish

### DIFF
--- a/ci/publish-splinter-crates
+++ b/ci/publish-splinter-crates
@@ -51,6 +51,7 @@ CMD cargo login $CARGO_CRED \
  && cargo clean \
  && cargo test \
  && cargo publish \
+ && sleep 10 \
  && cd /project/splinter/services/scabbard/libscabbard \
  && sed -i'' -e "s/splinter = {.*$/splinter\ =\ \"$REPO_VERSION\"/" Cargo.toml \
  && rm -f ../../../Cargo.lock ./Cargo.lock \


### PR DESCRIPTION
Cargo's index updates are not instantaneous, so a brief sleep is necessary
to ensure that the newly published splinter version is available for use by
libscabbard.

More information about Cargo's index udpates can be found at
https://internals.rust-lang.org/t/changes-to-how-crates-io-handles-index-updates/9608

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>