### PR TITLE
Add RoutingTable traits as well as a RwLock implementation.

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -95,6 +95,7 @@ experimental = [
     "biome-notifications",
     "biome-user",
     "circuit-template",
+    "routing-table",
     "service-arg-validation",
     "service-network",
     "ws-transport",
@@ -122,6 +123,7 @@ rest-api = [
 ]
 rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
 rest-api-cors = []
+routing-table = []
 sawtooth-signing-compat = ["sawtooth-sdk"]
 service-arg-validation = []
 service-network = []

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -102,6 +102,9 @@ experimental = [
     "zmq-transport",
 ]
 
+# used for turning benchmark tests on
+benchmark = []
+
 biome = []
 biome-credentials = ["biome", "biome-user", "bcrypt"]
 biome-key-management = ["biome"]

--- a/libsplinter/src/circuit/mod.rs
+++ b/libsplinter/src/circuit/mod.rs
@@ -16,6 +16,8 @@
 pub mod component;
 pub mod directory;
 pub mod handlers;
+#[cfg(feature = "routing-table")]
+pub mod routing;
 pub mod service;
 pub mod store;
 #[cfg(feature = "circuit-template")]

--- a/libsplinter/src/circuit/routing/error.rs
+++ b/libsplinter/src/circuit/routing/error.rs
@@ -1,0 +1,195 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for errors that can be raised by `RoutingTableReader` and `RoutingTableWriter` traits
+
+use std::error::Error;
+use std::fmt;
+
+/// Errors that could be raised when requesting a service
+#[derive(Debug, PartialEq)]
+pub struct FetchServiceError(pub String);
+
+impl Error for FetchServiceError {}
+
+impl fmt::Display for FetchServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when requesting all services in a circuit
+#[derive(Debug, PartialEq)]
+pub enum ListServiceError {
+    /// Internal error
+    InternalError(String),
+    CircuitNotFound(String),
+}
+
+impl Error for ListServiceError {}
+
+impl fmt::Display for ListServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ListServiceError::InternalError(msg) => write!(f, "Received internal error: {}", msg),
+            ListServiceError::CircuitNotFound(circuit_id) => {
+                write!(f, "Circuit does not exist: {}", circuit_id)
+            }
+        }
+    }
+}
+
+/// Errors that could be raised when requesting all nodes
+#[derive(Debug, PartialEq)]
+pub struct ListNodesError(pub String);
+
+impl Error for ListNodesError {}
+
+impl fmt::Display for ListNodesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when requesting a node
+#[derive(Debug, PartialEq)]
+pub struct FetchNodeError(pub String);
+
+impl Error for FetchNodeError {}
+
+impl fmt::Display for FetchNodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when requesting all circuits
+#[derive(Debug, PartialEq)]
+pub struct ListCircuitsError(pub String);
+
+impl Error for ListCircuitsError {}
+
+impl fmt::Display for ListCircuitsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when requesting a circuit
+#[derive(Debug, PartialEq)]
+pub struct FetchCircuitError(pub String);
+
+impl Error for FetchCircuitError {}
+
+impl fmt::Display for FetchCircuitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when adding a service
+#[derive(Debug, PartialEq)]
+pub struct AddServiceError(pub String);
+
+impl Error for AddServiceError {}
+
+impl fmt::Display for AddServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when removing a service
+#[derive(Debug, PartialEq)]
+pub struct RemoveServiceError(pub String);
+
+impl Error for RemoveServiceError {}
+
+impl fmt::Display for RemoveServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when adding a circuit
+#[derive(Debug, PartialEq)]
+pub struct AddCircuitError(pub String);
+
+impl Error for AddCircuitError {}
+
+impl fmt::Display for AddCircuitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when adding circuits
+#[derive(Debug, PartialEq)]
+pub struct AddCircuitsError(pub String);
+
+impl Error for AddCircuitsError {}
+
+impl fmt::Display for AddCircuitsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when removing a circuit
+#[derive(Debug, PartialEq)]
+pub struct RemoveCircuitError(pub String);
+
+impl Error for RemoveCircuitError {}
+
+impl fmt::Display for RemoveCircuitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when adding a node
+#[derive(Debug, PartialEq)]
+pub struct AddNodeError(pub String);
+
+impl Error for AddNodeError {}
+
+impl fmt::Display for AddNodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when adding nodes
+#[derive(Debug, PartialEq)]
+pub struct AddNodesError(pub String);
+
+impl Error for AddNodesError {}
+
+impl fmt::Display for AddNodesError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}
+
+/// Errors that could be raised when removing a node
+#[derive(Debug, PartialEq)]
+pub struct RemoveNodeError(pub String);
+
+impl Error for RemoveNodeError {}
+
+impl fmt::Display for RemoveNodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Received internal error: {}", self.0)
+    }
+}

