### PR TITLE
BACKPORT: Ignore clippy error for redundant field names in unsubscribe

### DIFF
--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -366,6 +366,7 @@ impl ServiceConnector {
         )
     }
 
+    #[allow(clippy::redundant_field_names)]
     pub fn unsubscribe(&self, subscriber_id: SubscriberId) -> Result<(), ServiceConnectionError> {
         agent_msg!(
             self.sender,


### PR DESCRIPTION
This clippy error cannot be fixed as suggested because the issue
is wrapped in a macro that does not allow leaving off the field
name when creating the Unsubscribe message for service notfications.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>