### PR TITLE
Add circuit template environment variable

### DIFF
--- a/cli/man/splinter-circuit-template-arguments.1.md
+++ b/cli/man/splinter-circuit-template-arguments.1.md
@@ -22,8 +22,12 @@ Circuit templates help simplify the process of creating new circuits with the
 building a circuit from the template. This command lists the arguments that are
 defined in the specified circuit template.
 
-All available templates are located in the circuit templates directory,
-`/usr/share/splinter/circuit-templates`.
+All available templates are located in the default circuit templates directory,
+`/usr/share/splinter/circuit-templates`, unless `SPLINTER_CIRCUIT_TEMPLATE_PATH`
+is set. Note, if multiple template storage directories are specified in the
+`SPLINTER_CIRCUIT_TEMPLATE_PATH`, they are searched from first to last for
+template files. The first file matching the specified `TEMPLATE-NAME` will
+be displayed.
 
 FLAGS
 =====
@@ -45,8 +49,18 @@ ARGUMENTS
 =========
 `TEMPLATE-NAME`
 : Name of the circuit template containing the arguments of interest. The
-  template file must exist in the circuit template directory,
-    `/usr/share/splinter/circuit-templates`.
+  template file must exist in the specified circuit template directory.
+  The circuit template directory is by default
+  `/usr/share/splinter/circuit-templates`, unless
+  `SPLINTER_CIRCUIT_TEMPLATE_PATH` is set.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_CIRCUIT_TEMPLATE_PATH**
+: Paths containing circuit template files. Multiple values may be provided,
+  separated by `:`, using the format `DIR1:DIR2:DIR3`. If multiple directories
+  are specified, the directories are searched from first to last for template
+  files.
 
 EXAMPLES
 ========

--- a/cli/man/splinter-circuit-template-list.1.md
+++ b/cli/man/splinter-circuit-template-list.1.md
@@ -23,8 +23,12 @@ templates.
 A Scabbard circuit template is available by default (this template is packaged
 with the Splinter CLI).
 
-All available templates are located in the circuit templates directory,
-`/usr/share/splinter/circuit-templates`.
+All available templates are located in the default circuit templates directory,
+`/usr/share/splinter/circuit-templates`, unless `SPLINTER_CIRCUIT_TEMPLATE_PATH`
+is set. Note, if multiple template storage directories are specified in the
+`SPLINTER_CIRCUIT_TEMPLATE_PATH`, they are searched from first to last for
+template files. The first file matching the specified `TEMPLATE-NAME` will
+be displayed.
 
 Tip: Use the `splinter circuit template arguments` command to see the required
 arguments for a specific circuit template.
@@ -45,11 +49,28 @@ FLAGS
 : Increases verbosity (the opposite of -q). Specify multiple times for more
   output.
 
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the circuit templates. (default `human`).
+  Possible values for formatting are `human` and `csv`. The `human` option
+  displays the circuit template file information in a formatted table, while
+  `csv` prints the circuit template file information via comma-separated values.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_CIRCUIT_TEMPLATE_PATH**
+: Paths containing circuit template files. Multiple values may be provided,
+  separated by `:`, using the format `DIR1:DIR2:DIR3`. If multiple directories
+  are specified, the directories are searched from first to last for template
+  files.
+
 EXAMPLES
 ========
 The following example lists the circuit templates on a system that has only the
 `scabbard` template, which is available by default (packaged with the Splinter CLI)
