### PR TITLE
Remove allowed_nodes list for services in circuits and proposals

### DIFF
--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
@@ -17,7 +17,6 @@ DROP TABLE IF EXISTS proposed_circuit;
 DROP TABLE IF EXISTS proposed_node;
 DROP TABLE IF EXISTS proposed_node_endpoint;
 DROP TABLE IF EXISTS proposed_service;
-DROP TABLE IF EXISTS proposed_services_allowed_node;
 DROP TABLE IF EXISTS proposed_service_argument;
 DROP TABLE IF EXISTS vote_record;
 DROP TABLE IF EXISTS circuit_proposal;

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/down.sql
@@ -21,7 +21,6 @@ DROP TABLE IF EXISTS proposed_service_argument;
 DROP TABLE IF EXISTS vote_record;
 DROP TABLE IF EXISTS circuit_proposal;
 DROP TABLE IF EXISTS service;
-DROP TABLE IF EXISTS service_allowed_node;
 DROP TABLE IF EXISTS service_argument;
 DROP TABLE IF EXISTS circuit;
 DROP TABLE IF EXISTS circuit_member;

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -80,16 +80,8 @@ CREATE TABLE IF NOT EXISTS service (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id),
-    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS service_allowed_node (
-    circuit_id                TEXT NOT NULL,
-    service_id                TEXT NOT NULL,
-    allowed_node              TEXT NOT NULL,
-    PRIMARY KEY (circuit_id, service_id, allowed_node),
-    FOREIGN KEY (service_id) REFERENCES service(service_id),
     FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -61,16 +61,8 @@ CREATE TABLE IF NOT EXISTS proposed_service (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS proposed_service_allowed_node (
-    circuit_id                TEXT NOT NULL,
-    service_id                TEXT NOT NULL,
-    allowed_node              TEXT NOT NULL,
-    PRIMARY KEY (circuit_id, service_id, allowed_node),
-    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
     FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
 );
 

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
@@ -17,7 +17,6 @@ DROP TABLE IF EXISTS proposed_circuit;
 DROP TABLE IF EXISTS proposed_node;
 DROP TABLE IF EXISTS proposed_node_endpoint;
 DROP TABLE IF EXISTS proposed_service;
-DROP TABLE IF EXISTS proposed_service_allowed_node;
 DROP TABLE IF EXISTS proposed_service_argument;
 DROP TABLE IF EXISTS vote_record;
 DROP TABLE IF EXISTS circuit_proposal;

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/down.sql
@@ -21,7 +21,6 @@ DROP TABLE IF EXISTS proposed_service_argument;
 DROP TABLE IF EXISTS vote_record;
 DROP TABLE IF EXISTS circuit_proposal;
 DROP TABLE IF EXISTS service;
-DROP TABLE IF EXISTS service_allowed_node;
 DROP TABLE IF EXISTS service_argument;
 DROP TABLE IF EXISTS circuit;
 DROP TABLE IF EXISTS circuit_member;

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -80,16 +80,8 @@ CREATE TABLE IF NOT EXISTS service (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id),
-    FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS service_allowed_node (
-    circuit_id                TEXT NOT NULL,
-    service_id                TEXT NOT NULL,
-    allowed_node              TEXT NOT NULL,
-    PRIMARY KEY (circuit_id, service_id, allowed_node),
-    FOREIGN KEY (service_id) REFERENCES service(service_id),
     FOREIGN KEY (circuit_id) REFERENCES circuit(circuit_id) ON DELETE CASCADE
 );
 

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -61,16 +61,8 @@ CREATE TABLE IF NOT EXISTS proposed_service (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
     PRIMARY KEY (circuit_id, service_id),
-    FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS proposed_service_allowed_node (
-    circuit_id                TEXT NOT NULL,
-    service_id                TEXT NOT NULL,
-    allowed_node              TEXT NOT NULL,
-    PRIMARY KEY (circuit_id, service_id, allowed_node),
-    FOREIGN KEY (service_id) REFERENCES proposed_service(service_id),
     FOREIGN KEY (circuit_id) REFERENCES proposed_circuit(circuit_id) ON DELETE CASCADE
 );
 

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -20,8 +20,8 @@ use std::convert::TryFrom;
 
 use crate::admin::store::diesel::schema::{
     circuit, circuit_member, circuit_proposal, node_endpoint, proposed_circuit, proposed_node,
-    proposed_node_endpoint, proposed_service, proposed_service_argument, service,
-    service_allowed_node, service_argument, vote_record,
+    proposed_node_endpoint, proposed_service, proposed_service_argument, service, service_argument,
+    vote_record,
 };
 use crate::admin::store::error::AdminServiceStoreError;
 use crate::admin::store::{
@@ -247,6 +247,7 @@ pub struct ServiceModel {
     pub circuit_id: String,
     pub service_id: String,
     pub service_type: String,
+    pub node_id: String,
 }
 
 impl From<&Circuit> for Vec<ServiceModel> {
@@ -258,39 +259,9 @@ impl From<&Circuit> for Vec<ServiceModel> {
                 circuit_id: circuit.circuit_id().into(),
                 service_id: service.service_id().into(),
                 service_type: service.service_type().into(),
+                node_id: service.node_id().into(),
             })
             .collect()
-    }
-}
-
-/// Database model representation of the `allowed_nodes` in a `Service`
-#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "service_allowed_node"]
-#[belongs_to(ServiceModel, foreign_key = "service_id")]
-#[primary_key(circuit_id, service_id, allowed_node)]
-pub struct ServiceAllowedNodeModel {
-    pub circuit_id: String,
-    pub service_id: String,
-    pub allowed_node: String,
-}
-
-impl From<&Circuit> for Vec<ServiceAllowedNodeModel> {
-    fn from(circuit: &Circuit) -> Self {
-        let mut allowed_nodes = Vec::new();
-        for service in circuit.roster() {
-            allowed_nodes.extend(
-                service
-                    .allowed_nodes()
-                    .iter()
-                    .map(|node| ServiceAllowedNodeModel {
-                        circuit_id: circuit.circuit_id().into(),
-                        service_id: service.service_id().into(),
-                        allowed_node: node.clone(),
-                    })
-                    .collect::<Vec<ServiceAllowedNodeModel>>(),
-            );
-        }
-        allowed_nodes
     }
 }
 

--- a/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
@@ -22,12 +22,9 @@ use super::AdminServiceStoreOperations;
 use crate::admin::store::{
     diesel::{
         models::{
-            CircuitMemberModel, CircuitModel, NodeEndpointModel, ServiceAllowedNodeModel,
-            ServiceArgumentModel, ServiceModel,
+            CircuitMemberModel, CircuitModel, NodeEndpointModel, ServiceArgumentModel, ServiceModel,
         },
-        schema::{
-            circuit, circuit_member, node_endpoint, service, service_allowed_node, service_argument,
-        },
+        schema::{circuit, circuit_member, node_endpoint, service, service_argument},
     },
     error::AdminServiceStoreError,
     Circuit, CircuitNode,
@@ -151,14 +148,6 @@ impl<'a> AdminServiceStoreAddCircuitOperation
                     context: String::from("Unable to insert Service arguments"),
                     source: Box::new(err),
                 })?;
-            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
-            insert_into(service_allowed_node::table)
-                .values(&service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert Service allowed nodes"),
-                    source: Box::new(err),
-                })?;
 
             Ok(())
         })
