### PR TITLE
Circuit template clean-up

### DIFF
--- a/cli/packaging/scabbard_circuit_template.yaml
+++ b/cli/packaging/scabbard_circuit_template.yaml
@@ -1,14 +1,14 @@
 version: v1
 args:
-    - name: $(a:ADMIN_KEYS)
+    - name: $(ADMIN_KEYS)
       required: false
-      default: $(a:SIGNER_PUB_KEY)
+      default: $(SIGNER_PUB_KEY)
       description: >-
         Public keys used to verify transactions in the scabbard service
-    - name: $(a:NODES)
+    - name: $(NODES)
       required: true
       description: "List of node IDs"
-    - name: $(a:SIGNER_PUB_KEY)
+    - name: $(SIGNER_PUB_KEY)
       required: false
       description: "Public key of the signer"
 rules:
@@ -16,7 +16,7 @@ rules:
         service-type: 'scabbard'
         service-args:
         - key: 'admin_keys'
-          value: [$(a:ADMIN_KEYS)]
+          value: [$(ADMIN_KEYS)]
         - key: 'peer_services'
-          value: '$(r:ALL_OTHER_SERVICES)'
+          value: '$(ALL_OTHER_SERVICES)'
         first-service: 'a000'

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -51,8 +51,8 @@ impl CreateCircuitMessageBuilder {
     }
 
     #[cfg(feature = "circuit-template")]
-    pub fn add_services(&mut self, service_builders: &[SplinterServiceBuilder]) {
-        self.services.extend(service_builders.to_owned());
+    pub fn create_circuit_builder(&self) -> CreateCircuitBuilder {
+        self.create_circuit_builder.clone()
     }
 
     #[cfg(feature = "circuit-template")]

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -37,7 +37,7 @@ use super::{
 };
 
 use api::{CircuitServiceSlice, CircuitSlice};
-use builder::CreateCircuitMessageBuilder;
+pub(crate) use builder::CreateCircuitMessageBuilder;
 use payload::make_signed_payload;
 
 pub struct CircuitProposeAction;
@@ -74,9 +74,8 @@ impl Action for CircuitProposeAction {
                 };
                 template.add_arguments(&user_args);
                 template.set_nodes(&builder.get_node_ids());
-                let template_builders = template.into_builders()?;
-                builder.add_services(&template_builders.service_builders());
-                builder.set_create_circuit_builder(&template_builders.create_circuit_builder());
+
+                template.apply_to_builder(&mut builder)?;
             }
         }
 

--- a/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
+++ b/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
@@ -1,17 +1,17 @@
 version: v1
 args:
-    - name: $(a:ADMIN_KEYS)
+    - name: $(ADMIN_KEYS)
       required: false
-      default: $(a:SIGNER_PUB_KEY)
+      default: $(SIGNER_PUB_KEY)
       description: >-
         Public keys used to verify transactions in the scabbard service
-    - name: $(a:NODES)
+    - name: $(NODES)
       required: true
       description: "List of node IDs"
-    - name: $(a:SIGNER_PUB_KEY)
+    - name: $(SIGNER_PUB_KEY)
       required: false
       description: "Public key of the signer"
-    - name: $(a:GAMEROOM_NAME)
+    - name: $(GAMEROOM_NAME)
       required: true
       description: "Name of the gameroom"
 rules:
@@ -21,14 +21,14 @@ rules:
         service-type: 'scabbard'
         service-args:
         - key: 'admin_keys'
-          value: [$(a:ADMIN_KEYS)]
+          value: [$(ADMIN_KEYS)]
         - key: 'peer_services'
-          value: '$(r:ALL_OTHER_SERVICES)'
+          value: '$(ALL_OTHER_SERVICES)'
         first-service: 'a000'
     set-metadata:
         encoding: json
         metadata:
             - key: "scabbard_admin_keys"
-              value: ["$(a:ADMIN_KEYS)"]
+              value: ["$(ADMIN_KEYS)"]
             - key: "alias"
