### PR TITLE
Add AdminServiceStore Trait and YAML backend

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -92,6 +92,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "admin-service-store",
     "biome-notifications",
     "biome-user",
     "circuit-template",
@@ -107,6 +108,7 @@ experimental = [
 # used for turning benchmark tests on
 benchmark = []
 
+admin-service-store = []
 biome = []
 biome-credentials = ["biome", "biome-user", "bcrypt"]
 biome-key-management = ["biome"]

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -17,3 +17,5 @@ pub mod messages;
 #[cfg(feature = "rest-api")]
 pub mod rest_api;
 pub mod service;
+#[cfg(feature = "admin-service-store")]
+pub mod store;

--- a/libsplinter/src/admin/store/builders.rs
+++ b/libsplinter/src/admin/store/builders.rs
@@ -1,0 +1,1017 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs for building the native representations of circuits, proposals, services and nodes
+
+use crate::admin::messages::{is_valid_circuit_id, is_valid_service_id};
+
+use super::error::BuilderError;
+use super::{
+    AuthorizationType, Circuit, CircuitNode, CircuitProposal, DurabilityType, PersistenceType,
+    ProposalType, ProposedCircuit, ProposedNode, ProposedService, RouteType, Service, VoteRecord,
+};
+
+/// Builder to be used to build a `Circuit`
+#[derive(Default, Clone)]
+pub struct CircuitBuilder {
+    circuit_id: Option<String>,
+    roster: Option<Vec<Service>>,
+    members: Option<Vec<String>>,
+    auth: Option<AuthorizationType>,
+    persistence: Option<PersistenceType>,
+    durability: Option<DurabilityType>,
+    routes: Option<RouteType>,
+    circuit_management_type: Option<String>,
+}
+
+impl CircuitBuilder {
+    /// Creates a new circuit builder
+    pub fn new() -> Self {
+        CircuitBuilder::default()
+    }
+
+    /// Returns the circuit ID in the builder
+    pub fn circuit_id(&self) -> Option<String> {
+        self.circuit_id.clone()
+    }
+
+    /// Returns the list of services in the builder
+    pub fn roster(&self) -> Option<Vec<Service>> {
+        self.roster.clone()
+    }
+
+    /// Returns the list of node IDs in the builder
+    pub fn members(&self) -> Option<Vec<String>> {
+        self.members.clone()
+    }
+
+    /// Returns the authorization type in the builder
+    pub fn auth(&self) -> Option<AuthorizationType> {
+        self.auth.clone()
+    }
+
+    /// Returns the persistence type in the builder
+    pub fn persistence(&self) -> Option<PersistenceType> {
+        self.persistence.clone()
+    }
+
+    /// Returns the durability type in the builder
+    pub fn durability(&self) -> Option<DurabilityType> {
+        self.durability.clone()
+    }
+
+    /// Returns the routing type in the builder
+    pub fn routes(&self) -> Option<RouteType> {
+        self.routes.clone()
+    }
+
+    /// Returns the circuit management type in the builder
+    pub fn circuit_management_type(&self) -> Option<String> {
+        self.circuit_management_type.clone()
+    }
+
+    /// Sets the circuit ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit
+    pub fn with_circuit_id(mut self, circuit_id: &str) -> CircuitBuilder {
+        self.circuit_id = Some(circuit_id.into());
+        self
+    }
+
+    /// Sets the list of services that are included in the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `services` - List of services
+    pub fn with_roster(mut self, services: &[Service]) -> CircuitBuilder {
+        self.roster = Some(services.into());
+        self
+    }
+
+    /// Sets the list of node IDs for the members in the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `members` - List of node IDs
+    pub fn with_members(mut self, members: &[String]) -> CircuitBuilder {
+        self.members = Some(members.into());
+        self
+    }
+
+    /// Sets the authorization type
+    ///
+    /// # Arguments
+    ///
+    ///  * `auth` - The authorization type for the circuit
+    pub fn with_auth(mut self, auth: &AuthorizationType) -> CircuitBuilder {
+        self.auth = Some(auth.clone());
+        self
+    }
+
+    /// Sets the persistence type
+    ///
+    /// # Arguments
+    ///
+    ///  * `persistence` - The persistence type for the circuit
+    pub fn with_persistence(mut self, persistence: &PersistenceType) -> CircuitBuilder {
+        self.persistence = Some(persistence.clone());
+        self
+    }
+
+    /// Sets the durabilitye type
+    ///
+    /// # Arguments
+    ///
+    ///  * `durability` - The durability type for the circuit
+    pub fn with_durability(mut self, durability: &DurabilityType) -> CircuitBuilder {
+        self.durability = Some(durability.clone());
+        self
+    }
+
+    /// Sets the routing type
+    ///
+    /// # Arguments
+    ///
+    ///  * `route_type` - The routing type for the circuit
+    pub fn with_routes(mut self, route_type: &RouteType) -> CircuitBuilder {
+        self.routes = Some(route_type.clone());
+        self
+    }
+
+    /// Sets the circuit management type
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_management_type` - The circuit management type for a circuit
+    pub fn with_circuit_management_type(mut self, circuit_management_type: &str) -> CircuitBuilder {
+        self.circuit_management_type = Some(circuit_management_type.into());
+        self
+    }
+
+    /// Builds a `Circuit`
+    ///
+    /// Returns an error if the circuit ID, roster, members or circuit management
+    /// type are not set.
+    pub fn build(self) -> Result<Circuit, BuilderError> {
+        let circuit_id = match self.circuit_id {
+            Some(circuit_id) if is_valid_circuit_id(&circuit_id) => circuit_id,
+            Some(circuit_id) => {
+                return Err(BuilderError::InvalidField(format!(
+                    "circuit_id is invalid ({}): must be an 11 character string composed of two, \
+                     5 character base62 strings joined with a '-' (example: abcDE-F0123)",
+                    circuit_id,
+                )))
+            }
+            None => return Err(BuilderError::MissingField("circuit_id".to_string())),
+        };
+
+        let roster = self
+            .roster
+            .ok_or_else(|| BuilderError::MissingField("roster".to_string()))?;
+
+        let members = self
+            .members
+            .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
+
+        let auth = self.auth.unwrap_or_else(|| AuthorizationType::Trust);
+
+        let persistence = self.persistence.unwrap_or_else(PersistenceType::default);
+
+        let durability = self
+            .durability
+            .unwrap_or_else(|| DurabilityType::NoDurability);
+
+        let routes = self.routes.unwrap_or_else(RouteType::default);
+
+        let circuit_management_type = self
+            .circuit_management_type
+            .ok_or_else(|| BuilderError::MissingField("circuit_management_type".to_string()))?;
+
+        let create_circuit_message = Circuit {
+            id: circuit_id,
+            roster,
+            members,
+            auth,
+            persistence,
+            durability,
+            routes,
+            circuit_management_type,
+        };
+
+        Ok(create_circuit_message)
+    }
+}
+
+/// Builder to be used to build a `ProposedCircuit` which will be included in a `CircuitProposal`
+#[derive(Default, Clone)]
+pub struct ProposedCircuitBuilder {
+    circuit_id: Option<String>,
+    roster: Option<Vec<ProposedService>>,
+    members: Option<Vec<ProposedNode>>,
+    authorization_type: Option<AuthorizationType>,
+    persistence: Option<PersistenceType>,
+    durability: Option<DurabilityType>,
+    routes: Option<RouteType>,
+    circuit_management_type: Option<String>,
+    application_metadata: Option<Vec<u8>>,
+    comments: Option<String>,
+}
+
+impl ProposedCircuitBuilder {
+    /// Creates a new proposed circuit builder
+    pub fn new() -> Self {
+        ProposedCircuitBuilder::default()
+    }
+
+    // Returns the circuit ID in the builder
+    pub fn circuit_id(&self) -> Option<String> {
+        self.circuit_id.clone()
+    }
+
+    /// Returns the list of services in the builder
+    pub fn roster(&self) -> Option<Vec<ProposedService>> {
+        self.roster.clone()
+    }
+
+    /// Returns the list of node IDs in the builder
+    pub fn members(&self) -> Option<Vec<ProposedNode>> {
+        self.members.clone()
+    }
+
+    /// Returns the authorization type in the builder
+    pub fn authorization_type(&self) -> Option<AuthorizationType> {
+        self.authorization_type.clone()
+    }
+
+    /// Returns the persistence type in the builder
+    pub fn persistence(&self) -> Option<PersistenceType> {
+        self.persistence.clone()
+    }
+
+    /// Returns the durability type in the builder
+    pub fn durability(&self) -> Option<DurabilityType> {
+        self.durability.clone()
+    }
+
+    /// Returns the routing type in the builder
+    pub fn routes(&self) -> Option<RouteType> {
+        self.routes.clone()
+    }
+
+    /// Returns the circuit management type in the builder
+    pub fn circuit_management_type(&self) -> Option<String> {
+        self.circuit_management_type.clone()
+    }
+
+    /// Returns the appplication metdata in the builder
+    pub fn application_metadata(&self) -> Option<Vec<u8>> {
+        self.application_metadata.clone()
+    }
+
+    /// Returns the comments describing the circuit proposal in the builder
+    pub fn comments(&self) -> Option<String> {
+        self.comments.clone()
+    }
+
+    /// Sets the circuit ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit
+    pub fn with_circuit_id(mut self, circuit_id: &str) -> ProposedCircuitBuilder {
+        self.circuit_id = Some(circuit_id.into());
+        self
+    }
+
+    /// Sets the list of services that are included in the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `services` - List of proposed services
+    pub fn with_roster(mut self, services: &[ProposedService]) -> ProposedCircuitBuilder {
+        self.roster = Some(services.into());
+        self
+    }
+
+    /// Sets the list of nodes that are included in the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `members` - List of proposed nodes
+    pub fn with_members(mut self, members: &[ProposedNode]) -> ProposedCircuitBuilder {
+        self.members = Some(members.into());
+        self
+    }
+
+    /// Sets the authorization type
+    ///
+    /// # Arguments
+    ///
+    ///  * `auth` - The authorization type for the circuit
+    pub fn with_authorization_type(mut self, auth: &AuthorizationType) -> ProposedCircuitBuilder {
+        self.authorization_type = Some(auth.clone());
+        self
+    }
+
+    /// Sets the persistence type
+    ///
+    /// # Arguments
+    ///
+    ///  * `persistence` - The persistence type for the circuit
+    pub fn with_persistence(mut self, persistence: &PersistenceType) -> ProposedCircuitBuilder {
+        self.persistence = Some(persistence.clone());
+        self
+    }
+
+    /// Sets the durability type
+    ///
+    /// # Arguments
+    ///
+    ///  * `durability` - The durability type for the circuit
+    pub fn with_durability(mut self, durability: &DurabilityType) -> ProposedCircuitBuilder {
+        self.durability = Some(durability.clone());
+        self
+    }
+
+    /// Sets the routes type
+    ///
+    /// # Arguments
+    ///
+    ///  * `routes` - The routes type for the circuit
+    pub fn with_routes(mut self, route_type: &RouteType) -> ProposedCircuitBuilder {
+        self.routes = Some(route_type.clone());
+        self
+    }
+
+    /// Sets the circuit managment type
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_management_type` - The circuit_management_type for the circuit
+    pub fn with_circuit_management_type(
+        mut self,
+        circuit_management_type: &str,
+    ) -> ProposedCircuitBuilder {
+        self.circuit_management_type = Some(circuit_management_type.into());
+        self
+    }
+
+    /// Sets the application metadata
+    ///
+    /// # Arguments
+    ///
+    ///  * `application_metadata` - The application_metadata for the proposed circuit
+    pub fn with_application_metadata(
+        mut self,
+        application_metadata: &[u8],
+    ) -> ProposedCircuitBuilder {
+        self.application_metadata = Some(application_metadata.into());
+        self
+    }
+
+    /// Sets the comments
+    ///
+    /// # Arguments
+    ///
+    ///  * `comments` - The comments describing the purpose of the proposed circuit
+    pub fn with_comments(mut self, comments: &str) -> ProposedCircuitBuilder {
+        self.comments = Some(comments.into());
+        self
+    }
+
+    /// Builds a `ProposedCircuit`
+    ///
+    /// Returns an error if the circuit ID, roster, members or circuit management
+    /// type are not set.
+    pub fn build(self) -> Result<ProposedCircuit, BuilderError> {
+        let circuit_id = match self.circuit_id {
+            Some(circuit_id) if is_valid_circuit_id(&circuit_id) => circuit_id,
+            Some(circuit_id) => {
+                return Err(BuilderError::InvalidField(format!(
+                    "circuit_id is invalid ({}): must be an 11 character string composed of two, \
+                     5 character base62 strings joined with a '-' (example: abcDE-F0123)",
+                    circuit_id,
+                )))
+            }
+            None => return Err(BuilderError::MissingField("circuit_id".to_string())),
+        };
+
+        let roster = self
+            .roster
+            .ok_or_else(|| BuilderError::MissingField("roster".to_string()))?;
+
+        let members = self
+            .members
+            .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
+
+        let authorization_type = self
+            .authorization_type
+            .unwrap_or_else(|| AuthorizationType::Trust);
+
+        let persistence = self.persistence.unwrap_or_else(PersistenceType::default);
+
+        let durability = self
+            .durability
+            .unwrap_or_else(|| DurabilityType::NoDurability);
+
+        let routes = self.routes.unwrap_or_else(RouteType::default);
+
+        let circuit_management_type = self
+            .circuit_management_type
+            .ok_or_else(|| BuilderError::MissingField("circuit_management_type".to_string()))?;
+
+        let application_metadata = self.application_metadata.unwrap_or_default();
+
+        let comments = self.comments.unwrap_or_default();
+
+        let create_circuit_message = ProposedCircuit {
+            circuit_id,
+            roster,
+            members,
+            authorization_type,
+            persistence,
+            durability,
+            routes,
+            circuit_management_type,
+            application_metadata,
+            comments,
+        };
+
+        Ok(create_circuit_message)
+    }
+}
+
+impl From<ProposedCircuit> for Circuit {
+    fn from(circuit: ProposedCircuit) -> Self {
+        Circuit {
+            id: circuit.circuit_id,
+            roster: circuit.roster.into_iter().map(Service::from).collect(),
+            members: circuit
+                .members
+                .iter()
+                .map(|node| node.node_id.to_string())
+                .collect(),
+            auth: circuit.authorization_type,
+            persistence: circuit.persistence,
+            durability: circuit.durability,
+            routes: circuit.routes,
+            circuit_management_type: circuit.circuit_management_type,
+        }
+    }
+}
+
+/// Builder to be used to build a `CircuitProposal`
+#[derive(Clone, Default)]
+pub struct CircuitProposalBuilder {
+    proposal_type: Option<ProposalType>,
+    circuit_id: Option<String>,
+    circuit_hash: Option<String>,
+    circuit: Option<ProposedCircuit>,
+    votes: Option<Vec<VoteRecord>>,
+    requester: Option<Vec<u8>>,
+    requester_node_id: Option<String>,
+}
+
+impl CircuitProposalBuilder {
+    /// Creates a new circuit proposal builder
+    pub fn new() -> Self {
+        CircuitProposalBuilder::default()
+    }
+
+    /// Returns the proposal type of the builder
+    pub fn proposal_type(&self) -> Option<ProposalType> {
+        self.proposal_type.clone()
+    }
+
+    /// Returns the circuit ID
+    pub fn circuit_id(&self) -> Option<String> {
+        self.circuit_id.clone()
+    }
+
+    /// Returns the hash of the proposed circuit
+    pub fn circuit_hash(&self) -> Option<String> {
+        self.circuit_hash.clone()
+    }
+
+    /// Returns the circuit being proposed
+    pub fn circuit(&self) -> Option<ProposedCircuit> {
+        self.circuit.clone()
+    }
+
+    /// Returns the list of current votes
+    pub fn votes(&self) -> Option<Vec<VoteRecord>> {
+        self.votes.clone()
+    }
+
+    /// Returns the public key of the original request of the proposal
+    pub fn requester(&self) -> Option<Vec<u8>> {
+        self.requester.clone()
+    }
+
+    /// Returns the the ID of the node the requester is permissioned to submit proposals for
+    pub fn requester_node_id(&self) -> Option<String> {
+        self.requester_node_id.clone()
+    }
+
+    /// Set the proposal type of the circuit proposal
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal_type` - The type of proposal being built
+    pub fn with_proposal_type(mut self, proposal_type: &ProposalType) -> CircuitProposalBuilder {
+        self.proposal_type = Some(proposal_type.clone());
+        self
+    }
+
+    /// Set the circuit ID for the circuit the proposal is for
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique circuit ID for the proposed circuit
+    pub fn with_circuit_id(mut self, circuit_id: &str) -> CircuitProposalBuilder {
+        self.circuit_id = Some(circuit_id.to_string());
+        self
+    }
+
+    /// Set the hash the proposed circuit the proposal is for. This will be used to validate votes
+    /// are for the correct proposal
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique circuit ID for the proposed circuit
+    pub fn with_circuit_hash(mut self, circuit_hash: &str) -> CircuitProposalBuilder {
+        self.circuit_hash = Some(circuit_hash.to_string());
+        self
+    }
+
+    /// Sets the proposed circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit` - The circuit that is being proposed
+    pub fn with_circuit(mut self, circuit: &ProposedCircuit) -> CircuitProposalBuilder {
+        self.circuit = Some(circuit.clone());
+        self
+    }
+
+    /// Sets the list of existing vote records
+    ///
+    /// # Arguments
+    ///
+    ///  * `votes` - A list of vote records
+    pub fn with_votes(mut self, votes: &[VoteRecord]) -> CircuitProposalBuilder {
+        self.votes = Some(votes.to_vec());
+        self
+    }
+
+    /// Sets the public key for the requester of the proposal
+    ///
+    /// # Arguments
+    ///
+    ///  * `requester` - The public key of the requester
+    pub fn with_requester(mut self, requester: &[u8]) -> CircuitProposalBuilder {
+        self.requester = Some(requester.to_vec());
+        self
+    }
+
+    /// Sets the requester node ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `requester_node_od` - The node ID of the node the requester has permissions to submit
+    ///       proposals for
+    pub fn with_requester_node_id(mut self, requester_node_id: &str) -> CircuitProposalBuilder {
+        self.requester_node_id = Some(requester_node_id.to_string());
+        self
+    }
+
+    /// Builds a `CircuitProposal`
+    ///
+    /// Returns an error if the circuit ID, circuit, circuit hash, requester, or requester node id
+    /// is not set.
+    pub fn build(self) -> Result<CircuitProposal, BuilderError> {
+        let circuit_id = match self.circuit_id {
+            Some(circuit_id) if is_valid_circuit_id(&circuit_id) => circuit_id,
+            Some(circuit_id) => {
+                return Err(BuilderError::InvalidField(format!(
+                    "circuit_id is invalid ({}): must be an 11 character string composed of two, \
+                     5 character base62 strings joined with a '-' (example: abcDE-F0123)",
+                    circuit_id,
+                )))
+            }
+            None => return Err(BuilderError::MissingField("circuit_id".to_string())),
+        };
+
+        let proposal_type = self
+            .proposal_type
+            .ok_or_else(|| BuilderError::MissingField("proposal_type".to_string()))?;
+
+        let circuit_hash = self
+            .circuit_hash
+            .ok_or_else(|| BuilderError::MissingField("circuit_hash".to_string()))?;
+
+        let circuit = self
+            .circuit
+            .ok_or_else(|| BuilderError::MissingField("circuit".to_string()))?;
+
+        let votes = self.votes.unwrap_or_default();
+
+        let requester = self
+            .requester
+            .ok_or_else(|| BuilderError::MissingField("requester".to_string()))?;
+
+        let requester_node_id = self
+            .requester_node_id
+            .ok_or_else(|| BuilderError::MissingField("requester node id".to_string()))?;
+
+        Ok(CircuitProposal {
+            proposal_type,
+            circuit_id,
+            circuit_hash,
+            circuit,
+            votes,
+            requester,
+            requester_node_id,
+        })
+    }
+}
+
+/// Builder for creating a `CircutNode`
+#[derive(Default, Clone)]
+pub struct CircuitNodeBuilder {
+    node_id: Option<String>,
+    endpoints: Option<Vec<String>>,
+}
+
+impl CircuitNodeBuilder {
+    /// Creates a `CircuitNodeBuilder`
+    pub fn new() -> Self {
+        CircuitNodeBuilder::default()
+    }
+
+    /// Returns the unique node ID
+    pub fn node_id(&self) -> Option<String> {
+        self.node_id.clone()
+    }
+
+    /// Returns the list of endpoints for the node
+    pub fn endpoints(&self) -> Option<Vec<String>> {
+        self.endpoints.clone()
+    }
+
+    /// Sets the node ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `node_id` - The unique node ID for node
+    pub fn with_node_id(mut self, node_id: &str) -> CircuitNodeBuilder {
+        self.node_id = Some(node_id.into());
+        self
+    }
+
+    /// Sets the endpoints
+    ///
+    /// # Arguments
+    ///
+    ///  * `endpoints` - The list of endpoints for the node
+    pub fn with_endpoints(mut self, endpoints: &[String]) -> CircuitNodeBuilder {
+        self.endpoints = Some(endpoints.into());
+        self
+    }
+
+    /// Builds the `CircuitNode`
+    ///
+    /// Returns an error if the node ID or endpoints are not set
+    pub fn build(self) -> Result<CircuitNode, BuilderError> {
+        let node_id = self
+            .node_id
+            .ok_or_else(|| BuilderError::MissingField("node_id".to_string()))?;
+
+        let endpoints = self
+            .endpoints
+            .ok_or_else(|| BuilderError::MissingField("endpoints".to_string()))?;
+
+        let node = CircuitNode {
+            id: node_id,
+            endpoints,
+        };
+
+        Ok(node)
+    }
+}
+
+/// Builder for creating a `ProposedNode`
+#[derive(Default, Clone)]
+pub struct ProposedNodeBuilder {
+    node_id: Option<String>,
+    endpoints: Option<Vec<String>>,
+}
+
+impl ProposedNodeBuilder {
+    /// Creates a `ProposedNodeBuider`
+    pub fn new() -> Self {
+        ProposedNodeBuilder::default()
+    }
+
+    /// Returns the unique node ID
+    pub fn node_id(&self) -> Option<String> {
+        self.node_id.clone()
+    }
+
+    /// Returns the list of endpoints for the node
+    pub fn endpoints(&self) -> Option<Vec<String>> {
+        self.endpoints.clone()
+    }
+
+    /// Sets the node ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `node_id` - The unique node ID for node
+    pub fn with_node_id(mut self, node_id: &str) -> ProposedNodeBuilder {
+        self.node_id = Some(node_id.into());
+        self
+    }
+
+    /// Sets the endpoints
+    ///
+    /// # Arguments
+    ///
+    ///  * `endpoints` - The list of endpoints for the node
+    pub fn with_endpoints(mut self, endpoints: &[String]) -> ProposedNodeBuilder {
+        self.endpoints = Some(endpoints.into());
+        self
+    }
+
+    /// Builds the `ProposedNode`
+    ///
+    /// Returns an error if the node ID or endpoints are not set
+    pub fn build(self) -> Result<ProposedNode, BuilderError> {
+        let node_id = self
+            .node_id
+            .ok_or_else(|| BuilderError::MissingField("node_id".to_string()))?;
+
+        let endpoints = self
+            .endpoints
+            .ok_or_else(|| BuilderError::MissingField("endpoints".to_string()))?;
+
+        let node = ProposedNode { node_id, endpoints };
+
+        Ok(node)
+    }
+}
+
+impl From<ProposedNode> for CircuitNode {
+    fn from(node: ProposedNode) -> Self {
+        CircuitNode {
+            id: node.node_id,
+            endpoints: node.endpoints,
+        }
+    }
+}
+
+/// Builder for creating a `Service`
+#[derive(Default, Clone)]
+pub struct ServiceBuilder {
+    service_id: Option<String>,
+    service_type: Option<String>,
+    allowed_nodes: Option<Vec<String>>,
+    arguments: Option<Vec<(String, String)>>,
+}
+
+impl ServiceBuilder {
+    /// Creates a new `ServiceBuilder`
+    pub fn new() -> Self {
+        ServiceBuilder::default()
+    }
+
+    /// Returns the service specific service ID
+    pub fn service_id(&self) -> Option<String> {
+        self.service_id.clone()
+    }
+
+    /// Returns the service type
+    pub fn service_type(&self) -> Option<String> {
+        self.service_type.clone()
+    }
+
+    /// Returns the list of allowed nodes the service can connect to
+    pub fn allowed_nodes(&self) -> Option<Vec<String>> {
+        self.allowed_nodes.clone()
+    }
+
+    /// Returns the list of arguments for the service
+    pub fn arguments(&self) -> Option<Vec<(String, String)>> {
+        self.arguments.clone()
+    }
+
+    /// Sets the service ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The unique service ID for service
+    pub fn with_service_id(mut self, service_id: &str) -> ServiceBuilder {
+        self.service_id = Some(service_id.into());
+        self
+    }
+
+    /// Sets the service type
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_type` - The service type of the service
+    pub fn with_service_type(mut self, service_type: &str) -> ServiceBuilder {
+        self.service_type = Some(service_type.into());
+        self
+    }
+
+    /// Sets the allowed nodes
+    ///
+    /// # Arguments
+    ///
+    ///  * `allowed_nodes` - A list of node IDs the service can connect to
+    pub fn with_allowed_nodes(mut self, allowed_nodes: &[String]) -> ServiceBuilder {
+        self.allowed_nodes = Some(allowed_nodes.into());
+        self
+    }
+
+    /// Sets the service arguments
+    ///
+    /// # Arguments
+    ///
+    ///  * `arguments` - A list of key-value pairs for the arguments for the service
+    pub fn with_arguments(mut self, arguments: &[(String, String)]) -> ServiceBuilder {
+        self.arguments = Some(arguments.to_vec());
+        self
+    }
+
+    /// Builds the `Service`
+    ///
+    /// Returns an error if the service ID, service_type, or allowed nodes is not set
+    pub fn build(self) -> Result<Service, BuilderError> {
+        let service_id = match self.service_id {
+            Some(service_id) if is_valid_service_id(&service_id) => service_id,
+            Some(service_id) => {
+                return Err(BuilderError::InvalidField(format!(
+                    "service_id is invalid ({}): must be a 4 character base62 string",
+                    service_id,
+                )))
+            }
+            None => return Err(BuilderError::MissingField("service_id".to_string())),
+        };
+
+        let service_type = self
+            .service_type
+            .ok_or_else(|| BuilderError::MissingField("service_type".to_string()))?;
+
+        let allowed_nodes = self
+            .allowed_nodes
+            .ok_or_else(|| BuilderError::MissingField("allowed_nodes".to_string()))?;
+
+        let arguments = self.arguments.unwrap_or_default();
+
+        let service = Service {
+            service_id,
+            service_type,
+            allowed_nodes,
+            arguments,
+        };
+
+        Ok(service)
+    }
+}
+
+/// Builder for creating a `ProposedService`
+#[derive(Default, Clone)]
+pub struct ProposedServiceBuilder {
+    service_id: Option<String>,
+    service_type: Option<String>,
+    allowed_nodes: Option<Vec<String>>,
+    arguments: Option<Vec<(String, String)>>,
+}
+
+impl ProposedServiceBuilder {
+    /// Creates a new `ProposedServiceBuilder`
+    pub fn new() -> Self {
+        ProposedServiceBuilder::default()
+    }
+
+    /// Returns the service specific service ID
+    pub fn service_id(&self) -> Option<String> {
+        self.service_id.clone()
+    }
+
+    /// Returns the service type
+    pub fn service_type(&self) -> Option<String> {
+        self.service_type.clone()
+    }
+
+    /// Returns the list of allowed nodes the service can connect to
+    pub fn allowed_nodes(&self) -> Option<Vec<String>> {
+        self.allowed_nodes.clone()
+    }
+
+    /// Returns the list of arguments for the service
+    pub fn arguments(&self) -> Option<Vec<(String, String)>> {
+        self.arguments.clone()
+    }
+
+    /// Sets the service ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The unique service ID for service
+    pub fn with_service_id(mut self, service_id: &str) -> ProposedServiceBuilder {
+        self.service_id = Some(service_id.into());
+        self
+    }
+
+    /// Sets the service type
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_type` - The service type of the service
+    pub fn with_service_type(mut self, service_type: &str) -> ProposedServiceBuilder {
+        self.service_type = Some(service_type.into());
+        self
+    }
+
+    /// Sets the allowed nodes
+    ///
+    /// # Arguments
+    ///
+    ///  * `allowed_nodes` - A list of node IDs the service can connect to
+    pub fn with_allowed_nodes(mut self, allowed_nodes: &[String]) -> ProposedServiceBuilder {
+        self.allowed_nodes = Some(allowed_nodes.into());
+        self
+    }
+
+    /// Sets the service arguments
+    ///
+    /// # Arguments
+    ///
+    ///  * `arguments` - A list of key-value pairs for the arguments for the service
+    pub fn with_arguments(mut self, arguments: &[(String, String)]) -> ProposedServiceBuilder {
+        self.arguments = Some(arguments.to_vec());
+        self
+    }
+
+    /// Builds the `ProposedService`
+    ///
+    /// Returns an error if the service ID, service_type, or allowed nodes is not set
+    pub fn build(self) -> Result<ProposedService, BuilderError> {
+        let service_id = match self.service_id {
+            Some(service_id) if is_valid_service_id(&service_id) => service_id,
+            Some(service_id) => {
+                return Err(BuilderError::InvalidField(format!(
+                    "service_id is invalid ({}): must be a 4 character base62 string",
+                    service_id,
+                )))
+            }
+            None => return Err(BuilderError::MissingField("service_id".to_string())),
+        };
+
+        let service_type = self
+            .service_type
+            .ok_or_else(|| BuilderError::MissingField("service_type".to_string()))?;
+
+        let allowed_nodes = self
+            .allowed_nodes
+            .ok_or_else(|| BuilderError::MissingField("allowed_nodes".to_string()))?;
+
+        let arguments = self.arguments.unwrap_or_default();
+
+        let service = ProposedService {
+            service_id,
+            service_type,
+            allowed_nodes,
+            arguments,
+        };
+
+        Ok(service)
+    }
+}
+
+impl From<ProposedService> for Service {
+    fn from(service: ProposedService) -> Self {
+        Service {
+            service_id: service.service_id,
+            service_type: service.service_type,
+            allowed_nodes: service.allowed_nodes,
+            arguments: service.arguments,
+        }
+    }
+}

--- a/libsplinter/src/admin/store/error.rs
+++ b/libsplinter/src/admin/store/error.rs
@@ -1,0 +1,114 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for errors that can be raised while using an admin service store, as well as errors
+//! raised by the builders
+
+use std::error::Error;
+use std::fmt;
+
+/// Represents AdminServiceStore errors
+#[derive(Debug)]
+pub enum AdminServiceStoreError {
+    /// Represents CRUD operations failures
+    OperationError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents store query failures
+    QueryError {
+        context: String,
+        source: Box<dyn Error>,
+    },
+    /// Represents general failures in the store
+    StorageError {
+        context: String,
+        source: Option<Box<dyn Error>>,
+    },
+    /// Represents an issue connecting to the store
+    ConnectionError(Box<dyn Error>),
+    NotFoundError(String),
+}
+
+impl Error for AdminServiceStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            AdminServiceStoreError::OperationError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            AdminServiceStoreError::OperationError { source: None, .. } => None,
+            AdminServiceStoreError::QueryError { source, .. } => Some(&**source),
+            AdminServiceStoreError::StorageError {
+                source: Some(source),
+                ..
+            } => Some(&**source),
+            AdminServiceStoreError::StorageError { source: None, .. } => None,
+            AdminServiceStoreError::ConnectionError(err) => Some(&**err),
+            AdminServiceStoreError::NotFoundError(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for AdminServiceStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AdminServiceStoreError::OperationError {
+                context,
+                source: Some(source),
+            } => write!(f, "failed to perform operation: {}: {}", context, source),
+            AdminServiceStoreError::OperationError {
+                context,
+                source: None,
+            } => write!(f, "failed to perform operation: {}", context),
+            AdminServiceStoreError::QueryError { context, source } => {
+                write!(f, "failed query: {}: {}", context, source)
+            }
+            AdminServiceStoreError::StorageError {
+                context,
+                source: Some(source),
+            } => write!(
+                f,
+                "the underlying storage returned an error: {}: {}",
+                context, source
+            ),
+            AdminServiceStoreError::StorageError {
+                context,
+                source: None,
+            } => write!(f, "the underlying storage returned an error: {}", context),
+            AdminServiceStoreError::ConnectionError(err) => {
+                write!(f, "failed to connect to underlying storage: {}", err)
+            }
+            AdminServiceStoreError::NotFoundError(ref s) => write!(f, "Not found: {}", s),
+        }
+    }
+}
+
+/// Represents errors raised while building
+#[derive(Debug)]
+pub enum BuilderError {
+    InvalidField(String),
+    MissingField(String),
+}
+
+impl Error for BuilderError {}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BuilderError::InvalidField(ref s) => write!(f, "unable to build, invalid field: {}", s),
+            BuilderError::MissingField(ref s) => write!(f, "unable to build, missing field: {}", s),
+        }
+    }
+}

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -1,0 +1,454 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines an API for managing the API for writing and reading circuit state and pending circuit
+//! proposals. The provided `AdminServiceStore` trait makes no assumptions about the storage
+//! backend.
+//!
+//! The public interface includes the trait [`AdminServiceStore`] and structs for
+//! [`Circuit`], [`ProposedCircuit`], [`CircuitNode`], [`ProposedNode`], [`Service`],
+//! [`ProposedService`], and [`CircuitProposal`]. A YAML backed [`YamlAdminServiceStore`] is
+//! also available.
+//!
+//! Builders are also provided. The structs are [`CircuitBuilder`], [`ProposedCircuitBuilder`],
+//! [`CircuitNodeBuilder`], [`ProposedNodeBuilder`], [`ServiceBuilder`],
+//! [`ProposedServiceBuilder`], and [`CircuitProposalBuilder`].
+//!
+//! [`AdminServiceStore`]: trait.AdminServiceStore.html
+//! [`Circuit`]: struct.Circuit.html
+//! [`ProposedCircuit`]: struct.ProposedCircuit.html
+//! [`CircuitNode`]: struct.CircuitNode.html
+//! [`ProposedNode`]: struct.ProposedNode.html
+//! [`Service`]: struct.Service.html
+//! [`ProposedService`]: struct.ProposedService.html
+//! [`CircuitProposal`]: struct.CircuitProposal.html
+//! [`YamlAdminServiceStore`]: yaml/struct.YamlAdminServiceStore.html
+//!
+//! [`CircuitBuilder`]: struct.CircuitBuilder.html
+//! [`ProposedCircuitBuilder`]: struct.ProposedCircuitBuilder.html
+//! [`CircuitNodeBuilder`]: struct.CircuitNodeBuilder.html
+//! [`ProposedNodeBuilder`]: struct.ProposedNodeBuilder.html
+//! [`ServiceBuilder`]: struct.ServiceBuilder.html
+//! [`ProposedServiceBuilder`]: struct.ProposedServiceBuilder.html
+//! [`CircuitProposalBuilder`]: struct.CircuitProposalBuilder.html
+
+mod builders;
+pub mod error;
+
+use std::cmp::Ordering;
+use std::fmt;
+
+use crate::hex::{as_hex, deserialize_hex};
+
+pub use self::builders::{
+    CircuitBuilder, CircuitNodeBuilder, CircuitProposalBuilder, ProposedCircuitBuilder,
+    ProposedNodeBuilder, ProposedServiceBuilder, ServiceBuilder,
+};
+use self::error::AdminServiceStoreError;
+
+/// Native representation of a circuit in state
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Circuit {
+    id: String,
+    roster: Vec<Service>,
+    members: Vec<String>,
+    auth: AuthorizationType,
+    persistence: PersistenceType,
+    durability: DurabilityType,
+    routes: RouteType,
+    circuit_management_type: String,
+}
+
+/// Native representation of a circuit that is being proposed in a proposal
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ProposedCircuit {
+    circuit_id: String,
+    roster: Vec<ProposedService>,
+    members: Vec<ProposedNode>,
+    authorization_type: AuthorizationType,
+    persistence: PersistenceType,
+    durability: DurabilityType,
+    routes: RouteType,
+    circuit_management_type: String,
+    #[serde(serialize_with = "as_hex")]
+    #[serde(deserialize_with = "deserialize_hex")]
+    #[serde(default)]
+    application_metadata: Vec<u8>,
+    comments: String,
+}
+
+/// Native representation of a circuit proposal
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct CircuitProposal {
+    pub proposal_type: ProposalType,
+    pub circuit_id: String,
+    pub circuit_hash: String,
+    pub circuit: ProposedCircuit,
+    pub votes: Vec<VoteRecord>,
+    #[serde(serialize_with = "as_hex")]
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub requester: Vec<u8>,
+    pub requester_node_id: String,
+}
+
+impl CircuitProposal {
+    /// Adds a vote record to a pending circuit proposal
+    pub fn add_vote(&mut self, vote: VoteRecord) {
+        self.votes.push(vote);
+    }
+}
+
+/// Native representation of a vote record for a proposal
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct VoteRecord {
+    pub public_key: Vec<u8>,
+    pub vote: Vote,
+    pub voter_node_id: String,
+}
+
+/// Represents a vote, either accept or reject, for a circuit proposal
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum Vote {
+    Accept,
+    Reject,
+}
+
+/// Represents the of  type change the circuit proposal is for
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum ProposalType {
+    Create,
+    UpdateRoster,
+    AddNode,
+    RemoveNode,
+    Destroy,
+}
+
+/// What type of authorization the circuit requires
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum AuthorizationType {
+    Trust,
+}
+
+/// A circuits message persistence strategy
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum PersistenceType {
+    Any,
+}
+
+impl Default for PersistenceType {
+    fn default() -> Self {
+        PersistenceType::Any
+    }
+}
+
+/// A circuits durability requirement
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum DurabilityType {
+    NoDurability,
+}
+
+/// How messages are expected to be routed across a circuit
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum RouteType {
+    Any,
+}
+
+impl Default for RouteType {
+    fn default() -> Self {
+        RouteType::Any
+    }
+}
+
+/// Native representation of a node included in circuit
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct CircuitNode {
+    id: String,
+    endpoints: Vec<String>,
+}
+
+/// Native representation of a node in a proposed circuit
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ProposedNode {
+    node_id: String,
+    endpoints: Vec<String>,
+}
+
+/// Native representation of a service that is a part of circuit
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Service {
+    service_id: String,
+    service_type: String,
+    allowed_nodes: Vec<String>,
+    arguments: Vec<(String, String)>,
+}
+
+/// Native representation of a service that is a part of a proposed circuit
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ProposedService {
+    service_id: String,
+    service_type: String,
+    allowed_nodes: Vec<String>,
+    arguments: Vec<(String, String)>,
+}
+
+/// The unique ID of service made up of a circuit ID and the individual service ID.
+/// A service ID is only required to be unique from within a circuit.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct ServiceId {
+    circuit_id: String,
+    service_id: String,
+}
+
+impl ServiceId {
+    /// Create a new service ID
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` - the ID of the circuit the service belongs to
+    /// * `service_id` - the individual ID for the service
+    pub fn new(circuit_id: String, service_id: String) -> Self {
+        ServiceId {
+            circuit_id,
+            service_id,
+        }
+    }
+
+    /// Returns the circuit ID
+    pub fn circuit(&self) -> &str {
+        &self.circuit_id
+    }
+
+    /// Returns the service ID
+    pub fn service_id(&self) -> &str {
+        &self.service_id
+    }
+
+    /// Decompose this ServiceId into a tuple of (<circuit ID>, <service ID>).
+    pub fn into_parts(self) -> (String, String) {
+        (self.circuit_id, self.service_id)
+    }
+}
+
+impl fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}::{}", self.circuit_id, self.service_id)
+    }
+}
+
+impl Eq for ServiceId {}
+
+impl Ord for ServiceId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let compare = self.circuit_id.cmp(&other.circuit_id);
+        if compare == Ordering::Equal {
+            self.service_id.cmp(&other.service_id)
+        } else {
+            compare
+        }
+    }
+}
+
+impl PartialOrd for ServiceId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Predicate for filtering the lists of circuits and circuit proposals
+pub enum CircuitPredicate {
+    ManagmentTypeEq(String),
+    MembersInclude(Vec<String>),
+}
+
+impl CircuitPredicate {
+    /// Apply this predicate against a given circuit
+    pub fn apply_to_circuit(&self, circuit: &Circuit) -> bool {
+        match self {
+            CircuitPredicate::ManagmentTypeEq(man_type) => {
+                &circuit.circuit_management_type == man_type
+            }
+            CircuitPredicate::MembersInclude(nodes) => {
+                for node_id in nodes.iter() {
+                    if !circuit.members.contains(node_id) {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    /// Apply this predicate against a given circuit proposal
+    pub fn apply_to_proposals(&self, proposal: &CircuitProposal) -> bool {
+        match self {
+            CircuitPredicate::ManagmentTypeEq(man_type) => {
+                &proposal.circuit.circuit_management_type == man_type
+            }
+            CircuitPredicate::MembersInclude(nodes) => {
+                for node_id in nodes {
+                    if proposal
+                        .circuit
+                        .members
+                        .iter()
+                        .find(|node| node_id == &node.node_id)
+                        .is_none()
+                    {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+}
+
+/// Defines methods for CRUD operations and fetching and listing circuits, proposals, nodes and
+/// services without defining a storage strategy
+pub trait AdminServiceStore: Send + Sync {
+    /// Adds a circuit proposal to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal` - The proposal to be added
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID already exists
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
+
+    /// Updates a circuit proposal in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal` - The proposal with the updated information
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID does not exist
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
+
+    /// Removes a circuit proposal from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal_id` - The unique ID of the circuit proposal to be removed
+    ///
+    ///  Returns an error if a `CircuitProposal` with specified ID does not exist
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError>;
+
+    /// Fetches a circuit proposal from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal_id` - The unique ID of the circuit proposal to be returned
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError>;
+
+    /// List circuit proposals from the underlying storage
+    ///
+    /// The proposals returned can be filtered by provided `CircuitPredicate`. This enables
+    /// filtering by management type and members.
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError>;
+
+    /// Adds a circuit to the underlying storage. Also includes the associated Services and
+    /// Nodes
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit` - The circuit to be added to state
+    ///  * `nodes` - A list of nodes that represent the circuit's members
+    ///
+    ///  Returns an error if a `Circuit` with the same ID already exists
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError>;
+
+    /// Updates a circuit in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit` - The circuit with the updated information
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID does not exist
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError>;
+
+    /// Removes a circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit to be removed
+    ///
+    ///  Returns an error if a `Circuit` with the specified ID does not exist
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
+
+    /// Fetches a circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit to be returned
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError>;
+
+    /// List all circuits from the underlying storage
+    ///
+    /// The proposals returned can be filtered by provided `CircuitPredicate`. This enables
+    /// filtering by management type and members.
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError>;
+
+    /// Adds a circuit to the underlying storage based on the proposal that is already in state.
+    /// Also includes the associated Services and Nodes. The associated circuit proposal for
+    /// the circuit ID is also removed
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The ID of the circuit proposal that should be converted to a circuit
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
+
+    /// Fetches a node from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `node_id` - The unique ID of the node to be returned
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError>;
+
+    /// List all nodes from the underlying storage
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError>;
+
+    /// Fetches a service from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The `ServiceId` of a service made up of the circuit ID and service ID
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError>;
+
+    /// List all services in a specific circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit the services belong to
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError>;
+}

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -45,6 +45,7 @@
 
 mod builders;
 pub mod error;
