### PR TITLE
Use uppercase 'F' for `format` short flag

### DIFF
--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -42,7 +42,7 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` FORMAT
+`-F`, `--format` FORMAT
 : Specifies the output format of the circuit. (default `human`). Possible values
   for formatting are `human` and `csv`.
 

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -41,7 +41,7 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` FORMAT
+`-F`, `--format` FORMAT
 : Specifies the output format of the circuit proposal. (default `human`).
   Possible values for formatting are `human` and `csv`. The `human` option
   displays the circuit proposals information in a formatted table, while `csv`

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -41,7 +41,7 @@ FLAGS
 
 OPTIONS
 =======
-`-f`, `--format` FORMAT
+`-F`, `--format` FORMAT
 : Specifies the output format of the circuit proposal. (default `human`).
   Possible values for formatting are `human` and `csv`.
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -595,7 +595,13 @@ impl Action for CircuitListAction {
         let filter = arg_matches.and_then(|args| args.value_of("member"));
 
         let format = arg_matches
-            .and_then(|args| args.value_of("format"))
+            .and_then(|args| {
+                if let Some(val) = args.value_of("hidden_format") {
+                    Some(val)
+                } else {
+                    args.value_of("format")
+                }
+            })
             .unwrap_or("human");
 
         list_circuits(&url, filter, format)
@@ -646,7 +652,11 @@ impl Action for CircuitShowAction {
             .value_of("circuit")
             .ok_or_else(|| CliError::ActionError("'circuit' argument is required".to_string()))?;
 
-        let format = args.value_of("format").unwrap_or("human");
+        let format = if let Some(val) = args.value_of("hidden_format") {
+            val
+        } else {
+            args.value_of("format").unwrap_or("human")
+        };
 
         show_circuit(&url, circuit_id, format)
     }
@@ -726,7 +736,13 @@ impl Action for CircuitProposalsAction {
         let member_filter = arg_matches.and_then(|args| args.value_of("member"));
 
         let format = arg_matches
-            .and_then(|args| args.value_of("format"))
+            .and_then(|args| {
+                if let Some(val) = args.value_of("hidden_format") {
+                    Some(val)
+                } else {
+                    args.value_of("format")
+                }
+            })
             .unwrap_or("human");
 
         list_proposals(&url, management_type_filter, member_filter, format)

--- a/cli/src/action/circuit/template.rs
+++ b/cli/src/action/circuit/template.rs
@@ -27,7 +27,13 @@ impl Action for ListCircuitTemplates {
         let templates = CircuitTemplate::list_available_templates()?;
 
         let format = arg_matches
-            .and_then(|args| args.value_of("format"))
+            .and_then(|args| {
+                if let Some(val) = args.value_of("hidden_format") {
+                    Some(val)
+                } else {
+                    args.value_of("format")
+                }
+            })
             .unwrap_or("human");
 
         if format == "csv" {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -404,11 +404,19 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 )
                 .arg(
                     Arg::with_name("format")
-                        .short("f")
+                        .short("F")
                         .long("format")
                         .help("Output format")
                         .possible_values(&["human", "csv"])
                         .default_value("human")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("hidden_format")
+                        .short("f")
+                        .hidden(true)
+                        .help("Output format")
+                        .possible_values(&["human", "csv"])
                         .takes_value(true),
                 ),
         )
@@ -430,11 +438,19 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 )
                 .arg(
                     Arg::with_name("format")
-                        .short("f")
+                        .short("F")
                         .long("format")
                         .help("Output format")
                         .possible_values(&["human", "yaml", "json"])
                         .default_value("human")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("hidden_format")
+                        .short("f")
+                        .hidden(true)
+                        .help("Output format")
+                        .possible_values(&["human", "yaml", "json"])
                         .takes_value(true),
                 ),
         )
@@ -468,11 +484,19 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 )
                 .arg(
                     Arg::with_name("format")
-                        .short("f")
+                        .short("F")
                         .long("format")
                         .help("Output format")
                         .possible_values(&["human", "csv"])
                         .default_value("human")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("hidden_format")
+                        .short("f")
+                        .hidden(true)
+                        .help("Output format")
+                        .possible_values(&["human", "csv"])
                         .takes_value(true),
                 ),
         );


### PR DESCRIPTION
Updates the short flag for the `format` option from a lowercase 'f' to
an uppercase 'F' to reflect normal usage. Also adds a hidden subcommand
argument assigned to the lowercase 'f' which performs the same function
as the uppercase 'F', to ensure backward-compatibility.