### PR TITLE
Remove deprecation warnings from stable API

### DIFF
--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -200,7 +200,6 @@ impl PeerManagerConnector {
     ///
     /// Returns a `PeerNotificationIter` that can be used to receive notifications about connected
     /// and disconnected peers
-    #[deprecated(since = "0.4.1", note = "please use `subscribe_sender` instead")]
     pub fn subscribe(&self) -> Result<PeerNotificationIter, PeerManagerError> {
         let (send, recv) = channel();
         match self.sender.send(PeerManagerMessage::Subscribe(send)) {

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -98,7 +98,6 @@ impl PeerInterconnect {
     }
 
     /// Returns a `ShutdownHandle` that can be used to shutdown `PeerInterconnect`
-    #[deprecated(since = "0.4.1", note = "Please use shutdown_signaler() instead.")]
     pub fn shutdown_handle(&self) -> ShutdownHandle {
         ShutdownHandle::from(self.shutdown_signaler.clone())
     }
@@ -129,10 +128,6 @@ impl PeerInterconnect {
         debug!("Shutting down peer interconnect sender (complete)");
     }
 
-    #[deprecated(
-        since = "0.4.1",
-        note = "Please use shutdown_signaler().shutdown() and await_shutdown() instead."
-    )]
     /// Calls shutdown on the shutdown handle and then waits for the `PeerInterconnect` threads to
     /// finish
     pub fn shutdown_and_wait(self) {

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -146,7 +146,6 @@ impl PeerManager {
     /// * `identity` - The unique ID of the node this `PeerManager` belongs to
     /// * `strict_ref_counts` - Determines whether or not to panic when attempting to remove a
     ///   reference to peer that is not referenced.
-    #[deprecated(since = "0.4.1", note = "Please use PeerManagerBuilder instead")]
     pub fn new(
         connector: Connector,
         max_retry_attempts: Option<u64>,
@@ -184,11 +183,6 @@ impl PeerManager {
     /// handles notifications from the `ConnectionManager`.
     ///
     /// Returns a `PeerManagerConnector` that can be used to send requests to the `PeerManager`.
-    #[deprecated(
-        since = "0.4.1",
-        note = "Please use connector() instead. The PeerManagerBuilder starts up the PeerManager \
-         now"
-    )]
     pub fn start(&mut self) -> Result<PeerManagerConnector, PeerManagerError> {
         Ok(PeerManagerConnector::new(self.sender.clone()))
     }
@@ -197,7 +191,6 @@ impl PeerManager {
         PeerManagerConnector::new(self.sender.clone())
     }
 
-    #[deprecated(since = "0.4.1", note = "Please use shutdown_signaler() instead.")]
     /// Returns a `ShutdownHandle` for this `PeerManager`
     pub fn shutdown_handle(&self) -> Option<ShutdownHandle> {
         Some(ShutdownHandle::from(self.shutdown_signaler.clone()))
@@ -217,10 +210,6 @@ impl PeerManager {
         debug!("Shutting down peer manager (complete)");
     }
 
-    #[deprecated(
-        since = "0.4.1",
-        note = "Please use shutdown_signaler().shutdown() and await_shutdown() instead."
-    )]
     /// Sends a shutdown signal and waits for the `PeerManager` thread to shutdown
     pub fn shutdown_and_wait(self) {
         self.shutdown_signaler.shutdown();
@@ -2420,11 +2409,9 @@ pub mod tests {
 
         let connector = cm.connector();
 
-        #[allow(deprecated)]
         let mut peer_manager =
             PeerManager::new(connector, Some(1), Some(1), "my_id".to_string(), true);
 
-        #[allow(deprecated)]
         peer_manager.start().expect("Cannot start peer_manager");
 
         peer_manager.shutdown_signaler().shutdown();

--- a/libsplinter/src/transport/matrix.rs
+++ b/libsplinter/src/transport/matrix.rs
@@ -72,7 +72,6 @@ impl ConnectionMatrixEnvelope {
     }
 
     /// Returns the bytes of the payload while consuming the `ConnectionMatrixEnvelope`
-    #[deprecated(since = "0.4.1", note = "Please use into_inner() instead")]
     pub fn take_payload(self) -> Vec<u8> {
         self.payload
     }


### PR DESCRIPTION
When new APIs were backported to 0.4, the old API
were marked with deprecation notices. These should be
removed as the "deprecated" methods are still considered
stable in 0.4.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>