### PR TITLE
Fix scabbard template formatting

### DIFF
--- a/cli/packaging/scabbard_circuit_template.yaml
+++ b/cli/packaging/scabbard_circuit_template.yaml
@@ -1,14 +1,14 @@
 version: v1
 args:
-    - name: $(ADMIN_KEYS)
+    - name: ADMIN_KEYS
       required: false
       default: $(SIGNER_PUB_KEY)
       description: >-
         Public keys used to verify transactions in the scabbard service
-    - name: $(NODES)
+    - name: NODES
       required: true
       description: "List of node IDs"
-    - name: $(SIGNER_PUB_KEY)
+    - name: SIGNER_PUB_KEY
       required: false
       description: "Public key of the signer"
 rules:


### PR DESCRIPTION
Fixes the scabbard template formatting to remove '&()' from argument
names.

Signed-off-by: Shannyn Telander <telander@bitwise.io>