### PR TITLE
Export ISOLATION_ID in publish-docker ci script

### DIFF
--- a/ci/publish-docker
+++ b/ci/publish-docker
@@ -39,9 +39,9 @@ fi
 if [ -z $1 ]
 then
     # If no arguments are provided to the script
-    ISOLATION_ID=$REPO_VERSION
+    export ISOLATION_ID=$REPO_VERSION
 else
-    ISOLATION_ID=$1
+    export ISOLATION_ID=$1
     if [ $1 == "experimental" ];
     then
         export CARGO_ARGS="-- --features experimental"


### PR DESCRIPTION
Without this change, this script doesn't perform as expected when run as part of
a Github Actions workflow. The ISOLATION_ID provided in the docker .env file
is used instead of the value passed to the script.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>