### PR TITLE
Make travis clone entire repo history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
     - NAMESPACE="splintercommunity/"
     - VERSION=AUTO_STRICT
 
+git:
+  depth: false
+
 before_install:
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-`uname -s`-`uname -m` > docker-compose


### PR DESCRIPTION
By default Travis uses a limited clone depth which interferes with
our get_version script when the repo gets sufficiently far from a tag.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>