### PR TITLE
BACKPORT: Update subscribing to PeerManagerNotfications to take a sender 

### DIFF
--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -323,7 +323,7 @@ impl Connector {
     ///
     /// # Errors
     ///
-    /// Returns a ConnectionManagerError is the connection manager
+    /// Returns a ConnectionManagerError if the connection manager
     /// has stopped running.
     pub fn unsubscribe(&self, subscriber_id: SubscriberId) -> Result<(), ConnectionManagerError> {
         let (sender, recv) = channel();


### PR DESCRIPTION
Backport changes from https://github.com/Cargill/splinter/pull/908

Note: Commits differ slightly because deprecated versions are changed.