### PR TITLE
Use gameroom circuit template in Gameroom daemon

### DIFF
--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -53,10 +53,20 @@ scabbard = { path = "../../../services/scabbard/libscabbard", features = ["event
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-splinter = { path = "../../../libsplinter", features = ["biome", "events", "postgres", "registry"]}
 reqwest = { version = "0.10", features = ["blocking"] }
 tokio = "0.1"
 transact = "0.2"
+
+[dependencies.splinter]
+path = "../../../libsplinter"
+features = [
+    "biome",
+    "events",
+    "postgres",
+    "registry",
+    "circuit-template",
+]
+
 
 [features]
 default = []

--- a/examples/gameroom/daemon/src/application_metadata/error.rs
+++ b/examples/gameroom/daemon/src/application_metadata/error.rs
@@ -21,6 +21,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum ApplicationMetadataError {
+    #[cfg(feature = "test-authorization-handler")]
     SerializationError(SerdeError),
     DeserializationError(SerdeError),
 }
@@ -28,6 +29,7 @@ pub enum ApplicationMetadataError {
 impl Error for ApplicationMetadataError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            #[cfg(feature = "test-authorization-handler")]
             ApplicationMetadataError::SerializationError(err) => Some(err),
             ApplicationMetadataError::DeserializationError(err) => Some(err),
         }
@@ -37,6 +39,7 @@ impl Error for ApplicationMetadataError {
 impl fmt::Display for ApplicationMetadataError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            #[cfg(feature = "test-authorization-handler")]
             ApplicationMetadataError::SerializationError(e) => {
                 write!(f, "Failed to serialize ApplicationMetadata: {}", e)
             }

--- a/examples/gameroom/daemon/src/application_metadata/mod.rs
+++ b/examples/gameroom/daemon/src/application_metadata/mod.rs
@@ -26,6 +26,7 @@ pub struct ApplicationMetadata {
 }
 
 impl ApplicationMetadata {
+    #[cfg(feature = "test-authorization-handler")]
     pub fn new(alias: &str, scabbard_admin_keys: &[String]) -> ApplicationMetadata {
         ApplicationMetadata {
             alias: alias.to_string(),
@@ -37,6 +38,7 @@ impl ApplicationMetadata {
         serde_json::from_slice(bytes).map_err(ApplicationMetadataError::DeserializationError)
     }
 
+    #[cfg(feature = "test-authorization-handler")]
     pub fn to_bytes(&self) -> Result<Vec<u8>, ApplicationMetadataError> {
         serde_json::to_vec(self).map_err(ApplicationMetadataError::SerializationError)
     }


### PR DESCRIPTION
Updates the `propose_gameroom` REST API endpoint function to use a
CircuitCreateTemplate to generate the CreateCircuit admin message
used to propose a gameroom.

This also updates the module for ApplicationMetadata to remove the
now unused functions that were only used in the `propose_gameroom`
function. Also removes an error variant that is no longer used.

Signed-off-by: Shannyn Telander <telander@bitwise.io>

In terms of testing this PR, the best approach would probably be to rebuild `gameroomd` and attempt to submit a gameroom through the UI, which should end successfully on each node. :) 