@@ -273,14 +262,6 @@ impl<'a> AdminServiceStoreAddCircuitOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert Service arguments"),
-                    source: Box::new(err),
-                })?;
-            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
-            insert_into(service_allowed_node::table)
-                .values(&service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert Service allowed nodes"),
                     source: Box::new(err),
                 })?;
 

--- a/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
@@ -21,13 +21,11 @@ use crate::admin::store::{
     diesel::{
         models::{
             CircuitProposalModel, ProposedCircuitModel, ProposedNodeEndpointModel,
-            ProposedNodeModel, ProposedServiceAllowedNodeModel, ProposedServiceArgumentModel,
-            ProposedServiceModel, VoteRecordModel,
+            ProposedNodeModel, ProposedServiceArgumentModel, ProposedServiceModel, VoteRecordModel,
         },
         schema::{
             circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
-            proposed_service, proposed_service_allowed_node, proposed_service_argument,
-            vote_record,
+            proposed_service, proposed_service_argument, vote_record,
         },
     },
     error::AdminServiceStoreError,
@@ -117,16 +115,6 @@ impl<'a> AdminServiceStoreAddProposalOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert ProposedService's arguments"),
-                    source: Box::new(err),
-                })?;
-            // Insert `allowed_nodes` from the `Services` inserted above
-            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
-                Vec::from(proposal.circuit());
-            insert_into(proposed_service_allowed_node::table)
-                .values(proposed_service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
                     source: Box::new(err),
                 })?;
             // Insert `votes` from the `CircuitProposal`
