### PR TITLE
Initialize diesel backend for AdminServiceStore

### DIFF
--- a/libsplinter/src/admin/store/diesel/migrations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/migrations/mod.rs
@@ -1,0 +1,46 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides database migrations for the `DieselAdminServiceStore`.
+
+#[cfg(feature = "postgres")]
+pub mod postgres;
+#[cfg(feature = "sqlite")]
+pub mod sqlite;
+
+use std::error::Error;
+use std::fmt;
+
+#[cfg(feature = "postgres")]
+pub use postgres::run_migrations as run_postgres_migrations;
+#[cfg(feature = "sqlite")]
+pub use sqlite::run_migrations as run_sqlite_migrations;
+
+#[derive(Debug)]
+pub struct MigrationError {
+    pub context: String,
+    pub source: Box<dyn Error>,
+}
+
+impl Error for MigrationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&*self.source)
+    }
+}
+
+impl fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Error applying registry migrations: {}", self.context)
+    }
+}

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
@@ -1,0 +1,29 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS proposed_circuit;
+DROP TABLE IF EXISTS proposed_node;
+DROP TABLE IF EXISTS proposed_node_endpoint;
+DROP TABLE IF EXISTS proposed_service;
+DROP TABLE IF EXISTS proposed_services_allowed_node;
+DROP TABLE IF EXISTS proposed_service_argument;
+DROP TABLE IF EXISTS vote_record;
+DROP TABLE IF EXISTS circuit_proposal;
+DROP TABLE IF EXISTS service;
+DROP TABLE IF EXISTS service_allowed_node;
+DROP TABLE IF EXISTS service_argument;
+DROP TABLE IF EXISTS circuit;
+DROP TABLE IF EXISTS circuit_member;
+DROP TABLE IF EXISTS node_endpoint;

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -1,0 +1,135 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS circuit_proposal (
+    proposal_type             TEXT NOT NULL,
+    circuit_id                TEXT PRIMARY KEY,
+    circuit_hash              TEXT NOT NULL,
+    requester                 BINARY NOT NULL,
+    requester_node_id         TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS vote_record (
+    circuit_id                TEXT NOT NULL,
+    public_key                BINARY NOT NULL,
+    vote                      TEXT NOT NULL,
+    voter_node_id             TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, voter_node_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit_proposal(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_circuit (
+    circuit_id                TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL,
+    application_metadata      BINARY NOT NULL,
+    comments                  TEXT NOT NULL,
+    PRIMARY KEY (circuit_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit_proposal(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_node (
+    circuit_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, node_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_node_endpoint (
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    PRIMARY KEY (node_id, endpoint),
+    FOREIGN KEY (node_id) REFERENCES proposed_node(node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service_allowed_node (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    allowed_node              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, allowed_node),
+    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key),
+    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service_allowed_node (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    allowed_node              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, allowed_node),
+    FOREIGN KEY (service_id) REFERENCES service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key),
+    FOREIGN KEY (service_id) REFERENCES service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS circuit (
+    circuit_id                TEXT PRIMARY KEY,
+    auth                      TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS circuit_member (
+    circuit_id                TEXT NOT NULL,
+    node_id                    TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, node_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS node_endpoint (
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    PRIMARY KEY (node_id, endpoint),
+    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id) ON DELETE CASCADE
+);

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/mod.rs
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines utilities to interact with AdminServiceStore tables in a PostgreSQL database.
+
+embed_migrations!("./src/admin/store/diesel/migrations/postgres/migrations");
+
+use diesel::pg::PgConnection;
+
+use super::MigrationError;
+
+/// Run database migrations to create tables defined by the AdminServiceStore
+///
+/// # Arguments
+///
+/// * `conn` - Connection to PostgreSQL database
+///
+pub fn run_migrations(conn: &PgConnection) -> Result<(), MigrationError> {
+    embedded_migrations::run(conn).map_err(|err| MigrationError {
+        context: "Failed to embed migrations".to_string(),
+        source: Box::new(err),
+    })?;
+
+    info!("Successfully applied PostgreSQL AdminServiceStore migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
@@ -1,0 +1,29 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS proposed_circuit;
+DROP TABLE IF EXISTS proposed_node;
+DROP TABLE IF EXISTS proposed_node_endpoint;
+DROP TABLE IF EXISTS proposed_service;
+DROP TABLE IF EXISTS proposed_service_allowed_node;
+DROP TABLE IF EXISTS proposed_service_argument;
+DROP TABLE IF EXISTS vote_record;
+DROP TABLE IF EXISTS circuit_proposal;
+DROP TABLE IF EXISTS service;
+DROP TABLE IF EXISTS service_allowed_node;
+DROP TABLE IF EXISTS service_argument;
+DROP TABLE IF EXISTS circuit;
+DROP TABLE IF EXISTS circuit_member;
+DROP TABLE IF EXISTS node_endpoint;

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -1,0 +1,135 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS circuit_proposal (
+    proposal_type             TEXT NOT NULL,
+    circuit_id                TEXT PRIMARY KEY,
+    circuit_hash              TEXT NOT NULL,
+    requester                 BINARY NOT NULL,
+    requester_node_id         TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS vote_record (
+    circuit_id                TEXT NOT NULL,
+    public_key                BINARY NOT NULL,
+    vote                      TEXT NOT NULL,
+    voter_node_id             TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, voter_node_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit_proposal(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_circuit (
+    circuit_id                TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL,
+    application_metadata      BINARY NOT NULL,
+    comments                  TEXT NOT NULL,
+    PRIMARY KEY (circuit_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit_proposal(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_node (
+    circuit_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, node_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_node_endpoint (
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    PRIMARY KEY (node_id, endpoint),
+    FOREIGN KEY (node_id) REFERENCES proposed_node(node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service_allowed_node (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    allowed_node              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, allowed_node),
+    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS proposed_service_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key),
+    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service_allowed_node (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    allowed_node              TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, allowed_node),
+    FOREIGN KEY (service_id) REFERENCES service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS service_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key),
+    FOREIGN KEY (service_id) REFERENCES service(service_id),
+    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS circuit (
+    circuit_id                TEXT PRIMARY KEY,
+    auth                      TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS circuit_member (
+    circuit_id                TEXT NOT NULL,
+    node_id                    TEXT NOT NULL,
+    PRIMARY KEY (circuit_id, node_id),
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS node_endpoint (
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    PRIMARY KEY (node_id, endpoint),
+    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id) ON DELETE CASCADE
+);

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/mod.rs
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Defines utilities to interact with AdminServiceStore tables in a SQLite database.
+
+embed_migrations!("./src/admin/store/diesel/migrations/sqlite/migrations");
+
+use diesel::sqlite::SqliteConnection;
+
+use super::MigrationError;
+
+/// Run database migrations to create tables defined by the AdminServiceStore
+///
+/// # Arguments
+///
+/// * `conn` - Connection to SQLite database
+///
+pub fn run_migrations(conn: &SqliteConnection) -> Result<(), MigrationError> {
+    embedded_migrations::run(conn).map_err(|err| MigrationError {
+        context: "Failed to embed migrations".to_string(),
+        source: Box::new(err),
+    })?;
+
+    info!("Successfully applied SQLite AdminServiceStore migrations");
+
+    Ok(())
+}

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -15,5 +15,6 @@
 //! Database backend support for the AdminServiceStore, powered by
 //! [`Diesel`](https://crates.io/crates/diesel).
 
+pub mod migrations;
 mod models;
 mod schema;

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database backend support for the AdminServiceStore, powered by
+//! [`Diesel`](https://crates.io/crates/diesel).
+
+mod models;
+mod schema;

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -1,0 +1,550 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database representations used to implement a diesel backend for the `AdminServiceStore`.
+//! These structs differ slightly from their associated native representation to conform to
+//! the requirements for storing data with a diesel backend.
+
+use std::convert::TryFrom;
+
+use crate::admin::store::diesel::schema::{
+    circuit, circuit_member, circuit_proposal, node_endpoint, proposed_circuit, proposed_node,
+    proposed_node_endpoint, proposed_service, proposed_service_allowed_node,
+    proposed_service_argument, service, service_allowed_node, service_argument, vote_record,
+};
+use crate::admin::store::error::AdminServiceStoreError;
+use crate::admin::store::{
+    AuthorizationType, DurabilityType, PersistenceType, ProposalType, RouteType, Vote, VoteRecord,
+};
+use crate::admin::store::{Circuit, CircuitProposal, ProposedCircuit};
+
+/// Database model representation of a `CircuitProposal`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "circuit_proposal"]
+#[primary_key(circuit_id)]
+pub struct CircuitProposalModel {
+    pub proposal_type: String,
+    pub circuit_id: String,
+    pub circuit_hash: String,
+    pub requester: Vec<u8>,
+    pub requester_node_id: String,
+}
+
+impl From<&CircuitProposal> for CircuitProposalModel {
+    fn from(proposal: &CircuitProposal) -> Self {
+        CircuitProposalModel {
+            proposal_type: String::from(&proposal.proposal_type),
+            circuit_id: proposal.circuit_id.clone(),
+            circuit_hash: proposal.circuit_hash.clone(),
+            requester: proposal.requester.clone(),
+            requester_node_id: proposal.requester_node_id.clone(),
+        }
+    }
+}
+
+/// Database model representation of a `ProposedCircuit`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_circuit"]
+#[belongs_to(CircuitProposalModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id)]
+pub struct ProposedCircuitModel {
+    pub circuit_id: String,
+    pub authorization_type: String,
+    pub persistence: String,
+    pub durability: String,
+    pub routes: String,
+    pub circuit_management_type: String,
+    pub application_metadata: Vec<u8>,
+    pub comments: String,
+}
+
+impl From<&ProposedCircuit> for ProposedCircuitModel {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        ProposedCircuitModel {
+            circuit_id: proposed_circuit.circuit_id.clone(),
+            authorization_type: String::from(&proposed_circuit.authorization_type),
+            persistence: String::from(&proposed_circuit.persistence),
+            durability: String::from(&proposed_circuit.durability),
+            routes: String::from(&proposed_circuit.routes),
+            circuit_management_type: proposed_circuit.circuit_management_type.clone(),
+            application_metadata: proposed_circuit.application_metadata.clone(),
+            comments: proposed_circuit.comments.clone(),
+        }
+    }
+}
+
+/// Database model representation of a `VoteRecord`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "vote_record"]
+#[belongs_to(CircuitProposalModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id, voter_node_id)]
+pub struct VoteRecordModel {
+    pub circuit_id: String,
+    pub public_key: Vec<u8>,
+    pub vote: String,
+    pub voter_node_id: String,
+}
+
+impl From<&CircuitProposal> for Vec<VoteRecordModel> {
+    fn from(proposal: &CircuitProposal) -> Self {
+        proposal
+            .votes
+            .iter()
+            .map(|vote| VoteRecordModel {
+                circuit_id: proposal.circuit_id.clone(),
+                public_key: vote.public_key.clone(),
+                vote: String::from(&vote.vote),
+                voter_node_id: vote.voter_node_id.clone(),
+            })
+            .collect()
+    }
+}
+
+impl TryFrom<&VoteRecordModel> for VoteRecord {
+    type Error = AdminServiceStoreError;
+    fn try_from(vote: &VoteRecordModel) -> Result<Self, Self::Error> {
+        Ok(VoteRecord {
+            public_key: vote.public_key.clone(),
+            vote: Vote::try_from(vote.vote.clone())?,
+            voter_node_id: vote.voter_node_id.clone(),
+        })
+    }
+}
+
+/// Database model representation of a `ProposedNode`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_node"]
+#[belongs_to(ProposedCircuitModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id, node_id)]
+pub struct ProposedNodeModel {
+    pub circuit_id: String,
+    pub node_id: String,
+}
+
+impl From<&ProposedCircuit> for Vec<ProposedNodeModel> {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        proposed_circuit
+            .members
+            .iter()
+            .map(|node| ProposedNodeModel {
+                circuit_id: proposed_circuit.circuit_id.clone(),
+                node_id: node.node_id.clone(),
+            })
+            .collect()
+    }
+}
+
+/// Database model representation of the endpoint values associated with a `ProposedNode`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_node_endpoint"]
+#[belongs_to(ProposedNodeModel, foreign_key = "node_id")]
+#[primary_key(node_id, endpoint)]
+pub struct ProposedNodeEndpointModel {
+    pub node_id: String,
+    pub endpoint: String,
+}
+
+impl From<&ProposedCircuit> for Vec<ProposedNodeEndpointModel> {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        let mut endpoint_models = Vec::new();
+        for node in &proposed_circuit.members {
+            endpoint_models.extend(
+                node.endpoints
+                    .iter()
+                    .map(|endpoint| ProposedNodeEndpointModel {
+                        node_id: node.node_id.clone(),
+                        endpoint: endpoint.clone(),
+                    })
+                    .collect::<Vec<ProposedNodeEndpointModel>>(),
+            );
+        }
+        endpoint_models
+    }
+}
+
+/// Database model representation of a `ProposedService`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_service"]
+#[belongs_to(ProposedCircuitModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id, service_id)]
+pub struct ProposedServiceModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub service_type: String,
+}
+
+impl From<&ProposedCircuit> for Vec<ProposedServiceModel> {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        proposed_circuit
+            .roster
+            .iter()
+            .map(|service| ProposedServiceModel {
+                circuit_id: proposed_circuit.circuit_id.clone(),
+                service_id: service.service_id.clone(),
+                service_type: service.service_type.clone(),
+            })
+            .collect()
+    }
+}
+
+/// Database model representation of the `allowed_nodes` associated with a `ProposedService`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_service_allowed_node"]
+#[belongs_to(ProposedServiceModel, foreign_key = "service_id")]
+#[primary_key(circuit_id, service_id, allowed_node)]
+pub struct ProposedServiceAllowedNodeModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub allowed_node: String,
+}
+
+impl From<&ProposedCircuit> for Vec<ProposedServiceAllowedNodeModel> {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        let mut allowed_nodes = Vec::new();
+        for service in &proposed_circuit.roster {
+            allowed_nodes.extend(
+                service
+                    .allowed_nodes
+                    .iter()
+                    .map(|node| ProposedServiceAllowedNodeModel {
+                        circuit_id: proposed_circuit.circuit_id.clone(),
+                        service_id: service.service_id.clone(),
+                        allowed_node: node.clone(),
+                    })
+                    .collect::<Vec<ProposedServiceAllowedNodeModel>>(),
+            );
+        }
+        allowed_nodes
+    }
+}
+
+/// Database model representation of the arguments associated with a `ProposedService`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "proposed_service_argument"]
+#[belongs_to(ProposedServiceModel, foreign_key = "service_id")]
+#[primary_key(circuit_id, service_id, key)]
+pub struct ProposedServiceArgumentModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub key: String,
+    pub value: String,
+}
+
+impl From<&ProposedCircuit> for Vec<ProposedServiceArgumentModel> {
+    fn from(proposed_circuit: &ProposedCircuit) -> Self {
+        let mut service_arguments = Vec::new();
+        for service in &proposed_circuit.roster {
+            service_arguments.extend(
+                service
+                    .arguments
+                    .iter()
+                    .map(|(key, value)| ProposedServiceArgumentModel {
+                        circuit_id: proposed_circuit.circuit_id.clone(),
+                        service_id: service.service_id.clone(),
+                        key: key.clone(),
+                        value: value.clone(),
+                    })
+                    .collect::<Vec<ProposedServiceArgumentModel>>(),
+            );
+        }
+        service_arguments
+    }
+}
+
+/// Database model representation of `Service`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "service"]
+#[belongs_to(CircuitModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id, service_id)]
+pub struct ServiceModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub service_type: String,
+}
+
+impl From<&Circuit> for Vec<ServiceModel> {
+    fn from(circuit: &Circuit) -> Self {
+        circuit
+            .roster
+            .iter()
+            .map(|service| ServiceModel {
+                circuit_id: circuit.id.clone(),
+                service_id: service.service_id.clone(),
+                service_type: service.service_type.clone(),
+            })
+            .collect()
+    }
+}
+
+/// Database model representation of the `allowed_nodes` in a `Service`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "service_allowed_node"]
+#[belongs_to(ServiceModel, foreign_key = "service_id")]
+#[primary_key(circuit_id, service_id, allowed_node)]
+pub struct ServiceAllowedNodeModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub allowed_node: String,
+}
+
+impl From<&Circuit> for Vec<ServiceAllowedNodeModel> {
+    fn from(circuit: &Circuit) -> Self {
+        let mut allowed_nodes = Vec::new();
+        for service in &circuit.roster {
+            allowed_nodes.extend(
+                service
+                    .allowed_nodes
+                    .iter()
+                    .map(|node| ServiceAllowedNodeModel {
+                        circuit_id: circuit.id.clone(),
+                        service_id: service.service_id.clone(),
+                        allowed_node: node.clone(),
+                    })
+                    .collect::<Vec<ServiceAllowedNodeModel>>(),
+            );
+        }
+        allowed_nodes
+    }
+}
+
+/// Database model representation of the arguments in a `Service`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "service_argument"]
+#[belongs_to(ServiceModel, foreign_key = "service_id")]
+#[primary_key(circuit_id, service_id, key)]
+pub struct ServiceArgumentModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub key: String,
+    pub value: String,
+}
+
+impl From<&Circuit> for Vec<ServiceArgumentModel> {
+    fn from(circuit: &Circuit) -> Self {
+        let mut service_arguments = Vec::new();
+        for service in &circuit.roster {
+            service_arguments.extend(
+                service
+                    .arguments
+                    .iter()
+                    .map(|(key, value)| ServiceArgumentModel {
+                        circuit_id: circuit.id.clone(),
+                        service_id: service.service_id.clone(),
+                        key: key.clone(),
+                        value: value.clone(),
+                    })
+                    .collect::<Vec<ServiceArgumentModel>>(),
+            );
+        }
+        service_arguments
+    }
+}
+
+/// Database model representation of a `Circuit`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "circuit"]
+#[primary_key(circuit_id)]
+pub struct CircuitModel {
+    pub circuit_id: String,
+    pub auth: String,
+    pub persistence: String,
+    pub durability: String,
+    pub routes: String,
+    pub circuit_management_type: String,
+}
+
+impl From<&Circuit> for CircuitModel {
+    fn from(circuit: &Circuit) -> Self {
+        CircuitModel {
+            circuit_id: circuit.id.clone(),
+            auth: String::from(&circuit.auth),
+            persistence: String::from(&circuit.persistence),
+            durability: String::from(&circuit.durability),
+            routes: String::from(&circuit.routes),
+            circuit_management_type: circuit.circuit_management_type.clone(),
+        }
+    }
+}
+
+/// Database model representation of the `members` of a `Circuit`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "circuit_member"]
+#[belongs_to(CircuitModel, foreign_key = "circuit_id")]
+#[primary_key(circuit_id, node_id)]
+pub struct CircuitMemberModel {
+    pub circuit_id: String,
+    pub node_id: String,
+}
+
+impl From<&Circuit> for Vec<CircuitMemberModel> {
+    fn from(circuit: &Circuit) -> Self {
+        circuit
+            .members
+            .iter()
+            .map(|node_id| CircuitMemberModel {
+                circuit_id: circuit.id.clone(),
+                node_id: node_id.clone(),
+            })
+            .collect()
+    }
+}
+
+/// Database model representation of the endpoint values associated with a `Circuit` member `node_id`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "node_endpoint"]
+#[belongs_to(CircuitMemberModel, foreign_key = "node_id")]
+#[primary_key(node_id, endpoint)]
+pub struct NodeEndpointModel {
+    pub node_id: String,
+    pub endpoint: String,
+}
+
+// All enums associated with the above structs have TryFrom and From implemented in order to
+// translate the enums to a `Text` representation to be stored in the database.
+
+impl TryFrom<String> for Vote {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Accept" => Ok(Vote::Accept),
+            "Reject" => Ok(Vote::Reject),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to Vote".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&Vote> for String {
+    fn from(variant: &Vote) -> Self {
+        match variant {
+            Vote::Accept => String::from("Accept"),
+            Vote::Reject => String::from("Reject"),
+        }
+    }
+}
+
+impl TryFrom<String> for ProposalType {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Create" => Ok(ProposalType::Create),
+            "UpdateRoster" => Ok(ProposalType::UpdateRoster),
+            "AddNode" => Ok(ProposalType::AddNode),
+            "RemoveNode" => Ok(ProposalType::RemoveNode),
+            "Destroy" => Ok(ProposalType::Destroy),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to ProposalType".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&ProposalType> for String {
+    fn from(variant: &ProposalType) -> Self {
+        match variant {
+            ProposalType::Create => String::from("Create"),
+            ProposalType::UpdateRoster => String::from("UpdateRoster"),
+            ProposalType::AddNode => String::from("AddNode"),
+            ProposalType::RemoveNode => String::from("RemoveNode"),
+            ProposalType::Destroy => String::from("Destroy"),
+        }
+    }
+}
+
+impl TryFrom<String> for AuthorizationType {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Trust" => Ok(AuthorizationType::Trust),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to AuthorizationType".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&AuthorizationType> for String {
+    fn from(variant: &AuthorizationType) -> Self {
+        match variant {
+            AuthorizationType::Trust => String::from("Trust"),
+        }
+    }
+}
+
+impl TryFrom<String> for PersistenceType {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Any" => Ok(PersistenceType::Any),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to PersistenceType".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&PersistenceType> for String {
+    fn from(variant: &PersistenceType) -> Self {
+        match variant {
+            PersistenceType::Any => String::from("Any"),
+        }
+    }
+}
+
+impl TryFrom<String> for DurabilityType {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "NoDurability" => Ok(DurabilityType::NoDurability),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to DurabilityType".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&DurabilityType> for String {
+    fn from(variant: &DurabilityType) -> Self {
+        match variant {
+            DurabilityType::NoDurability => String::from("NoDurability"),
+        }
+    }
+}
+
+impl TryFrom<String> for RouteType {
+    type Error = AdminServiceStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Any" => Ok(RouteType::Any),
+            _ => Err(AdminServiceStoreError::StorageError {
+                context: "Unable to convert string to RouteType".into(),
+                source: None,
+            }),
+        }
+    }
+}
+
+impl From<&RouteType> for String {
+    fn from(variant: &RouteType) -> Self {
+        match variant {
+            RouteType::Any => String::from("Any"),
+        }
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides database operations for the `DieselAdminServiceStore`.
+
+pub struct AdminServiceStoreOperations<'a, C> {
+    #[allow(dead_code)]
+    conn: &'a C,
+}
+
+impl<'a, C: diesel::Connection> AdminServiceStoreOperations<'a, C> {
+    pub fn new(conn: &'a C) -> Self {
+        AdminServiceStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -1,0 +1,134 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    circuit_proposal (circuit_id) {
+        proposal_type -> Text,
+        circuit_id -> Text,
+        circuit_hash -> Text,
+        requester -> Binary,
+        requester_node_id -> Text,
+    }
+}
+
+table! {
+    proposed_circuit (circuit_id) {
+        circuit_id -> Text,
+        authorization_type -> Text,
+        persistence -> Text,
+        durability -> Text,
+        routes -> Text,
+        circuit_management_type -> Text,
+        application_metadata -> Binary,
+        comments -> Text,
+    }
+}
+
+table! {
+    vote_record (circuit_id, voter_node_id) {
+        circuit_id -> Text,
+        public_key -> Binary,
+        vote -> Text,
+        voter_node_id -> Text,
+    }
+}
+
+table! {
+    proposed_node (circuit_id, node_id) {
+        circuit_id -> Text,
+        node_id -> Text,
+    }
+}
+
+table! {
+    proposed_node_endpoint (node_id, endpoint) {
+        node_id -> Text,
+        endpoint -> Text,
+    }
+}
+
+table! {
+    proposed_service (circuit_id, service_id) {
+        circuit_id -> Text,
+        service_id -> Text,
+        service_type -> Text,
+    }
+}
+
+table! {
+    proposed_service_allowed_node (circuit_id, service_id, allowed_node) {
+        circuit_id -> Text,
+        service_id -> Text,
+        allowed_node -> Text,
+    }
+}
+
+table! {
+    proposed_service_argument (circuit_id, service_id, key) {
+        circuit_id -> Text,
+        service_id -> Text,
+        key -> Text,
+        value -> Text,
+    }
+}
+
+table! {
+    service (circuit_id, service_id) {
+        circuit_id -> Text,
+        service_id -> Text,
+        service_type -> Text,
+    }
+}
+
+table! {
+    service_allowed_node (circuit_id, service_id, allowed_node) {
+        circuit_id -> Text,
+        service_id -> Text,
+        allowed_node -> Text,
+    }
+}
+
+table! {
+    service_argument (circuit_id, service_id, key) {
+        circuit_id -> Text,
+        service_id -> Text,
+        key -> Text,
+        value -> Text,
+    }
+}
+
+table! {
+    circuit (circuit_id) {
+        circuit_id -> Text,
+        auth -> Text,
+        persistence -> Text,
+        durability -> Text,
+        routes -> Text,
+        circuit_management_type -> Text,
+    }
+}
+
+table! {
+    circuit_member (circuit_id, node_id) {
+        circuit_id -> Text,
+        node_id -> Text,
+    }
+}
+
+table! {
+    node_endpoint (node_id, endpoint) {
+        node_id -> Text,
+        endpoint -> Text,
+    }
+}

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -44,6 +44,8 @@
 //! [`CircuitProposalBuilder`]: struct.CircuitProposalBuilder.html
 
 mod builders;
+#[cfg(feature = "diesel")]
+pub mod diesel;
 pub mod error;
 pub mod yaml;
 


### PR DESCRIPTION
Adds the following necessary for the AdminServiceStore diesel backend: 
* Models
* Schemas
* Postgres and Sqlite migrations
* DIeselAdminServiceStore and AdminServiceStoreOperations, structs in support the operations necessary to implement the AdminServiceStore trait for each backend