+pub mod yaml;
 
 use std::cmp::Ordering;
 use std::fmt;

--- a/libsplinter/src/admin/store/yaml/error.rs
+++ b/libsplinter/src/admin/store/yaml/error.rs
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for errors that can be raised while using the YAML admin service store
+
+use std::error::Error;
+use std::fmt;
+
+/// Represents YamlAdminStoreError errors
+#[derive(Debug)]
+pub enum YamlAdminStoreError {
+    /// A general error occurred in the node registry
+    GeneralError {
+        context: String,
+        source: Option<Box<dyn Error + Send>>,
+    },
+}
+
+impl YamlAdminStoreError {
+    /// Create a new general error with just a context string (no source error).
+    pub fn general_error(context: &str) -> Self {
+        YamlAdminStoreError::GeneralError {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    /// Create a new general error with a context string and a source error.
+    pub fn general_error_with_source(context: &str, err: Box<dyn Error + Send>) -> Self {
+        YamlAdminStoreError::GeneralError {
+            context: context.into(),
+            source: Some(err),
+        }
+    }
+}
+
+impl Error for YamlAdminStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            YamlAdminStoreError::GeneralError { source, .. } => {
+                if let Some(ref err) = source {
+                    Some(&**err)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for YamlAdminStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            YamlAdminStoreError::GeneralError { context, source } => {
+                if let Some(ref err) = source {
+                    write!(f, "{}: {}", context, err)
+                } else {
+                    f.write_str(&context)
+                }
+            }
+        }
+    }
+}

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1,0 +1,1832 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines a YAML backed implementation of the `AdminServiceStore`. The goal of this
+//! implementation is to support Splinter v0.4 YAML state files.
+//!
+//! The public interface includes the struct [`YamlAdminServiceStore`].
+//!
+//! [`YamlAdminServiceStore`]: struct.YamlAdminServiceStore.html
+
+pub mod error;
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use self::error::YamlAdminStoreError;
+
+use super::{
+    AdminServiceStore, AdminServiceStoreError, AuthorizationType, Circuit, CircuitNode,
+    CircuitPredicate, CircuitProposal, DurabilityType, PersistenceType, RouteType, Service,
+    ServiceId,
+};
+
+/// A YAML backed implementation of the `AdminServiceStore`
+pub struct YamlAdminServiceStore {
+    circuit_file_path: String,
+    proposal_file_path: String,
+    state: Arc<Mutex<YamlState>>,
+}
+
+impl YamlAdminServiceStore {
+    /// Creates a new `YamlAdminServiceStore`. If the file paths provided exist, the existing state
+    /// will be cached in the store. If the files do not exist, they will be created with empty
+    /// state.
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_file_path` - The path to file that contains circuit state
+    ///  * `proposal_file_path` - The path to file that contains circuit proposal state
+    ///
+    /// Returns an error if the file paths cannot be read from or written to
+    pub fn new(
+        circuit_file_path: String,
+        proposal_file_path: String,
+    ) -> Result<Self, YamlAdminStoreError> {
+        let mut store = YamlAdminServiceStore {
+            circuit_file_path: circuit_file_path.to_string(),
+            proposal_file_path: proposal_file_path.to_string(),
+            state: Arc::new(Mutex::new(YamlState::default())),
+        };
+
+        let circuit_file_path_buf = PathBuf::from(circuit_file_path);
+        let proposal_file_path_buf = PathBuf::from(proposal_file_path);
+
+        // If file already exists, read it; otherwise initialize it.
+        if circuit_file_path_buf.is_file() && proposal_file_path_buf.is_file() {
+            store.read_state()?;
+        } else if circuit_file_path_buf.is_file() {
+            // read circuit
+            store.read_circuit_state()?;
+            // write proposals
+            store.write_proposal_state()?;
+        } else if proposal_file_path_buf.is_file() {
+            // write circuit
+            store.write_circuit_state()?;
+            // read proposals
+            store.read_proposal_state()?;
+        } else {
+            // write all empty state
+            store.write_state()?;
+        }
+
+        Ok(store)
+    }
+
+    /// Read circuit state from the circuit file path and cache the contents in the store
+    fn read_circuit_state(&mut self) -> Result<(), YamlAdminStoreError> {
+        let circuit_file = File::open(&self.circuit_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to open YAML circuit state file",
+                Box::new(err),
+            )
+        })?;
+
+        let yaml_state_circuits: YamlCircuitState = serde_yaml::from_reader(&circuit_file)
+            .map_err(|err| {
+                YamlAdminStoreError::general_error_with_source(
+                    "Failed to read YAML circuit state file",
+                    Box::new(err),
+                )
+            })?;
+
+        let yaml_state = CircuitState::from(yaml_state_circuits);
+
+        let mut state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        for (circuit_id, circuit) in yaml_state.circuits.iter() {
+            for service in circuit.roster.iter() {
+                let service_id =
+                    ServiceId::new(service.service_id.to_string(), circuit_id.to_string());
+
+                state.service_directory.insert(service_id, service.clone());
+            }
+        }
+
+        state.circuit_state = yaml_state;
+        Ok(())
+    }
+
+    /// Read circuit proposal state from the proposal file path and cache the contents in the
+    /// store
+    fn read_proposal_state(&mut self) -> Result<(), YamlAdminStoreError> {
+        let proposal_file = File::open(&self.proposal_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to open YAML proposal state file",
+                Box::new(err),
+            )
+        })?;
+
+        let proposals_state: ProposalState =
+            serde_yaml::from_reader(&proposal_file).map_err(|err| {
+                YamlAdminStoreError::general_error_with_source(
+                    "Failed to read YAML proposal state file",
+                    Box::new(err),
+                )
+            })?;
+
+        let mut state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        state.proposal_state = proposals_state;
+        Ok(())
+    }
+
+    /// Read circuit state from the circuit file path and cache the contents in the store and then
+    /// read circuit proposal state from the proposal file path and cache the contents in the
+    /// store
+    fn read_state(&mut self) -> Result<(), YamlAdminStoreError> {
+        let circuit_file = File::open(&self.circuit_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to open YAML circuit state file",
+                Box::new(err),
+            )
+        })?;
+
+        let yaml_state_circuits: YamlCircuitState = serde_yaml::from_reader(&circuit_file)
+            .map_err(|err| {
+                YamlAdminStoreError::general_error_with_source(
+                    "Failed to read YAML circuit state file",
+                    Box::new(err),
+                )
+            })?;
+
+        let yaml_state = CircuitState::from(yaml_state_circuits);
+
+        let proposal_file = File::open(&self.proposal_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to open YAML proposal state file",
+                Box::new(err),
+            )
+        })?;
+
+        let proposals_state: ProposalState =
+            serde_yaml::from_reader(&proposal_file).map_err(|err| {
+                YamlAdminStoreError::general_error_with_source(
+                    "Failed to read YAML proposal state file",
+                    Box::new(err),
+                )
+            })?;
+
+        let mut state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        for (circuit_id, circuit) in yaml_state.circuits.iter() {
+            for service in circuit.roster.iter() {
+                let service_id =
+                    ServiceId::new(service.service_id.to_string(), circuit_id.to_string());
+
+                state.service_directory.insert(service_id, service.clone());
+            }
+        }
+
+        state.circuit_state = yaml_state;
+        state.proposal_state = proposals_state;
+
+        Ok(())
+    }
+
+    /// Write the current circuit state to file at the circuit file path
+    fn write_circuit_state(&self) -> Result<(), YamlAdminStoreError> {
+        let state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        let circuit_output = serde_yaml::to_vec(&YamlCircuitState::from(
+            state.circuit_state.clone(),
+        ))
+        .map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to write circuit state to YAML",
+                Box::new(err),
+            )
+        })?;
+
+        let mut circuit_file = File::create(&self.circuit_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to open YAML circuit state file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        circuit_file.write_all(&circuit_output).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML circuit state file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        // Append newline to file
+        writeln!(circuit_file).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML circuit file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Write the current circuit proposal state to file at the proposal file path
+    fn write_proposal_state(&self) -> Result<(), YamlAdminStoreError> {
+        let state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        let proposal_output = serde_yaml::to_vec(&state.proposal_state).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to write proposal state to YAML",
+                Box::new(err),
+            )
+        })?;
+
+        let mut proposal_file = File::create(&self.proposal_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to open YAML proposal state file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        proposal_file.write_all(&proposal_output).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML proposal state file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        // Append newline to file
+        writeln!(proposal_file).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML proposal file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Write the current circuit state to file at the circuit file path and then write the current
+    /// proposal state to the file at the proposal file path
+    fn write_state(&self) -> Result<(), YamlAdminStoreError> {
+        let state = self.state.lock().map_err(|_| {
+            YamlAdminStoreError::general_error("YAML admin service store's internal lock poisoned")
+        })?;
+
+        let circuit_output = serde_yaml::to_vec(&YamlCircuitState::from(
+            state.circuit_state.clone(),
+        ))
+        .map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to write circuit state to YAML",
+                Box::new(err),
+            )
+        })?;
+
+        let mut circuit_file = File::create(&self.circuit_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to open YAML circuit state file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        circuit_file.write_all(&circuit_output).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML circuit state file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        // Append newline to file
+        writeln!(circuit_file).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML circuit file '{}'",
+                    self.circuit_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        let proposal_output = serde_yaml::to_vec(&state.proposal_state).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                "Failed to write proposal state to YAML",
+                Box::new(err),
+            )
+        })?;
+
+        let mut proposal_file = File::create(&self.proposal_file_path).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to open YAML proposal state file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        proposal_file.write_all(&proposal_output).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML proposal state file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        // Append newline to file
+        writeln!(proposal_file).map_err(|err| {
+            YamlAdminStoreError::general_error_with_source(
+                &format!(
+                    "Failed to write to YAML proposal file '{}'",
+                    self.proposal_file_path
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        Ok(())
+    }
+}
+
+/// Defines methods for CRUD operations and fetching and listing circuits, proposals, nodes and
+/// services from a YAML file backend
+impl AdminServiceStore for YamlAdminServiceStore {
+    /// Adds a circuit proposal to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal` - The proposal to be added
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID already exists
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if state
+                .proposal_state
+                .proposals
+                .contains_key(&proposal.circuit_id)
+            {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A proposal with ID {} already exists", proposal.circuit_id),
+                    source: None,
+                });
+            } else {
+                state
+                    .proposal_state
+                    .proposals
+                    .insert(proposal.circuit_id.to_string(), proposal);
+            }
+        }
+
+        self.write_proposal_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write proposal state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Updates a circuit proposal in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal` - The proposal with the updated information
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID does not exist
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if state
+                .proposal_state
+                .proposals
+                .contains_key(&proposal.circuit_id)
+            {
+                state
+                    .proposal_state
+                    .proposals
+                    .insert(proposal.circuit_id.to_string(), proposal);
+            } else {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A proposal with ID {} does not exist", proposal.circuit_id),
+                    source: None,
+                });
+            }
+        }
+
+        self.write_proposal_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write proposal state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Removes a circuit proposal from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal_id` - The unique ID of the circuit proposal to be removed
+    ///
+    ///  Returns an error if a `CircuitProposal` with specified ID does not exist
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if state.proposal_state.proposals.contains_key(proposal_id) {
+                state.proposal_state.proposals.remove(proposal_id);
+            } else {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A proposal with ID {} does not exist", proposal_id),
+                    source: None,
+                });
+            }
+        }
+
+        self.write_proposal_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write proposal state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Fetches a circuit proposal from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `proposal_id` - The unique ID of the circuit proposal to be returned
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .proposal_state
+            .proposals
+            .get(proposal_id)
+            .cloned())
+    }
+
+    /// List circuit proposals from the underlying storage
+    ///
+    /// The proposals returned can be filtered by provided CircuitPredicate. This enables
+    /// filtering by management type and members.
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError> {
+        let mut proposals: Vec<CircuitProposal> = self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .proposal_state
+            .proposals
+            .iter()
+            .map(|(_, proposal)| proposal.clone())
+            .collect::<Vec<CircuitProposal>>();
+
+        proposals.retain(|proposal| {
+            predicates
+                .iter()
+                .all(|predicate| predicate.apply_to_proposals(proposal))
+        });
+
+        Ok(Box::new(proposals.into_iter()))
+    }
+
+    /// Adds a circuit to the underlying storage. Also includes the associated Services and
+    /// Nodes
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit` - The circuit to be added to state
+    ///  * `nodes` - A list of nodes that represent the circuit's members
+    ///
+    ///  Returns an error if a `Circuit` with the same ID already exists
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if state.circuit_state.circuits.contains_key(&circuit.id) {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A circuit with ID {} already exists", circuit.id),
+                    source: None,
+                });
+            } else {
+                for service in circuit.roster.iter() {
+                    let service_id =
+                        ServiceId::new(service.service_id.to_string(), circuit.id.to_string());
+
+                    state.service_directory.insert(service_id, service.clone());
+                }
+
+                for node in nodes.into_iter() {
+                    if !state.circuit_state.nodes.contains_key(&node.id) {
+                        state.circuit_state.nodes.insert(node.id.to_string(), node);
+                    }
+                }
+
+                state
+                    .circuit_state
+                    .circuits
+                    .insert(circuit.id.to_string(), circuit);
+            }
+        }
+
+        self.write_circuit_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write circuit state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Updates a circuit in the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit` - The circuit with the updated information
+    ///
+    ///  Returns an error if a `CircuitProposal` with the same ID does not exist
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if state.circuit_state.circuits.contains_key(&circuit.id) {
+                state
+                    .circuit_state
+                    .circuits
+                    .insert(circuit.id.to_string(), circuit);
+            } else {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A circuit with ID {} does not exist", circuit.id),
+                    source: None,
+                });
+            }
+        }
+
+        self.write_circuit_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write circuit state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Removes a circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit to be removed
+    ///
+    ///  Returns an error if a `Circuit` with the specified ID does not exist
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+            if state.circuit_state.circuits.contains_key(circuit_id) {
+                let circuit = state.circuit_state.circuits.remove(circuit_id);
+                if let Some(circuit) = circuit {
+                    for service in circuit.roster.iter() {
+                        let service_id =
+                            ServiceId::new(service.service_id.to_string(), circuit_id.to_string());
+                        state.service_directory.remove(&service_id);
+                    }
+                }
+            } else {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A circuit with ID {} does not exist", circuit_id),
+                    source: None,
+                });
+            }
+        }
+
+        self.write_circuit_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write circuit state yaml file".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Fetches a circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit to be returned
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .circuit_state
+            .circuits
+            .get(circuit_id)
+            .cloned())
+    }
+
+    /// List all circuits from the underlying storage
+    ///
+    /// The proposals returned can be filtered by provided CircuitPredicate. This enables
+    /// filtering by management type and members.
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError> {
+        let mut circuits: Vec<Circuit> = self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .circuit_state
+            .circuits
+            .iter()
+            .map(|(_, circuit)| circuit.clone())
+            .collect();
+
+        circuits.retain(|circuit| {
+            predicates
+                .iter()
+                .all(|predicate| predicate.apply_to_circuit(circuit))
+        });
+
+        Ok(Box::new(circuits.into_iter()))
+    }
+
+    /// Adds a circuit to the underlying storage based on the proposal that is already in state..
+    /// Also includes the associated Services and Nodes. The associated circuit proposal for
+    /// the circuit ID is also removed
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The ID of the circuit proposal that should be converted to a circuit
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        {
+            let mut state =
+                self.state
+                    .lock()
+                    .map_err(|_| AdminServiceStoreError::StorageError {
+                        context: "YAML admin service store's internal lock was poisoned"
+                            .to_string(),
+                        source: None,
+                    })?;
+
+            if let Some(proposal) = state.proposal_state.proposals.remove(circuit_id) {
+                let nodes = proposal.circuit.members.to_vec();
+                let services = proposal.circuit.roster.to_vec();
+
+                let circuit = Circuit::from(proposal.circuit);
+                state
+                    .circuit_state
+                    .circuits
+                    .insert(circuit.id.to_string(), circuit);
+
+                for service in services.into_iter() {
+                    let service_id =
+                        ServiceId::new(service.service_id.to_string(), circuit_id.to_string());
+
+                    state
+                        .service_directory
+                        .insert(service_id, Service::from(service));
+                }
+
+                for node in nodes.into_iter() {
+                    if !state.circuit_state.nodes.contains_key(&node.node_id) {
+                        state
+                            .circuit_state
+                            .nodes
+                            .insert(node.node_id.to_string(), CircuitNode::from(node));
+                    }
+                }
+            } else {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: format!("A circuit with ID {} does not exist", circuit_id),
+                    source: None,
+                });
+            }
+        }
+
+        self.write_state()
+            .map_err(|err| AdminServiceStoreError::StorageError {
+                context: "Unable to write circiut state yaml files".to_string(),
+                source: Some(Box::new(err)),
+            })
+    }
+
+    /// Fetches a node from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `node_id` - The unique ID of the node to be returned
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .circuit_state
+            .nodes
+            .get(node_id)
+            .cloned())
+    }
+
+    /// List all nodes from the underlying storage
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError> {
+        let nodes: Vec<CircuitNode> = self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .circuit_state
+            .nodes
+            .iter()
+            .map(|(_, node)| node.clone())
+            .collect();
+
+        Ok(Box::new(nodes.into_iter()))
+    }
+
+    /// Fetches a service from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The `ServiceId` of a service made up of the circuit ID and service ID
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .service_directory
+            .get(service_id)
+            .cloned())
+    }
+
+    /// List all services in a specific circuit from the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_id` - The unique ID of the circuit the services belong to
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError> {
+        let services: Vec<Service> = self
+            .state
+            .lock()
+            .map_err(|_| AdminServiceStoreError::StorageError {
+                context: "YAML admin service store's internal lock was poisoned".to_string(),
+                source: None,
+            })?
+            .circuit_state
+            .circuits
+            .get(circuit_id)
+            .ok_or(AdminServiceStoreError::OperationError {
+                context: format!("Circuit {} does not exist", circuit_id),
+                source: None,
+            })?
+            .roster
+            .clone();
+
+        Ok(Box::new(services.into_iter()))
+    }
+}
+
+/// YAML file specific circuit definition. This circuit definition in the 0.4v YAML stores service
+/// arguments in a map format, which differs from the definition defined in the AdminServiceStore.
+/// To handle this, circuit needs to be converted to the correct format during read/write
+/// operations.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct YamlCircuit {
+    id: String,
+    roster: Vec<YamlService>,
+    members: Vec<String>,
+    auth: AuthorizationType,
+    persistence: PersistenceType,
+    durability: DurabilityType,
+    routes: RouteType,
+    circuit_management_type: String,
+}
+
+impl From<YamlCircuit> for Circuit {
+    fn from(circuit: YamlCircuit) -> Self {
+        Circuit {
+            id: circuit.id,
+            roster: circuit.roster.into_iter().map(Service::from).collect(),
+            members: circuit.members,
+            auth: circuit.auth,
+            persistence: circuit.persistence,
+            durability: circuit.durability,
+            routes: circuit.routes,
+            circuit_management_type: circuit.circuit_management_type,
+        }
+    }
+}
+
+impl From<Circuit> for YamlCircuit {
+    fn from(circuit: Circuit) -> Self {
+        YamlCircuit {
+            id: circuit.id,
+            roster: circuit.roster.into_iter().map(YamlService::from).collect(),
+            members: circuit.members,
+            auth: circuit.auth,
+            persistence: circuit.persistence,
+            durability: circuit.durability,
+            routes: circuit.routes,
+            circuit_management_type: circuit.circuit_management_type,
+        }
+    }
+}
+
+/// YAML file specific service definition. This service definition in the 0.4v YAML stores
+/// arguments in a map format, which differs from the definition defined in the AdminServiceStore.
+/// To handle this, service needs to be converted to the correct format during read/write
+/// operations.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct YamlService {
+    service_id: String,
+    service_type: String,
+    allowed_nodes: Vec<String>,
+    arguments: BTreeMap<String, String>,
+}
+
+impl From<YamlService> for Service {
+    fn from(service: YamlService) -> Self {
+        Service {
+            service_id: service.service_id,
+            service_type: service.service_type,
+            allowed_nodes: service.allowed_nodes,
+            arguments: service
+                .arguments
+                .into_iter()
+                .map(|(key, value)| (key, value))
+                .collect(),
+        }
+    }
+}
+
+impl From<Service> for YamlService {
+    fn from(service: Service) -> Self {
+        YamlService {
+            service_id: service.service_id,
+            service_type: service.service_type,
+            allowed_nodes: service.allowed_nodes,
+            arguments: service
+                .arguments
+                .into_iter()
+                .map(|(key, value)| (key, value))
+                .collect(),
+        }
+    }
+}
+
+/// YAML file specific state definition that can be read and written to the circuit YAML state file
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+struct YamlCircuitState {
+    nodes: BTreeMap<String, CircuitNode>,
+    circuits: BTreeMap<String, YamlCircuit>,
+}
+
+impl From<YamlCircuitState> for CircuitState {
+    fn from(state: YamlCircuitState) -> Self {
+        CircuitState {
+            nodes: state.nodes,
+            circuits: state
+                .circuits
+                .into_iter()
+                .map(|(id, circuit)| (id, Circuit::from(circuit)))
+                .collect(),
+        }
+    }
+}
+
+impl From<CircuitState> for YamlCircuitState {
+    fn from(state: CircuitState) -> Self {
+        YamlCircuitState {
+            nodes: state.nodes,
+            circuits: state
+                .circuits
+                .into_iter()
+                .map(|(id, circuit)| (id, YamlCircuit::from(circuit)))
+                .collect(),
+        }
+    }
+}
+
+/// The circuit state that is cached by the YAML admin service store and used to respond to fetch
+/// requests
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+struct CircuitState {
+    nodes: BTreeMap<String, CircuitNode>,
+    circuits: BTreeMap<String, Circuit>,
+}
+
+/// The proposal state that is cached by the YAML admin service store and used to respond to fetch
+/// requests
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+struct ProposalState {
+    proposals: BTreeMap<String, CircuitProposal>,
+}
+
+/// The combination of circuit and circuit proposal state
+#[derive(Debug, Clone, Default)]
+struct YamlState {
+    circuit_state: CircuitState,
+    proposal_state: ProposalState,
+    service_directory: BTreeMap<ServiceId, Service>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use tempdir::TempDir;
+
+    use super::*;
+
+    use crate::admin::store::builders::{
+        CircuitBuilder, CircuitNodeBuilder, CircuitProposalBuilder, ProposedCircuitBuilder,
+        ProposedNodeBuilder, ProposedServiceBuilder, ServiceBuilder,
+    };
+    use crate::admin::store::{ProposalType, Vote, VoteRecord};
+    use crate::hex::parse_hex;
+
+    const CIRCUIT_STATE: &[u8] = b"---
+nodes:
+    acme-node-000:
+        id: acme-node-000
+        endpoints:
+          - \"tcps://splinterd-node-acme:8044\"
+    bubba-node-000:
+        id: bubba-node-000
+        endpoints:
+          - \"tcps://splinterd-node-bubba:8044\"
+circuits:
+    WBKLF-AAAAA:
+        id: WBKLF-AAAAA
+        auth: Trust
+        members:
+          - bubba-node-000
+          - acme-node-000
+        roster:
+          - service_id: a000
+            service_type: scabbard
+            allowed_nodes:
+              - acme-node-000
+            arguments:
+              admin_keys: '[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]'
+              peer_services: '[\"a001\"]'
+          - service_id: a001
+            service_type: scabbard
+            allowed_nodes:
+              - bubba-node-000
+            arguments:
+              admin_keys: '[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]'
+              peer_services: '[\"a000\"]'
+        persistence: Any
+        durability: NoDurability
+        routes: Any
+        circuit_management_type: gameroom";
+
+    const PROPOSAL_STATE: &[u8] = b"---
+proposals:
+    WBKLF-BBBBB:
+        proposal_type: Create
+        circuit_id: WBKLF-BBBBB
+        circuit_hash: 7ddc426972710adc0b2ecd49e89a9dd805fb9206bf516079724c887bedbcdf1d
+        circuit:
+            circuit_id: WBKLF-BBBBB
+            roster:
+            - service_id: a000
+              service_type: scabbard
+              allowed_nodes:
+                - acme-node-000
+              arguments:
+                - - peer_services
+                  - '[\"a001\"]'
+                - - admin_keys
+                  - '[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]'
+            - service_id: a001
+              service_type: scabbard
+              allowed_nodes:
+                - bubba-node-000
+              arguments:
+                - - peer_services
+                  - '[\"a000\"]'
+                - - admin_keys
+                  - '[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]'
+            members:
+            - node_id: bubba-node-000
+              endpoints:
+                - \"tcps://splinterd-node-bubba:8044\"
+            - node_id: acme-node-000
+              endpoints:
+                - \"tcps://splinterd-node-acme:8044\"
+            authorization_type: Trust
+            persistence: Any
+            durability: NoDurability
+            routes: Any
+            circuit_management_type: gameroom
+            application_metadata: ''
+            comments: \"\"
+        votes: []
+        requester: 0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482
+        requester_node_id: acme-node-000";
+
+    // Validate that if the YAML state files do not exist, the YamlAdminServiceStore will create
+    // the files with empty states.
+    //
+    // 1. Creates a empty temp directory
+    // 2. Create a YAML admin service directory
+    // 3. Validate that the circuit and proposals YAMLfiles were created in the temp dir.
+    #[test]
+    fn test_write_new_files() {
+        let temp_dir = TempDir::new("test_write_new_files").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // validate the files do not exist
+        assert!(!PathBuf::from(circuit_path.clone()).is_file());
+        assert!(!PathBuf::from(proposals_path.clone()).is_file());
+
+        // create YamlAdminServiceStore
+        let _store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        // validate the files exist now
+        assert!(PathBuf::from(circuit_path.clone()).is_file());
+        assert!(PathBuf::from(proposals_path.clone()).is_file());
+    }
+
+    // Validate that the YAML admin service store can properly load circuit and proposals state
+    // from existing YAML files
+    //
+    // 1. Creates a temp directory with existing circuit and proposals yaml files
+    // 2. Create a YAML admin service directory
+    // 3. Validate that the circuit and proposals can be fetched from state
+    #[test]
+    fn test_read_existing_files() {
+        // create temp dir
+        let temp_dir = TempDir::new("test_read_existing_files").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write yaml files to temp_dir
+        write_file(CIRCUIT_STATE, &circuit_path);
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        assert!(store
+            .fetch_proposal("WBKLF-BBBBB")
+            .expect("unable to fetch proposals")
+            .is_some());
+        assert!(store
+            .fetch_circuit("WBKLF-AAAAA")
+            .expect("unable to fetch circuits")
+            .is_some());
+    }
+
+    // Test the proposal CRUD operations
+    //
+    // 1. Setup the temp directory with existing state
+    // 2. Fetch an existing proposal from state, validate proposal is returned
+    // 3. Fetch an non exisitng proposal from state, validate None
+    // 4. Update fetched proposal with a vote record and update, validate ok
+    // 5. Call update with new proposal, validate error is returned
+    // 6. Add new proposal, validate ok
+    // 7. List proposal, validate both the updated original proposal and new proposal is returned
+    // 8. Remove original proposal, validate okay
+    // 9. Validate the proposal state YAML in the temp dir matches the expected bytes and only
+    //    the new proposals
+    #[test]
+    fn test_proposals() {
+        // create temp dir
+        let temp_dir = TempDir::new("test_proposals").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write yaml files to temp_dir
+        write_file(CIRCUIT_STATE, &circuit_path);
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        // fetch existing proposal from state
+        let mut proposal = store
+            .fetch_proposal("WBKLF-BBBBB")
+            .expect("unable to fetch proposals")
+            .expect("Expected proposal, got none");
+
+        assert_eq!(proposal, create_expected_proposal());
+
+        // fetch nonexisting proposal from state
+        assert!(store
+            .fetch_proposal("WBKLF-BADD")
+            .expect("unable to fetch proposals")
+            .is_none());
+
+        proposal.add_vote(VoteRecord {
+            public_key: parse_hex(
+                "035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550",
+            )
+            .unwrap(),
+            vote: Vote::Accept,
+            voter_node_id: "bubba-node-000".into(),
+        });
+
+        store
+            .update_proposal(proposal.clone())
+            .expect("Unable to update proposal");
+
+        let new_proposal = new_proposal();
+
+        assert!(
+            store.update_proposal(new_proposal.clone()).is_err(),
+            "Updating new proposal should fail"
+        );
+
+        store
+            .add_proposal(new_proposal.clone())
+            .expect("Unable to add proposal");
+
+        assert_eq!(
+            store
+                .list_proposals(&vec![])
+                .expect("Unable to get list of proposals")
+                .collect::<Vec<CircuitProposal>>(),
+            vec![proposal, new_proposal.clone()]
+        );
+
+        store
+            .remove_proposal("WBKLF-BBBBB")
+            .expect("Unable to remove proposals");
+
+        let mut yaml_state = BTreeMap::new();
+        yaml_state.insert(new_proposal.circuit_id.to_string(), new_proposal);
+        let mut yaml_state_vec = serde_yaml::to_vec(&ProposalState {
+            proposals: yaml_state,
+        })
+        .unwrap();
+
+        // Add new line because the file has a new added to it
+        yaml_state_vec.append(&mut "\n".as_bytes().to_vec());
+
+        let mut contents = vec![];
+        File::open(proposals_path.clone())
+            .unwrap()
+            .read_to_end(&mut contents)
+            .expect("Unable to read proposals");
+
+        assert_eq!(yaml_state_vec, contents)
+    }
+
+    // Test the circuit CRUD operations
+    //
+    // 1. Setup the temp directory with existing state
+    // 2. Fetch an existing circuit from state, validate circuit is returned
+    // 3. Fetch an non exisitng circuit from state, validate None
+    // 4. Update fetched proposa with a vote record and update, validate ok
+    // 5. Call update with new circuit, validate error is returned
+    // 6. Add new circuit, validate ok
+    // 7. List circuit, validate both the updated original circuit and new circuit is returned
+    // 8. Remove original circuit, validate okay
+    // 9. Validate the circuit state YAML in the temp dir matches the expected bytes and contains
+    //    only the new circuit
+    #[test]
+    fn test_circuit() {
+        // create temp dir
+        let temp_dir = TempDir::new("test_circuit").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write yaml files to temp_dir
+        write_file(CIRCUIT_STATE, &circuit_path);
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        // fetch existing circuit from state
+        let mut circuit = store
+            .fetch_circuit("WBKLF-AAAAA")
+            .expect("unable to fetch circuit")
+            .expect("Expected circuit, got none");
+
+        assert_eq!(circuit, create_expected_circuit());
+
+        // fetch nonexisting circuitfrom state
+        assert!(store
+            .fetch_circuit("WBKLF-BADD")
+            .expect("unable to fetch circuit")
+            .is_none());
+
+        circuit.circuit_management_type = "test".to_string();
+
+        store
+            .update_circuit(circuit.clone())
+            .expect("Unable to update circuit");
+
+        let (new_circuit, new_node) = new_circuit();
+
+        assert!(
+            store.update_circuit(new_circuit.clone()).is_err(),
+            "Updating new cirucit should fail"
+        );
+
+        store
+            .add_circuit(new_circuit.clone(), vec![new_node.clone()])
+            .expect("Unable to add cirucit");
+
+        assert_eq!(
+            store
+                .list_circuits(&vec![])
+                .expect("Unable to get list of circuits")
+                .collect::<Vec<Circuit>>(),
+            vec![circuit, new_circuit.clone()]
+        );
+
+        store
+            .remove_circuit("WBKLF-AAAAA")
+            .expect("Unable to remove circuit");
+
+        let mut yaml_circuits = BTreeMap::new();
+        let mut yaml_nodes = BTreeMap::new();
+        yaml_circuits.insert(new_circuit.id.to_string(), YamlCircuit::from(new_circuit));
+        yaml_nodes.insert(
+            "acme-node-000".to_string(),
+            CircuitNode {
+                id: "acme-node-000".to_string(),
+                endpoints: vec!["tcps://splinterd-node-acme:8044".into()],
+            },
+        );
+        yaml_nodes.insert(
+            "bubba-node-000".to_string(),
+            CircuitNode {
+                id: "bubba-node-000".to_string(),
+                endpoints: vec!["tcps://splinterd-node-bubba:8044".into()],
+            },
+        );
+        yaml_nodes.insert(new_node.id.to_string(), new_node);
+        let mut yaml_state_vec = serde_yaml::to_vec(&YamlCircuitState {
+            circuits: yaml_circuits,
+            nodes: yaml_nodes,
+        })
+        .unwrap();
+
+        // Add new line because the file has a new added to it
+        yaml_state_vec.append(&mut "\n".as_bytes().to_vec());
+
+        let mut contents = vec![];
+        File::open(circuit_path.clone())
+            .unwrap()
+            .read_to_end(&mut contents)
+            .expect("Unable to read proposals");
+
+        assert_eq!(yaml_state_vec, contents)
+    }
+
+    // Test the node CRUD operations
+    //
+    // 1. Setup the temp directory with existing state
+    // 2. Check that the expected node is returned when fetched
+    // 3. Check that the expected nodes are returned when list_nodes is called
+    #[test]
+    fn test_node() {
+        // create temp dir
+        let temp_dir = TempDir::new("test_node").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write yaml files to temp_dir
+        write_file(CIRCUIT_STATE, &circuit_path);
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        let node = store
+            .fetch_node("acme-node-000")
+            .expect("Unable to fetch node")
+            .expect("expected node, got none");
+
+        assert_eq!(
+            node,
+            CircuitNode {
+                id: "acme-node-000".to_string(),
+                endpoints: vec!["tcps://splinterd-node-acme:8044".into()],
+            }
+        );
+
+        assert_eq!(
+            store.list_nodes().unwrap().collect::<Vec<CircuitNode>>(),
+            vec![
+                CircuitNode {
+                    id: "acme-node-000".to_string(),
+                    endpoints: vec!["tcps://splinterd-node-acme:8044".into()],
+                },
+                CircuitNode {
+                    id: "bubba-node-000".to_string(),
+                    endpoints: vec!["tcps://splinterd-node-bubba:8044".into()],
+                }
+            ]
+        );
+    }
+
+    // Test the service CRUD operations
+    //
+    // 1. Setup the temp directory with existing state
+    // 2. Check that the expected service is returned when fetched
+    // 3. Check that the expected services are returned when list_services is called
+    #[test]
+    fn test_service() {
+        // create temp dir
+        let temp_dir = TempDir::new("test_service").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write yaml files to temp_dir
+        write_file(CIRCUIT_STATE, &circuit_path);
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        let service_id = ServiceId::new("a000".to_string(), "WBKLF-AAAAA".to_string());
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        let service = store
+            .fetch_service(&service_id)
+            .expect("Unable to fetch service")
+            .expect("unable to get expected service, got none");
+
+        assert_eq!(
+            service,
+            ServiceBuilder::default()
+                .with_service_id("a000")
+                .with_service_type("scabbard")
+                .with_allowed_nodes(&vec!["acme-node-000".into()])
+                .with_arguments(&vec![
+                    (
+                        "admin_keys".into(),
+                        "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
+                            .into()
+                    ),
+                    ("peer_services".into(), "[\"a001\"]".into()),
+                ])
+                .build()
+                .expect("Unable to build service"),
+        );
+
+        assert_eq!(
+            store
+                .list_services("WBKLF-AAAAA")
+                .unwrap()
+                .collect::<Vec<Service>>(),
+            vec![
+                ServiceBuilder::default()
+                    .with_service_id("a000")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_arguments(&vec![
+                    ("admin_keys".into(),
+                   "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
+                   .into()),
+                   ("peer_services".into(), "[\"a001\"]".into()),
+                ])
+                    .build()
+                    .expect("Unable to build service"),
+                ServiceBuilder::default()
+                    .with_service_id("a001")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_arguments(&vec![
+                        ("admin_keys".into(),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
+                       .into()),
+                           ("peer_services".into(), "[\"a000\"]".into()),
+                    ])
+                    .build()
+                    .expect("Unable to build service")
+            ]
+        );
+    }
+
+    // Test that a proposals can be upgraded to a circuit and both yaml files are upgraded.
+    //
+    // 1. Setup the temp directory with existing proposal state
+    // 2. Upgrade proposal to circuit, validate ok
+    // 3. Check that proposals are now empty
+    // 4. Check that the circuit, nodes and services have been set
+    #[test]
+    fn test_upgrading_proposals_to_circuit() {
+        // create temp dir
+        let temp_dir =
+            TempDir::new("est_upgrading_proposals_to_circuit").expect("Failed to create temp dir");
+        let circuit_path = temp_dir
+            .path()
+            .join("circuits.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        let proposals_path = temp_dir
+            .path()
+            .join("circuit_proposals.yaml")
+            .to_str()
+            .expect("Failed to get path")
+            .to_string();
+
+        // write proposal to state
+        write_file(PROPOSAL_STATE, &proposals_path);
+
+        // create YamlAdminServiceStore
+        let store = YamlAdminServiceStore::new(circuit_path.clone(), proposals_path.clone())
+            .expect("Unable to create yaml admin store");
+
+        let service_id = ServiceId::new("a000".to_string(), "WBKLF-BBBBB".to_string());
+        assert_eq!(store.fetch_circuit("WBKLF-BBBBB").unwrap(), None);
+        assert_eq!(store.fetch_node("acme-node-000").unwrap(), None);
+        assert_eq!(store.fetch_service(&service_id).unwrap(), None);
+
+        store
+            .upgrade_proposal_to_circuit("WBKLF-BBBBB")
+            .expect("Unable to upgrade proposalto circuit");
+
+        assert_eq!(store.list_proposals(&vec![]).unwrap().next(), None);
+
+        assert!(store.fetch_circuit("WBKLF-BBBBB").unwrap().is_some());
+        assert!(store.fetch_node("acme-node-000").unwrap().is_some());
+        assert!(store.fetch_service(&service_id).unwrap().is_some());
+    }
+
+    fn write_file(data: &[u8], file_path: &str) {
+        let mut file = File::create(file_path).expect("Error creating test yaml file.");
+        file.write_all(data)
+            .expect("unable to write test file to temp dir")
+    }
+
+    fn create_expected_proposal() -> CircuitProposal {
+        CircuitProposalBuilder::default()
+            .with_proposal_type(&ProposalType::Create)
+            .with_circuit_id("WBKLF-BBBBB")
+            .with_circuit_hash(
+                "7ddc426972710adc0b2ecd49e89a9dd805fb9206bf516079724c887bedbcdf1d")
+            .with_circuit(
+                &ProposedCircuitBuilder::default()
+                    .with_circuit_id("WBKLF-BBBBB")
+                    .with_roster(&vec![
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a000")
+                            .with_service_type("scabbard")
+                            .with_allowed_nodes(&vec!["acme-node-000".into()])
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a001\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service"),
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a001")
+                            .with_service_type("scabbard")
+                            .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a000\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service")
+                        ])
+
+                    .with_members(
+                        &vec![
+                        ProposedNodeBuilder::default()
+                            .with_node_id("bubba-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-bubba:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ProposedNodeBuilder::default()
+                            .with_node_id("acme-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-acme:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ]
+                    )
+                    .with_circuit_management_type("gameroom")
+                    .build().expect("Unable to build circuit")
+            )
+            .with_requester(
+                &parse_hex(
+                    "0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482").unwrap())
+            .with_requester_node_id("acme-node-000")
+            .build().expect("Unable to build proposals")
+    }
+
+    fn create_expected_circuit() -> Circuit {
+        CircuitBuilder::default()
+            .with_circuit_id("WBKLF-AAAAA")
+            .with_roster(&vec![
+                ServiceBuilder::default()
+                    .with_service_id("a000")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_arguments(&vec![
+                        ("admin_keys".into(),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
+                            .into()),
+                       ("peer_services".into(), "[\"a001\"]".into()),
+                    ])
+                    .build()
+                    .expect("Unable to build service"),
+                ServiceBuilder::default()
+                    .with_service_id("a001")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_arguments(&vec![(
+                        "admin_keys".into(),
+                        "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
+                            .into()
+                    ),(
+                        "peer_services".into(), "[\"a000\"]".into()
+                    )])
+                    .build()
+                    .expect("Unable to build service"),
+            ])
+            .with_members(&vec!["bubba-node-000".into(), "acme-node-000".into()])
+            .with_circuit_management_type("gameroom")
+            .build()
+            .expect("Unable to build circuit")
+    }
+
+    fn new_proposal() -> CircuitProposal {
+        CircuitProposalBuilder::default()
+            .with_proposal_type(&ProposalType::Create)
+            .with_circuit_id("WBKLF-CCCCC")
+            .with_circuit_hash(
+                "7ddc426972710adc0b2ecd49e89a9dd805fb9206bf516079724c887bedbcdf1d")
+            .with_circuit(
+                &ProposedCircuitBuilder::default()
+                    .with_circuit_id("WBKLF-PqfoE")
+                    .with_roster(&vec![
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a000")
+                            .with_service_type("scabbard")
+                            .with_allowed_nodes(&vec!["acme-node-000".into()])
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a001\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service"),
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a001")
+                            .with_service_type("scabbard")
+                            .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a000\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service")
+                        ])
+
+                    .with_members(
+                        &vec![
+                        ProposedNodeBuilder::default()
+                            .with_node_id("bubba-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-bubba:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ProposedNodeBuilder::default()
+                            .with_node_id("acme-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-acme:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ]
+                    )
+                    .with_circuit_management_type("test")
+                    .build().expect("Unable to build circuit")
+            )
+            .with_requester(
+                &parse_hex(
+                    "0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482").unwrap())
+            .with_requester_node_id("acme-node-000")
+            .build().expect("Unable to build proposals")
+    }
+
+    fn new_circuit() -> (Circuit, CircuitNode) {
+        (CircuitBuilder::default()
+            .with_circuit_id("WBKLF-DDDDD")
+            .with_roster(&vec![
+                ServiceBuilder::default()
+                    .with_service_id("a000")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_arguments(&vec![
+                        ("peer_services".into(), "[\"a001\"]".into()),
+                        ("admin_keys".into(),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                    ])
+                    .build().expect("Unable to build service"),
+                ServiceBuilder::default()
+                    .with_service_id("a001")
+                    .with_service_type("scabbard")
+                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_arguments(&vec![
+                        ("peer_services".into(), "[\"a000\"]".into()),
+                        ("admin_keys".into(),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                    ])
+                    .build().expect("Unable to build service")
+                ])
+            .with_members(
+                &vec![
+                    "bubba-node-000".into(),
+                    "acme-node-000".into(),
+                    "new-node-000".into()
+                ]
+            )
+            .with_circuit_management_type("test")
+            .build().expect("Unable to build circuit"),
+        CircuitNodeBuilder::default()
+            .with_node_id("new-node-000".into())
+            .with_endpoints(&vec!["tcps://splinterd-node-new:8044".into()])
+            .build().expect("Unable to build node"))
+    }
+}


### PR DESCRIPTION
This PR defines an API for managing the API for writing and
reading circuit state and pending circuit proposals. The
provided `AdminServiceStore` trait makes no assumptions about
the storage backend.

This module also include the structs that will be stored/returned by
the service store.

This is added behind an experimental feature at is not currently used.

The YAML backend is compatible with the current circuit/proposals state files.