-in the circuit template directory, `/usr/share/splinter/circuit-templates`.
+in the circuit template directory, `/usr/share/splinter/circuit-templates`, unless
+`SPLINTER_CIRCUIT_TEMPLATE_PATH` is set.
 
 ```
 $ splinter circuit template list

--- a/cli/man/splinter-circuit-template-show.1.md
+++ b/cli/man/splinter-circuit-template-show.1.md
@@ -20,8 +20,12 @@ Circuit templates help simplify the process of creating new circuits with the
 `splinter circuit propose` command. This command displays the entire template
 definition, including the arguments and rules, for the specified template.
 
-All available templates are located in the circuit templates directory,
-`/usr/share/splinter/circuit-templates`.
+All available templates are located in the default circuit templates directory,
+`/usr/share/splinter/circuit-templates`, unless `SPLINTER_CIRCUIT_TEMPLATE_PATH`
+is set. Note, if multiple template storage directories are specified in the
+`SPLINTER_CIRCUIT_TEMPLATE_PATH`, they are searched from first to last for
+template files. The first file matching the specified `TEMPLATE-NAME` will
+be displayed.
 
 Tip: Use the `splinter circuit template arguments` command to show only the
 required arguments for a specific circuit template.
@@ -46,13 +50,24 @@ ARGUMENTS
 =========
 `TEMPLATE-NAME`
 : Name of the circuit template to be displayed. The template file must exist in
-  the circuit template directory, `/usr/share/splinter/circuit-templates`.
+  the specified circuit template directory. The circuit template directory is by
+  default `/usr/share/splinter/circuit-templates`, unless
+  `SPLINTER_CIRCUIT_TEMPLATE_PATH` is set.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_CIRCUIT_TEMPLATE_PATH**
+: Paths containing circuit template files. Multiple values may be provided,
+  separated by `:`, using the format `DIR1:DIR2:DIR3`. If multiple directories
+  are specified, the directories are searched from first to last for template
+  files.
 
 EXAMPLES
 ========
 The following command shows the details of the `scabbard` circuit template,
 which is available by default (packaged with the Splinter CLI) in the default
-circuit template directory, `/usr/share/splinter/circuit-templates`.
+circuit template directory, `/usr/share/splinter/circuit-templates`, unless
+`SPLINTER_CIRCUIT_TEMPLATE_PATH` is set.
 
 ```
 $ splinter circuit template show scabbard

--- a/cli/man/splinter-circuit-template.1.md
+++ b/cli/man/splinter-circuit-template.1.md
@@ -29,7 +29,11 @@ with the Splinter CLI). This template can be used as a model for other circuit
 templates.
 
 All available templates are located in the default circuit templates directory,
-`/usr/share/splinter/circuit-templates`.
+`/usr/share/splinter/circuit-templates`, unless `SPLINTER_CIRCUIT_TEMPLATE_PATH`
+is set. Note, if multiple template storage directories are specified in the
+`SPLINTER_CIRCUIT_TEMPLATE_PATH`, they are searched from first to last for
+template files. The first file matching the specified `TEMPLATE-NAME` will
+be displayed.
 
 FLAGS
 =====
@@ -57,6 +61,14 @@ SUBCOMMANDS
 
 `show`
 : Display a specific available template.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_CIRCUIT_TEMPLATE_PATH**
+: Paths containing circuit template files. Multiple values may be provided,
+  separated by `:`, using the format `DIR1:DIR2:DIR3`. If multiple directories
+  are specified, the directories are searched from first to last for template
+  files.
 
 SEE ALSO
 ========

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -482,7 +482,19 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         SubCommand::with_name("template")
             .about("Manage circuit templates")
             .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(SubCommand::with_name("list").about("List available templates"))