@@ -223,16 +211,6 @@ impl<'a> AdminServiceStoreAddProposalOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert ProposedService's arguments"),
-                    source: Box::new(err),
-                })?;
-            // Insert `allowed_nodes` from the `Services` inserted above
-            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
-                Vec::from(proposal.circuit());
-            insert_into(proposed_service_allowed_node::table)
-                .values(proposed_service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
                     source: Box::new(err),
                 })?;
             // Insert `votes` from the `CircuitProposal`

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -22,11 +22,8 @@ use diesel::{
 use super::AdminServiceStoreOperations;
 use crate::admin::store::{
     diesel::{
-        models::{
-            CircuitMemberModel, CircuitModel, ServiceAllowedNodeModel, ServiceArgumentModel,
-            ServiceModel,
-        },
-        schema::{circuit, circuit_member, service, service_allowed_node, service_argument},
+        models::{CircuitMemberModel, CircuitModel, ServiceArgumentModel, ServiceModel},
+        schema::{circuit, circuit_member, service, service_argument},
     },
     error::AdminServiceStoreError,
     Circuit,
@@ -80,15 +77,6 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                     source: Box::new(err),
                 })?;
             delete(
-                service_allowed_node::table
-                    .filter(service_allowed_node::circuit_id.eq(circuit.circuit_id())),
-            )
-            .execute(self.conn)
-            .map_err(|err| AdminServiceStoreError::QueryError {
-                context: String::from("Failed to remove old Services' allowed nodes"),
-                source: Box::new(err),
-            })?;
-            delete(
                 service_argument::table
                     .filter(service_argument::circuit_id.eq(circuit.circuit_id())),
             )
@@ -104,14 +92,6 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert Services"),
-                    source: Box::new(err),
-                })?;
-            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
-            insert_into(service_allowed_node::table)
-                .values(&service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert Services' allowed nodes"),
                     source: Box::new(err),
                 })?;
             let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
@@ -179,15 +159,6 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                     source: Box::new(err),
                 })?;
             delete(
-                service_allowed_node::table
-                    .filter(service_allowed_node::circuit_id.eq(circuit.circuit_id())),
-            )
-            .execute(self.conn)
-            .map_err(|err| AdminServiceStoreError::QueryError {
-                context: String::from("Failed to remove old Services' allowed nodes"),
-                source: Box::new(err),
-            })?;
-            delete(
                 service_argument::table
                     .filter(service_argument::circuit_id.eq(circuit.circuit_id())),
             )
@@ -203,14 +174,6 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert Services"),
-                    source: Box::new(err),
-                })?;
-            let service_allowed_node: Vec<ServiceAllowedNodeModel> = Vec::from(&circuit);
-            insert_into(service_allowed_node::table)
-                .values(&service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert Services' allowed nodes"),
                     source: Box::new(err),
                 })?;
             let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -24,13 +24,11 @@ use crate::admin::store::{
     diesel::{
         models::{
             CircuitProposalModel, ProposedCircuitModel, ProposedNodeEndpointModel,
-            ProposedNodeModel, ProposedServiceAllowedNodeModel, ProposedServiceArgumentModel,
-            ProposedServiceModel, VoteRecordModel,
+            ProposedNodeModel, ProposedServiceArgumentModel, ProposedServiceModel, VoteRecordModel,
         },
         schema::{
             circuit_proposal, proposed_circuit, proposed_node, proposed_node_endpoint,
-            proposed_service, proposed_service_allowed_node, proposed_service_argument,
-            vote_record,
+            proposed_service, proposed_service_argument, vote_record,
         },
     },
     error::AdminServiceStoreError,
@@ -142,15 +140,6 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 context: String::from("Failed to remove old proposed Services' arguments"),
                 source: Box::new(err),
             })?;
