### PR TITLE
Add database backend for AdminServiceStore

### DIFF
--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -131,5 +131,5 @@ CREATE TABLE IF NOT EXISTS node_endpoint (
     node_id                TEXT NOT NULL,
     endpoint               TEXT NOT NULL,
     PRIMARY KEY (node_id, endpoint),
-    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id) ON DELETE CASCADE
+    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id)
 );

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS service_allowed_node (
     allowed_node              TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id, allowed_node),
     FOREIGN KEY (service_id) REFERENCES service(service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS service_argument (
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS service_argument (
     value                     TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id, key),
     FOREIGN KEY (service_id) REFERENCES service(service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS circuit (

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -131,5 +131,5 @@ CREATE TABLE IF NOT EXISTS node_endpoint (
     node_id                TEXT NOT NULL,
     endpoint               TEXT NOT NULL,
     PRIMARY KEY (node_id, endpoint),
-    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id) ON DELETE CASCADE
+    FOREIGN KEY (node_id) REFERENCES circuit_member(node_id)
 );

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS service_allowed_node (
     allowed_node              TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id, allowed_node),
     FOREIGN KEY (service_id) REFERENCES service(service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS service_argument (
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS service_argument (
     value                     TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id, key),
     FOREIGN KEY (service_id) REFERENCES service(service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
+    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS circuit (

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -23,10 +23,31 @@
 
 pub mod migrations;
 mod models;
-pub mod operations;
+mod operations;
 mod schema;
 
 use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::admin::store::{
+    error::AdminServiceStoreError, AdminServiceStore, Circuit, CircuitNode, CircuitPredicate,
+    CircuitProposal, Service, ServiceId,
+};
+use operations::add_circuit::AdminServiceStoreAddCircuitOperation as _;
+use operations::add_proposal::AdminServiceStoreAddProposalOperation as _;
+use operations::fetch_circuit::AdminServiceStoreFetchCircuitOperation as _;
+use operations::fetch_node::AdminServiceStoreFetchNodeOperation as _;
+use operations::fetch_proposal::AdminServiceStoreFetchProposalOperation as _;
+use operations::fetch_service::AdminServiceStoreFetchServiceOperation as _;
+use operations::list_circuits::AdminServiceStoreListCircuitsOperation as _;
+use operations::list_nodes::AdminServiceStoreListNodesOperation as _;
+use operations::list_proposals::AdminServiceStoreListProposalsOperation as _;
+use operations::list_services::AdminServiceStoreListServicesOperation as _;
+use operations::remove_circuit::AdminServiceStoreRemoveCircuitOperation as _;
+use operations::remove_proposal::AdminServiceStoreRemoveProposalOperation as _;
+use operations::update_circuit::AdminServiceStoreUpdateCircuitOperation as _;
+use operations::update_proposal::AdminServiceStoreUpdateProposalOperation as _;
+use operations::upgrade::AdminServiceStoreUpgradeProposalToCircuitOperation as _;
+use operations::AdminServiceStoreOperations;
 
 /// A database-backed AdminServiceStore, powered by [`Diesel`](https://crates.io/crates/diesel).
 pub struct DieselAdminServiceStore<C: diesel::Connection + 'static> {
@@ -59,5 +80,175 @@ impl Clone for DieselAdminServiceStore<diesel::pg::PgConnection> {
         Self {
             connection_pool: self.connection_pool.clone(),
         }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl AdminServiceStore for DieselAdminServiceStore<diesel::pg::PgConnection> {
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_proposal(proposal)
+    }
+
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).update_proposal(proposal)
+    }
+
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).remove_proposal(proposal_id)
+    }
+
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_proposal(proposal_id)
+    }
+
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_proposals(predicates)
+    }
+
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_circuit(circuit, nodes)
+    }
+
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).update_circuit(circuit)
+    }
+
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).remove_circuit(circuit_id)
+    }
+
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_circuit(circuit_id)
+    }
+
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_circuits(predicates)
+    }
+
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?)
+            .upgrade_proposal_to_circuit(circuit_id)
+    }
+
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_node(node_id)
+    }
+
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_nodes()
+    }
+
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_service(service_id)
+    }
+
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_services(circuit_id)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl AdminServiceStore for DieselAdminServiceStore<diesel::sqlite::SqliteConnection> {
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_proposal(proposal)
+    }
+
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).update_proposal(proposal)
+    }
+
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).remove_proposal(proposal_id)
+    }
+
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_proposal(proposal_id)
+    }
+
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_proposals(predicates)
+    }
+
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_circuit(circuit, nodes)
+    }
+
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).update_circuit(circuit)
+    }
+
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).remove_circuit(circuit_id)
+    }
+
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_circuit(circuit_id)
+    }
+
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_circuits(predicates)
+    }
+
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?)
+            .upgrade_proposal_to_circuit(circuit_id)
+    }
+
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_node(node_id)
+    }
+
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_nodes()
+    }
+
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).fetch_service(service_id)
+    }
+
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError> {
+        AdminServiceStoreOperations::new(&*self.connection_pool.get()?).list_services(circuit_id)
     }
 }