+            .subcommand(
+                SubCommand::with_name("list")
+                    .about("List available templates")
+                    .arg(
+                        Arg::with_name("format")
+                            .short("F")
+                            .long("format")
+                            .help("Output format")
+                            .possible_values(&["human", "csv"])
+                            .default_value("human")
+                            .takes_value(true),
+                    ),
+            )
             .subcommand(
                 SubCommand::with_name("show").about("Show a template").arg(
                     Arg::with_name("name")

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -15,6 +15,7 @@
 //! Data structure and implementation of the circuit template representation for the CLI.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use splinter::circuit::template::{
     CircuitCreateTemplate, CircuitTemplateError, CircuitTemplateManager, RuleArgument,
@@ -34,7 +35,7 @@ pub struct CircuitTemplate {
 
 impl CircuitTemplate {
     /// Lists all available circuit templates found in the default template directory.
-    pub fn list_available_templates() -> Result<Vec<String>, CliError> {
+    pub fn list_available_templates() -> Result<Vec<(String, PathBuf)>, CliError> {
         let mut paths = Vec::new();
         if let Ok(env_paths) = std::env::var(SPLINTER_CIRCUIT_TEMPLATE_PATH) {
             paths.extend(
@@ -90,7 +91,7 @@ impl CircuitTemplate {
         paths.push(DEFAULT_TEMPLATE_DIR.to_string());
         let manager = CircuitTemplateManager::new(&paths);
         let possible_values = manager.list_available_templates()?;
-        if !possible_values.iter().any(|val| val == name) {
+        if !possible_values.iter().any(|(stem, _)| stem == name) {
             return Err(CliError::ActionError(format!(
                 "Template with name {} was not found. Available templates: {:?}",
                 name, possible_values

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 use splinter::circuit::template::{
     CircuitCreateTemplate, CircuitTemplateError, CircuitTemplateManager, RuleArgument,
+    DEFAULT_TEMPLATE_DIR, SPLINTER_CIRCUIT_TEMPLATE_PATH,
 };
 
 use crate::action::circuit::CreateCircuitMessageBuilder;
@@ -34,7 +35,17 @@ pub struct CircuitTemplate {
 impl CircuitTemplate {
     /// Lists all available circuit templates found in the default template directory.
     pub fn list_available_templates() -> Result<Vec<String>, CliError> {
-        let manager = CircuitTemplateManager::default();
+        let mut paths = Vec::new();
+        if let Ok(env_paths) = std::env::var(SPLINTER_CIRCUIT_TEMPLATE_PATH) {
+            paths.extend(
+                env_paths
+                    .split(':')
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<String>>(),
+            );
+        }
+        paths.push(DEFAULT_TEMPLATE_DIR.to_string());
+        let manager = CircuitTemplateManager::new(&paths);
         let templates = manager.list_available_templates()?;
         Ok(templates)
     }
@@ -45,7 +56,17 @@ impl CircuitTemplate {
     ///
     /// * `name` - File name of the circuit template YAML file.
     pub fn load_raw(name: &str) -> Result<String, CliError> {
-        let manager = CircuitTemplateManager::default();
+        let mut paths = Vec::new();
+        if let Ok(env_paths) = std::env::var(SPLINTER_CIRCUIT_TEMPLATE_PATH) {
+            paths.extend(
+                env_paths
+                    .split(':')
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<String>>(),
+            );
+        }
+        paths.push(DEFAULT_TEMPLATE_DIR.to_string());
+        let manager = CircuitTemplateManager::new(&paths);
         let template_yaml = manager.load_raw_yaml(name)?;
         Ok(template_yaml)
     }
@@ -57,7 +78,17 @@ impl CircuitTemplate {
     ///
     /// * `name` - File name of the circuit template YAML file.
     pub fn load(name: &str) -> Result<Self, CliError> {
-        let manager = CircuitTemplateManager::default();
+        let mut paths = Vec::new();
+        if let Ok(env_paths) = std::env::var(SPLINTER_CIRCUIT_TEMPLATE_PATH) {
+            paths.extend(
+                env_paths
+                    .split(':')
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<String>>(),
+            );
+        }
+        paths.push(DEFAULT_TEMPLATE_DIR.to_string());
+        let manager = CircuitTemplateManager::new(&paths);
         let possible_values = manager.list_available_templates()?;
         if !possible_values.iter().any(|val| val == name) {
             return Err(CliError::ActionError(format!(

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -22,7 +22,7 @@ use gameroom_database::{
 use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::{CreateCircuit, CreateCircuitBuilder, SplinterNode};
-use splinter::circuit::template::{CircuitCreateTemplate, DEFAULT_TEMPLATE_DIR};
+use splinter::circuit::template::CircuitCreateTemplate;
 use splinter::protocol;
 use splinter::protos::admin::{
     CircuitManagementPayload, CircuitManagementPayload_Action as Action,
@@ -96,10 +96,7 @@ pub async fn propose_gameroom(
     splinterd_url: web::Data<String>,
     gameroomd_data: web::Data<GameroomdData>,
 ) -> HttpResponse {
-    let mut template = match CircuitCreateTemplate::from_yaml_file(&format!(
-        "{}/gameroom.yaml",
-        &DEFAULT_TEMPLATE_DIR
-    )) {
+    let mut template = match CircuitCreateTemplate::from_yaml_file("gameroom.yaml") {
         Ok(template) => template,
         Err(err) => {
             error!("Failed to load Gameroom template: {}", err);

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -39,6 +39,7 @@ crossbeam-channel = "0.3"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
 futures = { version = "0.1", optional = true }
+glob = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
 jsonwebtoken = { version = "6.0", optional = true }
 log = "0.3.0"
@@ -115,7 +116,7 @@ biome-credentials = ["biome", "biome-user", "bcrypt"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
 biome-user = ["biome"]
-circuit-template = []
+circuit-template = ["glob"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []


### PR DESCRIPTION
Adds a circuit template environment variable to allow users to change the directory circuit templates are stored in. This also affects the circuit templates packaged within Gameroom and the Splinter CLI. 