### PR TITLE
BACKPORT: Update SEE ALSO section in the man page template to have correct format

### DIFF
--- a/cli/man/TEMPLATE.1.md.example
+++ b/cli/man/TEMPLATE.1.md.example
@@ -81,6 +81,6 @@ SEE ALSO
 <!--
 Related man pages or documentation (if possible)
 -->
-
-For more information, see the Splinter documentation at
-https://www.splinter.dev/docs/0.4/
+| `related-command(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.4/


### PR DESCRIPTION
The format for this section was updated in all the existing man pages
but the template was missed.