--- a/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
@@ -1,0 +1,290 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "add circuit" operation for the `DieselAdminServiceStore`.
+
+use std::collections::HashMap;
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitMemberModel, CircuitModel, NodeEndpointModel, ServiceAllowedNodeModel,
+            ServiceArgumentModel, ServiceModel,
+        },
+        schema::{
+            circuit, circuit_member, node_endpoint, service, service_allowed_node, service_argument,
+        },
+    },
+    error::AdminServiceStoreError,
+    Circuit, CircuitNode,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreAddCircuitOperation {
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceStoreAddCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Check if the circuit already exists in the `AdminServiceStore`, in which case
+            // an error is returned.
+            if circuit::table
+                .filter(circuit::circuit_id.eq(&circuit.id))
+                .first::<CircuitModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Circuit"),
+                    source: Box::new(err),
+                })?
+                .is_some()
+            {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: String::from("Circuit already exists in AdminServiceStore"),
+                    source: None,
+                });
+            }
+
+            // Create a `CircuitModel` from the `Circuit` to add to database
+            let circuit_model: CircuitModel = CircuitModel::from(&circuit);
+            insert_into(circuit::table)
+                .values(circuit_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit"),
+                    source: Box::new(err),
+                })?;
+            // Create a list of circuit members from `nodes`
+            let circuit_members: Vec<CircuitMemberModel> = nodes
+                .iter()
+                .map(|node| CircuitMemberModel {
+                    circuit_id: circuit.id.clone(),
+                    node_id: node.id.clone(),
+                })
+                .collect();
+            insert_into(circuit_member::table)
+                .values(circuit_members)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit members"),
+                    source: Box::new(err),
+                })?;
+            // Iterate over the list of `CircuitNodes` to extract the `node_id` and `endpoints`, to
+            // convert them into the `NodeEndpointModel`. Then, verify the `node_id` does not
+            // already have associated `node_endpoint` entries before inserting the list of
+            // `NodeEndpointModel`.
+            for (node_id, endpoints) in nodes
+                .iter()
+                .map(|node| {
+                    (
+                        node.id.clone(),
+                        node.endpoints
+                            .iter()
+                            .map(|endpoint| NodeEndpointModel {
+                                node_id: node.id.clone(),
+                                endpoint: endpoint.clone(),
+                            })
+                            .collect::<Vec<NodeEndpointModel>>(),
+                    )
+                })
+                .collect::<HashMap<String, Vec<NodeEndpointModel>>>()
+                .into_iter()
+            {
+                if let Some(0) = node_endpoint::table
+                    .filter(node_endpoint::node_id.eq(&node_id))
+                    .count()
+                    .first(self.conn)
+                    .optional()
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Error occurred counting CircuitNode endpoints"),
+                        source: Box::new(err),
+                    })?
+                {
+                    insert_into(node_endpoint::table)
+                        .values(endpoints)
+                        .execute(self.conn)
+                        .map_err(|err| AdminServiceStoreError::QueryError {
+                            context: String::from("Unable to insert Circuit members"),
+                            source: Box::new(err),
+                        })?;
+                }
+            }
+
+            // Build `Services` and all associated data from `circuit`
+            let circuit_services: Vec<ServiceModel> = Vec::from(&circuit);
+            insert_into(service::table)
+                .values(&circuit_services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services"),
+                    source: Box::new(err),
+                })?;
+            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            insert_into(service_argument::table)
+                .values(&service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service arguments"),
+                    source: Box::new(err),
+                })?;
+            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
+            insert_into(service_allowed_node::table)
+                .values(&service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service allowed nodes"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceStoreAddCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_circuit(
+        &self,
+        circuit: Circuit,
+        nodes: Vec<CircuitNode>,
+    ) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Check if the circuit already exists in the `AdminServiceStore`, in which case
+            // an error is returned.
+            if circuit::table
+                .filter(circuit::circuit_id.eq(&circuit.id))
+                .first::<CircuitModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Circuit"),
+                    source: Box::new(err),
+                })?
+                .is_some()
+            {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: String::from("Circuit already exists in AdminServiceStore"),
+                    source: None,
+                });
+            }
+
+            // Create a `CircuitModel` from the `Circuit` to add to database
+            let circuit_model: CircuitModel = CircuitModel::from(&circuit);
+            insert_into(circuit::table)
+                .values(circuit_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit"),
+                    source: Box::new(err),
+                })?;
+            // Create a list of circuit members from `nodes`
+            let circuit_member: Vec<CircuitMemberModel> = nodes
+                .iter()
+                .map(|node| CircuitMemberModel {
+                    circuit_id: circuit.id.clone(),
+                    node_id: node.id.clone(),
+                })
+                .collect();
+            insert_into(circuit_member::table)
+                .values(circuit_member)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit members"),
+                    source: Box::new(err),
+                })?;
+            // Iterate over the list of `CircuitNodes` to extract the `node_id` and `endpoints`, to
+            // convert them into the `NodeEndpointModel`. Then, verify the `node_id` does not
+            // already have associated `node_endpoint` entries before inserting the list of
+            // `NodeEndpointModel`.
+            for (node_id, endpoints) in nodes
+                .iter()
+                .map(|node| {
+                    (
+                        node.id.clone(),
+                        node.endpoints
+                            .iter()
+                            .map(|endpoint| NodeEndpointModel {
+                                node_id: node.id.clone(),
+                                endpoint: endpoint.clone(),
+                            })
+                            .collect::<Vec<NodeEndpointModel>>(),
+                    )
+                })
+                .collect::<HashMap<String, Vec<NodeEndpointModel>>>()
+                .into_iter()
+            {
+                if let Some(0) = node_endpoint::table
+                    .filter(node_endpoint::node_id.eq(&node_id))
+                    .count()
+                    .first(self.conn)
+                    .optional()
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Error occurred counting CircuitNode endpoints"),
+                        source: Box::new(err),
+                    })?
+                {
+                    insert_into(node_endpoint::table)
+                        .values(endpoints)
+                        .execute(self.conn)
+                        .map_err(|err| AdminServiceStoreError::QueryError {
+                            context: String::from("Unable to insert Circuit members"),
+                            source: Box::new(err),
+                        })?;
+                }
+            }
+
+            // Build `Services` and all associated data from `circuit`
+            let circuit_services: Vec<ServiceModel> = Vec::from(&circuit);
+            insert_into(service::table)
+                .values(&circuit_services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services"),
+                    source: Box::new(err),
+                })?;
+            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            insert_into(service_argument::table)
+                .values(&service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service arguments"),
+                    source: Box::new(err),
+                })?;
+            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
+            insert_into(service_allowed_node::table)
+                .values(&service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service allowed nodes"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
@@ -1,0 +1,251 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "add proposal" operation for the `DieselAdminServiceStore`.
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitProposalModel, ProposedCircuitModel, ProposedNodeEndpointModel,
+            ProposedNodeModel, ProposedServiceAllowedNodeModel, ProposedServiceArgumentModel,
+            ProposedServiceModel, VoteRecordModel,
+        },
+        schema::{
+            circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
+            proposed_service, proposed_service_allowed_node, proposed_service_argument,
+            vote_record,
+        },
+    },
+    error::AdminServiceStoreError,
+    CircuitProposal,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreAddProposalOperation {
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceStoreAddProposalOperation
+    for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        // Insert `CircuitProposal` and all associated types into database after verifying that
+        // the proposal exists
+        self.conn.transaction::<(), _, _>(|| {
+            // Check if a `CircuitProposal` already exists with the given `circuit_id`
+            if circuit_proposal::table
+                .filter(circuit_proposal::circuit_id.eq(&proposal.circuit_id))
+                .first::<CircuitProposalModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Diesel error occurred fetching Proposal"),
+                    source: Box::new(err),
+                })?
+                .is_some()
+            {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: String::from("CircuitProposal already exists in AdminServiceStore"),
+                    source: None,
+                });
+            }
+
+            // Insert the database model of the `CircuitProposal`
+            let circuit_proposal_model = CircuitProposalModel::from(&proposal);
+            insert_into(circuit_proposal::table)
+                .values(circuit_proposal_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal"),
+                    source: Box::new(err),
+                })?;
+            // Insert `ProposedCircuitModel`, representing the `proposed_circuit` of a `CircuitProposal`
+            let proposed_circuit_model = ProposedCircuitModel::from(&proposal.circuit);
+            insert_into(proposed_circuit::table)
+                .values(proposed_circuit_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedCircuit"),
+                    source: Box::new(err),
+                })?;
+            // Insert `members` of a `ProposedCircuit`
+            let proposed_members: Vec<ProposedNodeModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode"),
+                    source: Box::new(err),
+                })?;
+            // Insert the node `endpoints` and the proposed `members` of a `ProposedCircuit`
+            let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode's endpoint"),
+                    source: Box::new(err),
+                })?;
+            // Insert `roster`, list of `Services` of a `ProposedCircuit`
+            let proposed_services: Vec<ProposedServiceModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_service::table)
+                .values(proposed_services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService"),
+                    source: Box::new(err),
+                })?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_argument::table)
+                .values(proposed_service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert `allowed_nodes` from the `Services` inserted above
+            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_allowed_node::table)
+                .values(proposed_service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
+                    source: Box::new(err),
+                })?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_records: Vec<VoteRecordModel> = Vec::from(&proposal);
+            insert_into(vote_record::table)
+                .values(vote_records)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal's vote_records"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceStoreAddProposalOperation
+    for AdminServiceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        // Insert `CircuitProposal` and all associated types into database
+        self.conn.transaction::<(), _, _>(|| {
+            // Check if a `CircuitProposal` already exists with the given `circuit_id`, in which
+            // case an error is returned.
+            if circuit_proposal::table
+                .filter(circuit_proposal::circuit_id.eq(&proposal.circuit_id))
+                .first::<CircuitProposalModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Diesel error occurred fetching Proposal"),
+                    source: Box::new(err),
+                })?
+                .is_some()
+            {
+                return Err(AdminServiceStoreError::OperationError {
+                    context: String::from("CircuitProposal already exists in AdminServiceStore"),
+                    source: None,
+                });
+            }
+
+            // Insert the database model of the `CircuitProposal`
+            let circuit_proposal_model = CircuitProposalModel::from(&proposal);
+            insert_into(circuit_proposal::table)
+                .values(circuit_proposal_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal"),
+                    source: Box::new(err),
+                })?;
+            // Insert `ProposedCircuitModel`, representing the `proposed_circuit` of a `CircuitProposal`
+            let proposed_circuit_model = ProposedCircuitModel::from(&proposal.circuit);
+            insert_into(proposed_circuit::table)
+                .values(proposed_circuit_model)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedCircuit"),
+                    source: Box::new(err),
+                })?;
+            // Insert `members` of a `ProposedCircuit`
+            let proposed_members: Vec<ProposedNodeModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode"),
+                    source: Box::new(err),
+                })?;
+            // Insert the node `endpoints` the proposed `members` of a `ProposedCircuit`
+            let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode's endpoint"),
+                    source: Box::new(err),
+                })?;
+            // Insert `roster`, list of `Services` of a `ProposedCircuit`
+            let proposed_services: Vec<ProposedServiceModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_service::table)
+                .values(proposed_services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService"),
+                    source: Box::new(err),
+                })?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_argument::table)
+                .values(proposed_service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert `allowed_nodes` from the `Services` inserted above
+            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_allowed_node::table)
+                .values(proposed_service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
+                    source: Box::new(err),
+                })?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_records: Vec<VoteRecordModel> = Vec::from(&proposal);
+            insert_into(vote_record::table)
+                .values(vote_records)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal's vote_records"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/fetch_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/fetch_circuit.rs
@@ -1,0 +1,93 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "fetch circuit" operation for the `DieselAdminServiceStore`.
+
+use diesel::prelude::*;
+use std::convert::TryFrom;
+
+use super::{list_services::AdminServiceStoreListServicesOperation, AdminServiceStoreOperations};
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitMemberModel, CircuitModel},
+        schema::{circuit, circuit_member},
+    },
+    error::AdminServiceStoreError,
+    AuthorizationType, Circuit, CircuitBuilder, DurabilityType, PersistenceType, RouteType,
+    Service,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreFetchCircuitOperation {
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreFetchCircuitOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError> {
+        self.conn.transaction::<Option<Circuit>, _, _>(|| {
+            // Retrieve the `circuit` entry with the matching `circuit_id`
+            let circuit: CircuitModel = circuit::table
+                .select(circuit::all_columns)
+                .filter(circuit::circuit_id.eq(circuit_id.to_string()))
+                .first::<CircuitModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Circuit"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "Circuit does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Collecting the members of the `Circuit`
+            let members: Vec<CircuitMemberModel> = circuit_member::table
+                .filter(circuit_member::circuit_id.eq(circuit_id.to_string()))
+                .load(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to load Circuit members"),
+                    source: Box::new(err),
+                })?;
+
+            // Collecting services associated with the `Circuit` using the `list_services` method,
+            // which provides a list of the `Services` with the matching `circuit_id`.
+            let services: Vec<Service> = self.list_services(&circuit_id)?.collect();
+            let circuit_member: Vec<String> = members
+                .iter()
+                .map(|member| member.node_id.to_string())
+                .collect();
+
+            Ok(Some(
+                CircuitBuilder::new()
+                    .with_circuit_id(&circuit.circuit_id)
+                    .with_roster(&services)
+                    .with_members(&circuit_member)
+                    .with_auth(&AuthorizationType::try_from(circuit.auth)?)
+                    .with_persistence(&PersistenceType::try_from(circuit.persistence)?)
+                    .with_durability(&DurabilityType::try_from(circuit.durability)?)
+                    .with_routes(&RouteType::try_from(circuit.routes)?)
+                    .build()
+                    .map_err(|err| AdminServiceStoreError::StorageError {
+                        context: String::from("Failed to build Circuit"),
+                        source: Some(Box::new(err)),
+                    })?,
+            ))
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/fetch_node.rs
+++ b/libsplinter/src/admin/store/diesel/operations/fetch_node.rs
@@ -1,0 +1,72 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "fetch node" operation for the `DieselAdminServiceStore`.
+
+use diesel::prelude::*;
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitMemberModel, NodeEndpointModel},
+        schema::{circuit_member, node_endpoint},
+    },
+    error::AdminServiceStoreError,
+    CircuitNode,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreFetchNodeOperation {
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreFetchNodeOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn fetch_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError> {
+        self.conn.transaction::<Option<CircuitNode>, _, _>(|| {
+            // Retrieves the `circuit_member` entry with the matching `node_id`.
+            let member: CircuitMemberModel = circuit_member::table
+                .filter(circuit_member::node_id.eq(&node_id))
+                .first::<CircuitMemberModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Diesel error occurred fetching Node"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "CircuitNode does not exist in AdminServiceStore",
+                    ))
+                })?;
+            // Collect all `node_endpoint` entries with the matching `node_id`.
+            let endpoints: Vec<String> = node_endpoint::table
+                .filter(node_endpoint::node_id.eq(&member.node_id))
+                .load(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to load CircuitNode endpoints"),
+                    source: Box::new(err),
+                })?
+                .into_iter()
+                .map(|endpoint_model: NodeEndpointModel| endpoint_model.endpoint)
+                .collect();
+            Ok(Some(CircuitNode {
+                id: member.node_id,
+                endpoints,
+            }))
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/fetch_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/fetch_proposal.rs
@@ -1,0 +1,283 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "fetch proposal" operation for the `DieselRegistry`.
+
+use diesel::{
+    prelude::*,
+    sql_types::{Binary, Text},
+};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitProposalModel, ProposedCircuitModel, ProposedNodeModel,
+            ProposedServiceArgumentModel, ProposedServiceModel, VoteRecordModel,
+        },
+        schema::{
+            circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
+            proposed_service, proposed_service_allowed_node, proposed_service_argument,
+            vote_record,
+        },
+    },
+    error::AdminServiceStoreError,
+    AuthorizationType, CircuitProposal, CircuitProposalBuilder, DurabilityType, PersistenceType,
+    ProposalType, ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder, ProposedService,
+    ProposedServiceBuilder, RouteType, VoteRecord,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreFetchProposalOperation {
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreFetchProposalOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    CircuitProposalModel: diesel::Queryable<(Text, Text, Text, Binary, Text), C::Backend>,
+    ProposedCircuitModel:
+        diesel::Queryable<(Text, Text, Text, Text, Text, Text, Binary, Text), C::Backend>,
+    VoteRecordModel: diesel::Queryable<(Text, Binary, Text, Text), C::Backend>,
+{
+    fn fetch_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<CircuitProposal>, AdminServiceStoreError> {
+        self.conn.transaction::<Option<CircuitProposal>, _, _>(|| {
+            let (proposal, proposed_circuit): (CircuitProposalModel, ProposedCircuitModel) =
+                circuit_proposal::table
+                    // The `circuit_proposal` and `proposed_circuit` have a one-to-one relationhip
+                    // which allows for the returned entries to be returned as a pair, and the
+                    // `inner_join` allows for the data from each table to be returned in this query.
+                    .inner_join(
+                        proposed_circuit::table
+                            .on(circuit_proposal::circuit_id.eq(proposed_circuit::circuit_id)),
+                    )
+                    // Filters the entries by the provided `proposal_id`
+                    .filter(circuit_proposal::circuit_id.eq(proposal_id))
+                    .first::<(CircuitProposalModel, ProposedCircuitModel)>(self.conn)
+                    .optional()
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from(
+                            "Error occurred fetching CircuitProposal and ProposedCircuit",
+                        ),
+                        source: Box::new(err),
+                    })?
+                    .ok_or_else(|| {
+                        AdminServiceStoreError::NotFoundError(String::from(
+                            "CircuitProposal and ProposedCircuit do not exist in AdminServiceStore",
+                        ))
+                    })?;
+            // If the proposal exists, we must fetch all associated data
+            let mut proposed_node_endpoints: HashMap<String, Vec<String>> = HashMap::new();
+            let mut nodes: HashMap<String, ProposedNodeBuilder> = HashMap::new();
+            for (node, endpoint) in proposed_node::table
+                // As `proposed_node` and `proposed_node_endpoint` have a one-to-many relationship,
+                // this join will return all matching entries as there are `proposed_node_endpoint`
+                // entries.
+                .inner_join(
+                    proposed_node_endpoint::table
+                        .on(proposed_node::node_id.eq(proposed_node_endpoint::node_id)),
+                )
+                // Filters the entries based on the provided `proposal_id`.
+                .filter(proposed_node::circuit_id.eq(&proposal.circuit_id))
+                // Selects only the necessary columns from the data being retrieved, used to
+                // populate the list of `ProposedNodes`.
+                .select((proposed_node::all_columns, proposed_node_endpoint::endpoint))
+                .load::<(ProposedNodeModel, String)>(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to load proposed node endpoints"),
+                    source: Box::new(err),
+                })?
+            {
+                if let Some(endpoint_list) = proposed_node_endpoints.get_mut(&node.node_id) {
+                    endpoint_list.push(endpoint.to_string());
+                } else {
+                    proposed_node_endpoints
+                        .insert(node.node_id.to_string(), vec![endpoint.to_string()]);
+                }
+                if !nodes.contains_key(&node.node_id) {
+                    nodes.insert(
+                        node.node_id.to_string(),
+                        ProposedNodeBuilder::new().with_node_id(&node.node_id),
+                    );
+                }
+            }
+            let built_proposed_nodes: Vec<ProposedNode> = nodes
+                .into_iter()
+                .map(|(id, mut builder)| {
+                    if let Some(endpoints) = proposed_node_endpoints.get(&id) {
+                        builder = builder.with_endpoints(endpoints);
+                    }
+                    builder
+                        .build()
+                        .map_err(|err| AdminServiceStoreError::StorageError {
+                            context: String::from("Failed to build ProposedNode"),
+                            source: Some(Box::new(err)),
+                        })
+                })
+                .collect::<Result<Vec<ProposedNode>, AdminServiceStoreError>>()?;
+
+            // Create HashMap of `service_id` to a `ProposedServiceBuilder` to collect
+            // `ProposedService` information
+            let mut proposed_services: HashMap<String, ProposedServiceBuilder> = HashMap::new();
+            // Create HashMap of `service_id` to the associated argument values
+            let mut arguments_map: HashMap<String, Vec<(String, String)>> = HashMap::new();
+            // Create HashMap of `service_id` to the associated allowed nodes
+            let mut allowed_nodes_map: HashMap<String, Vec<String>> = HashMap::new();
+            // Collect all 'proposed_service' entries and associated data using `inner_join`, as
+            // `proposed_service` has a one-to-many relationship to both `proposed_service_argument`
+            // and `propoosed_service_allowed_node`.
+            for (proposed_service, opt_arg, opt_allowed_node) in proposed_service::table
+                .filter(proposed_service::circuit_id.eq(&proposal.circuit_id))
+                // The `proposed_service` table has a one-to-many relationship with the
+                // `proposed_service_argument` table. The `inner_join` will retrieve the
+                // `proposed_service` and all `proposed_service_argument` entries with the matching
+                // `circuit_id` and `service_id`.
+                .inner_join(
+                    proposed_service_argument::table.on(proposed_service::circuit_id
+                        .eq(proposed_service_argument::circuit_id)
+                        .and(
+                            proposed_service::service_id.eq(proposed_service_argument::service_id),
+                        )),
+                )
+                // The `proposed_service` table has a one-to-many relationship with the
+                // `proposed_service_allowed_node` table. The `inner_join` will retrieve the
+                // `proposed_service` and all `proposed_service_allowed_node` entries with the
+                // matching `circuit_id` and `service_id`.
+                .inner_join(
+                    proposed_service_allowed_node::table.on(proposed_service::circuit_id
+                        .eq(proposed_service_allowed_node::circuit_id)
+                        .and(
+                            proposed_service::service_id
+                                .eq(proposed_service_allowed_node::service_id),
+                        )),
+                )
+                // Making the `proposed_service_argument` and `proposed_service_allowed_node` data
+                // `nullable`, removes the requirement for different numbers of each to be returned
+                // with, or without an associated entry from the other table.
+                .select((
+                    proposed_service::all_columns,
+                    proposed_service_argument::all_columns.nullable(),
+                    proposed_service_allowed_node::allowed_node.nullable(),
+                ))
+                .load::<(
+                    ProposedServiceModel,
+                    Option<ProposedServiceArgumentModel>,
+                    Option<String>,
+                )>(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to load service information"),
+                    source: Box::new(err),
+                })?
+            {
+                if let Some(arg_model) = opt_arg {
+                    if let Some(args) = arguments_map.get_mut(&proposed_service.service_id) {
+                        args.push((arg_model.key.to_string(), arg_model.value.to_string()));
+                    } else {
+                        arguments_map.insert(
+                            proposed_service.service_id.to_string(),
+                            vec![(arg_model.key.to_string(), arg_model.value.to_string())],
+                        );
+                    }
+                }
+                if let Some(allowed_node) = opt_allowed_node {
+                    if let Some(list) = allowed_nodes_map.get_mut(&proposed_service.service_id) {
+                        list.push(allowed_node.to_string());
+                    } else {
+                        allowed_nodes_map.insert(
+                            proposed_service.service_id.to_string(),
+                            vec![allowed_node.to_string()],
+                        );
+                    }
+                }
+                // Insert new `ProposedServiceBuilder` if it does not already exist
+                if !proposed_services.contains_key(&proposed_service.service_id) {
+                    proposed_services.insert(
+                        proposed_service.service_id.to_string(),
+                        ProposedServiceBuilder::new()
+                            .with_service_id(&proposed_service.service_id)
+                            .with_service_type(&proposed_service.service_type),
+                    );
+                }
+            }
+            let built_proposed_services: Vec<ProposedService> = proposed_services
+                .into_iter()
+                .map(|(id, mut builder)| {
+                    if let Some(args) = arguments_map.get(&id) {
+                        builder = builder.with_arguments(&args);
+                    }
+                    if let Some(allowed_nodes) = allowed_nodes_map.get(&id) {
+                        builder = builder.with_allowed_nodes(&allowed_nodes);
+                    }
+                    builder
+                        .build()
+                        .map_err(|err| AdminServiceStoreError::StorageError {
+                            context: String::from("Unable to build ProposedService"),
+                            source: Some(Box::new(err)),
+                        })
+                })
+                .collect::<Result<Vec<ProposedService>, AdminServiceStoreError>>()?;
+
+            // Retrieve all associated `VoteRecord` entries
+            let vote_record: Vec<VoteRecord> = vote_record::table
+                .filter(vote_record::circuit_id.eq(&proposal.circuit_id))
+                .load::<VoteRecordModel>(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to load proposal's vote records"),
+                    source: Box::new(err),
+                })?
+                .into_iter()
+                .filter_map(|vote| VoteRecord::try_from(&vote).ok())
+                .collect();
+            let native_proposed_circuit = ProposedCircuitBuilder::new()
+                .with_circuit_id(&proposal.circuit_id)
+                .with_roster(&built_proposed_services)
+                .with_members(built_proposed_nodes.as_slice())
+                .with_authorization_type(&AuthorizationType::try_from(
+                    proposed_circuit.authorization_type,
+                )?)
+                .with_persistence(&PersistenceType::try_from(proposed_circuit.persistence)?)
+                .with_durability(&DurabilityType::try_from(proposed_circuit.durability)?)
+                .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
+                .build()
+                .map_err(|err| AdminServiceStoreError::StorageError {
+                    context: String::from("Failed to build ProposedCircuit"),
+                    source: Some(Box::new(err)),
+                })?;
+            Ok(Some(
+                CircuitProposalBuilder::new()
+                    .with_proposal_type(&ProposalType::try_from(proposal.proposal_type)?)
+                    .with_circuit_id(&proposal.circuit_id)
+                    .with_circuit_hash(&proposal.circuit_hash)
+                    .with_circuit(&native_proposed_circuit)
+                    .with_votes(&vote_record)
+                    .with_requester(&proposal.requester)
+                    .with_requester_node_id(&proposal.requester_node_id)
+                    .build()
+                    .map_err(|err| AdminServiceStoreError::StorageError {
+                        context: String::from("Failed to build CircuitProposal"),
+                        source: Some(Box::new(err)),
+                    })?,
+            ))
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/fetch_service.rs
+++ b/libsplinter/src/admin/store/diesel/operations/fetch_service.rs
@@ -1,0 +1,103 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "fetch service" operation for the `DieselAdminServiceStore`.
+
+use diesel::prelude::*;
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{ServiceAllowedNodeModel, ServiceArgumentModel, ServiceModel},
+        schema::{service, service_allowed_node, service_argument},
+    },
+    error::AdminServiceStoreError,
+    Service, ServiceBuilder, ServiceId,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreFetchServiceOperation {
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreFetchServiceOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn fetch_service(
+        &self,
+        service_id: &ServiceId,
+    ) -> Result<Option<Service>, AdminServiceStoreError> {
+        self.conn.transaction::<Option<Service>, _, _>(|| {
+            // Fetch the `service` entry with the matching `service_id`.
+            let service: ServiceModel = service::table
+                .filter(service::circuit_id.eq(&service_id.circuit_id))
+                .filter(service::service_id.eq(&service_id.service_id))
+                .first::<ServiceModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Service"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "Service does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Collect the `service_argument` entries with the associated `circuit_id` found
+            // in the `service` entry previously fetched and the provided `service_id`.
+            let arguments: Vec<(String, String)> = service_argument::table
+                .filter(service_argument::circuit_id.eq(&service_id.circuit_id))
+                .filter(service_argument::service_id.eq(&service_id.service_id))
+                .load::<ServiceArgumentModel>(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Service arguments"),
+                    source: Box::new(err),
+                })?
+                .iter()
+                .map(|arg| (arg.key.to_string(), arg.value.to_string()))
+                .collect();
+
+            // Collect the `allowed_node` entries with the associated `circuit_id` found
+            // in the `service` entry previously fetched and the provided `service_id`.
+            let allowed_nodes: Vec<String> = service_allowed_node::table
+                .filter(service_allowed_node::circuit_id.eq(&service_id.circuit_id))
+                .filter(service_allowed_node::service_id.eq(&service_id.service_id))
+                .load::<ServiceAllowedNodeModel>(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Service allowed nodes"),
+                    source: Box::new(err),
+                })?
+                .iter()
+                .map(|entry| entry.allowed_node.to_string())
+                .collect();
+            let return_service = ServiceBuilder::new()
+                .with_service_id(&service.service_id)
+                .with_service_type(&service.service_type)
+                .with_arguments(&arguments)
+                .with_allowed_nodes(&allowed_nodes)
+                .build()
+                .map_err(|err| AdminServiceStoreError::StorageError {
+                    context: String::from("Failed to build Service"),
+                    source: Some(Box::new(err)),
+                })?;
+            Ok(Some(return_service))
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -1,0 +1,266 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list circuits" operation for the `DieselAdminServiceStore`.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use diesel::{
+    dsl::{exists, not},
+    prelude::*,
+};
+
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitMemberModel, CircuitModel, ServiceArgumentModel, ServiceModel},
+        schema::{circuit, circuit_member, service, service_allowed_node, service_argument},
+    },
+    error::AdminServiceStoreError,
+    AuthorizationType, Circuit, CircuitBuilder, CircuitPredicate, DurabilityType, PersistenceType,
+    RouteType, Service, ServiceBuilder,
+};
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreListCircuitsOperation {
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreListCircuitsOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn list_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError> {
+        // Collect the management types included in the list of `CircuitPredicates`
+        let management_types: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::ManagmentTypeEq(man_type) => Some(man_type.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<String>>();
+        // Collects the members included in the list of `CircuitPredicates`
+        let members: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::MembersInclude(members) => Some(members.to_vec()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        self.conn
+            .transaction::<Box<dyn ExactSizeIterator<Item = Circuit>>, _, _>(|| {
+                // Collects circuits which match the circuit predicates
+                let circuits: HashMap<String, CircuitModel> = circuit::table
+                    // Filters based on the circuit's management type
+                    .filter(circuit::circuit_management_type.eq_any(management_types))
+                    // Circuits are filtered by where there doesn't exist any `circuit_member` entries that
+                    // have a matching circuit_id value and have a node_id field that does not equal
+                    // any of the IDs collected from the `CircuitPredicates`.
+                    .filter(not(exists(
+                        // Selects all `circuit_member` entries where the `node_id` is not equal
+                        // to any of the members in the circuit predicates
+                        circuit_member::table.filter(
+                            circuit_member::circuit_id
+                                .eq(circuit::circuit_id)
+                                .and(circuit_member::node_id.ne_all(members)),
+                        ),
+                    )))
+                    .load::<CircuitModel>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Unable to load Circuit information"),
+                        source: Box::new(err),
+                    })?
+                    // Once the `CircuitModels` have been collected, organize into a HashMap
+                    .into_iter()
+                    .map(|model| (model.circuit_id.to_string(), model))
+                    .collect();
+                // Store circuit IDs separately to make it easier to filter following queries
+                let circuit_ids: Vec<String> = circuits.keys().cloned().collect();
+
+                // Collect the `Circuit` members and put them in a HashMap to associate the list
+                // of `node_ids` to the `circuit_id`
+                let mut circuit_members: HashMap<String, Vec<String>> = HashMap::new();
+                for member in circuit_member::table
+                    .filter(circuit_member::circuit_id.eq_any(&circuit_ids))
+                    .load::<CircuitMemberModel>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Unable to load Circuit member information"),
+                        source: Box::new(err),
+                    })?
+                {
+                    if let Some(members) = circuit_members.get_mut(&member.circuit_id) {
+                        members.push(member.node_id.to_string());
+                    } else {
+                        circuit_members.insert(
+                            member.circuit_id.to_string(),
+                            vec![member.node_id.to_string()],
+                        );
+                    }
+                }
+
+                // Create HashMap of (`circuit_id`, ` service_id`) to a `ServiceBuilder`
+                let mut services: HashMap<(String, String), ServiceBuilder> = HashMap::new();
+                // Create HashMap of (`circuit_id`, `service_id`) to the associated argument values
+                let mut arguments_map: HashMap<(String, String), Vec<(String, String)>> =
+                    HashMap::new();
+                // Create HashMap of (`circuit_id`, `service_id`) to the associated allowed nodes
+                let mut allowed_nodes_map: HashMap<(String, String), Vec<String>> = HashMap::new();
+                // Collects all `service`, `service_argument`, and `service_allowed_node` entries
+                // using an inner_join on the `service_id`, since the relationship between `service`
+                // and `service_argument` and between `service` and `service_allowed_node` is one-
+                // to-many. Adding the models retrieved from the database backend to HashMaps
+                // removed the duplicate `service` entries collected, and also makes it simpler
+                // to build each `Service` later on.
+                for (service, opt_arg, opt_allowed_node) in service::table
+                    // Filters the services based on the circuit_ids collected based on the circuits
+                    // which matched the predicates.
+                    .filter(service::circuit_id.eq_any(&circuit_ids))
+                    // Joins a `service_argument` entry to a `service` entry, based on `service_id`.
+                    .inner_join(
+                        service_argument::table
+                            .on(service::service_id.eq(service_argument::service_id)),
+                    )
+                    // Joins a `service_allowed_node` entry to a `service` entry, based on
+                    // `service_id`.
+                    .inner_join(
+                        service_allowed_node::table
+                            .on(service::service_id.eq(service_allowed_node::service_id)),
+                    )
+                    // Collects all data from the `service` entry, and the pertinent data from the
+                    // `service_argument` and `service_allowed_node` entry.
+                    // Making `service_argument` and `service_allowed_node` nullable is required
+                    // to return all matching records since the relationship with services is
+                    // one-to-many for each.
+                    .select((
+                        service::all_columns,
+                        service_argument::all_columns.nullable(),
+                        service_allowed_node::allowed_node.nullable(),
+                    ))
+                    .load::<(ServiceModel, Option<ServiceArgumentModel>, Option<String>)>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Unable to load Service information"),
+                        source: Box::new(err),
+                    })?
+                {
+                    if let Some(arg_model) = opt_arg {
+                        if let Some(args) = arguments_map.get_mut(&(
+                            service.circuit_id.to_string(),
+                            service.service_id.to_string(),
+                        )) {
+                            args.push((arg_model.key.to_string(), arg_model.value.to_string()));
+                        } else {
+                            arguments_map.insert(
+                                (
+                                    service.circuit_id.to_string(),
+                                    service.service_id.to_string(),
+                                ),
+                                vec![(arg_model.key.to_string(), arg_model.value.to_string())],
+                            );
+                        }
+                    }
+                    if let Some(allowed_node) = opt_allowed_node {
+                        if let Some(list) = allowed_nodes_map.get_mut(&(
+                            service.circuit_id.to_string(),
+                            service.service_id.to_string(),
+                        )) {
+                            list.push(allowed_node.to_string());
+                        } else {
+                            allowed_nodes_map.insert(
+                                (
+                                    service.circuit_id.to_string(),
+                                    service.service_id.to_string(),
+                                ),
+                                vec![allowed_node.to_string()],
+                            );
+                        }
+                    }
+                    // Insert new `ServiceBuilder` if it does not already exist
+                    services
+                        .entry((
+                            service.circuit_id.to_string(),
+                            service.service_id.to_string(),
+                        ))
+                        .or_insert_with(|| {
+                            ServiceBuilder::new()
+                                .with_service_id(&service.service_id)
+                                .with_service_type(&service.service_type)
+                        });
+                }
+                // Collect the `Services` mapped to `circuit_ids` after adding any `service_arguments`
+                // and `service_allowed_nodes` to the `ServiceBuilder`.
+                let mut built_services: HashMap<String, Vec<Service>> = HashMap::new();
+                for ((circuit_id, service_id), mut builder) in services.into_iter() {
+                    if let Some(args) =
+                        arguments_map.get(&(circuit_id.to_string(), service_id.to_string()))
+                    {
+                        builder = builder.with_arguments(&args);
+                    }
+                    if let Some(allowed_nodes) =
+                        allowed_nodes_map.get(&(circuit_id.to_string(), service_id.to_string()))
+                    {
+                        builder = builder.with_allowed_nodes(&allowed_nodes);
+                    }
+                    let service =
+                        builder
+                            .build()
+                            .map_err(|err| AdminServiceStoreError::StorageError {
+                                context: String::from("Unable to build Service"),
+                                source: Some(Box::new(err)),
+                            })?;
+                    if let Some(service_list) = built_services.get_mut(&circuit_id) {
+                        service_list.push(service);
+                    } else {
+                        built_services.insert(circuit_id.to_string(), vec![service]);
+                    }
+                }
+
+                let mut ret_circuits: Vec<Circuit> = Vec::new();
+                for (id, model) in circuits {
+                    let mut circuit_builder = CircuitBuilder::new()
+                        .with_circuit_id(&model.circuit_id)
+                        .with_auth(&AuthorizationType::try_from(model.auth)?)
+                        .with_persistence(&PersistenceType::try_from(model.persistence)?)
+                        .with_durability(&DurabilityType::try_from(model.durability)?)
+                        .with_routes(&RouteType::try_from(model.routes)?);
+
+                    if let Some(members) = circuit_members.get(&id) {
+                        circuit_builder = circuit_builder.with_members(&members);
+                    }
+                    if let Some(services) = built_services.get(&id) {
+                        circuit_builder = circuit_builder.with_roster(&services);
+                    }
+
+                    ret_circuits.push(circuit_builder.build().map_err(|err| {
+                        AdminServiceStoreError::OperationError {
+                            context: String::from("Unable to build Circuit"),
+                            source: Some(Box::new(err)),
+                        }
+                    })?);
+                }
+
+                Ok(Box::new(ret_circuits.into_iter()))
+            })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
@@ -1,0 +1,81 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list nodes" operation for the `DieselAdminServiceStore`.
+
+use std::collections::HashMap;
+
+use diesel::{prelude::*, sql_types::Text};
+
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitMemberModel, NodeEndpointModel},
+        schema::{circuit_member, node_endpoint},
+    },
+    error::AdminServiceStoreError,
+    CircuitNode,
+};
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreListNodesOperation {
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreListNodesOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    NodeEndpointModel: diesel::Queryable<(Text, Text), C::Backend>,
+{
+    fn list_nodes(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitNode>>, AdminServiceStoreError> {
+        // Collect all pertinent node entries from the database, including the `circuit_member`
+        // and the `node_endpoint`.
+        let nodes_info: Vec<(CircuitMemberModel, NodeEndpointModel)> = circuit_member::table
+            // As `circuit_member` and `node_endpoint` have a one-to-many relationship, this join
+            // will return all matching entries as there are `node_endpoint` entries.
+            .inner_join(node_endpoint::table.on(circuit_member::node_id.eq(node_endpoint::node_id)))
+            .load(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Unable to load node information"),
+                source: Box::new(err),
+            })?;
+        let mut node_map: HashMap<String, Vec<String>> = HashMap::new();
+        // Iterate over the list of node data retrieved from the database, in order to collect all
+        // endpoints associated with the `node_ids` in a HashMap.
+        nodes_info.iter().for_each(|(node, node_endpoint)| {
+            if let Some(endpoint_list) = node_map.get_mut(&node.node_id) {
+                endpoint_list.push(node_endpoint.endpoint.to_string());
+            } else {
+                node_map.insert(
+                    node.node_id.to_string(),
+                    vec![node_endpoint.endpoint.to_string()],
+                );
+            }
+        });
+        let nodes: Vec<CircuitNode> = node_map
+            .iter()
+            .map(|(node_id, endpoints)| CircuitNode {
+                id: node_id.to_string(),
+                endpoints: endpoints.to_vec(),
+            })
+            .collect();
+        Ok(Box::new(nodes.into_iter()))
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -1,0 +1,364 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list proposals" operation for the `DieselAdminServiceStore`.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use diesel::{
+    dsl::{exists, not},
+    prelude::*,
+    sql_types::{Binary, Text},
+};
+
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitProposalModel, ProposedCircuitModel, ProposedNodeModel,
+            ProposedServiceArgumentModel, ProposedServiceModel, VoteRecordModel,
+        },
+        schema::{
+            circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
+            proposed_service, proposed_service_allowed_node, proposed_service_argument,
+            vote_record,
+        },
+    },
+    error::AdminServiceStoreError,
+    AuthorizationType, CircuitPredicate, CircuitProposal, CircuitProposalBuilder, DurabilityType,
+    PersistenceType, ProposalType, ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder,
+    ProposedService, ProposedServiceBuilder, RouteType, VoteRecord,
+};
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreListProposalsOperation {
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreListProposalsOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    CircuitProposalModel: diesel::Queryable<(Text, Text, Text, Binary, Text), C::Backend>,
+    ProposedCircuitModel:
+        diesel::Queryable<(Text, Text, Text, Text, Text, Text, Binary, Text), C::Backend>,
+    VoteRecordModel: diesel::Queryable<(Text, Binary, Text, Text), C::Backend>,
+{
+    fn list_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError> {
+        // Collect the management types included in the list of `CircuitPredicates`
+        let management_types: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::ManagmentTypeEq(man_type) => Some(man_type.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<String>>();
+        // Collects the members included in the list of `CircuitPredicates`
+        let members: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::MembersInclude(members) => Some(members.to_vec()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        self.conn
+            .transaction::<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, _, _>(|| {
+                // Collects proposed circuits which match the circuit predicates
+                let proposed_circuits: HashMap<
+                    String,
+                    (ProposedCircuitModel, CircuitProposalModel),
+                > = proposed_circuit::table
+                    .filter(proposed_circuit::circuit_management_type.eq_any(management_types))
+                    // Join the `circuit_proposal` table as these are one-to-one, and this eliminates
+                    // the need for an additional query.
+                    .inner_join(
+                        circuit_proposal::table
+                            .on(circuit_proposal::circuit_id.eq(proposed_circuit::circuit_id)),
+                    )
+                    // Proposed circuits are filtered by where there doesn't exist any `proposed_nodes`
+                    // entries that have a matching circuit_id value and have a node_id field that does
+                    // not equal any of the IDs collected from the `CircuitPredicates`.
+                    .filter(not(exists(
+                        // Selects all `proposed_node` entries where the `node_id` is not equal
+                        // to any of the members in the circuit predicates
+                        proposed_node::table.filter(
+                            proposed_node::circuit_id
+                                .eq(proposed_circuit::circuit_id)
+                                .and(proposed_node::node_id.ne_all(members)),
+                        ),
+                    )))
+                    .load::<(ProposedCircuitModel, CircuitProposalModel)>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Unable to load proposed Circuit information"),
+                        source: Box::new(err),
+                    })?
+                    // Once the `ProposedCircuitModels` and `CircuitProposalModels` have been collected,
+                    // organize into a HashMap.
+                    .into_iter()
+                    .map(|(proposed_circuit, circuit_proposal)| {
+                        (
+                            proposed_circuit.circuit_id.to_string(),
+                            (proposed_circuit, circuit_proposal),
+                        )
+                    })
+                    .collect();
+                let proposal_builders: HashMap<
+                    String,
+                    (CircuitProposalBuilder, ProposedCircuitBuilder),
+                > = proposed_circuits
+                    .into_iter()
+                    .map(|(circuit_id, (proposed_circuit, proposal))| {
+                        let proposal_builder = CircuitProposalBuilder::new()
+                            .with_proposal_type(&ProposalType::try_from(proposal.proposal_type)?)
+                            .with_circuit_id(&proposal.circuit_id)
+                            .with_circuit_hash(&proposal.circuit_hash)
+                            .with_requester(&proposal.requester)
+                            .with_requester_node_id(&proposal.requester_node_id);
+                        let proposed_circuit_builder = ProposedCircuitBuilder::new()
+                            .with_circuit_id(&proposed_circuit.circuit_id)
+                            .with_authorization_type(&AuthorizationType::try_from(
+                                proposed_circuit.authorization_type,
+                            )?)
+                            .with_persistence(&PersistenceType::try_from(
+                                proposed_circuit.persistence,
+                            )?)
+                            .with_durability(&DurabilityType::try_from(
+                                proposed_circuit.durability,
+                            )?)
+                            .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
+                            .with_circuit_management_type(&proposed_circuit.circuit_management_type)
+                            .with_application_metadata(&proposed_circuit.application_metadata)
+                            .with_comments(&proposed_circuit.comments);
+                        Ok((circuit_id, (proposal_builder, proposed_circuit_builder)))
+                    })
+                    .collect::<Result<HashMap<_, _>, AdminServiceStoreError>>()?;
+
+                // Collect `ProposedServices` to apply to the `ProposedCircuit`
+                // Create HashMap of (`circuit_id`, `service_id`) to a `ProposedServiceBuilder`
+                let mut proposed_services: HashMap<(String, String), ProposedServiceBuilder> =
+                    HashMap::new();
+                // Create HashMap of (`circuit_id`, `service_id`) to the associated argument values
+                let mut arguments_map: HashMap<(String, String), Vec<(String, String)>> =
+                    HashMap::new();
+                // Create HashMap of (`circuit_id`, `service_id`) to the associated allowed nodes
+                let mut allowed_nodes_map: HashMap<(String, String), Vec<String>> = HashMap::new();
+                for (proposed_service, opt_arg, opt_allowed_node) in proposed_service::table
+                    .inner_join(
+                        proposed_service_argument::table
+                            .on(proposed_service::service_id
+                                .eq(proposed_service_argument::service_id)),
+                    )
+                    .inner_join(proposed_service_allowed_node::table.on(
+                        proposed_service::service_id.eq(proposed_service_allowed_node::service_id),
+                    ))
+                    .select((
+                        proposed_service::all_columns,
+                        proposed_service_argument::all_columns.nullable(),
+                        proposed_service_allowed_node::allowed_node.nullable(),
+                    ))
+                    .load::<(
+                        ProposedServiceModel,
+                        Option<ProposedServiceArgumentModel>,
+                        Option<String>,
+                    )>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Unable to load ProposedService information"),
+                        source: Box::new(err),
+                    })?
+                {
+                    if let Some(arg_model) = opt_arg {
+                        if let Some(args) = arguments_map.get_mut(&(
+                            proposed_service.circuit_id.to_string(),
+                            proposed_service.service_id.to_string(),
+                        )) {
+                            args.push((arg_model.key.to_string(), arg_model.value.to_string()));
+                        } else {
+                            arguments_map.insert(
+                                (
+                                    proposed_service.circuit_id.to_string(),
+                                    proposed_service.service_id.to_string(),
+                                ),
+                                vec![(arg_model.key.to_string(), arg_model.value.to_string())],
+                            );
+                        }
+                    }
+                    if let Some(allowed_node) = opt_allowed_node {
+                        if let Some(list) = allowed_nodes_map.get_mut(&(
+                            proposed_service.circuit_id.to_string(),
+                            proposed_service.service_id.to_string(),
+                        )) {
+                            list.push(allowed_node.to_string());
+                        } else {
+                            allowed_nodes_map.insert(
+                                (
+                                    proposed_service.circuit_id.to_string(),
+                                    proposed_service.service_id.to_string(),
+                                ),
+                                vec![allowed_node.to_string()],
+                            );
+                        }
+                    }
+                    // Insert new `ProposedServiceBuilder` if it does not already exist
+                    proposed_services
+                        .entry((
+                            proposed_service.circuit_id.to_string(),
+                            proposed_service.service_id.to_string(),
+                        ))
+                        .or_insert_with(|| {
+                            ProposedServiceBuilder::new()
+                                .with_service_id(&proposed_service.service_id)
+                                .with_service_type(&proposed_service.service_type)
+                        });
+                }
+                // Need to collect the `ProposedServices` mapped to `circuit_ids`
+                let mut built_proposed_services: HashMap<String, Vec<ProposedService>> =
+                    HashMap::new();
+                for ((circuit_id, service_id), mut builder) in proposed_services.into_iter() {
+                    if let Some(args) =
+                        arguments_map.get(&(circuit_id.to_string(), service_id.to_string()))
+                    {
+                        builder = builder.with_arguments(&args);
+                    }
+                    if let Some(allowed_nodes) =
+                        allowed_nodes_map.get(&(circuit_id.to_string(), service_id.to_string()))
+                    {
+                        builder = builder.with_allowed_nodes(&allowed_nodes);
+                    }
+                    let proposed_service =
+                        builder
+                            .build()
+                            .map_err(|err| AdminServiceStoreError::StorageError {
+                                context: String::from("Unable to build ProposedService"),
+                                source: Some(Box::new(err)),
+                            })?;
+                    if let Some(service_list) = built_proposed_services.get_mut(&circuit_id) {
+                        service_list.push(proposed_service);
+                    } else {
+                        built_proposed_services
+                            .insert(circuit_id.to_string(), vec![proposed_service]);
+                    }
+                }
+                // Collect `ProposedNodes` and proposed node endpoints
+                let mut proposed_node_endpoints: HashMap<String, Vec<String>> = HashMap::new();
+                let mut proposed_nodes: HashMap<(String, String), ProposedNodeBuilder> =
+                    HashMap::new();
+                for (node, endpoint) in proposed_node::table
+                    .inner_join(
+                        proposed_node_endpoint::table
+                            .on(proposed_node::node_id.eq(proposed_node_endpoint::node_id)),
+                    )
+                    .select((proposed_node::all_columns, proposed_node_endpoint::endpoint))
+                    .load::<(ProposedNodeModel, String)>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Failed to load proposed nodes"),
+                        source: Box::new(err),
+                    })?
+                {
+                    if let Some(endpoint_list) = proposed_node_endpoints.get_mut(&node.node_id) {
+                        endpoint_list.push(endpoint.to_string());
+                    } else {
+                        proposed_node_endpoints
+                            .insert(node.node_id.to_string(), vec![endpoint.to_string()]);
+                    }
+                    proposed_nodes
+                        .entry((node.circuit_id.to_string(), node.node_id.to_string()))
+                        .or_insert_with(|| ProposedNodeBuilder::new().with_node_id(&node.node_id));
+                }
+                let mut built_proposed_nodes: HashMap<String, Vec<ProposedNode>> = HashMap::new();
+                for ((circuit_id, node_id), mut builder) in proposed_nodes.into_iter() {
+                    if let Some(endpoints) = proposed_node_endpoints.get(&node_id) {
+                        builder = builder.with_endpoints(endpoints);
+                    }
+                    if let Some(nodes) = built_proposed_nodes.get_mut(&circuit_id) {
+                        nodes.push(builder.build().map_err(|err| {
+                            AdminServiceStoreError::StorageError {
+                                context: String::from("Failed to build ProposedNode"),
+                                source: Some(Box::new(err)),
+                            }
+                        })?);
+                    } else {
+                        built_proposed_nodes.insert(
+                            circuit_id.to_string(),
+                            vec![builder.build().map_err(|err| {
+                                AdminServiceStoreError::StorageError {
+                                    context: String::from("Failed to build ProposedNode"),
+                                    source: Some(Box::new(err)),
+                                }
+                            })?],
+                        );
+                    }
+                }
+
+                // Collect votes to apply to the 'CircuitProposal'
+                let mut vote_records: HashMap<String, Vec<VoteRecord>> = HashMap::new();
+                for vote in vote_record::table
+                    .load::<VoteRecordModel>(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Failed to load proposal's vote records"),
+                        source: Box::new(err),
+                    })?
+                    .into_iter()
+                {
+                    if let Some(votes) = vote_records.get_mut(&vote.circuit_id) {
+                        votes.push(VoteRecord::try_from(&vote)?);
+                    } else {
+                        vote_records.insert(
+                            vote.circuit_id.to_string(),
+                            vec![VoteRecord::try_from(&vote)?],
+                        );
+                    }
+                }
+
+                let mut proposals: Vec<CircuitProposal> = Vec::new();
+                for (circuit_id, (mut proposal_builder, mut proposed_circuit_builder)) in
+                    proposal_builders
+                {
+                    if let Some(services) = built_proposed_services.get(&circuit_id) {
+                        proposed_circuit_builder = proposed_circuit_builder.with_roster(&services);
+                    }
+                    if let Some(nodes) = built_proposed_nodes.get(&circuit_id) {
+                        proposed_circuit_builder = proposed_circuit_builder.with_members(nodes);
+                    }
+                    if let Some(votes) = vote_records.get(&circuit_id) {
+                        proposal_builder = proposal_builder.with_votes(&votes);
+                    }
+                    proposals.push(
+                        proposal_builder
+                            .with_circuit(&proposed_circuit_builder.build().map_err(|err| {
+                                AdminServiceStoreError::StorageError {
+                                    context: String::from("Failed to build ProposedCircuit"),
+                                    source: Some(Box::new(err)),
+                                }
+                            })?)
+                            .build()
+                            .map_err(|err| AdminServiceStoreError::StorageError {
+                                context: String::from("Failed to build CircuitProposal"),
+                                source: Some(Box::new(err)),
+                            })?,
+                    )
+                }
+
+                Ok(Box::new(proposals.into_iter()))
+            })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/list_services.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_services.rs
@@ -1,0 +1,140 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list services" operation for the `DieselAdminServiceStore`.
+
+use std::collections::HashMap;
+
+use diesel::prelude::*;
+
+use crate::admin::store::{
+    diesel::{
+        models::{ServiceArgumentModel, ServiceModel},
+        schema::{service, service_allowed_node, service_argument},
+    },
+    error::AdminServiceStoreError,
+    Service, ServiceBuilder,
+};
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreListServicesOperation {
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreListServicesOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn list_services(
+        &self,
+        circuit_id: &str,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Service>>, AdminServiceStoreError> {
+        // Create HashMap of `service_id` to a `ServiceBuilder` to collect `Service` information
+        let mut services: HashMap<String, ServiceBuilder> = HashMap::new();
+        // Create HashMap of `service_id` to the associated argument values
+        let mut arguments_map: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        // Create HashMap of `service_id` to the associated allowed nodes
+        let mut allowed_nodes_map: HashMap<String, Vec<String>> = HashMap::new();
+        // Collect all 'service' entries and associated data using `inner_join`, as each `service`
+        // entry has a one-to-many relationship to `service_argument` and `service_allowed_node`
+        for (service, opt_arg, opt_allowed_node) in service::table
+            // Filter retrieved 'service' entries by the provided `circuit_id`
+            .filter(service::circuit_id.eq(&circuit_id))
+            // The `service` table has a one-to-many relationship with the `service_argument` table.
+            // The `inner_join` will retrieve the `service` and all `service_argument` entries
+            // with the matching `circuit_id` and `service_id`.
+            .inner_join(
+                service_argument::table.on(service::circuit_id
+                    .eq(service_argument::circuit_id)
+                    .and(service::service_id.eq(service_argument::service_id))),
+            )
+            // The `service` table has a one-to-many relationship with the `service_allowed_node`
+            // table. The `inner_join` will retrieve the `service` and all `service_allowed_node`
+            // entries with the matching `circuit_id` and `service_id`.
+            .inner_join(
+                service_allowed_node::table.on(service::circuit_id
+                    .eq(service_allowed_node::circuit_id)
+                    .and(service::service_id.eq(service_allowed_node::service_id))),
+            )
+            // Making the `service_argument` and `service_allowed_node` data `nullable`, removes
+            // the requirement for different numbers of each to be returned with, or without
+            // an associated entry from the other table.
+            .select((
+                service::all_columns,
+                service_argument::all_columns.nullable(),
+                service_allowed_node::allowed_node.nullable(),
+            ))
+            .load::<(ServiceModel, Option<ServiceArgumentModel>, Option<String>)>(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Unable to load Service information"),
+                source: Box::new(err),
+            })?
+        {
+            if let Some(arg_model) = opt_arg {
+                if let Some(args) = arguments_map.get_mut(&service.service_id) {
+                    args.push((arg_model.key.to_string(), arg_model.value.to_string()));
+                } else {
+                    arguments_map.insert(
+                        service.service_id.to_string(),
+                        vec![(arg_model.key.to_string(), arg_model.value.to_string())],
+                    );
+                }
+            }
+            if let Some(allowed_node) = opt_allowed_node {
+                if let Some(list) = allowed_nodes_map.get_mut(&service.service_id) {
+                    list.push(allowed_node.to_string());
+                } else {
+                    allowed_nodes_map.insert(
+                        service.service_id.to_string(),
+                        vec![allowed_node.to_string()],
+                    );
+                }
+            }
+            // Insert new `ServiceBuilder` if it does not already exist
+            if !services.contains_key(&service.service_id) {
+                services.insert(
+                    service.service_id.to_string(),
+                    ServiceBuilder::new()
+                        .with_service_id(&service.service_id)
+                        .with_service_type(&service.service_type),
+                );
+            }
+        }
+
+        let ret_services: Vec<Service> = services
+            .into_iter()
+            .map(|(id, mut builder)| {
+                if let Some(args) = arguments_map.get(&id) {
+                    builder = builder.with_arguments(&args);
+                }
+                if let Some(allowed_nodes) = allowed_nodes_map.get(&id) {
+                    builder = builder.with_allowed_nodes(&allowed_nodes);
+                }
+                builder
+                    .build()
+                    .map_err(|err| AdminServiceStoreError::StorageError {
+                        context: String::from("Unable to build Service"),
+                        source: Some(Box::new(err)),
+                    })
+            })
+            .collect::<Result<Vec<Service>, AdminServiceStoreError>>()?;
+        Ok(Box::new(ret_services.into_iter()))
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -16,6 +16,10 @@
 
 pub(super) mod add_circuit;
 pub(super) mod add_proposal;
+pub(super) mod list_circuits;
+pub(super) mod list_nodes;
+pub(super) mod list_proposals;
+pub(super) mod list_services;
 
 pub struct AdminServiceStoreOperations<'a, C> {
     #[allow(dead_code)]

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -16,6 +16,10 @@
 
 pub(super) mod add_circuit;
 pub(super) mod add_proposal;
+pub(super) mod fetch_circuit;
+pub(super) mod fetch_node;
+pub(super) mod fetch_proposal;
+pub(super) mod fetch_service;
 pub(super) mod list_circuits;
 pub(super) mod list_nodes;
 pub(super) mod list_proposals;

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -26,6 +26,9 @@ pub(super) mod list_proposals;
 pub(super) mod list_services;
 pub(super) mod remove_circuit;
 pub(super) mod remove_proposal;
+pub(super) mod update_circuit;
+pub(super) mod update_proposal;
+pub(super) mod upgrade;
 
 pub struct AdminServiceStoreOperations<'a, C> {
     #[allow(dead_code)]

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -24,6 +24,8 @@ pub(super) mod list_circuits;
 pub(super) mod list_nodes;
 pub(super) mod list_proposals;
 pub(super) mod list_services;
+pub(super) mod remove_circuit;
+pub(super) mod remove_proposal;
 
 pub struct AdminServiceStoreOperations<'a, C> {
     #[allow(dead_code)]

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -14,6 +14,9 @@
 
 //! Provides database operations for the `DieselAdminServiceStore`.
 
+pub(super) mod add_circuit;
+pub(super) mod add_proposal;
+
 pub struct AdminServiceStoreOperations<'a, C> {
     #[allow(dead_code)]
     conn: &'a C,

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -31,7 +31,6 @@ pub(super) mod update_proposal;
 pub(super) mod upgrade;
 
 pub struct AdminServiceStoreOperations<'a, C> {
-    #[allow(dead_code)]
     conn: &'a C,
 }
 

--- a/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
@@ -1,0 +1,86 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "remove circuit" operation for the `DieselAdminServiceStore`.
+
+use diesel::{dsl::delete, prelude::*};
+
+use crate::admin::store::{
+    diesel::schema::{circuit, circuit_member, node_endpoint},
+    error::AdminServiceStoreError,
+};
+
+use super::{fetch_circuit::AdminServiceStoreFetchCircuitOperation, AdminServiceStoreOperations};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreRemoveCircuitOperation {
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreRemoveCircuitOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+{
+    fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the circuit attempting to be removed exists.
+            self.fetch_circuit(&circuit_id).and_then(|opt_circuit| {
+                // Remove the `circuit` entry with the matching `circuit_id`
+                // The `circuit_id` foreign key has cascade delete, meaning all related tables
+                // associated to the `circuit` table via the `circuit_id` will be deleted, if the
+                // corresponding `circuit` entry with the matching `circuit_id` is deleted.
+                delete(circuit::table.find(&circuit_id))
+                    .execute(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Failed to delete Circuit"),
+                        source: Box::new(err),
+                    })?;
+
+                // Must individually remove the circuit's members' `node_endpoint` entries, to
+                // check first if the `node_id` is a member of any other circuit, and the
+                // `node_endpoint` data is still valid and, therefore, should not be deleted.
+                if let Some(circuit) = opt_circuit {
+                    for node_id in circuit.members.iter() {
+                        // Count the amount of `circuit_member` entries with the same `node_id`. If
+                        // there are still `circuit_member` entries with the associated `node_id`,
+                        // or the count is not equal to 0, the `node_enpoint` should not be deleted.
+                        if let Some(0) = circuit_member::table
+                            .filter(circuit_member::node_id.eq(&node_id))
+                            .count()
+                            .first(self.conn)
+                            .optional()
+                            .map_err(|err| AdminServiceStoreError::QueryError {
+                                context: String::from(
+                                    "Error occurred counting CircuitNode endpoints",
+                                ),
+                                source: Box::new(err),
+                            })?
+                        {
+                            delete(node_endpoint::table.filter(node_endpoint::node_id.eq(node_id)))
+                                .execute(self.conn)
+                                .map_err(|err| AdminServiceStoreError::QueryError {
+                                    context: String::from(
+                                        "Failed to delete `node_endpoint` entries",
+                                    ),
+                                    source: Box::new(err),
+                                })?;
+                        }
+                    }
+                }
+                Ok(())
+            })
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "remove proposal" operation for the `DieselAdminServiceStore`.
+
+use diesel::{
+    dsl::delete,
+    prelude::*,
+    sql_types::{Binary, Text},
+};
+
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitProposalModel, ProposedCircuitModel, VoteRecordModel},
+        schema::circuit_proposal,
+    },
+    error::AdminServiceStoreError,
+};
+
+use super::{fetch_proposal::AdminServiceStoreFetchProposalOperation, AdminServiceStoreOperations};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreRemoveProposalOperation {
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreRemoveProposalOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    CircuitProposalModel: diesel::Queryable<(Text, Text, Text, Binary, Text), C::Backend>,
+    ProposedCircuitModel:
+        diesel::Queryable<(Text, Text, Text, Text, Text, Text, Binary, Text), C::Backend>,
+    VoteRecordModel: diesel::Queryable<(Text, Binary, Text, Text), C::Backend>,
+{
+    fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the `proposal` being removed exists
+            self.fetch_proposal(&proposal_id).and_then(|_| {
+                // Remove the `proposal` entry with the matching `proposal_id`, which is represented
+                // in the `circuit_proposal` by the `circuit_id`.
+                // The `circuit_id` foreign key has cascade delete, meaning all related tables
+                // associated to the `circuit` table via the `circuit_id` will be deleted, if the
+                // corresponding `circuit` entry with the matching `circuit_id` is deleted.
+                delete(circuit_proposal::table.find(&proposal_id))
+                    .execute(self.conn)
+                    .map_err(|err| AdminServiceStoreError::QueryError {
+                        context: String::from("Failed to delete CircuitProposal"),
+                        source: Box::new(err),
+                    })?;
+                Ok(())
+            })
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -1,0 +1,229 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "update circuit" operation for the `DieselAdminServiceStore`.
+
+use diesel::{
+    dsl::{delete, insert_into, update},
+    prelude::*,
+};
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitMemberModel, CircuitModel, ServiceAllowedNodeModel, ServiceArgumentModel,
+            ServiceModel,
+        },
+        schema::{circuit, circuit_member, service, service_allowed_node, service_argument},
+    },
+    error::AdminServiceStoreError,
+    Circuit,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateCircuitOperation {
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceStoreUpdateCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the `circuit` entry to be updated exists
+            circuit::table
+                .filter(circuit::circuit_id.eq(&circuit.id))
+                .first::<CircuitModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Circuit"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "Circuit does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Update existing `Circuit`
+            let circuit_model = CircuitModel::from(&circuit);
+            update(circuit::table.find(&circuit.id))
+                .set((
+                    circuit::auth.eq(circuit_model.auth),
+                    circuit::persistence.eq(circuit_model.persistence),
+                    circuit::durability.eq(circuit_model.durability),
+                    circuit::routes.eq(circuit_model.routes),
+                    circuit::circuit_management_type.eq(circuit_model.circuit_management_type),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update Circuit"),
+                    source: Box::new(err),
+                })?;
+            // Delete existing data associated with the `Circuit`
+            delete(service::table.filter(service::circuit_id.eq(&circuit.id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old Services"),
+                    source: Box::new(err),
+                })?;
+            delete(
+                service_allowed_node::table
+                    .filter(service_allowed_node::circuit_id.eq(&circuit.id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old Services' allowed nodes"),
+                source: Box::new(err),
+            })?;
+            delete(service_argument::table.filter(service_argument::circuit_id.eq(&circuit.id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old Service arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert new data associate with the `Circuit`
+            let services: Vec<ServiceModel> = Vec::from(&circuit);
+            insert_into(service::table)
+                .values(&services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services"),
+                    source: Box::new(err),
+                })?;
+            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
+            insert_into(service_allowed_node::table)
+                .values(&service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services' allowed nodes"),
+                    source: Box::new(err),
+                })?;
+            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            insert_into(service_argument::table)
+                .values(&service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service arguments"),
+                    source: Box::new(err),
+                })?;
+            let circuit_member: Vec<CircuitMemberModel> = Vec::from(&circuit);
+            insert_into(circuit_member::table)
+                .values(circuit_member)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit members"),
+                    source: Box::new(err),
+                })?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceStoreUpdateCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the `circuit` entry to be updated exists
+            circuit::table
+                .filter(circuit::circuit_id.eq(&circuit.id))
+                .first::<CircuitModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred fetching Circuit"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "Circuit does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Update existing `Circuit`
+            let circuit_model = CircuitModel::from(&circuit);
+            update(circuit::table.find(&circuit.id))
+                .set((
+                    circuit::auth.eq(circuit_model.auth),
+                    circuit::persistence.eq(circuit_model.persistence),
+                    circuit::durability.eq(circuit_model.durability),
+                    circuit::routes.eq(circuit_model.routes),
+                    circuit::circuit_management_type.eq(circuit_model.circuit_management_type),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update Circuit"),
+                    source: Box::new(err),
+                })?;
+            // Delete existing data associated with the `Circuit`
+            delete(service::table.filter(service::circuit_id.eq(&circuit.id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old Services"),
+                    source: Box::new(err),
+                })?;
+            delete(
+                service_allowed_node::table
+                    .filter(service_allowed_node::circuit_id.eq(&circuit.id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old Services' allowed nodes"),
+                source: Box::new(err),
+            })?;
+            delete(service_argument::table.filter(service_argument::circuit_id.eq(&circuit.id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old Service arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert new `Circuit` data
+            let services: Vec<ServiceModel> = Vec::from(&circuit);
+            insert_into(service::table)
+                .values(&services)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services"),
+                    source: Box::new(err),
+                })?;
+            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
+            insert_into(service_allowed_node::table)
+                .values(&service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Services' allowed nodes"),
+                    source: Box::new(err),
+                })?;
+            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            insert_into(service_argument::table)
+                .values(&service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Service arguments"),
+                    source: Box::new(err),
+                })?;
+            let circuit_member: Vec<CircuitMemberModel> = Vec::from(&circuit);
+            insert_into(circuit_member::table)
+                .values(circuit_member)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert Circuit members"),
+                    source: Box::new(err),
+                })?;
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -1,0 +1,402 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "update proposal" operation for the `DieselAdminServiceStore`.
+
+use diesel::{
+    dsl::{delete, insert_into, update},
+    prelude::*,
+};
+
+use super::AdminServiceStoreOperations;
+use crate::admin::store::{
+    diesel::{
+        models::{
+            CircuitProposalModel, ProposedCircuitModel, ProposedNodeEndpointModel,
+            ProposedNodeModel, ProposedServiceAllowedNodeModel, ProposedServiceArgumentModel,
+            ProposedServiceModel, VoteRecordModel,
+        },
+        schema::{
+            circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
+            proposed_service, proposed_service_allowed_node, proposed_service_argument,
+            vote_record,
+        },
+    },
+    error::AdminServiceStoreError,
+    CircuitProposal,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateProposalOperation {
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceStoreUpdateProposalOperation
+    for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the `circuit_proposal` entry to be updated exists
+            circuit_proposal::table
+                .filter(circuit_proposal::circuit_id.eq(&proposal.circuit_id))
+                .first::<CircuitProposalModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Diesel error occurred fetching CircuitProposal"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "CircuitProposal does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Update existing `CircuitProposal`
+            let proposal_model = CircuitProposalModel::from(&proposal);
+            update(circuit_proposal::table.find(&proposal.circuit_id))
+                .set((
+                    circuit_proposal::proposal_type.eq(proposal_model.proposal_type),
+                    circuit_proposal::circuit_hash.eq(proposal_model.circuit_hash),
+                    circuit_proposal::requester.eq(proposal_model.requester),
+                    circuit_proposal::requester_node_id.eq(proposal_model.requester_node_id),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update CircuitProposal"),
+                    source: Box::new(err),
+                })?;
+            // Update existing `ProposedCircuit`
+            let proposed_circuit_model = ProposedCircuitModel::from(&proposal.circuit);
+            update(proposed_circuit::table.find(&proposal.circuit_id))
+                .set((
+                    proposed_circuit::authorization_type
+                        .eq(proposed_circuit_model.authorization_type),
+                    proposed_circuit::persistence.eq(proposed_circuit_model.persistence),
+                    proposed_circuit::durability.eq(proposed_circuit_model.durability),
+                    proposed_circuit::routes.eq(proposed_circuit_model.routes),
+                    proposed_circuit::circuit_management_type
+                        .eq(proposed_circuit_model.circuit_management_type),
+                    proposed_circuit::application_metadata
+                        .eq(proposed_circuit_model.application_metadata),
+                    proposed_circuit::comments.eq(proposed_circuit_model.comments),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update ProposedCircuit"),
+                    source: Box::new(err),
+                })?;
+
+            // Delete existing data associated with the `CircuitProposal` and `ProposedCircuit`
+            let node_ids: Vec<String> = proposed_node::table
+                .filter(proposed_node::circuit_id.eq(&proposal.circuit_id))
+                .select(proposed_node::node_id)
+                .load(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to fetch old proposed nodes"),
+                    source: Box::new(err),
+                })?;
+
+            delete(proposed_node::table.filter(proposed_node::circuit_id.eq(&proposal.circuit_id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old proposed Nodes"),
+                    source: Box::new(err),
+                })?;
+            delete(
+                proposed_node_endpoint::table
+                    .filter(proposed_node_endpoint::node_id.eq_any(&node_ids)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old node endpoints"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service::table
+                    .filter(proposed_service::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service_argument::table
+                    .filter(proposed_service_argument::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services' arguments"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service_allowed_node::table
+                    .filter(proposed_service_allowed_node::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services' allowed nodes"),
+                source: Box::new(err),
+            })?;
+            delete(vote_record::table.filter(vote_record::circuit_id.eq(&proposal.circuit_id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old proposal's vote records"),
+                    source: Box::new(err),
+                })?;
+
+            // Insert the updated info for all of the `CircuitProposal` and `ProposedCircuit`
+            // associated data
+            // Insert `members` of a `ProposedCircuit`
+            let proposed_members: Vec<ProposedNodeModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode"),
+                    source: Box::new(err),
+                })?;
+            // Insert the node `endpoints` the proposed `members` of a `ProposedCircuit`
+            let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode's endpoint"),
+                    source: Box::new(err),
+                })?;
+            // Insert `roster`, list of `Services` of a `ProposedCircuit`
+            let proposed_service: Vec<ProposedServiceModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_service::table)
+                .values(proposed_service)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService"),
+                    source: Box::new(err),
+                })?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_argument::table)
+                .values(proposed_service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert `allowed_nodes` from the `Services` inserted above
+            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_allowed_node::table)
+                .values(proposed_service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
+                    source: Box::new(err),
+                })?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_record: Vec<VoteRecordModel> = Vec::from(&proposal);
+            insert_into(vote_record::table)
+                .values(vote_record)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal's vote_records"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceStoreUpdateProposalOperation
+    for AdminServiceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify the `circuit_proposal` entry to be updated exists
+            circuit_proposal::table
+                .filter(circuit_proposal::circuit_id.eq(&proposal.circuit_id))
+                .first::<CircuitProposalModel>(self.conn)
+                .optional()
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Diesel error occurred fetching CircuitProposal"),
+                    source: Box::new(err),
+                })?
+                .ok_or_else(|| {
+                    AdminServiceStoreError::NotFoundError(String::from(
+                        "CircuitProposal does not exist in AdminServiceStore",
+                    ))
+                })?;
+
+            // Update existing `CircuitProposal`
+            let proposal_model = CircuitProposalModel::from(&proposal);
+            update(circuit_proposal::table.find(&proposal.circuit_id))
+                .set((
+                    circuit_proposal::proposal_type.eq(proposal_model.proposal_type),
+                    circuit_proposal::circuit_hash.eq(proposal_model.circuit_hash),
+                    circuit_proposal::requester.eq(proposal_model.requester),
+                    circuit_proposal::requester_node_id.eq(proposal_model.requester_node_id),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update CircuitProposal"),
+                    source: Box::new(err),
+                })?;
+            // Update existing `ProposedCircuit`
+            let proposed_circuit_model = ProposedCircuitModel::from(&proposal.circuit);
+            update(proposed_circuit::table.find(&proposal.circuit_id))
+                .set((
+                    proposed_circuit::authorization_type
+                        .eq(proposed_circuit_model.authorization_type),
+                    proposed_circuit::persistence.eq(proposed_circuit_model.persistence),
+                    proposed_circuit::durability.eq(proposed_circuit_model.durability),
+                    proposed_circuit::routes.eq(proposed_circuit_model.routes),
+                    proposed_circuit::circuit_management_type
+                        .eq(proposed_circuit_model.circuit_management_type),
+                    proposed_circuit::application_metadata
+                        .eq(proposed_circuit_model.application_metadata),
+                    proposed_circuit::comments.eq(proposed_circuit_model.comments),
+                ))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to update ProposedCircuit"),
+                    source: Box::new(err),
+                })?;
+
+            // Delete existing data associated with the `CircuitProposal` and `ProposedCircuit`
+            let node_ids: Vec<String> = proposed_node::table
+                .filter(proposed_node::circuit_id.eq(&proposal.circuit_id))
+                .select(proposed_node::node_id)
+                .load(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to fetch old proposed nodes"),
+                    source: Box::new(err),
+                })?;
+
+            delete(proposed_node::table.filter(proposed_node::circuit_id.eq(&proposal.circuit_id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old proposed Nodes"),
+                    source: Box::new(err),
+                })?;
+            delete(
+                proposed_node_endpoint::table
+                    .filter(proposed_node_endpoint::node_id.eq_any(&node_ids)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old node endpoints"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service::table
+                    .filter(proposed_service::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service_argument::table
+                    .filter(proposed_service_argument::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services' arguments"),
+                source: Box::new(err),
+            })?;
+            delete(
+                proposed_service_allowed_node::table
+                    .filter(proposed_service_allowed_node::circuit_id.eq(&proposal.circuit_id)),
+            )
+            .execute(self.conn)
+            .map_err(|err| AdminServiceStoreError::QueryError {
+                context: String::from("Failed to remove old proposed Services' allowed nodes"),
+                source: Box::new(err),
+            })?;
+            delete(vote_record::table.filter(vote_record::circuit_id.eq(&proposal.circuit_id)))
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Failed to remove old proposal's vote records"),
+                    source: Box::new(err),
+                })?;
+
+            // Insert the updated info for all of the `CircuitProposal` and `ProposedCircuit`
+            // associated data
+            // Insert `members` of a `ProposedCircuit`
+            let proposed_members: Vec<ProposedNodeModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode"),
+                    source: Box::new(err),
+                })?;
+            // Insert the node `endpoints` the proposed `members` of a `ProposedCircuit`
+            let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedNode's endpoint"),
+                    source: Box::new(err),
+                })?;
+            // Insert `roster`, list of `Services` of a `ProposedCircuit`
+            let proposed_service: Vec<ProposedServiceModel> = Vec::from(&proposal.circuit);
+            insert_into(proposed_service::table)
+                .values(proposed_service)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService"),
+                    source: Box::new(err),
+                })?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_argument::table)
+                .values(proposed_service_argument)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's arguments"),
+                    source: Box::new(err),
+                })?;
+            // Insert `allowed_nodes` from the `Services` inserted above
+            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
+                Vec::from(&proposal.circuit);
+            insert_into(proposed_service_allowed_node::table)
+                .values(proposed_service_allowed_node)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
+                    source: Box::new(err),
+                })?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_record: Vec<VoteRecordModel> = Vec::from(&proposal);
+            insert_into(vote_record::table)
+                .values(vote_record)
+                .execute(self.conn)
+                .map_err(|err| AdminServiceStoreError::QueryError {
+                    context: String::from("Unable to insert CircuitProposal's vote_records"),
+                    source: Box::new(err),
+                })?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "upgrade proposal to circuit" operation for the `DieselAdminServiceStore`.
+
+use diesel::prelude::*;
+
+use crate::admin::store::{error::AdminServiceStoreError, CircuitBuilder, CircuitNode, Service};
+
+use super::{
+    add_circuit::AdminServiceStoreAddCircuitOperation,
+    fetch_proposal::AdminServiceStoreFetchProposalOperation,
+    remove_proposal::AdminServiceStoreRemoveProposalOperation, AdminServiceStoreOperations,
+};
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreUpgradeProposalToCircuitOperation {
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Attempting to fetch the proposal to be upgraded. If not found, an error is returned.
+            let proposal = match self.fetch_proposal(circuit_id)? {
+                Some(proposal) => Ok(proposal),
+                None => Err(AdminServiceStoreError::NotFoundError(format!(
+                    "Cannot find circuit proposal with id: {}",
+                    circuit_id
+                ))),
+            }?;
+            // Need to construct the `Circuit` from the `ProposedCircuit`
+            let proposed_circuit = &proposal.circuit;
+            let circuit = CircuitBuilder::new()
+                .with_circuit_id(&proposed_circuit.circuit_id)
+                .with_roster(
+                    &proposed_circuit
+                        .roster
+                        .iter()
+                        .map(Service::from)
+                        .collect::<Vec<Service>>(),
+                )
+                .with_members(
+                    &proposed_circuit
+                        .members
+                        .iter()
+                        .map(|node| node.node_id.to_string())
+                        .collect::<Vec<String>>(),
+                )
+                .with_auth(&proposed_circuit.authorization_type)
+                .with_persistence(&proposed_circuit.persistence)
+                .with_durability(&proposed_circuit.durability)
+                .with_routes(&proposed_circuit.routes)
+                .with_circuit_management_type(&proposed_circuit.circuit_management_type)
+                .build()
+                .map_err(|err| AdminServiceStoreError::StorageError {
+                    context: String::from("Failed to build Circuit"),
+                    source: Some(Box::new(err)),
+                })?;
+            let circuit_nodes = proposed_circuit
+                .members
+                .iter()
+                .map(CircuitNode::from)
+                .collect::<Vec<CircuitNode>>();
+
+            self.remove_proposal(&proposal.circuit_id)
+                .and_then(|_| self.add_circuit(circuit, circuit_nodes))?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
+    for AdminServiceStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            // Attempting to fetch the proposal to be upgraded. If not found, an error is returned.
+            let proposal = match self.fetch_proposal(circuit_id)? {
+                Some(proposal) => Ok(proposal),
+                None => Err(AdminServiceStoreError::NotFoundError(format!(
+                    "Cannot find circuit proposal with id: {}",
+                    circuit_id
+                ))),
+            }?;
+            // Need to construct the `Circuit` from the `ProposedCircuit`
+            let proposed_circuit = &proposal.circuit;
+            let circuit = CircuitBuilder::new()
+                .with_circuit_id(&proposed_circuit.circuit_id)
+                .with_roster(
+                    &proposed_circuit
+                        .roster
+                        .iter()
+                        .map(Service::from)
+                        .collect::<Vec<Service>>(),
+                )
+                .with_members(
+                    &proposed_circuit
+                        .members
+                        .iter()
+                        .map(|node| node.node_id.to_string())
+                        .collect::<Vec<String>>(),
+                )
+                .with_auth(&proposed_circuit.authorization_type)
+                .with_persistence(&proposed_circuit.persistence)
+                .with_durability(&proposed_circuit.durability)
+                .with_routes(&proposed_circuit.routes)
+                .with_circuit_management_type(&proposed_circuit.circuit_management_type)
+                .build()
+                .map_err(|err| AdminServiceStoreError::StorageError {
+                    context: String::from("Failed to build Circuit"),
+                    source: Some(Box::new(err)),
+                })?;
+            let circuit_nodes = proposed_circuit
+                .members
+                .iter()
+                .map(CircuitNode::from)
+                .collect::<Vec<CircuitNode>>();
+
+            self.remove_proposal(&proposal.circuit_id)
+                .and_then(|_| self.add_circuit(circuit, circuit_nodes))?;
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -132,3 +132,23 @@ table! {
         endpoint -> Text,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    proposed_circuit,
+    proposed_node,
+    proposed_node_endpoint,
+    proposed_service,
+    proposed_service_allowed_node,
+    proposed_service_argument,
+    vote_record,
+    circuit_proposal,
+);
+
+allow_tables_to_appear_in_same_query!(
+    service,
+    service_allowed_node,
+    service_argument,
+    circuit,
+    circuit_member,
+    node_endpoint
+);

--- a/libsplinter/src/admin/store/error.rs
+++ b/libsplinter/src/admin/store/error.rs
@@ -95,6 +95,23 @@ impl fmt::Display for AdminServiceStoreError {
     }
 }
 
