### PR TITLE
Remove serde serilization decorators from AdminServiceStore struct API

### DIFF
--- a/libsplinter/src/admin/store/circuit_proposal.rs
+++ b/libsplinter/src/admin/store/circuit_proposal.rs
@@ -15,7 +15,6 @@
 //! Structs for building services
 
 use crate::admin::messages::is_valid_circuit_id;
-use crate::hex::{as_hex, deserialize_hex};
 
 use super::error::BuilderError;
 use super::ProposedCircuit;
@@ -28,8 +27,6 @@ pub struct CircuitProposal {
     circuit_hash: String,
     circuit: ProposedCircuit,
     votes: Vec<VoteRecord>,
-    #[serde(serialize_with = "as_hex")]
-    #[serde(deserialize_with = "deserialize_hex")]
     requester: Vec<u8>,
     requester_node_id: String,
 }
@@ -261,8 +258,6 @@ impl CircuitProposalBuilder {
 // Native representation of a vote record for a proposal
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct VoteRecord {
-    #[serde(serialize_with = "as_hex")]
-    #[serde(deserialize_with = "deserialize_hex")]
     public_key: Vec<u8>,
     vote: Vote,
     voter_node_id: String,

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -15,7 +15,6 @@
 //! Structs for building proposed circuits
 
 use crate::admin::messages::is_valid_circuit_id;
-use crate::hex::{as_hex, deserialize_hex};
 
 use super::error::BuilderError;
 use super::{
@@ -33,9 +32,6 @@ pub struct ProposedCircuit {
     durability: DurabilityType,
     routes: RouteType,
     circuit_management_type: String,
-    #[serde(serialize_with = "as_hex")]
-    #[serde(deserialize_with = "deserialize_hex")]
-    #[serde(default)]
     application_metadata: Vec<u8>,
     comments: String,
 }


### PR DESCRIPTION
Serde should not be a part of the public API of the structs for the
AdminServiceStore.

This commit also add Yaml specific structs for CircuitProposal,
ProposedCircuit, and VoteRecord because the Vec<u8> in those
structs must be converted to a hex string for storage. This
was done automatically before with the serde decorators, and now
needs to be done explicitly.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>