### PR TITLE
Pin @types/node dependency

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -17,7 +17,7 @@
     "generate-proto-files": "node scripts/compile_protobuf.js > src/compiled_protos.json"
   },
   "dependencies": {
-    "@types/node": "^12.12.6",
+    "@types/node": "12.12.6",
     "@types/request-promise": "^4.1.44",
     "@types/sjcl": "^1.0.28",
     "axios": "^0.19.0",


### PR DESCRIPTION
An update in a dependency of this package is causing a build failure in
gameroom. Once the upstream dependency is fixed, this change should be
removed.

Issue here:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/45927

Signed-off-by: Darian Plumb <dplumb@bitwise.io>