### PR TITLE
Remove duplicate COPY instruction from scabbard-cli Dockerfile

### DIFF
--- a/services/scabbard/cli/Dockerfile-installed-bionic
+++ b/services/scabbard/cli/Dockerfile-installed-bionic
@@ -37,7 +37,6 @@ COPY examples/gameroom/database/Cargo.toml \
      /build/examples/gameroom/database/Cargo.toml
 
 # Copy over source files
-COPY Cargo.toml /build/Cargo.toml
 COPY libsplinter /build/libsplinter
 COPY services/scabbard/cli /build/services/scabbard/cli
 COPY services/scabbard/libscabbard /build/services/scabbard/libscabbard


### PR DESCRIPTION
This line is causing docker builds to fail during Github Action runs.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>