### PR TITLE
`circuit-template` doc additions and small clean-up

### DIFF
--- a/cli/man/splinter-circuit-template-arguments.1.md
+++ b/cli/man/splinter-circuit-template-arguments.1.md
@@ -22,6 +22,9 @@ Circuit templates help simplify the process of creating new circuits with the
 building a circuit from the template. This command lists the arguments that are
 defined in the specified circuit template.
 
+All available templates are located in the circuit templates directory,
+`/usr/share/splinter/circuit-templates`.
+
 FLAGS
 =====
 `-h`, `--help`
@@ -41,7 +44,9 @@ FLAGS
 ARGUMENTS
 =========
 `TEMPLATE-NAME`
-: Circuit template that contains the arguments of interest.
+: Name of the circuit template containing the arguments of interest. The
+  template file must exist in the circuit template directory,
+    `/usr/share/splinter/circuit-templates`.
 
 EXAMPLES
 ========

--- a/cli/man/splinter-circuit-template-list.1.md
+++ b/cli/man/splinter-circuit-template-list.1.md
@@ -23,6 +23,9 @@ templates.
 A Scabbard circuit template is available by default (this template is packaged
 with the Splinter CLI).
 
+All available templates are located in the circuit templates directory,
+`/usr/share/splinter/circuit-templates`.
+
 Tip: Use the `splinter circuit template arguments` command to see the required
 arguments for a specific circuit template.
 
@@ -45,7 +48,8 @@ FLAGS
 EXAMPLES
 ========
 The following example lists the circuit templates on a system that has only the
-`scabbard` template, which is available by default (packaged with the Splinter CLI).
+`scabbard` template, which is available by default (packaged with the Splinter CLI)
+in the circuit template directory, `/usr/share/splinter/circuit-templates`.
 
 ```
 $ splinter circuit template list

--- a/cli/man/splinter-circuit-template-show.1.md
+++ b/cli/man/splinter-circuit-template-show.1.md
@@ -20,6 +20,9 @@ Circuit templates help simplify the process of creating new circuits with the
 `splinter circuit propose` command. This command displays the entire template
 definition, including the arguments and rules, for the specified template.
 
+All available templates are located in the circuit templates directory,
+`/usr/share/splinter/circuit-templates`.
+
 Tip: Use the `splinter circuit template arguments` command to show only the
 required arguments for a specific circuit template.
 
@@ -42,12 +45,14 @@ FLAGS
 ARGUMENTS
 =========
 `TEMPLATE-NAME`
-: Circuit template to be displayed.
+: Name of the circuit template to be displayed. The template file must exist in
+  the circuit template directory, `/usr/share/splinter/circuit-templates`.
 
 EXAMPLES
 ========
 The following command shows the details of the `scabbard` circuit template,
-which is available by default (packaged with the Splinter CLI).
+which is available by default (packaged with the Splinter CLI) in the default
+circuit template directory, `/usr/share/splinter/circuit-templates`.
 
 ```
 $ splinter circuit template show scabbard

--- a/cli/man/splinter-circuit-template.1.md
+++ b/cli/man/splinter-circuit-template.1.md
@@ -28,6 +28,9 @@ A Scabbard circuit template, named `scabbard`, is available by default (packaged
 with the Splinter CLI). This template can be used as a model for other circuit
 templates.
 
+All available templates are located in the default circuit templates directory,
+`/usr/share/splinter/circuit-templates`.
+
 FLAGS
 =====
 `-h`, `--help`