-            delete(
-                proposed_service_allowed_node::table
-                    .filter(proposed_service_allowed_node::circuit_id.eq(proposal.circuit_id())),
-            )
-            .execute(self.conn)
-            .map_err(|err| AdminServiceStoreError::QueryError {
-                context: String::from("Failed to remove old proposed Services' allowed nodes"),
-                source: Box::new(err),
-            })?;
             delete(vote_record::table.filter(vote_record::circuit_id.eq(proposal.circuit_id())))
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
@@ -196,16 +185,6 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert ProposedService's arguments"),
-                    source: Box::new(err),
-                })?;
-            // Insert `allowed_nodes` from the `Services` inserted above
-            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
-                Vec::from(proposal.circuit());
-            insert_into(proposed_service_allowed_node::table)
-                .values(proposed_service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
                     source: Box::new(err),
                 })?;
             // Insert `votes` from the `CircuitProposal`
@@ -324,15 +303,6 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 context: String::from("Failed to remove old proposed Services' arguments"),
                 source: Box::new(err),
             })?;
-            delete(
-                proposed_service_allowed_node::table
-                    .filter(proposed_service_allowed_node::circuit_id.eq(proposal.circuit_id())),
-            )
-            .execute(self.conn)
-            .map_err(|err| AdminServiceStoreError::QueryError {
-                context: String::from("Failed to remove old proposed Services' allowed nodes"),
-                source: Box::new(err),
-            })?;
             delete(vote_record::table.filter(vote_record::circuit_id.eq(proposal.circuit_id())))
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
@@ -378,16 +348,6 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 .execute(self.conn)
                 .map_err(|err| AdminServiceStoreError::QueryError {
                     context: String::from("Unable to insert ProposedService's arguments"),
-                    source: Box::new(err),
-                })?;
-            // Insert `allowed_nodes` from the `Services` inserted above
-            let proposed_service_allowed_node: Vec<ProposedServiceAllowedNodeModel> =
-                Vec::from(proposal.circuit());
-            insert_into(proposed_service_allowed_node::table)
-                .values(proposed_service_allowed_node)
-                .execute(self.conn)
-                .map_err(|err| AdminServiceStoreError::QueryError {
-                    context: String::from("Unable to insert ProposedService's allowed_nodes"),
                     source: Box::new(err),
                 })?;
             // Insert `votes` from the `CircuitProposal`

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -63,14 +63,7 @@ table! {
         circuit_id -> Text,
         service_id -> Text,
         service_type -> Text,
-    }
-}
-
-table! {
-    proposed_service_allowed_node (circuit_id, service_id, allowed_node) {
-        circuit_id -> Text,
-        service_id -> Text,
-        allowed_node -> Text,
+        node_id -> Text,
     }
 }
 
@@ -138,7 +131,6 @@ allow_tables_to_appear_in_same_query!(
     proposed_node,
     proposed_node_endpoint,
     proposed_service,
-    proposed_service_allowed_node,
     proposed_service_argument,
     vote_record,
     circuit_proposal,

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -81,14 +81,7 @@ table! {
         circuit_id -> Text,
         service_id -> Text,
         service_type -> Text,
-    }
-}
-
-table! {
-    service_allowed_node (circuit_id, service_id, allowed_node) {
-        circuit_id -> Text,
-        service_id -> Text,
-        allowed_node -> Text,
+        node_id -> Text,
     }
 }
 
