### PR TITLE
Make the field name for authorization type consistent in Circuit and CircuitProposal

### DIFF
--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -315,7 +315,7 @@ impl From<ProposedCircuit> for Circuit {
                 .iter()
                 .map(|node| node.node_id().to_string())
                 .collect(),
-            authorization: circuit.authorization_type().clone(),
+            authorization: circuit.authorization().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -25,7 +25,7 @@ pub struct Circuit {
     id: String,
     roster: Vec<Service>,
     members: Vec<String>,
-    auth: AuthorizationType,
+    authorization: AuthorizationType,
     persistence: PersistenceType,
     durability: DurabilityType,
     routes: RouteType,
@@ -49,8 +49,8 @@ impl Circuit {
     }
 
     /// Returns the authorization type of the circuit
-    pub fn auth(&self) -> &AuthorizationType {
-        &self.auth
+    pub fn authorization(&self) -> &AuthorizationType {
+        &self.authorization
     }
 
     /// Returns the persistence type type of the circuit
@@ -116,7 +116,7 @@ pub struct CircuitBuilder {
     circuit_id: Option<String>,
     roster: Option<Vec<Service>>,
     members: Option<Vec<String>>,
-    auth: Option<AuthorizationType>,
+    authorization: Option<AuthorizationType>,
     persistence: Option<PersistenceType>,
     durability: Option<DurabilityType>,
     routes: Option<RouteType>,
@@ -145,8 +145,8 @@ impl CircuitBuilder {
     }
 
     /// Returns the authorization type in the builder
-    pub fn auth(&self) -> Option<AuthorizationType> {
-        self.auth.clone()
+    pub fn authorization(&self) -> Option<AuthorizationType> {
+        self.authorization.clone()
     }
 
     /// Returns the persistence type in the builder
@@ -203,9 +203,9 @@ impl CircuitBuilder {
     ///
     /// # Arguments
     ///
-    ///  * `auth` - The authorization type for the circuit
-    pub fn with_auth(mut self, auth: &AuthorizationType) -> CircuitBuilder {
-        self.auth = Some(auth.clone());
+    ///  * `authorization` - The authorization type for the circuit
+    pub fn with_authorization(mut self, authorization: &AuthorizationType) -> CircuitBuilder {
+        self.authorization = Some(authorization.clone());
         self
     }
 
@@ -274,7 +274,9 @@ impl CircuitBuilder {
             .members
             .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
 
-        let auth = self.auth.unwrap_or_else(|| AuthorizationType::Trust);
+        let authorization = self
+            .authorization
+            .unwrap_or_else(|| AuthorizationType::Trust);
 
         let persistence = self.persistence.unwrap_or_else(PersistenceType::default);
 
@@ -292,7 +294,7 @@ impl CircuitBuilder {
             id: circuit_id,
             roster,
             members,
-            auth,
+            authorization,
             persistence,
             durability,
             routes,
@@ -313,7 +315,7 @@ impl From<ProposedCircuit> for Circuit {
                 .iter()
                 .map(|node| node.node_id().to_string())
                 .collect(),
-            auth: circuit.authorization_type().clone(),
+            authorization: circuit.authorization_type().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS vote_record (
 
 CREATE TABLE IF NOT EXISTS proposed_circuit (
     circuit_id                TEXT NOT NULL,
-    authorization_type        TEXT NOT NULL,
+    authorization             TEXT NOT NULL,
     persistence               TEXT NOT NULL,
     durability                TEXT NOT NULL,
     routes                    TEXT NOT NULL,

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS service_argument (
 
 CREATE TABLE IF NOT EXISTS circuit (
     circuit_id                TEXT PRIMARY KEY,
-    auth                      TEXT NOT NULL,
+    authorization             TEXT NOT NULL,
     persistence               TEXT NOT NULL,
     durability                TEXT NOT NULL,
     routes                    TEXT NOT NULL,

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -61,7 +61,7 @@ impl From<&CircuitProposal> for CircuitProposalModel {
 #[primary_key(circuit_id)]
 pub struct ProposedCircuitModel {
     pub circuit_id: String,
-    pub authorization_type: String,
+    pub authorization: String,
     pub persistence: String,
     pub durability: String,
     pub routes: String,
@@ -74,7 +74,7 @@ impl From<&ProposedCircuit> for ProposedCircuitModel {
     fn from(proposed_circuit: &ProposedCircuit) -> Self {
         ProposedCircuitModel {
             circuit_id: proposed_circuit.circuit_id().into(),
-            authorization_type: String::from(proposed_circuit.authorization_type()),
+            authorization: String::from(proposed_circuit.authorization()),
             persistence: String::from(proposed_circuit.persistence()),
             durability: String::from(proposed_circuit.durability()),
             routes: String::from(proposed_circuit.routes()),

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -304,7 +304,7 @@ impl From<&Circuit> for Vec<ServiceArgumentModel> {
 #[primary_key(circuit_id)]
 pub struct CircuitModel {
     pub circuit_id: String,
-    pub auth: String,
+    pub authorization: String,
     pub persistence: String,
     pub durability: String,
     pub routes: String,
@@ -315,7 +315,7 @@ impl From<&Circuit> for CircuitModel {
     fn from(circuit: &Circuit) -> Self {
         CircuitModel {
             circuit_id: circuit.circuit_id().into(),
-            auth: String::from(circuit.auth()),
+            authorization: String::from(circuit.authorization()),
             persistence: String::from(circuit.persistence()),
             durability: String::from(circuit.durability()),
             routes: String::from(circuit.routes()),

--- a/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
@@ -77,7 +77,7 @@ where
                     .with_circuit_id(&circuit.circuit_id)
                     .with_roster(&services)
                     .with_members(&circuit_member)
-                    .with_auth(&AuthorizationType::try_from(circuit.auth)?)
+                    .with_authorization(&AuthorizationType::try_from(circuit.authorization)?)
                     .with_persistence(&PersistenceType::try_from(circuit.persistence)?)
                     .with_durability(&DurabilityType::try_from(circuit.durability)?)
                     .with_routes(&RouteType::try_from(circuit.routes)?)

--- a/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
@@ -218,8 +218,8 @@ where
                 .with_circuit_id(&proposal.circuit_id)
                 .with_roster(&built_proposed_services)
                 .with_members(built_proposed_nodes.as_slice())
-                .with_authorization_type(&AuthorizationType::try_from(
-                    proposed_circuit.authorization_type,
+                .with_authorization(&AuthorizationType::try_from(
+                    proposed_circuit.authorization,
                 )?)
                 .with_persistence(&PersistenceType::try_from(proposed_circuit.persistence)?)
                 .with_durability(&DurabilityType::try_from(proposed_circuit.durability)?)

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -209,7 +209,7 @@ where
                 for (id, model) in circuits {
                     let mut circuit_builder = CircuitBuilder::new()
                         .with_circuit_id(&model.circuit_id)
-                        .with_auth(&AuthorizationType::try_from(model.auth)?)
+                        .with_authorization(&AuthorizationType::try_from(model.authorization)?)
                         .with_persistence(&PersistenceType::try_from(model.persistence)?)
                         .with_durability(&DurabilityType::try_from(model.durability)?)
                         .with_routes(&RouteType::try_from(model.routes)?);

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -135,8 +135,8 @@ where
                             .with_requester_node_id(&proposal.requester_node_id);
                         let proposed_circuit_builder = ProposedCircuitBuilder::new()
                             .with_circuit_id(&proposed_circuit.circuit_id)
-                            .with_authorization_type(&AuthorizationType::try_from(
-                                proposed_circuit.authorization_type,
+                            .with_authorization(&AuthorizationType::try_from(
+                                proposed_circuit.authorization,
                             )?)
                             .with_persistence(&PersistenceType::try_from(
                                 proposed_circuit.persistence,

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -58,7 +58,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             let circuit_model = CircuitModel::from(&circuit);
             update(circuit::table.find(circuit.circuit_id()))
                 .set((
-                    circuit::auth.eq(circuit_model.auth),
+                    circuit::authorization.eq(circuit_model.authorization),
                     circuit::persistence.eq(circuit_model.persistence),
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),
@@ -140,7 +140,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             let circuit_model = CircuitModel::from(&circuit);
             update(circuit::table.find(circuit.circuit_id()))
                 .set((
-                    circuit::auth.eq(circuit_model.auth),
+                    circuit::authorization.eq(circuit_model.authorization),
                     circuit::persistence.eq(circuit_model.persistence),
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -78,8 +78,7 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
             let proposed_circuit_model = ProposedCircuitModel::from(proposal.circuit());
             update(proposed_circuit::table.find(proposal.circuit_id()))
                 .set((
-                    proposed_circuit::authorization_type
-                        .eq(proposed_circuit_model.authorization_type),
+                    proposed_circuit::authorization.eq(proposed_circuit_model.authorization),
                     proposed_circuit::persistence.eq(proposed_circuit_model.persistence),
                     proposed_circuit::durability.eq(proposed_circuit_model.durability),
                     proposed_circuit::routes.eq(proposed_circuit_model.routes),
@@ -241,8 +240,7 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
             let proposed_circuit_model = ProposedCircuitModel::from(proposal.circuit());
             update(proposed_circuit::table.find(proposal.circuit_id()))
                 .set((
-                    proposed_circuit::authorization_type
-                        .eq(proposed_circuit_model.authorization_type),
+                    proposed_circuit::authorization.eq(proposed_circuit_model.authorization),
                     proposed_circuit::persistence.eq(proposed_circuit_model.persistence),
                     proposed_circuit::durability.eq(proposed_circuit_model.durability),
                     proposed_circuit::routes.eq(proposed_circuit_model.routes),

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -60,7 +60,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_auth(proposed_circuit.authorization_type())
+                .with_authorization(proposed_circuit.authorization_type())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
@@ -115,7 +115,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_auth(proposed_circuit.authorization_type())
+                .with_authorization(proposed_circuit.authorization_type())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -60,7 +60,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_authorization(proposed_circuit.authorization_type())
+                .with_authorization(proposed_circuit.authorization())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
@@ -115,7 +115,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_authorization(proposed_circuit.authorization_type())
+                .with_authorization(proposed_circuit.authorization())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -25,7 +25,7 @@ table! {
 table! {
     proposed_circuit (circuit_id) {
         circuit_id -> Text,
-        authorization_type -> Text,
+        authorization -> Text,
         persistence -> Text,
         durability -> Text,
         routes -> Text,

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -97,7 +97,7 @@ table! {
 table! {
     circuit (circuit_id) {
         circuit_id -> Text,
-        auth -> Text,
+        authorization -> Text,
         persistence -> Text,
         durability -> Text,
         routes -> Text,

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -27,7 +27,7 @@ pub struct ProposedCircuit {
     circuit_id: String,
     roster: Vec<ProposedService>,
     members: Vec<ProposedNode>,
-    authorization_type: AuthorizationType,
+    authorization: AuthorizationType,
     persistence: PersistenceType,
     durability: DurabilityType,
     routes: RouteType,
@@ -53,8 +53,8 @@ impl ProposedCircuit {
     }
 
     /// Returns the authorization type of the circuit
-    pub fn authorization_type(&self) -> &AuthorizationType {
-        &self.authorization_type
+    pub fn authorization(&self) -> &AuthorizationType {
+        &self.authorization
     }
 
     /// Returns the persistence type type of the circuit
@@ -93,7 +93,7 @@ pub struct ProposedCircuitBuilder {
     circuit_id: Option<String>,
     roster: Option<Vec<ProposedService>>,
     members: Option<Vec<ProposedNode>>,
-    authorization_type: Option<AuthorizationType>,
+    authorization: Option<AuthorizationType>,
     persistence: Option<PersistenceType>,
     durability: Option<DurabilityType>,
     routes: Option<RouteType>,
@@ -124,8 +124,8 @@ impl ProposedCircuitBuilder {
     }
 
     /// Returns the authorizationtype in the builder
-    pub fn authorization_type(&self) -> Option<AuthorizationType> {
-        self.authorization_type.clone()
+    pub fn authorization(&self) -> Option<AuthorizationType> {
+        self.authorization.clone()
     }
 
     /// Returns the persistence type in the builder
@@ -188,13 +188,16 @@ impl ProposedCircuitBuilder {
         self
     }
 
-    /// Sets the authorizationtype
+    /// Sets the authorization type
     ///
     /// # Arguments
     ///
-    ///  * `auth` - The authorization type for the circuit
-    pub fn with_authorization_type(mut self, auth: &AuthorizationType) -> ProposedCircuitBuilder {
-        self.authorization_type = Some(auth.clone());
+    ///  * `authorization` - The authorization type for the circuit
+    pub fn with_authorization(
+        mut self,
+        authorization: &AuthorizationType,
+    ) -> ProposedCircuitBuilder {
+        self.authorization = Some(authorization.clone());
         self
     }
 
@@ -289,8 +292,8 @@ impl ProposedCircuitBuilder {
             .members
             .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
 
-        let authorization_type = self
-            .authorization_type
+        let authorization = self
+            .authorization
             .unwrap_or_else(|| AuthorizationType::Trust);
 
         let persistence = self.persistence.unwrap_or_else(PersistenceType::default);
@@ -313,7 +316,7 @@ impl ProposedCircuitBuilder {
             circuit_id,
             roster,
             members,
-            authorization_type,
+            authorization,
             persistence,
             durability,
             routes,

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1040,7 +1040,7 @@ impl TryFrom<YamlCircuit> for Circuit {
                     .collect::<Result<Vec<Service>, BuilderError>>()?,
             )
             .with_members(&circuit.members)
-            .with_auth(&circuit.auth)
+            .with_authorization(&circuit.auth)
             .with_persistence(&circuit.persistence)
             .with_durability(&circuit.durability)
             .with_routes(&circuit.routes)
@@ -1059,7 +1059,7 @@ impl From<Circuit> for YamlCircuit {
                 .map(|service| YamlService::from(service.clone()))
                 .collect(),
             members: circuit.members().to_vec(),
-            auth: circuit.auth().clone(),
+            auth: circuit.authorization().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1314,7 +1314,7 @@ impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
                     .collect::<Result<Vec<ProposedService>, BuilderError>>()?,
             )
             .with_members(&circuit.members)
-            .with_authorization_type(&circuit.authorization_type)
+            .with_authorization(&circuit.authorization_type)
             .with_persistence(&circuit.persistence)
             .with_durability(&circuit.durability)
             .with_routes(&circuit.routes)
@@ -1338,7 +1338,7 @@ impl From<ProposedCircuit> for YamlProposedCircuit {
                 .map(YamlProposedService::from)
                 .collect(),
             members: circuit.members().to_vec(),
-            authorization_type: circuit.authorization_type().clone(),
+            authorization_type: circuit.authorization().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),


### PR DESCRIPTION
The migrations file does not currently run successfully (This will be fixed in the next PR) so the migration file is updated directly. 