--- a/libsplinter/src/circuit/template/error.rs
+++ b/libsplinter/src/circuit/template/error.rs
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! An error wrapper for the errors generated throughout the module.
+
+/// General error wrapper
 #[derive(Debug)]
 pub struct CircuitTemplateError {
+    /// Human-readable description of the action attempted, which caused the error.
     context: String,
+    /// Optional field which provides a `source` error, in case an exception must be handled.
     source: Option<Box<dyn std::error::Error>>,
 }
 
 impl CircuitTemplateError {
+    /// Builds a `CircuitTemplateError` with a `context`. This sets the `source` field to `None`.
     pub fn new(context: &str) -> Self {
         Self {
             context: context.into(),
@@ -26,6 +32,7 @@ impl CircuitTemplateError {
         }
     }
 
+    /// Builds a `CircuitTemplateError` with a `context`, and a `source` error.
     pub fn new_with_source(context: &str, err: Box<dyn std::error::Error>) -> Self {
         Self {
             context: context.into(),

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides functionality to apply available rule arguments to create a `SplinterServiceBuilder`.
+
 use crate::admin::messages::is_valid_service_id;
 use crate::base62::next_base62_string;
 
@@ -22,6 +24,7 @@ const ALL_OTHER_SERVICES: &str = "$(r:ALL_OTHER_SERVICES)";
 const NODES_ARG: &str = "$(a:NODES)";
 const PEER_SERVICES_ARG: &str = "peer_services";
 
+/// Data structure used to create a `SplinterServiceBuilder`.
 pub(super) struct CreateServices {
     service_type: String,
     service_args: Vec<ServiceArgument>,
@@ -29,6 +32,7 @@ pub(super) struct CreateServices {
 }
 
 impl CreateServices {
+    /// Builds a `SplinterServiceBuilder` using the available circuit template arguments.
     pub fn apply_rule(
         &self,
         template_arguments: &[RuleArgument],
@@ -181,10 +185,15 @@ fn all_services(
 mod test {
     use super::*;
 
-    /*
-     * Test that CreateServices::apply_rules correcly sets ups
-     * the services builders
-     */
+    /// Verify that a `SplinterServiceBuilder` is accurately constructed using the `CreateServices`
+    /// `apply_rule` method.
+    ///
+    /// The test follows the procedure below:
+    /// 1. Generate a `CreateServices` object and a set of template arguments using mock data.
+    /// 2. Use the `apply_rule` method of the `CreateServices` object created in the previous step,
+    ///    resulting in 2 `SplinterServiceBuilder` objects.
+    ///
+    /// The `SplinterServiceBuilder` objects are then verified to have all expected values.
     #[test]
     fn test_create_service_apply_rules() {
         let create_services = make_create_service();
@@ -242,14 +251,34 @@ mod test {
             ("admin-keys".to_string(), "[\"signer_key\"]".to_string())
         );
 
-        // test that building services succeeds:
+        // Verify each `SplinterServiceBuilder` is able to `build` successfully.
         assert!(service_builders[0].clone().build().is_ok());
         assert!(service_builders[1].clone().build().is_ok());
     }
 
-    /*
-     * Test that CreateServices::apply_rules accurately detects an invalid `first_service`.
-     */
+    /// Verify the `CreateServices` `apply_rule` method accurately detects an invalid
+    /// `first_service`. In order to test the breadth of possible invalidities, this test creates
+    /// multiple, different invalid `first_service` objects.
+    /// Before the `first_service` objects are tested, a set of template arguments are generated
+    /// using mock data, to be passed to the `apply_rule` method for each invalid case.
+    ///
+    /// The different invalidities are tested as follows:
+    ///
+    /// 1. Once a `CreateServices` object has been created, the `first_service` field is set to
+    ///    an empty string. Then verifies the `apply_rule` method returns an error.
+    ///
+    /// 2. Once a `CreateServices` object has been created, the `first_service` field is set to
+    ///    a 3-character string, 'a00', which is invalid as this field must be a 4-character base-62
+    ///    string. Then verifies the `apply_rule` method returns an error.
+    ///
+    /// 3. Once a `CreateServices` object has been created, the `first_service` field is set to
+    ///    a 5-character string, 'a0000', which is invalid for the same reason as the previous step.
+    ///    Then verifies the `apply_rule` method returns an error.
+    ///
+    /// 4. Once a `CreateServices` object has been created, the `first_service` field is set to a
+    ///    4-character string, with an invalid character, ':'. This character is invalid as the
+    ///   field must contain a base-62 string. Then verifies the `apply_rule` method returns an error.
+    ///
     #[test]
     fn test_create_service_apply_rules_invalid_first_service() {
         let template_arguments = make_rule_arguments();

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Data structures to hold necessary information for setting the values in the builders generated
+//! from a circuit template. Also provides the general functionality to apply the circuit template
+//! `rules`.
+//!
+//! The public interface includes the structs [`CircuitManagement`], [`CreateServices`],
+//! [`SetMetadata`].
+
 mod create_services;
 mod set_management_type;
 mod set_metadata;
@@ -24,6 +31,8 @@ use create_services::CreateServices;
 use set_management_type::CircuitManagement;
 use set_metadata::SetMetadata;
 
+/// Available `rules` used to create the value for entries of a builder, based on the circuit
+/// template arguments that have been set.
 pub struct Rules {
     set_management_type: Option<CircuitManagement>,
     create_services: Option<CreateServices>,
@@ -31,6 +40,8 @@ pub struct Rules {
 }
 
 impl Rules {
+    /// Applies all available `Rules` for the circuit template. This updates all builders,
+    /// including the `SplinterServiceBuilder` objects and `CreateCircuitBuilder`.
     pub fn apply_rules(
         &self,
         builders: &mut Builders,
@@ -74,12 +85,15 @@ impl From<v1::Rules> for Rules {
     }
 }
 
+/// Data structure to hold an argument used by a rule.
 #[derive(Clone)]
 pub struct RuleArgument {
     name: String,
+    /// Represents whether the argument itself is required.
     required: bool,
     default_value: Option<String>,
     description: Option<String>,
+    /// Value specified by the user.
     user_value: Option<String>,
 }
 

--- a/libsplinter/src/circuit/template/rules/set_management_type.rs
+++ b/libsplinter/src/circuit/template/rules/set_management_type.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides functionality to set a `CreateCircuitBuilder` `management_type`.
+
 use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
 
+/// Data structure holding the circuit's intended `management_type`.
 pub(super) struct CircuitManagement {
     management_type: String,
 }
 
 impl CircuitManagement {
+    /// Adds the `management_type` to the provided `CreateCircuitBuilder`.
     pub fn apply_rule(
         &self,
         builder: CreateCircuitBuilder,

--- a/libsplinter/src/circuit/template/rules/set_metadata.rs
+++ b/libsplinter/src/circuit/template/rules/set_metadata.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides functionality to set the `metadata` field of a `CreateCircuitBuilder`.
+
 use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
 use super::{get_argument_value, is_arg, RuleArgument, Value};
 
+/// Data structure wrapping the `Metadata` object to be used to fill in the `metadata` field of the
+/// `CreateCircuitBuilder`.
 pub(super) struct SetMetadata {
     metadata: Metadata,
 }
@@ -76,6 +80,7 @@ impl From<v1::SetMetadata> for SetMetadata {
     }
 }
 
+/// Enum of the possible types of `Metadata` representations.
 pub(super) enum Metadata {
     Json { metadata: Vec<JsonMetadata> },
 }
@@ -90,6 +95,7 @@ impl From<v1::Metadata> for Metadata {
     }
 }
 
+/// Data structure of the JSON representation of `metadata`.
 pub(super) struct JsonMetadata {
     key: String,
     value: Value,

--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides the functionality to convert a template YAML file or serialized bytes to a native
+//! circuit template representation. Also offers a version guard, to ensure the native circuit
+//! template object is using a compatible circuit definition.
+
 pub mod v1;
 
 use std::fs::File;
@@ -20,17 +24,26 @@ use std::path::Path;
 
 use super::CircuitTemplateError;
 
+/// Version guard for the template, referring to the version of the circuit definition being used.
 #[derive(Deserialize, Debug)]
 struct TemplateVersionGuard {
     version: String,
 }
 
+/// Enum of the version options currently implemented. Each variant holds the circuit templates
+/// implemented for the corresponding circuit version.
 #[derive(Deserialize, Debug)]
 pub enum CircuitTemplate {
+    /// Circuit version 1.0 used for a `CircuitCreateTemplate`.
     V1(v1::CircuitCreateTemplate),
 }
 
 impl CircuitTemplate {
+    /// Creates a `CircuitTemplate` from a template YAML file.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_path` - Path to the template YAML file.
     pub fn load_from_file(file_path: &str) -> Result<Self, CircuitTemplateError> {
         let path = Path::new(file_path);
         if !path.is_file() {
@@ -47,6 +60,7 @@ impl CircuitTemplate {
         Ok(template)
     }
 
+    /// Creates a `CircuitTemplate` from serialized bytes.
     fn deserialize(mut reader: impl Read) -> Result<Self, CircuitTemplateError> {
         let mut data = Vec::new();
         reader.read_to_end(&mut data).map_err(|err| {
@@ -80,6 +94,7 @@ mod test {
 
     use tempdir::TempDir;
 
+    /// Example circuit template YAML file.
     const EXAMPLE_TEMPLATE_YAML: &[u8] = br##"version: v1
 args:
     - name: admin-keys
@@ -104,12 +119,20 @@ rules:
             - key: "alias"
               value: "$(sm:gameroom_name)" "##;
 
-    /*
-     * Verifies load_template correctly loads a template version 1
-     */
+    /// Verifies load_template correctly loads a `CircuitTemplate` with version 1.
+    ///
+    /// The test follows the procedure below:
+    /// 1. Sets up a temporary directory, to write a circuit template YAML file from the
+    ///    `EXAMPLE_TEMPLATE_YAML`.
+    /// 2. Uses the `load_from_file` method to load a `v1` `CircuitTemplate`.
+    /// 3. Matches on the `CircuitTemplate` in order to deconstruct the enum loaded in the previous
+    ///   step.
+    /// 4. Asserts the values of the `CircuitCreateTemplate` held in the `v1` template.
+    ///
+    /// This test verifies that all fields of the `CircuitCreateTemplate` has all of the
+    /// expected values and that all are correctly constructed.
     #[test]
     fn test_parse_template_v1() {
-        // create temp directoy
         let temp_dir = TempDir::new("test_parse_template_v1").unwrap();
         let temp_dir = temp_dir.path().to_path_buf();
         let file_path = get_file_path(temp_dir);

--- a/libsplinter/src/circuit/template/yaml_parser/v1.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/v1.rs
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Defines the `CircuitCreateTemplate` based on the current version of circuits, version 1.
+
+/// Struct to hold the necessary `rules` and `args` required to create a `CreateCircuitBuilder`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CircuitCreateTemplate {
+    /// Version of the circuit definition.
     version: String,
+    /// Required data to fill out the circuit template.
     args: Vec<RuleArgument>,
+    /// Automated process to define more complex entries of the `CreateCircuitBuilder`.
     rules: Rules,
 }
 
@@ -33,13 +39,18 @@ impl CircuitCreateTemplate {
     }
 }
 
+/// Struct to hold the value of and information about an argument.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuleArgument {
+    /// Name of the argument.
     name: String,
+    /// Whether or not the argument is required for the `CircuitCreateTemplate`.
     required: bool,
+    /// Optional value of the argument.
     #[serde(rename = "default")]
     #[serde(skip_serializing_if = "Option::is_none")]
     default_value: Option<String>,
+    /// Optional description of the argument.
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
 }
@@ -62,13 +73,18 @@ impl RuleArgument {
     }
 }
 
+/// Struct to hold the defined `rules`, which are automated processes to define entries of the
+/// `CreateCircuitBuilder` based on the `args` values.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Rules {
+    /// Process for defining the `circuit_management_type` of a circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
     set_management_type: Option<CircuitManagement>,
+    /// Process for defining the services of a circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
     create_services: Option<CreateServices>,
+    /// Process for defining the `metadata` field of a circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
     set_metadata: Option<SetMetadata>,
 }
@@ -87,6 +103,7 @@ impl Rules {
     }
 }
 
+/// The `management_type` used in the `set_management_type` rule.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CircuitManagement {
@@ -99,10 +116,13 @@ impl CircuitManagement {
     }
 }
 
+/// Struct to wrap the information used to define a `SplinterService`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct CreateServices {
+    /// Type of the `SplinterService` being constructed.
     service_type: String,
+    /// Arguments required to build the `SplinterService`.
     service_args: Vec<ServiceArgument>,
     first_service: String,
 }
@@ -121,6 +141,7 @@ impl CreateServices {
     }
 }
 
+/// Struct to wrap the name and value for an argument of a `SplinterService`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceArgument {
     key: String,
@@ -137,6 +158,7 @@ impl ServiceArgument {
     }
 }
 
+/// Struct to wrap the `metadata` used in the `set_metadata` rule.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SetMetadata {
     #[serde(flatten)]
@@ -149,6 +171,7 @@ impl SetMetadata {
     }
 }
 
+/// Enum of the possible types of `metadata` representations.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "encoding")]
 #[serde(rename_all(deserialize = "camelCase"))]
@@ -156,6 +179,7 @@ pub enum Metadata {
     Json { metadata: Vec<JsonMetadata> },
 }
 
+/// Struct of the data held in the `Metadata` object.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JsonMetadata {
     key: String,
@@ -172,6 +196,7 @@ impl JsonMetadata {
     }
 }
 
+/// Struct to represent single and list values within the `JsonMetadata`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Value {


### PR DESCRIPTION
Adds rust documentation to the `circuit-template` modules, as well as updates the template CLI man pages to mention the default circuit template directory location. 

Also makes a small update to the `list_available_templates` method, to simply log an error and keep going if it encounters an issue with an individual file. If it is unable to read from the directory itself, an error is returned. 