### PR TITLE
Fix accept bug with TCP/TCPS transport connections

### DIFF
--- a/libsplinter/src/transport/socket/frame.rs
+++ b/libsplinter/src/transport/socket/frame.rs
@@ -27,6 +27,7 @@ pub enum FrameError {
     InvalidChecksum,
     InvalidHeaderLength(usize),
     UnsupportedVersion,
+    HandshakeFailure(String),
 }
 
 impl std::fmt::Display for FrameError {
@@ -40,6 +41,7 @@ impl std::fmt::Display for FrameError {
                 HEADER_LENGTH, n
             ),
             FrameError::UnsupportedVersion => f.write_str("Unsupported frame version"),
+            FrameError::HandshakeFailure(msg) => f.write_str(&msg),
         }
     }
 }
@@ -51,6 +53,7 @@ impl std::error::Error for FrameError {
             FrameError::InvalidChecksum => None,
             FrameError::InvalidHeaderLength(_) => None,
             FrameError::UnsupportedVersion => None,
+            FrameError::HandshakeFailure(_) => None,
         }
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -335,11 +335,8 @@ impl SplinterDaemon {
                                 continue;
                             }
                             Err(AcceptError::IoError(err)) => {
-                                error!("Unable to receive new connections; exiting: {:?}", err);
-                                return Err(StartError::TransportError(format!(
-                                    "Accept Error: {:?}",
-                                    err
-                                )));
+                                warn!("Failed to accept connection on {}: {}", endpoint, err);
+                                continue;
                             }
                         };
                         debug!("Received connection from {}", connection.remote_endpoint());

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -340,16 +340,17 @@ impl SplinterDaemon {
                             }
                         };
                         debug!("Received connection from {}", connection.remote_endpoint());
-                        connection_connector_clone
-                            .add_inbound_connection(connection)
-                            .map_err(|err| {
-                                StartError::NetworkError(format!(
-                                    "Unable to add inbound connection: {}",
-                                    err
-                                ))
-                            })?;
+                        if let Err(err) =
+                            connection_connector_clone.add_inbound_connection(connection)
+                        {
+                            error!(
+                                "Unable to add inbound connection to connection manager: {}",
+                                err
+                            );
+                            error!("Exiting listener thread for {}", endpoint);
+                            break;
+                        }
                     }
-                    Ok(())
                 })
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
This change corrects an issue with the splinter daemon where the accept threads for TCP/TCPS transport exits on an `AcceptError`.  The fix is two-fold:

1. Frame negotiation now results in a handshake failure if the connection is terminated mid-negotiation.
2. The accept thread does not exit on an `AcceptError`: it logs and continues

Additionally, 

- If the accept thread encounters a error while adding the connection to the connection manager, it logs the error immediately.

## To Test

First, startup a splinterd instance:

```
export SPLINTER_HOME=$(pwd)/home/node1
cargo run \
    --manifest-path cli/Cargo.toml \
    cert generate \
    --skip
cargo run \
    --manifest-path splinterd/Cargo.toml \
    --features experimental \
    -- \
    -vv \
    --tls-insecure \
    --heartbeat 1 \
    --network-endpoints tcp://127.0.0.1:18044 \
    --network-endpoints tcps://127.0.0.1:18045 \
    --network-endpoints ws://127.0.0.1:18046 \
    --network-endpoints wss://127.0.0.1:18047 \
    --service-endpoint tcp://127.0.0.1:18048 \
    --rest-api-endpoint 127.0.0.1:18080 \
    --peers wss://127.0.0.1:28047
```

Then, use openssl s_client to connect to the tcps:// port:

```
% openssl s_client -connect 127.0.0.1:18045
CONNECTED(00000003)
depth=0 CN = localhost
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN = localhost
verify error:num=21:unable to verify the first certificate
verify return:1
---
Certificate chain
 0 s:/CN=localhost
   i:/CN=generated_ca
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIC2jCCAcKgAwIBAgIUJo59OVbX7QfLIV8MtQIRB4SK0kkwDQYJKoZIhvcNAQEL
BQAwFzEVMBMGA1UEAwwMZ2VuZXJhdGVkX2NhMB4XDTIwMDUxMjE1MzM1NFoXDTIx
MDUxMjE1MzM1NFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0B
AQEFAAOCAQ8AMIIBCgKCAQEA5kOFm7C53HSrkdo7glqMOnW2DyMoz/c1CI3rFXao
kMqhw11IZ9oFq36l7RxV4U3VG7+jxbop+dswYWlgeABTkU89JRdfBTKoUzoLFqKC
hfAhLizDyGBFuAoSmOoPwH8+pXDsXZ3UtzW3hpjJg2I2u1pK+ZE6Ii1wa0flewZF
KE7E0G9VXPmoAUlKKtVtexI9Vx5J9wnGKWhpvjj3q5Chl2r2cBzTtdFXh3WsBoTN
goXIxVxd7XtiGZNHjHqecXapKAX8AgW48/x0qtf/745g8y1n1QH2VoSLCkRWGznr
NpfNUcp9gSC5IiOIh4nJBIVw5C6xUK0Y4kElNu6XKh7tLQIDAQABoyEwHzAdBgNV
HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAEmr
ntyyb7k/LXnJgSpO4iEv1EeBb7wixBnGk/9K/MHt/Pm8sx3BBGSFPdYgDNioQr0K
RZcC2seUjSz+4u/AmQHcZXQpc2ct672fAC7aajGoEXW3FeU465CzkiypBd+F+0fI
TSkdtPGzbC9SiR1sA8j67jTPaGQaTQVLY6CM/bdrBTiQSipKkmgPZWehFX5tqhSd
kR6srGisWXlsa09yeqnGclmcEPECMWwfe589/2GPErke7aexG9Sqza7/kTwmqjp4
bq7OxV23oWrnDF17b9M9tt3SUHhEUjc07Wd8FFnIUgMXsda5WCrkE/6YBQba6Xg5
3Q0TzlLTnsvUFrQwO3I=
-----END CERTIFICATE-----
subject=/CN=localhost
issuer=/CN=generated_ca
---
No client certificate CA names sent
Server Temp Key: ECDH, X25519, 253 bits
---
SSL handshake has read 1355 bytes and written 293 bytes
---
New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES256-GCM-SHA384
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-AES256-GCM-SHA384
    Session-ID: F2ADCDC245B5D13934813A1F3438EFD05BB42C74AFCD67E53938C22807C8366A
    Session-ID-ctx:
    Master-Key: FC050DC80A21873E388EA22B6742556410ED5E4592224A895B15C17F260249F49A27368F191E1B087BFFECFAC1AA7B2A
    TLS session ticket lifetime hint: 7200 (seconds)
    TLS session ticket:
    0000 - 80 09 8f 94 20 40 d0 ab-b5 da 47 a2 28 66 f1 7f   .... @....G.(f..
    0010 - ac c0 b5 15 44 a2 a7 84-f4 37 5e 5c e6 49 0a 06   ....D....7^\.I..
    0020 - c5 82 39 14 f6 29 6c ea-75 d8 84 f9 23 7d 04 e5   ..9..)l.u...#}..
    0030 - 6b d6 b9 bf f3 86 88 f6-62 b8 45 ad 06 c7 67 6a   k.......b.E...gj
    0040 - 36 d5 be a5 9d 0b 27 16-80 ff c7 0e e9 12 fb 46   6.....'........F
    0050 - 86 21 af b8 92 a4 97 8e-fb 97 9e 13 a8 0f b5 42   .!.............B
    0060 - 4a cd ad 6c 67 93 e4 8f-f7 6a a4 7e 9d bd aa 3e   J..lg....j.~...>
    0070 - 99 70 aa 23 b3 a3 96 f0-5f d4 12 dd da fc f4 30   .p.#...._......0
    0080 - fd 5f 66 85 ce 59 08 14-4f f2 22 16 00 f2 1c 9b   ._f..Y..O.".....
    0090 - 9e 77 76 a1 ce 8a 42 25-e8 be 6d e1 a7 4c cb 11   .wv...B%..m..L..

    Start Time: 1596120662
    Timeout   : 7200 (sec)
    Verify return code: 21 (unable to verify the first certificate)
---
```

Press CTRL-C.

In the splinterd log, you will see:

```
[2020-07-30 10:56:25.226] T["<unnamed>"] WARN [splinterd::daemon] Failed to accept connection on tcps://127.0.0.1:18045: Unexpected protocol error: unable to complete handshake, due to closed connection
```
Repeat the above and you should continue to see this message.