+impl From<diesel::result::Error> for AdminServiceStoreError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::QueryBuilderError(std_err) => {
+                AdminServiceStoreError::QueryError {
+                    context: String::from("Error occurred building diesel query"),
+                    source: std_err,
+                }
+            }
+            _ => AdminServiceStoreError::StorageError {
+                context: String::from("A diesel error occurred"),
+                source: Some(Box::new(err)),
+            },
+        }
+    }
+}
+
 /// Represents errors raised while building
 #[derive(Debug)]
 pub enum BuilderError {

--- a/libsplinter/src/admin/store/error.rs
+++ b/libsplinter/src/admin/store/error.rs
@@ -112,6 +112,16 @@ impl From<diesel::result::Error> for AdminServiceStoreError {
     }
 }
 
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for AdminServiceStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> Self {
+        AdminServiceStoreError::StorageError {
+            context: String::from("Diesel error occurred"),
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
 /// Represents errors raised while building
 #[derive(Debug)]
 pub enum BuilderError {

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -180,6 +180,15 @@ pub struct CircuitNode {
     endpoints: Vec<String>,
 }
 
+impl From<&ProposedNode> for CircuitNode {
+    fn from(proposed_node: &ProposedNode) -> Self {
+        CircuitNode {
+            id: proposed_node.node_id.clone(),
+            endpoints: proposed_node.endpoints.clone(),
+        }
+    }
+}
+
 /// Native representation of a node in a proposed circuit
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ProposedNode {
@@ -194,6 +203,17 @@ pub struct Service {
     service_type: String,
     allowed_nodes: Vec<String>,
     arguments: Vec<(String, String)>,
+}
+
+impl From<&ProposedService> for Service {
+    fn from(proposed_service: &ProposedService) -> Self {
+        Service {
+            service_id: proposed_service.service_id.to_string(),
+            service_type: proposed_service.service_type.to_string(),
+            allowed_nodes: proposed_service.allowed_nodes.to_vec(),
+            arguments: proposed_service.arguments.to_vec(),
+        }
+    }
 }
 
 /// Native representation of a service that is a part of a proposed circuit


### PR DESCRIPTION
Implements the agnostic database backend for the AdminServiceStore. That includes a `DieselAdminServiceStore` and `DieselAdminServiceStoreOperations` structs which wrap a generic db connection, as well as operations implemented to implement the `AdminServiceStore` trait for the `DieselAdminServiceStore`.