@@ -138,7 +131,6 @@ allow_tables_to_appear_in_same_query!(
 
 allow_tables_to_appear_in_same_query!(
     service,
-    service_allowed_node,
     service_argument,
     circuit,
     circuit_member,

--- a/libsplinter/src/admin/store/proposed_service.rs
+++ b/libsplinter/src/admin/store/proposed_service.rs
@@ -22,7 +22,7 @@ use super::error::BuilderError;
 pub struct ProposedService {
     service_id: String,
     service_type: String,
-    allowed_nodes: Vec<String>,
+    node_id: String,
     arguments: Vec<(String, String)>,
 }
 
@@ -37,9 +37,9 @@ impl ProposedService {
         &self.service_type
     }
 
-    /// Returns the list of allowed nodes the proposed service can run on
-    pub fn allowed_nodes(&self) -> &[String] {
-        &self.allowed_nodes
+    /// Returns the node the proposed service can run on
+    pub fn node_id(&self) -> &str {
+        &self.node_id
     }
 
     /// Returns the list of key/value arugments for the  proposed service
@@ -53,7 +53,7 @@ impl ProposedService {
 pub struct ProposedServiceBuilder {
     service_id: Option<String>,
     service_type: Option<String>,
-    allowed_nodes: Option<Vec<String>>,
+    node_id: Option<String>,
     arguments: Option<Vec<(String, String)>>,
 }
 
@@ -73,9 +73,9 @@ impl ProposedServiceBuilder {
         self.service_type.clone()
     }
 
-    /// Returns the list of allowed nodes the service can connect to
-    pub fn allowed_nodes(&self) -> Option<Vec<String>> {
-        self.allowed_nodes.clone()
+    /// Returns the node ID the service can connect to
+    pub fn node_id(&self) -> Option<String> {
+        self.node_id.clone()
     }
 
     /// Returns the list of arguments for the service
@@ -103,13 +103,13 @@ impl ProposedServiceBuilder {
         self
     }
 
-    /// Sets the allowed nodes
+    /// Sets the node ID the service is allowed to connect to
     ///
     /// # Arguments
     ///
-    ///  * `allowed_nodes` - A list of node IDs the service can connect to
-    pub fn with_allowed_nodes(mut self, allowed_nodes: &[String]) -> ProposedServiceBuilder {
-        self.allowed_nodes = Some(allowed_nodes.into());
+    ///  * `node_id` - A node ID of the node the service can connect to
+    pub fn with_node_id(mut self, node_id: &str) -> ProposedServiceBuilder {
+        self.node_id = Some(node_id.into());
         self
     }
 
@@ -142,16 +142,16 @@ impl ProposedServiceBuilder {
             .service_type
             .ok_or_else(|| BuilderError::MissingField("service_type".to_string()))?;
 
-        let allowed_nodes = self
-            .allowed_nodes
-            .ok_or_else(|| BuilderError::MissingField("allowed_nodes".to_string()))?;
+        let node_id = self
+            .node_id
+            .ok_or_else(|| BuilderError::MissingField("node_id".to_string()))?;
 
         let arguments = self.arguments.unwrap_or_default();
 
         let service = ProposedService {
             service_id,
             service_type,
-            allowed_nodes,
+            node_id,
             arguments,
         };
 

--- a/libsplinter/src/admin/store/service.rs
+++ b/libsplinter/src/admin/store/service.rs
@@ -166,7 +166,7 @@ impl From<ProposedService> for Service {
         Service {
             service_id: service.service_id().to_string(),
             service_type: service.service_type().to_string(),
-            allowed_nodes: service.allowed_nodes().to_vec(),
+            allowed_nodes: vec![service.node_id().to_string()],
             arguments: service.arguments().to_vec(),
         }
     }
@@ -177,7 +177,7 @@ impl From<&ProposedService> for Service {
         Service {
             service_id: proposed_service.service_id().to_string(),
             service_type: proposed_service.service_type().to_string(),
-            allowed_nodes: proposed_service.allowed_nodes().to_vec(),
+            allowed_nodes: vec![proposed_service.node_id().to_string()],
             arguments: proposed_service.arguments().to_vec(),
         }
     }

--- a/libsplinter/src/admin/store/service.rs
+++ b/libsplinter/src/admin/store/service.rs
@@ -24,7 +24,7 @@ use super::ProposedService;
 pub struct Service {
     service_id: String,
     service_type: String,
-    allowed_nodes: Vec<String>,
+    node_id: String,
     arguments: Vec<(String, String)>,
 }
 
@@ -39,9 +39,9 @@ impl Service {
         &self.service_type
     }
 
-    /// Returns the list of allowed nodes the service can run on
-    pub fn allowed_nodes(&self) -> &[String] {
-        &self.allowed_nodes
+    /// Returns the node ID of the node the service can connect to
+    pub fn node_id(&self) -> &str {
+        &self.node_id
     }
 
     /// Returns the list of key/value arugments for the service
@@ -55,7 +55,7 @@ impl Service {
 pub struct ServiceBuilder {
     service_id: Option<String>,
     service_type: Option<String>,
-    allowed_nodes: Option<Vec<String>>,
+    node_id: Option<String>,
     arguments: Option<Vec<(String, String)>>,
 }
 
@@ -75,9 +75,9 @@ impl ServiceBuilder {
         self.service_type.clone()
     }
 
-    /// Returns the list of allowed nodes the service can connect to
-    pub fn allowed_nodes(&self) -> Option<Vec<String>> {
-        self.allowed_nodes.clone()
+    /// Returns the node ID of the node the service can connect to
+    pub fn node_id(&self) -> Option<String> {
+        self.node_id.clone()
     }
 
     /// Returns the list of arguments for the service
@@ -105,13 +105,13 @@ impl ServiceBuilder {
         self
     }
 
-    /// Sets the allowed nodes
+    /// Sets the node ID
     ///
     /// # Arguments
     ///
-    ///  * `allowed_nodes` - A list of node IDs the service can connect to
-    pub fn with_allowed_nodes(mut self, allowed_nodes: &[String]) -> ServiceBuilder {
-        self.allowed_nodes = Some(allowed_nodes.into());
+    ///  * `node_id` - The node ID of the node the service can connect to
+    pub fn with_node_id(mut self, node_id: &str) -> ServiceBuilder {
+        self.node_id = Some(node_id.into());
         self
     }
 
@@ -144,16 +144,16 @@ impl ServiceBuilder {
             .service_type
             .ok_or_else(|| BuilderError::MissingField("service_type".to_string()))?;
 
-        let allowed_nodes = self
-            .allowed_nodes
-            .ok_or_else(|| BuilderError::MissingField("allowed_nodes".to_string()))?;
+        let node_id = self
+            .node_id
+            .ok_or_else(|| BuilderError::MissingField("node_id".to_string()))?;
 
         let arguments = self.arguments.unwrap_or_default();
 
         let service = Service {
             service_id,
             service_type,
-            allowed_nodes,
+            node_id,
             arguments,
         };
 
@@ -166,7 +166,7 @@ impl From<ProposedService> for Service {
         Service {
             service_id: service.service_id().to_string(),
             service_type: service.service_type().to_string(),
-            allowed_nodes: vec![service.node_id().to_string()],
+            node_id: service.node_id().to_string(),
             arguments: service.arguments().to_vec(),
         }
     }
@@ -177,7 +177,7 @@ impl From<&ProposedService> for Service {
         Service {
             service_id: proposed_service.service_id().to_string(),
             service_type: proposed_service.service_type().to_string(),
-            allowed_nodes: vec![proposed_service.node_id().to_string()],
+            node_id: proposed_service.node_id().to_string(),
             arguments: proposed_service.arguments().to_vec(),
         }
     }

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1087,7 +1087,11 @@ impl TryFrom<YamlService> for Service {
         ServiceBuilder::new()
             .with_service_id(&service.service_id)
             .with_service_type(&service.service_type)
-            .with_allowed_nodes(&service.allowed_nodes)
+            .with_node_id(
+                &service.allowed_nodes.get(0).ok_or_else(|| {
+                    BuilderError::InvalidField("Must contain 1 node ID".to_string())
+                })?,
+            )
             .with_arguments(
                 &service
                     .arguments
@@ -1104,7 +1108,7 @@ impl From<Service> for YamlService {
         YamlService {
             service_id: service.service_id().into(),
             service_type: service.service_type().into(),
-            allowed_nodes: service.allowed_nodes().to_vec(),
+            allowed_nodes: vec![service.node_id().into()],
             arguments: service
                 .arguments()
                 .iter()
@@ -1762,7 +1766,7 @@ proposals:
                     ServiceBuilder::default()
                         .with_service_id("a000")
                         .with_service_type("scabbard")
-                        .with_allowed_nodes(&vec!["acme-node-000".into()])
+                        .with_node_id("acme-node-000")
                         .with_arguments(&vec![
                             ("admin_keys".into(),
                            "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -1774,7 +1778,7 @@ proposals:
                     ServiceBuilder::default()
                         .with_service_id("a001")
                         .with_service_type("scabbard")
-                        .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                        .with_node_id("bubba-node-000")
                         .with_arguments(&vec![(
                             "admin_keys".into(),
                             "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -1963,7 +1967,7 @@ proposals:
             ServiceBuilder::default()
                 .with_service_id("a000")
                 .with_service_type("scabbard")
-                .with_allowed_nodes(&vec!["acme-node-000".into()])
+                .with_node_id("acme-node-000")
                 .with_arguments(&vec![
                     (
                         "admin_keys".into(),
@@ -1985,7 +1989,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a000")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_node_id("acme-node-000")
                     .with_arguments(&vec![
                     ("admin_keys".into(),
                    "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -1997,7 +2001,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a001")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_node_id("bubba-node-000")
                     .with_arguments(&vec![
                         ("admin_keys".into(),
                        "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -2125,7 +2129,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a000")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_node_id("acme-node-000")
                     .with_arguments(&vec![
                         ("admin_keys".into(),
                        "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -2137,7 +2141,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a001")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_node_id("bubba-node-000")
                     .with_arguments(&vec![(
                         "admin_keys".into(),
                         "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
@@ -2215,7 +2219,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a000")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["acme-node-000".into()])
+                    .with_node_id("acme-node-000")
                     .with_arguments(&vec![
                         ("peer_services".into(), "[\"a001\"]".into()),
                         ("admin_keys".into(),
@@ -2225,7 +2229,7 @@ proposals:
                 ServiceBuilder::default()
                     .with_service_id("a001")
                     .with_service_type("scabbard")
-                    .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                    .with_node_id("bubba-node-000")
                     .with_arguments(&vec![
                         ("peer_services".into(), "[\"a000\"]".into()),
                         ("admin_keys".into(),

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -34,8 +34,8 @@ use super::{
     error::BuilderError, AdminServiceStore, AdminServiceStoreError, AuthorizationType, Circuit,
     CircuitBuilder, CircuitNode, CircuitPredicate, CircuitProposal, CircuitProposalBuilder,
     DurabilityType, PersistenceType, ProposalType, ProposedCircuit, ProposedCircuitBuilder,
-    ProposedNode, ProposedService, RouteType, Service, ServiceBuilder, ServiceId, Vote, VoteRecord,
-    VoteRecordBuilder,
+    ProposedNode, ProposedService, ProposedServiceBuilder, RouteType, Service, ServiceBuilder,
+    ServiceId, Vote, VoteRecord, VoteRecordBuilder,
 };
 
 use crate::hex::{parse_hex, to_hex};
@@ -1285,7 +1285,7 @@ impl From<VoteRecord> for YamlVoteRecord {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 struct YamlProposedCircuit {
     circuit_id: String,
-    roster: Vec<ProposedService>,
+    roster: Vec<YamlProposedService>,
     members: Vec<ProposedNode>,
     authorization_type: AuthorizationType,
     persistence: PersistenceType,
@@ -1302,7 +1302,13 @@ impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
     fn try_from(circuit: YamlProposedCircuit) -> Result<Self, Self::Error> {
         ProposedCircuitBuilder::new()
             .with_circuit_id(&circuit.circuit_id)
-            .with_roster(&circuit.roster)
+            .with_roster(
+                &circuit
+                    .roster
+                    .into_iter()
+                    .map(ProposedService::try_from)
+                    .collect::<Result<Vec<ProposedService>, BuilderError>>()?,
+            )
             .with_members(&circuit.members)
             .with_authorization_type(&circuit.authorization_type)
             .with_persistence(&circuit.persistence)
@@ -1321,7 +1327,12 @@ impl From<ProposedCircuit> for YamlProposedCircuit {
     fn from(circuit: ProposedCircuit) -> Self {
         YamlProposedCircuit {
             circuit_id: circuit.circuit_id().into(),
-            roster: circuit.roster().to_vec(),
+            roster: circuit
+                .roster()
+                .to_vec()
+                .into_iter()
+                .map(YamlProposedService::from)
+                .collect(),
             members: circuit.members().to_vec(),
             authorization_type: circuit.authorization_type().clone(),
             persistence: circuit.persistence().clone(),
@@ -1330,6 +1341,52 @@ impl From<ProposedCircuit> for YamlProposedCircuit {
             circuit_management_type: circuit.circuit_management_type().into(),
             application_metadata: to_hex(circuit.application_metadata()),
             comments: circuit.comments().into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default, Eq)]
+pub struct YamlProposedService {
+    service_id: String,
+    service_type: String,
+    allowed_nodes: Vec<String>,
+    arguments: Vec<(String, String)>,
+}
+
+impl TryFrom<YamlProposedService> for ProposedService {
+    type Error = BuilderError;
+
+    fn try_from(service: YamlProposedService) -> Result<Self, Self::Error> {
+        ProposedServiceBuilder::new()
+            .with_service_id(&service.service_id)
+            .with_service_type(&service.service_type)
+            .with_node_id(
+                &service.allowed_nodes.get(0).ok_or_else(|| {
+                    BuilderError::InvalidField("Must contain 1 node ID".to_string())
+                })?,
+            )
+            .with_arguments(
+                &service
+                    .arguments
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value.to_string()))
+                    .collect::<Vec<(String, String)>>(),
+            )
+            .build()
+    }
+}
+
+impl From<ProposedService> for YamlProposedService {
+    fn from(service: ProposedService) -> Self {
+        YamlProposedService {
+            service_id: service.service_id().into(),
+            service_type: service.service_type().into(),
+            allowed_nodes: vec![service.node_id().to_string()],
+            arguments: service
+                .arguments()
+                .iter()
+                .map(|(key, value)| (key.into(), value.into()))
+                .collect(),
         }
     }
 }
@@ -2020,7 +2077,7 @@ proposals:
                         ProposedServiceBuilder::default()
                             .with_service_id("a000")
                             .with_service_type("scabbard")
-                            .with_allowed_nodes(&vec!["acme-node-000".into()])
+                            .with_node_id(&"acme-node-000")
                             .with_arguments(&vec![
                                 ("peer_services".into(), "[\"a001\"]".into()),
                                 ("admin_keys".into(),
@@ -2030,7 +2087,7 @@ proposals:
                         ProposedServiceBuilder::default()
                             .with_service_id("a001")
                             .with_service_type("scabbard")
-                            .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                            .with_node_id(&"bubba-node-000")
                             .with_arguments(&vec![
                                 ("peer_services".into(), "[\"a000\"]".into()),
                                 ("admin_keys".into(),
@@ -2110,7 +2167,7 @@ proposals:
                         ProposedServiceBuilder::default()
                             .with_service_id("a000")
                             .with_service_type("scabbard")
-                            .with_allowed_nodes(&vec!["acme-node-000".into()])
+                            .with_node_id("acme-node-000")
                             .with_arguments(&vec![
                                 ("peer_services".into(), "[\"a001\"]".into()),
                                 ("admin_keys".into(),
@@ -2120,7 +2177,7 @@ proposals:
                         ProposedServiceBuilder::default()
                             .with_service_id("a001")
                             .with_service_type("scabbard")
-                            .with_allowed_nodes(&vec!["bubba-node-000".into()])
+                            .with_node_id("bubba-node-000")
                             .with_arguments(&vec![
                                 ("peer_services".into(), "[\"a000\"]".into()),
                                 ("admin_keys".into(),


### PR DESCRIPTION
Replace allowed_nodes list with node_id in Service and ProposedServce. The admin service already enforces that only one node is currently allowed in that list, so this PR only makes that more obvious.

This PR only effects the structs in the AdminServiceStore. The protobufs  and expected yaml state files will remain the same for backwards compatibility.