--- a/libsplinter/src/circuit/routing/memory/benchmarks.rs
+++ b/libsplinter/src/circuit/routing/memory/benchmarks.rs
@@ -1,0 +1,934 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains a set of benchmark tests for storing a large number of circuits, services,
+//! and nodes in the in-memory RoutingTable using a Rwlock.
+
+use super::{
+    Circuit, CircuitNode, RoutingTable, RoutingTableReader, RoutingTableWriter, Service, ServiceId,
+};
+
+extern crate test;
+
+use test::Bencher;
+
+use crate::base62::generate_random_base62_string;
+
+use rand::distributions::{Distribution, Uniform};
+
+use std::cmp::min;
+
+// Helper function for generating a large number of nodes with the associated services, that are
+// then added to circuits. The circuits contain a random number of nodes up to 10.
+fn generate_circuits(num_circuits: i64, total_num_node: i64) -> (Vec<Circuit>, Vec<CircuitNode>) {
+    // generate nodes and their associated services
+    let mut nodes = vec![];
+    for i in 0..total_num_node {
+        let node = CircuitNode {
+            node_id: format!("node_{}", i),
+            endpoints: vec![format!("inproc://node_{}", i)],
+        };
+        let service = Service {
+            service_id: generate_random_base62_string(4),
+            service_type: "benchmark".to_string(),
+            allowed_nodes: vec![format!("inproc://node_{}", i)],
+            arguments: vec![("peer_services".to_string(), "node-000".to_string())],
+        };
+        nodes.push((node, service));
+    }
+
+    let mut circuits = vec![];
+    let mut rng = rand::thread_rng();
+    let num_nodes = Uniform::from(2..(min(total_num_node, 10)));
+    let node_indexes = Uniform::from(0..total_num_node);
+    let mut used_nodes = vec![];
+    for _ in 0..num_circuits {
+        let num_of_nodes = num_nodes.sample(&mut rng);
+        let mut members = vec![];
+        let mut roster = vec![];
+        for _ in 0..num_of_nodes {
+            let node_index = node_indexes.sample(&mut rng);
+            let (node, service) = nodes
+                .get(node_index as usize)
+                .expect(&format!("Unable to get node at index {}", node_index));
+            members.push(node.node_id.clone());
+            used_nodes.push(node.clone());
+            roster.push(service.clone());
+        }
+
+        let circuit = Circuit {
+            circuit_id: format!(
+                "{}-{}",
+                generate_random_base62_string(5),
+                generate_random_base62_string(5)
+            ),
+            roster,
+            members,
+        };
+        circuits.push(circuit);
+    }
+    used_nodes.sort();
+    used_nodes.dedup();
+    // generate a circuit with generated nodes
+    (circuits, used_nodes)
+}
+
+// Test that a routing table that has been loaded with 2^14 circuits still functions.
+//
+// After the the circuits are loaded, verify that a circuit, service, and node can be fetched
+// from the routing table.
+#[test]
+fn test_high_load_2_to_14_circuits() {
+    let base: i64 = 2;
+    let (circuits, used_nodes) = generate_circuits(base.pow(14), base.pow(7));
+
+    let first_circuit = circuits.get(0).expect("Unable to get 1st circuit").clone();
+    let first_node = used_nodes.get(0).expect("Unable to get 1st node").clone();
+
+    let table = RoutingTable::default();
+    let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
+    let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+
+    let (mut circuit_to_add, mut circuits) = circuits.split_at(min(1000, circuits.len()));
+    writer
+        .add_nodes(used_nodes.clone())
+        .expect("Unable to add nodes");
+    while circuit_to_add.len() > 0 {
+        writer
+            .add_circuits(circuit_to_add.to_vec())
+            .expect("Unable to write circuits");
+        let (new, old) = circuits.split_at(min(1000, circuits.len()));
+        circuits = old;
+        circuit_to_add = new;
+    }
+
+    let fetched_circuit = reader
+        .fetch_circuit(&first_circuit.circuit_id)
+        .expect("Unable to fetch 1st circuit");
+    assert_eq!(fetched_circuit, Some(first_circuit.clone()));
+
+    let service = fetched_circuit
+        .expect("Unable to get 1st circuit")
+        .roster
+        .get(0)
+        .expect("Unable to get service")
+        .clone();
+    let service_id = ServiceId::new(
+        first_circuit.circuit_id.to_string(),
+        service.service_id.to_string(),
+    );
+    let fetched_service = reader
+        .fetch_service(&service_id)
+        .expect("Unable to fetch service");
+    assert_eq!(fetched_service, Some(service));
+
+    let fetched_node = reader
+        .fetch_node(&first_node.node_id)
+        .expect("Unable to fetch node");
+    assert_eq!(fetched_node, Some(first_node));
+}
+
+// Benchmark the time it takes to load 2^14 cirucits with 2^7 nodes, while a seperate thread is
+// also adding a new circuit continuously.
+//
+// The circuits are added 1000 at a time.
+#[bench]
+fn test_high_load_start_up_cost_threads(b: &mut Bencher) {
+    let base: i64 = 2;
+    let (circuits, used_nodes) = generate_circuits(base.pow(14), base.pow(7));
+
+    let first_circuit = circuits.get(0).expect("Unable to get 1st circuit").clone();
+
+    let table = RoutingTable::default();
+    let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
+    let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+    let mut thread_writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+    std::thread::spawn(move || loop {
+        let (thread_circuits, thread_nodes) = generate_circuits(1, base.pow(7));
+        let new_circuit = thread_circuits
+            .get(0)
+            .expect("Unable to get circuit")
+            .clone();
+        thread_writer
+            .add_circuit(
+                new_circuit.circuit_id.to_string(),
+                new_circuit,
+                thread_nodes,
+            )
+            .expect("Unable to add circuit");
+    });
+
+    b.iter(|| {
+        let (mut circuit_to_add, mut circuits) = circuits.split_at(min(1000, circuits.len()));
+        writer
+            .add_nodes(used_nodes.clone())
+            .expect("Unable to add nodes");
+        while circuit_to_add.len() > 0 {
+            writer
+                .add_circuits(circuit_to_add.to_vec())
+                .expect("Unable to write circuits");
+            let (new, old) = circuits.split_at(min(1000, circuits.len()));
+            circuits = old;
+            circuit_to_add = new;
+        }
+    });
+
+    let fetched_circuit = reader
+        .fetch_circuit(&first_circuit.circuit_id)
+        .expect("Unable to fetch circuit");
+    assert_eq!(fetched_circuit, Some(first_circuit.clone()));
+}
+
+// Benchmark the time it takes to load 2^14 circuits with 2^7 nodes.
+//
+// The circuits are added 1000 at a time.
+#[bench]
+fn test_high_load_start_up_cost(b: &mut Bencher) {
+    let base: i64 = 2;
+    let (circuits, used_nodes) = generate_circuits(base.pow(14), base.pow(7));
+
+    let first_circuit = circuits.get(1).expect("Unable to get 1st circuit").clone();
+
+    let table = RoutingTable::default();
+    let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
+    let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+
+    b.iter(|| {
+        let (mut circuit_to_add, mut circuits) = circuits.split_at(min(1000, circuits.len()));
+        writer
+            .add_nodes(used_nodes.clone())
+            .expect("Unable to add nodes");
+        while circuit_to_add.len() > 0 {
+            writer
+                .add_circuits(circuit_to_add.to_vec())
+                .expect("Unable to write circuits");
+            let (new, old) = circuits.split_at(min(1000, circuits.len()));
+            circuits = old;
+            circuit_to_add = new;
+        }
+    });
+
+    let fetched_circuit = reader
+        .fetch_circuit(&first_circuit.circuit_id)
+        .expect("Unable to get 1st circuit");
+    assert_eq!(fetched_circuit, Some(first_circuit));
+}
+
+// --------- Write benchmark tests -----------------
+//
+// The following benchmark tests benchmark the time it takes to add a new circuit to a loaded
+// routing table. The routing table is loaded with 2^x circuits from 3-14 and 2^x nodes from 3-7.
+
+// 2^3 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_3_node_3(b: &mut Bencher) {
+    run_write_test(3, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_3_node_4(b: &mut Bencher) {
+    run_write_test(3, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_3_node_5(b: &mut Bencher) {
+    run_write_test(3, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_3_node_6(b: &mut Bencher) {
+    run_write_test(3, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_3_node_7(b: &mut Bencher) {
+    run_write_test(3, 7, b);
+}
+
+// 2^4 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_4_node_3(b: &mut Bencher) {
+    run_write_test(4, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_4_node_4(b: &mut Bencher) {
+    run_write_test(4, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_4_node_5(b: &mut Bencher) {
+    run_write_test(4, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_4_node_6(b: &mut Bencher) {
+    run_write_test(4, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_4_node_7(b: &mut Bencher) {
+    run_write_test(4, 7, b);
+}
+
+// 2^5 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_5_node_3(b: &mut Bencher) {
+    run_write_test(5, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_5_node_4(b: &mut Bencher) {
+    run_write_test(5, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_5_node_5(b: &mut Bencher) {
+    run_write_test(5, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_5_node_6(b: &mut Bencher) {
+    run_write_test(5, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_5_node_7(b: &mut Bencher) {
+    run_write_test(5, 7, b);
+}
+
+// 2^6 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_6_node_3(b: &mut Bencher) {
+    run_write_test(6, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_6_node_4(b: &mut Bencher) {
+    run_write_test(6, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_6_node_5(b: &mut Bencher) {
+    run_write_test(6, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_6_node_6(b: &mut Bencher) {
+    run_write_test(6, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_6_node_7(b: &mut Bencher) {
+    run_write_test(6, 7, b);
+}
+
+// 2^7 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_7_node_3(b: &mut Bencher) {
+    run_write_test(7, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_7_node_4(b: &mut Bencher) {
+    run_write_test(7, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_7_node_5(b: &mut Bencher) {
+    run_write_test(7, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_7_node_6(b: &mut Bencher) {
+    run_write_test(7, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_7_node_7(b: &mut Bencher) {
+    run_write_test(7, 7, b);
+}
+
+// 2^8 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_8_node_3(b: &mut Bencher) {
+    run_write_test(8, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_8_node_4(b: &mut Bencher) {
+    run_write_test(8, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_8_node_5(b: &mut Bencher) {
+    run_write_test(8, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_8_node_6(b: &mut Bencher) {
+    run_write_test(8, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_8_node_7(b: &mut Bencher) {
+    run_write_test(8, 7, b);
+}
+
+// 2^9 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_9_node_3(b: &mut Bencher) {
+    run_write_test(9, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_9_node_4(b: &mut Bencher) {
+    run_write_test(9, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_9_node_5(b: &mut Bencher) {
+    run_write_test(9, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_9_node_6(b: &mut Bencher) {
+    run_write_test(9, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_9_node_7(b: &mut Bencher) {
+    run_write_test(9, 7, b);
+}
+
+// 2^10 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_10_node_3(b: &mut Bencher) {
+    run_write_test(10, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_10_node_4(b: &mut Bencher) {
+    run_write_test(10, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_10_node_5(b: &mut Bencher) {
+    run_write_test(10, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_10_node_6(b: &mut Bencher) {
+    run_write_test(10, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_10_node_7(b: &mut Bencher) {
+    run_write_test(10, 7, b);
+}
+
+// 2^11 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_11_node_3(b: &mut Bencher) {
+    run_write_test(11, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_11_node_4(b: &mut Bencher) {
+    run_write_test(11, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_11_node_5(b: &mut Bencher) {
+    run_write_test(11, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_11_node_6(b: &mut Bencher) {
+    run_write_test(11, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_11_node_7(b: &mut Bencher) {
+    run_write_test(11, 7, b);
+}
+
+// 2^12 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_12_node_3(b: &mut Bencher) {
+    run_write_test(12, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_12_node_4(b: &mut Bencher) {
+    run_write_test(12, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_12_node_5(b: &mut Bencher) {
+    run_write_test(12, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_12_node_6(b: &mut Bencher) {
+    run_write_test(12, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_12_node_7(b: &mut Bencher) {
+    run_write_test(12, 7, b);
+}
+
+// 2^13 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_13_node_3(b: &mut Bencher) {
+    run_write_test(13, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_13_node_4(b: &mut Bencher) {
+    run_write_test(13, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_13_node_5(b: &mut Bencher) {
+    run_write_test(13, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_13_node_6(b: &mut Bencher) {
+    run_write_test(13, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_13_node_7(b: &mut Bencher) {
+    run_write_test(13, 7, b);
+}
+
+// 2^14 circuits, node varying
+#[bench]
+fn test_high_load_performance_write_circuit_14_node_3(b: &mut Bencher) {
+    run_write_test(14, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_14_node_4(b: &mut Bencher) {
+    run_write_test(14, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_14_node_5(b: &mut Bencher) {
+    run_write_test(14, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_14_node_6(b: &mut Bencher) {
+    run_write_test(14, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_write_circuit_14_node_7(b: &mut Bencher) {
+    run_write_test(14, 7, b);
+}
+
+// Helper function for running the write benchmark tests. Takes the power of 2 that should be taken
+//  for the number of circuits and nodes.
+//
+// Starts the test by generating the required circuits and nodes and adds them to the routing table.
+// The time it takes to add a new circuit to the routing table is benchmarked.
+fn run_write_test(circuit_pow: u32, node_pow: u32, b: &mut Bencher) {
+    let base: i64 = 2;
+    let (circuits, used_nodes) = generate_circuits(base.pow(circuit_pow), base.pow(node_pow));
+
+    let (new_circuit_vec, new_used_nodes) = generate_circuits(1, base.pow(node_pow));
+    let new_circuit = new_circuit_vec.get(0).expect("Unable to get new circuit");
+
+    let table = RoutingTable::default();
+    let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+
+    let (mut circuit_to_add, mut circuits) = circuits.split_at(min(1000, circuits.len()));
+    writer.add_nodes(used_nodes).expect("Unable to add nodes");
+    while circuit_to_add.len() > 0 {
+        writer
+            .add_circuits(circuit_to_add.to_vec())
+            .expect("Unable to write circuits");
+        let (new, old) = circuits.split_at(min(1000, circuits.len()));
+        circuits = old;
+        circuit_to_add = new;
+    }
+
+    b.iter(|| {
+        writer
+            .add_circuit(
+                new_circuit.circuit_id.to_string(),
+                new_circuit.clone(),
+                new_used_nodes.clone(),
+            )
+            .expect("Unable to add circuit");
+    });
+}
+
+// --------- Read benchmark tests -----------------
+//
+// The following benchmark tests benchmark the time it takes to fetch a circuit from a loaded
+// routing table. The routing table is loaded with 2^x circuits from 3-14 and 2^x nodes from 3-7.
+
+// 2^3 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_3_node_3(b: &mut Bencher) {
+    run_read_test(3, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_3_node_4(b: &mut Bencher) {
+    run_read_test(3, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_3_node_5(b: &mut Bencher) {
+    run_read_test(3, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_3_node_6(b: &mut Bencher) {
+    run_read_test(3, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_3_node_7(b: &mut Bencher) {
+    run_read_test(3, 7, b);
+}
+
+// 2^4 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_4_node_3(b: &mut Bencher) {
+    run_read_test(4, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_4_node_4(b: &mut Bencher) {
+    run_read_test(4, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_4_node_5(b: &mut Bencher) {
+    run_read_test(4, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_4_node_6(b: &mut Bencher) {
+    run_read_test(4, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_4_node_7(b: &mut Bencher) {
+    run_read_test(4, 7, b);
+}
+
+// 2^5 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_5_node_3(b: &mut Bencher) {
+    run_read_test(5, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_5_node_4(b: &mut Bencher) {
+    run_read_test(5, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_5_node_5(b: &mut Bencher) {
+    run_read_test(5, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_5_node_6(b: &mut Bencher) {
+    run_read_test(5, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_5_node_7(b: &mut Bencher) {
+    run_read_test(5, 7, b);
+}
+
+// 2^6 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_6_node_3(b: &mut Bencher) {
+    run_read_test(6, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_6_node_4(b: &mut Bencher) {
+    run_read_test(6, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_6_node_5(b: &mut Bencher) {
+    run_read_test(6, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_6_node_6(b: &mut Bencher) {
+    run_read_test(6, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_6_node_7(b: &mut Bencher) {
+    run_read_test(6, 7, b);
+}
+
+// 2^7 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_7_node_3(b: &mut Bencher) {
+    run_read_test(7, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_7_node_4(b: &mut Bencher) {
+    run_read_test(7, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_7_node_5(b: &mut Bencher) {
+    run_read_test(7, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_7_node_6(b: &mut Bencher) {
+    run_read_test(7, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_7_node_7(b: &mut Bencher) {
+    run_read_test(7, 7, b);
+}
+
+// 2^8 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_8_node_3(b: &mut Bencher) {
+    run_read_test(8, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_8_node_4(b: &mut Bencher) {
+    run_read_test(8, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_8_node_5(b: &mut Bencher) {
+    run_read_test(8, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_8_node_6(b: &mut Bencher) {
+    run_read_test(8, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_8_node_7(b: &mut Bencher) {
+    run_read_test(8, 7, b);
+}
+
+// 2^9 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_9_node_3(b: &mut Bencher) {
+    run_read_test(9, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_9_node_4(b: &mut Bencher) {
+    run_read_test(9, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_9_node_5(b: &mut Bencher) {
+    run_read_test(9, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_9_node_6(b: &mut Bencher) {
+    run_read_test(9, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_9_node_7(b: &mut Bencher) {
+    run_read_test(9, 7, b);
+}
+
+// 2^10 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_10_node_3(b: &mut Bencher) {
+    run_read_test(10, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_10_node_4(b: &mut Bencher) {
+    run_read_test(10, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_10_node_5(b: &mut Bencher) {
+    run_read_test(10, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_10_node_6(b: &mut Bencher) {
+    run_read_test(10, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_10_node_7(b: &mut Bencher) {
+    run_read_test(10, 7, b);
+}
+
+// 2^11 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_11_node_3(b: &mut Bencher) {
+    run_read_test(11, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_11_node_4(b: &mut Bencher) {
+    run_read_test(11, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_11_node_5(b: &mut Bencher) {
+    run_read_test(11, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_11_node_6(b: &mut Bencher) {
+    run_read_test(11, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_11_node_7(b: &mut Bencher) {
+    run_read_test(11, 7, b);
+}
+
+// 2^12 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_12_node_3(b: &mut Bencher) {
+    run_read_test(12, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_12_node_4(b: &mut Bencher) {
+    run_read_test(12, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_12_node_5(b: &mut Bencher) {
+    run_read_test(12, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_12_node_6(b: &mut Bencher) {
+    run_read_test(12, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_12_node_7(b: &mut Bencher) {
+    run_read_test(12, 7, b);
+}
+
+// 2^13 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_13_node_3(b: &mut Bencher) {
+    run_read_test(13, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_13_node_4(b: &mut Bencher) {
+    run_read_test(13, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_13_node_5(b: &mut Bencher) {
+    run_read_test(13, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_13_node_6(b: &mut Bencher) {
+    run_read_test(13, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_13_node_7(b: &mut Bencher) {
+    run_read_test(13, 7, b);
+}
+
+// 2^14 circuits, node varying
+#[bench]
+fn test_high_load_performance_read_circuit_14_node_3(b: &mut Bencher) {
+    run_read_test(14, 3, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_14_node_4(b: &mut Bencher) {
+    run_read_test(14, 4, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_14_node_5(b: &mut Bencher) {
+    run_read_test(14, 5, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_14_node_6(b: &mut Bencher) {
+    run_read_test(14, 6, b);
+}
+
+#[bench]
+fn test_high_load_performance_read_circuit_14_node_7(b: &mut Bencher) {
+    run_read_test(14, 7, b);
+}
+
+// Helper function for running the read benchmark tests. Takes the power of 2 that should be taken
+// for the number of circuits and nodes.
+//
+// Starts the test by generating the required circuits and nodes and adds them to the routing table.
+// The time it takes to fetch a circuit from the routing table is benchmarked.
+fn run_read_test(circuit_pow: u32, node_pow: u32, b: &mut Bencher) {
+    let base: i64 = 2;
+    let (circuits, used_nodes) = generate_circuits(base.pow(circuit_pow), base.pow(node_pow));
+
+    let first_circuit = circuits.get(1).expect("Unable to get 1st circuit").clone();
+
+    let table = RoutingTable::default();
+    let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
+    let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
+
+    let (mut circuit_to_add, mut circuits) = circuits.split_at(min(1000, circuits.len()));
+    writer.add_nodes(used_nodes).expect("Unable to add nodes");
+    while circuit_to_add.len() > 0 {
+        writer
+            .add_circuits(circuit_to_add.to_vec())
+            .expect("Unable to write circuits");
+        let (new, old) = circuits.split_at(min(1000, circuits.len()));
+        circuits = old;
+        circuit_to_add = new;
+    }
+
+    let mut fetched_circuit = None;
+
+    b.iter(|| {
+        fetched_circuit = reader
+            .fetch_circuit(&first_circuit.circuit_id)
+            .expect("Unable to fetch circuits");
+    });
+
+    assert_eq!(fetched_circuit, Some(first_circuit));
+}

--- a/libsplinter/src/circuit/routing/memory/mod.rs
+++ b/libsplinter/src/circuit/routing/memory/mod.rs
@@ -1,0 +1,345 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of the circuit routing table reader and writer traits that uses a read/write
+//! lock
+//!
+//! The public interface includes the structs [`RoutingTable`].
+//!
+//! [`RoutingTable`]: struct.RoutingTable.html
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
+
+use super::error::{
+    AddCircuitError, AddCircuitsError, AddNodeError, AddNodesError, AddServiceError,
+    FetchCircuitError, FetchNodeError, FetchServiceError, ListCircuitsError, ListNodesError,
+    ListServiceError, RemoveCircuitError, RemoveNodeError, RemoveServiceError,
+};
+use super::{
+    Circuit, CircuitIter, CircuitNode, CircuitNodeIter, RoutingTableReader, RoutingTableWriter,
+    Service, ServiceId,
+};
+
+/// The internal state of the routing table that will be wrapped in a read-write lock
+#[derive(Clone, Default)]
+struct RoutingTableState {
+    /// Nodes that are listed in a set of circuits
+    nodes: BTreeMap<String, CircuitNode>,
+    /// The collection of circuits to be used for routing
+    circuits: BTreeMap<String, Circuit>,
+    /// Service ID to Service that contains the node the service is connected to. Not persisted.
+    service_directory: HashMap<ServiceId, Service>,
+}
+
+// An implementation of a routing table that uses a read-write lock to wrap the state.
+#[derive(Clone, Default)]
+pub struct RoutingTable {
+    state: Arc<RwLock<RoutingTableState>>,
+}
+
+impl RoutingTableReader for RoutingTable {
+    // ---------- methods to access service directory ----------
+    /// Returns the service with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ID for the service to be fetched
+    ///
+    /// Returns an error if the lock is poisoned.
+    fn fetch_service(&self, service_id: &ServiceId) -> Result<Option<Service>, FetchServiceError> {
+        Ok(self
+            .state
+            .read()
+            .map_err(|_| FetchServiceError(String::from("RoutingTable lock poisoned")))?
+            .service_directory
+            .get(service_id)
+            .map(Service::clone))
+    }
+
+    /// Returns all the services for the provided circuit
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID the circuit whose services should be returned
+    ///
+    /// Returns an error if the lock is poisoned or if the circuit does not exist
+    fn list_service(&self, circuit_id: &str) -> Result<Vec<Service>, ListServiceError> {
+        if let Some(circuit) = self
+            .state
+            .read()
+            .map_err(|_| {
+                ListServiceError::InternalError(String::from("RoutingTable lock poisoned"))
+            })?
+            .circuits
+            .get(circuit_id)
+        {
+            Ok(circuit.roster.clone())
+        } else {
+            Err(ListServiceError::CircuitNotFound(circuit_id.to_string()))
+        }
+    }
+
+    // ---------- methods to access circuit directory ----------
+
+    /// Returns the nodes in the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn list_nodes(&self) -> Result<CircuitNodeIter, ListNodesError> {
+        Ok(Box::new(
+            self.state
+                .read()
+                .map_err(|_| ListNodesError(String::from("RoutingTable lock poisoned")))?
+                .nodes
+                .clone()
+                .into_iter(),
+        ))
+    }
+
+    /// Returns the node with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node to be fetched
+    ///
+    /// Returns an error if the lock was poisoned
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, FetchNodeError> {
+        Ok(self
+            .state
+            .read()
+            .map_err(|_| FetchNodeError(String::from("RoutingTable lock poisoned")))?
+            .nodes
+            .get(node_id)
+            .cloned())
+    }
+
+    /// Returns the circuits in the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn list_circuits(&self) -> Result<CircuitIter, ListCircuitsError> {
+        Ok(Box::new(
+            self.state
+                .read()
+                .map_err(|_| ListCircuitsError(String::from("RoutingTable lock poisoned")))?
+                .circuits
+                .clone()
+                .into_iter(),
+        ))
+    }
+
+    /// Returns the circuit with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit to be fetched
+    ///
+    /// Returns an error if the lock is poisoned
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, FetchCircuitError> {
+        Ok(self
+            .state
+            .read()
+            .map_err(|_| FetchCircuitError(String::from("RoutingTable lock poisoned")))?
+            .circuits
+            .get(circuit_id)
+            .cloned())
+    }
+}
+
+impl RoutingTableWriter for RoutingTable {
+    /// Adds a new service to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ServiceId for the service
+    /// * `service` -  The service to be added to the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn add_service(
+        &mut self,
+        service_id: ServiceId,
+        service: Service,
+    ) -> Result<(), AddServiceError> {
+        self.state
+            .write()
+            .map_err(|_| AddServiceError(String::from("RoutingTable lock poisoned")))?
+            .service_directory
+            .insert(service_id, service);
+        Ok(())
+    }
+
+    /// Removes a service from the routing table if it exists
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ServiceId for the service
+    ///
+    /// Returns an error if the lock is poisoned
+    fn remove_service(&mut self, service_id: &ServiceId) -> Result<(), RemoveServiceError> {
+        self.state
+            .write()
+            .map_err(|_| RemoveServiceError(String::from("RoutingTable lock poisoned")))?
+            .service_directory
+            .remove(service_id);
+        Ok(())
+    }
+
+    /// Adds a new circuit to the routing table. Also adds the associated services and nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit
+    /// * `circuit` -  The circuit to be added to the routing table
+    /// * `nodes` - The list of circuit nodes that should be added along with the circuit
+    ///
+    /// Returns an error if the lock is poisoned
+    fn add_circuit(
+        &mut self,
+        circuit_id: String,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AddCircuitError> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| AddCircuitError(String::from("RoutingTable lock poisoned")))?;
+
+        for service in circuit.roster.iter() {
+            let service_id = ServiceId::new(
+                circuit.circuit_id.to_string(),
+                service.service_id.to_string(),
+            );
+
+            state.service_directory.insert(service_id, service.clone());
+        }
+
+        for node in nodes.into_iter() {
+            if !state.nodes.contains_key(&node.node_id) {
+                state.nodes.insert(node.node_id.to_string(), node);
+            }
+        }
+
+        state.circuits.insert(circuit_id, circuit);
+        Ok(())
+    }
+
+    /// Adds a list of circuits to the routing table. Also adds the associated services.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuits` - The list of circuits to be added to the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn add_circuits(&mut self, circuits: Vec<Circuit>) -> Result<(), AddCircuitsError> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| AddCircuitsError(String::from("RoutingTable lock poisoned")))?;
+        for circuit in circuits.into_iter() {
+            for service in circuit.roster.iter() {
+                let service_id = ServiceId::new(
+                    circuit.circuit_id.to_string(),
+                    service.service_id.to_string(),
+                );
+
+                state.service_directory.insert(service_id, service.clone());
+            }
+            state
+                .circuits
+                .insert(circuit.circuit_id.to_string(), circuit);
+        }
+        Ok(())
+    }
+
+    /// Removes a circuit from the routing table if it exists. Also removes the associated
+    /// services.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit
+    ///
+    /// Returns an error if the lock is poisoned
+    fn remove_circuit(&mut self, circuit_id: &str) -> Result<(), RemoveCircuitError> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| RemoveCircuitError(String::from("RoutingTable lock poisoned")))?;
+
+        let circuit = state.circuits.remove(circuit_id);
+
+        if let Some(circuit) = circuit {
+            for service in circuit.roster.iter() {
+                let service_id = ServiceId::new(
+                    circuit.circuit_id.to_string(),
+                    service.service_id.to_string(),
+                );
+
+                state.service_directory.remove(&service_id);
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds a new node to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node
+    /// * `node`- The node to add to the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn add_node(&mut self, id: String, node: CircuitNode) -> Result<(), AddNodeError> {
+        self.state
+            .write()
+            .map_err(|_| AddNodeError(String::from("RoutingTable lock poisoned")))?
+            .nodes
+            .insert(id, node);
+        Ok(())
+    }
+
+    /// Adds a list of node to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes`- The list of nodes to add to the routing table
+    ///
+    /// Returns an error if the lock is poisoned
+    fn add_nodes(&mut self, nodes: Vec<CircuitNode>) -> Result<(), AddNodesError> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| AddNodesError(String::from("RoutingTable lock poisoned")))?;
+        for node in nodes {
+            if !state.nodes.contains_key(&node.node_id) {
+                state.nodes.insert(node.node_id.to_string(), node);
+            }
+        }
+        Ok(())
+    }
+
+    /// Removes a node from the routing table if it exists
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node that should be removed
+    ///
+    /// Returns an error if the lock is poisoned
+    fn remove_node(&mut self, id: &str) -> Result<(), RemoveNodeError> {
+        self.state
+            .write()
+            .map_err(|_| RemoveNodeError(String::from("RoutingTable lock poisoned")))?
+            .nodes
+            .remove(id);
+        Ok(())
+    }
+}

--- a/libsplinter/src/circuit/routing/memory/mod.rs
+++ b/libsplinter/src/circuit/routing/memory/mod.rs
@@ -19,6 +19,9 @@
 //!
 //! [`RoutingTable`]: struct.RoutingTable.html
 
+#[cfg(all(feature = "benchmark", test))]
+mod benchmarks;
+
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 

--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -1,0 +1,293 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines traits and structs for an in-memory routing table
+//!
+//! The public interface includes the traits [`RoutingTableReader`] and [`RoutingTableWriter`] and
+//! the structs [`Service`], [`ServiceId`], [`Circuit`], and [`CircuitNode`]. It also includes
+//! a RwLock implmentation of the traits [`RoutingTable`].
+//!
+//! [`Circuit`]: struct.Circuit.html
+//! [`CircuitNode`]: struct.CircuitNode.html
+//! [`RoutingTable`]: memory/struct.RoutingTable.html
+//! [`RoutingTableReader`]: trait.RoutingTableReader.html
+//! [`RoutingTableWriter`]: trait.RoutingTableWriter.html
+//! [`Service`]: struct.Service.html
+//! [`ServiceId`]: struct.ServiceId.html
+
+mod error;
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use self::error::{
+    AddCircuitError, AddCircuitsError, AddNodeError, AddNodesError, AddServiceError,
+    FetchCircuitError, FetchNodeError, FetchServiceError, ListCircuitsError, ListNodesError,
+    ListServiceError, RemoveCircuitError, RemoveNodeError, RemoveServiceError,
+};
+
+/// The routing table representation of a circuit. It is simplified to only contain the required
+/// values for routing.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Circuit {
+    circuit_id: String,
+    roster: Vec<Service>,
+    members: Vec<String>,
+}
+
+impl Circuit {
+    /// Creates a new `Circuit`
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit
+    /// * `roster` - The list of services in the circuit
+    /// * `members` - The list of node IDs for the members of a circuit
+    pub fn new(circuit_id: String, roster: Vec<Service>, members: Vec<String>) -> Self {
+        Circuit {
+            circuit_id,
+            roster,
+            members,
+        }
+    }
+}
+
+/// The routing table representation of a node
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct CircuitNode {
+    node_id: String,
+    endpoints: Vec<String>,
+}
+
+impl CircuitNode {
+    /// Creates a new `CircuitNode`
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the circuit
+    /// * `endpoints` -  A list of endpoints the node can be reached at
+    pub fn new(node_id: String, endpoints: Vec<String>) -> Self {
+        CircuitNode { node_id, endpoints }
+    }
+}
+
+impl Ord for CircuitNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.node_id.cmp(&other.node_id)
+    }
+}
+
+impl PartialOrd for CircuitNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// The routing table representation of a service
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Service {
+    service_id: String,
+    service_type: String,
+    allowed_nodes: Vec<String>,
+    arguments: Vec<(String, String)>,
+}
+
+impl Service {
+    /// Creates a new `Service`
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ID for the service
+    /// * `service_type` - The type of service this is
+    /// * `allowed_nodes` - The list of node IDs that this service can connect to
+    /// * `arguments` - The key-value pairs of arguments that will be passed to the service
+    pub fn new(
+        service_id: String,
+        service_type: String,
+        allowed_nodes: Vec<String>,
+        arguments: Vec<(String, String)>,
+    ) -> Self {
+        Service {
+            service_id,
+            service_type,
+            allowed_nodes,
+            arguments,
+        }
+    }
+}
+
+/// The unique ID of a service made up of a circuit ID and service ID
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct ServiceId {
+    circuit_id: String,
+    service_id: String,
+}
+
+impl ServiceId {
+    /// Creates a new `ServiceID`
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit this service belongs to
+    /// * `service_id` -  The unique ID for the service
+    pub fn new(circuit_id: String, service_id: String) -> Self {
+        ServiceId {
+            circuit_id,
+            service_id,
+        }
+    }
+
+    /// Returns the circuit ID
+    pub fn circuit(&self) -> &str {
+        &self.circuit_id
+    }
+
+    /// Returns the service ID
+    pub fn service_id(&self) -> &str {
+        &self.service_id
+    }
+
+    /// Decompose the service id into a tuple of (<circuit ID>, <service ID>).
+    pub fn into_parts(self) -> (String, String) {
+        (self.circuit_id, self.service_id)
+    }
+}
+
+impl fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}::{}", self.circuit_id, self.service_id)
+    }
+}
+
+impl Eq for ServiceId {}
+
+/// The trait that defines a writer for updating the in-memory routing table
+pub trait RoutingTableWriter: Send {
+    /// Adds a new service to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ServiceId for the service
+    /// * `service` -  The service to be added to the routing table
+    fn add_service(
+        &mut self,
+        service_id: ServiceId,
+        service: Service,
+    ) -> Result<(), AddServiceError>;
+
+    /// Removes a service from the routing table if it exists
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ServiceId for the service
+    fn remove_service(&mut self, service_id: &ServiceId) -> Result<(), RemoveServiceError>;
+
+    /// Adds a new circuit to the routing table.  Also adds the associated services and nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit
+    /// * `circuit` -  The circuit to be added to the routing table
+    /// * `nodes` - The list of circuit nodes that should be added along with the circuit
+    fn add_circuit(
+        &mut self,
+        circuit_id: String,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AddCircuitError>;
+
+    /// Adds a list of circuits to the routing table. Also adds the associated services.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuits` - The list of circuits to be added to the routing table
+    fn add_circuits(&mut self, circuits: Vec<Circuit>) -> Result<(), AddCircuitsError>;
+
+    /// Removes a circuit from the routing table if it exists.  Also removes the associated
+    /// services.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit
+    fn remove_circuit(&mut self, circuit_id: &str) -> Result<(), RemoveCircuitError>;
+
+    /// Adds a new node to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node
+    /// * `node`- The node to add to the routing table
+    fn add_node(&mut self, node_id: String, node: CircuitNode) -> Result<(), AddNodeError>;
+
+    /// Adds a list of node to the routing table
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes`- The list of nodes to add to the routing table
+    fn add_nodes(&mut self, nodes: Vec<CircuitNode>) -> Result<(), AddNodesError>;
+
+    /// Removes a node from the routing table if it exists
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node that should be removed
+    fn remove_node(&mut self, node_id: &str) -> Result<(), RemoveNodeError>;
+}
+
+/// Type returned by the `RoutingTableReader::list_nodes` method
+pub type CircuitNodeIter = Box<dyn ExactSizeIterator<Item = (String, CircuitNode)> + Send>;
+
+/// Type returned by the `RoutingTableReader::list_circuits` method
+pub type CircuitIter = Box<dyn ExactSizeIterator<Item = (String, Circuit)> + Send>;
+
+/// The trait that defines a reader for reading the in-memory routing table
+pub trait RoutingTableReader: Send {
+    // ---------- methods to access service directory ----------
+
+    /// Returns the service with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` -  The unique ID for the service to be fetched
+    fn fetch_service(&self, service_id: &ServiceId) -> Result<Option<Service>, FetchServiceError>;
+
+    /// Returns all the services for the provided circuit
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID the circuit whose services should be returned
+    fn list_service(&self, circuit_id: &str) -> Result<Vec<Service>, ListServiceError>;
+
+    // ---------- methods to access circuit directory ----------
+
+    /// Returns the nodes in the routing table
+    fn list_nodes(&self) -> Result<CircuitNodeIter, ListNodesError>;
+
+    /// Returns the node with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` -  The unique ID for the node to be fetched
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, FetchNodeError>;
+
+    /// Returns the circuits in the routing table
+    fn list_circuits(&self) -> Result<CircuitIter, ListCircuitsError>;
+
+    /// Returns the circuit with the provided ID
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` -  The unique ID for the circuit to be fetched
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, FetchCircuitError>;
+}

--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -27,6 +27,7 @@
 //! [`ServiceId`]: struct.ServiceId.html
 
 mod error;
+pub mod memory;
 
 use std::cmp::Ordering;
 use std::fmt;

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(feature = "benchmark", feature(test))]
+
 #[macro_use]
 extern crate log;
 #[macro_use]


### PR DESCRIPTION
This is an experimental features and is not used yet. 

This PR also adds benchmark tests that can be run using:

(This was tested on 1.46.0-nightly)

`cargo +nightly bench --features routing-table,benchmark`