### PR TITLE
Update CLI man page 'SEE ALSO' link

### DIFF
--- a/cli/man/TEMPLATE.1.md.example
+++ b/cli/man/TEMPLATE.1.md.example
@@ -83,4 +83,4 @@ Related man pages or documentation (if possible)
 -->
 
 For more information, see the Splinter documentation at
-https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-cert-generate.1.md
+++ b/cli/man/splinter-cert-generate.1.md
@@ -102,4 +102,4 @@ SEE ALSO
 ========
 | `splinterd(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-cert.1.md
+++ b/cli/man/splinter-cert.1.md
@@ -54,6 +54,5 @@ SUBCOMMANDS
 SEE ALSO
 ========
 | `splinter-cert-generate(1)`
-| 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -116,4 +116,4 @@ SEE ALSO
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -110,4 +110,4 @@ SEE ALSO
 | `splinter-circuit-list(1)`
 | `splinter-circuit-vote(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -191,4 +191,4 @@ SEE ALSO
 | `splinter-circuit-template(1)`
 | `splinter-circuit-vote(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -109,4 +109,4 @@ SEE ALSO
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-template-arguments.1.md
+++ b/cli/man/splinter-circuit-template-arguments.1.md
@@ -77,4 +77,4 @@ SEE ALSO
 | `splinter-circuit-template-list(1)`
 | `splinter-circuit-template-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-template-list.1.md
+++ b/cli/man/splinter-circuit-template-list.1.md
@@ -62,4 +62,4 @@ SEE ALSO
 | `splinter-circuit-template-arguments(1)`
 | `splinter-circuit-template-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-template-show.1.md
+++ b/cli/man/splinter-circuit-template-show.1.md
@@ -86,4 +86,4 @@ SEE ALSO
 | `splinter-circuit-template-arguments(1)`
 | `splinter-circuit-template-list(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-template.1.md
+++ b/cli/man/splinter-circuit-template.1.md
@@ -64,4 +64,4 @@ SEE ALSO
 | `splinter-circuit-template-list(1)`
 | `splinter-circuit-template-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-vote.1.md
+++ b/cli/man/splinter-circuit-vote.1.md
@@ -95,4 +95,4 @@ SEE ALSO
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit.1.md
+++ b/cli/man/splinter-circuit.1.md
@@ -69,4 +69,4 @@ SEE ALSO
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-show(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-database-migrate.1.md
+++ b/cli/man/splinter-database-migrate.1.md
@@ -60,4 +60,4 @@ splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splin
 
 SEE ALSO
 ========
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-database.1.md
+++ b/cli/man/splinter-database.1.md
@@ -49,6 +49,5 @@ SUBCOMMANDS
 SEE ALSO
 ========
 | `splinter-database-migrate(1)`
-| 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-health-status.1.md
+++ b/cli/man/splinter-health-status.1.md
@@ -59,6 +59,5 @@ SEE ALSO
 ========
 | `splinter-circuit-list(1)`
 | `splinter-circuit-show(1)`
-| 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-health.1.md
+++ b/cli/man/splinter-health.1.md
@@ -47,6 +47,5 @@ SUBCOMMANDS
 SEE ALSO
 ========
 | `splinter-health-status(1)`
-| 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -97,4 +97,4 @@ writing file: "/etc/splinter/keys/splinterd.pub"
 SEE ALSO
 ========
 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter.1.md
+++ b/cli/man/splinter.1.md
@@ -96,8 +96,7 @@ SEE ALSO
 | `splinter-database-migrate(1)`
 | `splinter-health-status(1)`
 | `splinter-keygen(1)`
-| 
+|
 | `splinterd(1)`
-| 
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
-
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -377,4 +377,4 @@ SEE ALSO
 | `splinter-circuit-propose(1)`
 | `splinter-cert-generate(1)`
 |
-| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| Splinter documentation: https://www.splinter.dev/docs/0.5/


### PR DESCRIPTION
Updates the link in the 'SEE ALSO' section of the CLI man pages to point
to the Splinter website rather than the repository.

Signed-off-by: Shannyn Telander <telander@bitwise.io>