### PR TITLE
Update registry DB insert to be atomic 

### DIFF
--- a/libsplinter/src/events/ws.rs
+++ b/libsplinter/src/events/ws.rs
@@ -608,7 +608,7 @@ impl<T: ParseBytes<T> + 'static> Context<T> {
             // time elapsed since last reconnect attempt
             let elapsed = SystemTime::now()
                 .duration_since(self.last_reconnect)
-                .unwrap_or(Duration::from_secs(0));
+                .unwrap_or_else(|_| Duration::from_secs(0));
 
             if elapsed >= self.wait {
                 break;


### PR DESCRIPTION
Updates the `RegistryInsertNodeOperation::insert_node` operation for the
Diesel-backed registry store to be fully atomic. Previously, the query
to check for the existence of a node was outside the database
transaction that added or updated the node, which made the operation
non-atomic.

Signed-off-by: Logan Seeley <seeley@bitwise.io>