-              value: "$(a:GAMEROOM_NAME)"
+              value: "$(GAMEROOM_NAME)"

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -280,14 +280,14 @@ mod test {
     /// Example circuit template YAML file.
     const EXAMPLE_TEMPLATE_YAML: &[u8] = br##"version: v1
 args:
-    - name: $(a:ADMIN_KEYS)
+    - name: $(ADMIN_KEYS)
       required: false
-      default: $(a:SIGNER_PUB_KEY)
-    - name: $(a:NODES)
+      default: $(SIGNER_PUB_KEY)
+    - name: $(NODES)
       required: true
-    - name: $(a:SIGNER_PUB_KEY)
+    - name: $(SIGNER_PUB_KEY)
       required: false
-    - name: $(a:GAMEROOM_NAME)
+    - name: $(GAMEROOM_NAME)
       required: true
 rules:
     set-management-type:
@@ -296,17 +296,17 @@ rules:
         service-type: 'scabbard'
         service-args:
         - key: 'admin-keys'
-          value: [$(a:ADMIN_KEYS)]
+          value: [$(ADMIN_KEYS)]
         - key: 'peer_services'
-          value: '$(r:ALL_OTHER_SERVICES)'
+          value: '$(ALL_OTHER_SERVICES)'
         first-service: 'a000'
     set-metadata:
         encoding: json
         metadata:
             - key: "scabbard_admin_keys"
-              value: ["$(a:ADMIN_KEYS)"]
+              value: ["$(ADMIN_KEYS)"]
             - key: "alias"
-              value: "$(a:GAMEROOM_NAME)" "##;
+              value: "$(GAMEROOM_NAME)" "##;
 
     /// Verifies that Builders can be parsed from template v1 and correctly applies the
     /// `set-management-type`, `create-services` and `set-metadata` `rules` correctly.

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -20,8 +20,8 @@ use crate::base62::next_base62_string;
 use super::super::{yaml_parser::v1, CircuitTemplateError, SplinterServiceBuilder};
 use super::{get_argument_value, is_arg, RuleArgument, Value};
 
-const ALL_OTHER_SERVICES: &str = "$(r:ALL_OTHER_SERVICES)";
-const NODES_ARG: &str = "$(a:NODES)";
+const ALL_OTHER_SERVICES: &str = "$(ALL_OTHER_SERVICES)";
+const NODES_ARG: &str = "$(NODES)";
 const PEER_SERVICES_ARG: &str = "peer_services";
 
 /// Data structure used to create a `SplinterServiceBuilder`.
@@ -307,7 +307,7 @@ mod test {
         };
         let admin_keys_arg = ServiceArgument {
             key: "admin-keys".to_string(),
-            value: Value::List(vec!["$(a:ADMIN_KEYS)".to_string()]),
+            value: Value::List(vec!["$(ADMIN_KEYS)".to_string()]),
         };
 
         CreateServices {
@@ -321,7 +321,7 @@ mod test {
         let admin_keys_templae_arg = RuleArgument {
             name: "admin_keys".to_string(),
             required: false,
-            default_value: Some("$(a:SIGNER_PUB_KEY)".to_string()),
+            default_value: Some("$(SIGNER_PUB_KEY)".to_string()),
             description: None,
             user_value: None,
         };

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -201,7 +201,7 @@ mod test {
 
         let service_builders = create_services
             .apply_rule(&template_arguments)
-            .expect("Failled to apply rules");
+            .expect("Failed to apply rules");
 
         assert_eq!(service_builders.len(), 2);
 
@@ -318,7 +318,7 @@ mod test {
     }
 
     fn make_rule_arguments() -> Vec<RuleArgument> {
-        let admin_keys_templae_arg = RuleArgument {
+        let admin_keys_template_arg = RuleArgument {
             name: "admin_keys".to_string(),
             required: false,
             default_value: Some("$(SIGNER_PUB_KEY)".to_string()),
@@ -326,7 +326,7 @@ mod test {
             user_value: None,
         };
 
-        let nodes_templae_arg = RuleArgument {
+        let nodes_template_arg = RuleArgument {
             name: "nodes".to_string(),
             required: true,
             default_value: None,
@@ -342,6 +342,6 @@ mod test {
             user_value: Some("signer_key".to_string()),
         };
 
-        vec![admin_keys_templae_arg, nodes_templae_arg, signer_pub_key]
+        vec![admin_keys_template_arg, nodes_template_arg, signer_pub_key]
     }
 }

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -137,15 +137,15 @@ impl TryFrom<v1::RuleArgument> for RuleArgument {
 }
 
 fn is_arg(key: &str) -> bool {
-    key.starts_with("$(a:")
+    key.starts_with("$(")
 }
 
 fn strip_arg_marker(key: &str) -> Result<String, CircuitTemplateError> {
-    if key.starts_with("$(a:") && key.ends_with(')') {
+    if key.starts_with("$(") && key.ends_with(')') {
         let mut key = key.to_string();
         key.pop();
         Ok(key
-            .get(4..)
+            .get(2..)
             .ok_or_else(|| {
                 CircuitTemplateError::new(&format!("{} is not a valid argument name", key))
             })?

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -147,13 +147,13 @@ fn strip_arg_marker(key: &str) -> Result<String, CircuitTemplateError> {
         Ok(key
             .get(2..)
             .ok_or_else(|| {
-                CircuitTemplateError::new(&format!("{} is not a valid argument name", key))
+                CircuitTemplateError::new(&format!("\"{}\" is not a valid argument name", key))
             })?
             .to_string()
             .to_lowercase())
     } else {
         Err(CircuitTemplateError::new(&format!(
-            "{} is not a valid argument name",
+            "\"{}\" is not a valid argument name",
             key
         )))
     }
@@ -185,13 +185,13 @@ fn get_argument_value(
             None => {
                 if arg.required {
                     return Err(CircuitTemplateError::new(&format!(
-                        "Argument {} is required but was not provided",
+                        "Argument \"{}\" is required but was not provided",
                         key
                     )));
                 } else {
                     let default_value = arg.default_value.to_owned().ok_or_else(|| {
                         CircuitTemplateError::new(&format!(
-                            "Argument {} was not provided and no default value is set",
+                            "Argument \"{}\" was not provided and no default value is set",
                             key
                         ))
                     })?;
@@ -205,7 +205,7 @@ fn get_argument_value(
         },
         None => {
             return Err(CircuitTemplateError::new(&format!(
-                "Invalid template. Argument {} was expected but not provided",
+                "Invalid template. Argument \"{}\" was expected but not provided",
                 key
             )));
         }

--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -99,7 +99,7 @@ mod test {
 args:
     - name: admin-keys
       required: false
-      default: $(a:SIGNER_PUB_KEY)
+      default: $(SIGNER_PUB_KEY)
 rules:
     set-management-type:
         management-type: "gameroom"
@@ -109,7 +109,7 @@ rules:
         - key: 'admin-keys'
           value: [$(admin-keys)]
         - key: 'peer-services'
-          value: '$(r:ALL_OTHER_SERVICES)'
+          value: '$(ALL_OTHER_SERVICES)'
         first-service: 'a000'
     set-metadata:
         encoding: json
@@ -148,10 +148,7 @@ rules:
                 for arg in args {
                     assert_eq!(arg.name(), "admin-keys");
                     assert_eq!(arg.required(), false);
-                    assert_eq!(
-                        arg.default_value(),
-                        Some(&"$(a:SIGNER_PUB_KEY)".to_string())
-                    );
+                    assert_eq!(arg.default_value(), Some(&"$(SIGNER_PUB_KEY)".to_string()));
 
                     let create_services = template
                         .rules()
@@ -165,7 +162,7 @@ rules:
                     assert!(service_args.iter().any(|arg| arg.key() == "admin-keys"
                         && arg.value() == &Value::List(vec!["$(admin-keys)".to_string()])));
                     assert!(service_args.iter().any(|arg| arg.key() == "peer-services"
-                        && arg.value() == &Value::Single("$(r:ALL_OTHER_SERVICES)".to_string())));
+                        && arg.value() == &Value::Single("$(ALL_OTHER_SERVICES)".to_string())));
                 }
 
                 let management_type = template


### PR DESCRIPTION
* Removes the 'a:' & 'r:' prefix of template arguments. 
* Fixes a few typos and cleans up some error messages
* Changes the `into_builders` method to an `apply_to_builder` method which applies the template rules to the builder provided to the method. Also makes this change in the CLI circuit template implementation. 