### PR TITLE
More circuit - template cleanup

### DIFF
--- a/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
+++ b/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
@@ -1,17 +1,17 @@
 version: v1
 args:
-    - name: $(ADMIN_KEYS)
+    - name: ADMIN_KEYS
       required: false
       default: $(SIGNER_PUB_KEY)
       description: >-
         Public keys used to verify transactions in the scabbard service
-    - name: $(NODES)
+    - name: NODES
       required: true
       description: "List of node IDs"
-    - name: $(SIGNER_PUB_KEY)
+    - name: SIGNER_PUB_KEY
       required: false
       description: "Public key of the signer"
-    - name: $(GAMEROOM_NAME)
+    - name: GAMEROOM_NAME
       required: true
       description: "Name of the gameroom"
 rules:

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -246,14 +246,14 @@ mod test {
     /// Example circuit template YAML file.
     const EXAMPLE_TEMPLATE_YAML: &[u8] = br##"version: v1
 args:
-    - name: $(ADMIN_KEYS)
+    - name: ADMIN_KEYS
       required: false
       default: $(SIGNER_PUB_KEY)
-    - name: $(NODES)
+    - name: NODES
       required: true
-    - name: $(SIGNER_PUB_KEY)
+    - name: SIGNER_PUB_KEY
       required: false
-    - name: $(GAMEROOM_NAME)
+    - name: GAMEROOM_NAME
       required: true
 rules:
     set-management-type:

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -18,7 +18,7 @@ use crate::admin::messages::is_valid_service_id;
 use crate::base62::next_base62_string;
 
 use super::super::{yaml_parser::v1, CircuitTemplateError, SplinterServiceBuilder};
-use super::{get_argument_value, is_arg, RuleArgument, Value};
+use super::{get_argument_value, is_arg_value, RuleArgument, Value};
 
 const ALL_OTHER_SERVICES: &str = "$(ALL_OTHER_SERVICES)";
 const NODES_ARG: &str = "$(NODES)";
@@ -77,7 +77,7 @@ impl CreateServices {
                     if arg.key == PEER_SERVICES_ARG && value == ALL_OTHER_SERVICES {
                         service_builders = all_services(service_builders)?;
                     } else {
-                        let value = if is_arg(&value) {
+                        let value = if is_arg_value(&value) {
                             get_argument_value(&value, template_arguments)?
                         } else {
                             value.clone()
@@ -91,7 +91,7 @@ impl CreateServices {
                         .try_fold::<_, _, Result<_, CircuitTemplateError>>(
                             Vec::new(),
                             |mut acc, value| {
-                                let value = if is_arg(&value) {
+                                let value = if is_arg_value(&value) {
                                     get_argument_value(&value, template_arguments)?
                                 } else {
                                     value.to_string()

--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -21,7 +21,7 @@ use super::super::{yaml_parser::v1, CircuitTemplateError, SplinterServiceBuilder
 use super::{get_argument_value, is_arg_value, RuleArgument, Value};
 
 const ALL_OTHER_SERVICES: &str = "$(ALL_OTHER_SERVICES)";
-const NODES_ARG: &str = "$(NODES)";
+const NODES_ARG: &str = "NODES";
 const PEER_SERVICES_ARG: &str = "peer_services";
 
 /// Data structure used to create a `SplinterServiceBuilder`.

--- a/libsplinter/src/circuit/template/rules/mod.rs
+++ b/libsplinter/src/circuit/template/rules/mod.rs
@@ -133,7 +133,7 @@ impl TryFrom<v1::RuleArgument> for RuleArgument {
     type Error = CircuitTemplateError;
     fn try_from(arguments: v1::RuleArgument) -> Result<Self, Self::Error> {
         Ok(RuleArgument {
-            name: strip_arg_marker(arguments.name())?,
+            name: arguments.name().to_lowercase(),
             required: arguments.required(),
             default_value: arguments.default_value().map(String::from),
             description: arguments.description().map(String::from),
@@ -142,26 +142,17 @@ impl TryFrom<v1::RuleArgument> for RuleArgument {
     }
 }
 
-fn is_arg(key: &str) -> bool {
+fn is_arg_value(key: &str) -> bool {
     key.starts_with("$(")
 }
 
-fn strip_arg_marker(key: &str) -> Result<String, CircuitTemplateError> {
+fn strip_arg_marker(key: &str) -> String {
     if key.starts_with("$(") && key.ends_with(')') {
         let mut key = key.to_string();
         key.pop();
-        Ok(key
-            .get(2..)
-            .ok_or_else(|| {
-                CircuitTemplateError::new(&format!("\"{}\" is not a valid argument name", key))
-            })?
-            .to_string()
-            .to_lowercase())
+        key.trim_start_matches("$(").to_string().to_lowercase()
     } else {
-        Err(CircuitTemplateError::new(&format!(
-            "\"{}\" is not a valid argument name",
-            key
-        )))
+        key.to_string().to_lowercase()
     }
 }
 
@@ -184,7 +175,7 @@ fn get_argument_value(
     key: &str,
     template_arguments: &[RuleArgument],
 ) -> Result<String, CircuitTemplateError> {
-    let key = strip_arg_marker(key)?;
+    let key = strip_arg_marker(key);
     let value = match template_arguments.iter().find(|arg| arg.name == key) {
         Some(arg) => match arg.user_value() {
             Some(val) => val.to_string(),
@@ -201,7 +192,7 @@ fn get_argument_value(
                             key
                         ))
                     })?;
-                    if is_arg(&default_value) {
+                    if is_arg_value(&default_value) {
                         get_argument_value(&default_value, template_arguments)?
                     } else {
                         default_value

--- a/libsplinter/src/circuit/template/rules/set_management_type.rs
+++ b/libsplinter/src/circuit/template/rules/set_management_type.rs
@@ -14,7 +14,7 @@
 
 //! Provides functionality to set a `CreateCircuitBuilder` `management_type`.
 
-use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
+use super::super::{yaml_parser::v1, CircuitTemplateError};
 
 /// Data structure holding the circuit's intended `management_type`.
 pub(super) struct CircuitManagement {
@@ -23,11 +23,8 @@ pub(super) struct CircuitManagement {
 
 impl CircuitManagement {
     /// Adds the `management_type` to the provided `CreateCircuitBuilder`.
-    pub fn apply_rule(
-        &self,
-        builder: CreateCircuitBuilder,
-    ) -> Result<CreateCircuitBuilder, CircuitTemplateError> {
-        Ok(builder.with_circuit_management_type(&self.management_type))
+    pub fn apply_rule(&self) -> Result<String, CircuitTemplateError> {
+        Ok(self.management_type.to_string())
     }
 }
 

--- a/libsplinter/src/circuit/template/rules/set_metadata.rs
+++ b/libsplinter/src/circuit/template/rules/set_metadata.rs
@@ -14,7 +14,7 @@
 
 //! Provides functionality to set the `metadata` field of a `CreateCircuitBuilder`.
 
-use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
+use super::super::{yaml_parser::v1, CircuitTemplateError};
 use super::{get_argument_value, is_arg_value, RuleArgument, Value};
 
 /// Data structure wrapping the `Metadata` object to be used to fill in the `metadata` field of the
@@ -26,9 +26,8 @@ pub(super) struct SetMetadata {
 impl SetMetadata {
     pub fn apply_rule(
         &self,
-        builder: CreateCircuitBuilder,
         template_arguments: &[RuleArgument],
-    ) -> Result<CreateCircuitBuilder, CircuitTemplateError> {
+    ) -> Result<Vec<u8>, CircuitTemplateError> {
         match &self.metadata {
             Metadata::Json { metadata } => {
                 let metadata = metadata
@@ -66,7 +65,7 @@ impl SetMetadata {
 
                 let json_metadata = format!("{{{}}}", metadata.join(","));
 
-                Ok(builder.with_application_metadata(&json_metadata.as_bytes()))
+                Ok(json_metadata.as_bytes().to_vec())
             }
         }
     }

--- a/libsplinter/src/circuit/template/rules/set_metadata.rs
+++ b/libsplinter/src/circuit/template/rules/set_metadata.rs
@@ -15,7 +15,7 @@
 //! Provides functionality to set the `metadata` field of a `CreateCircuitBuilder`.
 
 use super::super::{yaml_parser::v1, CircuitTemplateError, CreateCircuitBuilder};
-use super::{get_argument_value, is_arg, RuleArgument, Value};
+use super::{get_argument_value, is_arg_value, RuleArgument, Value};
 
 /// Data structure wrapping the `Metadata` object to be used to fill in the `metadata` field of the
 /// `CreateCircuitBuilder`.
@@ -35,7 +35,7 @@ impl SetMetadata {
                     .iter()
                     .map(|metadata| match &metadata.value {
                         Value::Single(value) => {
-                            let value = if is_arg(&value) {
+                            let value = if is_arg_value(&value) {
                                 get_argument_value(&value, &template_arguments)?
                             } else {
                                 value.to_string()
@@ -46,7 +46,7 @@ impl SetMetadata {
                             let processed_values = values
                                 .iter()
                                 .map(|value| {
-                                    let value = if is_arg(&value) {
+                                    let value = if is_arg_value(&value) {
                                         get_argument_value(&value, &template_arguments)?
                                     } else {
                                         value.to_string()

--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -107,7 +107,7 @@ rules:
         service-type: 'scabbard'
         service-args:
         - key: 'admin-keys'
-          value: [$(admin-keys)]
+          value: [$(ADMIN-KEYS)]
         - key: 'peer-services'
           value: '$(ALL_OTHER_SERVICES)'
         first-service: 'a000'
@@ -115,9 +115,9 @@ rules:
         encoding: json
         metadata:
             - key: "scabbard_admin_keys"
-              value: [$(cs:ADMIN)]
+              value: [$(ADMIN-KEYS)]
             - key: "alias"
-              value: "$(sm:gameroom_name)" "##;
+              value: "$(GAMEROOM-NAME)" "##;
 
     /// Verifies load_template correctly loads a `CircuitTemplate` with version 1.
     ///
@@ -160,7 +160,7 @@ rules:
 
                     let service_args = create_services.service_args();
                     assert!(service_args.iter().any(|arg| arg.key() == "admin-keys"
-                        && arg.value() == &Value::List(vec!["$(admin-keys)".to_string()])));
+                        && arg.value() == &Value::List(vec!["$(ADMIN-KEYS)".to_string()])));
                     assert!(service_args.iter().any(|arg| arg.key() == "peer-services"
                         && arg.value() == &Value::Single("$(ALL_OTHER_SERVICES)".to_string())));
                 }
@@ -179,12 +179,13 @@ rules:
 
                 match metadata {
                     Metadata::Json { metadata } => {
-                        assert!(metadata.iter().any(|metadata| metadata.key()
-                            == "scabbard_admin_keys"
-                            && metadata.value() == &Value::List(vec!["$(cs:ADMIN)".to_string()])));
+                        assert!(metadata
+                            .iter()
+                            .any(|metadata| metadata.key() == "scabbard_admin_keys"
+                                && metadata.value()
+                                    == &Value::List(vec!["$(ADMIN-KEYS)".to_string()])));
                         assert!(metadata.iter().any(|metadata| metadata.key() == "alias"
-                            && metadata.value()
-                                == &Value::Single("$(sm:gameroom_name)".to_string())));
+                            && metadata.value() == &Value::Single("$(GAMEROOM-NAME)".to_string())));
                     }
                 }
             }


### PR DESCRIPTION
This removes the `$()` from argument names. Also reworks the `apply_rules` to directly use the `with_*` builder statements.