### PR TITLE
Implement OAuth authentication for libsplinter

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -158,7 +158,7 @@ mod tests {
     use serde_json::{to_value, Value as JsonValue};
 
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::circuit::{
         directory::CircuitDirectory, AuthorizationType, Circuit, DurabilityType, PersistenceType,
         RouteType, ServiceDefinition, SplinterState,
@@ -431,15 +431,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -436,6 +436,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -82,7 +82,7 @@ mod tests {
     use serde_json::{to_value, Value as JsonValue};
 
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::circuit::{
         directory::CircuitDirectory, AuthorizationType, Circuit, DurabilityType, PersistenceType,
         RouteType, ServiceDefinition, SplinterState,
@@ -212,15 +212,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -217,6 +217,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -175,7 +175,7 @@ mod tests {
         service::proposal_store::{ProposalFilter, ProposalIter, ProposalStoreError},
     };
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::rest_api::{
         paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
     };
@@ -611,15 +611,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -616,6 +616,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -91,7 +91,7 @@ mod tests {
         service::proposal_store::{ProposalFilter, ProposalIter, ProposalStoreError},
     };
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 
     #[test]
@@ -208,15 +208,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -213,6 +213,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/auth/oauth/error.rs
+++ b/libsplinter/src/auth/oauth/error.rs
@@ -48,6 +48,8 @@ impl Error for OAuthClientError {}
 pub enum OAuthClientConfigurationError {
     /// The specified authorization URL for the provider was invalid
     InvalidAuthUrl(String),
+    /// The specified redirect URL for the client was invalid
+    InvalidRedirectUrl(String),
     /// The specified token URL for the provider was invalid
     InvalidTokenUrl(String),
 }
@@ -58,6 +60,7 @@ impl fmt::Display for OAuthClientConfigurationError {
             Self::InvalidAuthUrl(msg) => {
                 write!(f, "provided authorization URL is invalid: {}", msg)
             }
+            Self::InvalidRedirectUrl(msg) => write!(f, "client redirect URL is invalid: {}", msg),
             Self::InvalidTokenUrl(msg) => write!(f, "provided token URL is invalid: {}", msg),
         }
     }

--- a/libsplinter/src/auth/oauth/error.rs
+++ b/libsplinter/src/auth/oauth/error.rs
@@ -17,6 +17,32 @@
 use std::error::Error;
 use std::fmt;
 
+/// An unrecoverable error that can occur when using an OAuth client
+#[derive(Debug)]
+pub struct OAuthClientError {
+    message: String,
+}
+
+impl OAuthClientError {
+    pub fn new(message: &str) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for OAuthClientError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "OAuth client encountered an unrecoverable error: {}",
+            self.message,
+        )
+    }
+}
+
+impl Error for OAuthClientError {}
+
 /// An error that can occur when configuring an OAuth client
 #[derive(Debug)]
 pub enum OAuthClientConfigurationError {

--- a/libsplinter/src/auth/oauth/error.rs
+++ b/libsplinter/src/auth/oauth/error.rs
@@ -17,16 +17,16 @@
 use std::error::Error;
 use std::fmt;
 
-/// An error that can occur when configuring a provider
+/// An error that can occur when configuring an OAuth client
 #[derive(Debug)]
-pub enum ProviderConfigurationError {
+pub enum OAuthClientConfigurationError {
     /// The specified authorization URL for the provider was invalid
     InvalidAuthUrl(String),
     /// The specified token URL for the provider was invalid
     InvalidTokenUrl(String),
 }
 
-impl fmt::Display for ProviderConfigurationError {
+impl fmt::Display for OAuthClientConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::InvalidAuthUrl(msg) => {
@@ -37,4 +37,4 @@ impl fmt::Display for ProviderConfigurationError {
     }
 }
 
-impl Error for ProviderConfigurationError {}
+impl Error for OAuthClientConfigurationError {}

--- a/libsplinter/src/auth/oauth/mod.rs
+++ b/libsplinter/src/auth/oauth/mod.rs
@@ -16,15 +16,25 @@
 
 mod error;
 
-use oauth2::basic::BasicClient;
-use oauth2::{AuthUrl, ClientId, ClientSecret, TokenUrl};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-pub use error::OAuthClientConfigurationError;
+use oauth2::{
+    basic::{BasicClient, BasicTokenResponse},
+    reqwest::http_client,
+    AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge,
+    PkceCodeVerifier, Scope, TokenResponse, TokenUrl,
+};
+
+pub use error::{OAuthClientConfigurationError, OAuthClientError};
 
 /// An OAuth2 client for Splinter
 #[derive(Clone)]
 pub struct OAuthClient {
     client: BasicClient,
+    /// List of (CSRF token, PKCE verifier) pairs for pending authorization requests
+    pending_authorizations: Arc<Mutex<HashMap<String, String>>>,
     scopes: Vec<String>,
 }
 
@@ -47,7 +57,125 @@ impl OAuthClient {
                 })?,
             ),
         );
-        Ok(Self { client, scopes })
+        Ok(Self {
+            client,
+            pending_authorizations: Default::default(),
+            scopes,
+        })
+    }
+
+    /// Generates the URL that the end user should be redirected to for authorization
+    pub fn get_authorization_url(&self) -> Result<String, OAuthClientError> {
+        let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+        let mut request = self
+            .client
+            .authorize_url(CsrfToken::new_random)
+            .set_pkce_challenge(pkce_challenge);
+        for scope in &self.scopes {
+            request = request.add_scope(Scope::new(scope.into()));
+        }
+        let (authorize_url, csrf_state) = request.url();
+
+        self.pending_authorizations
+            .lock()
+            .map_err(|_| OAuthClientError::new("pending authorizations lock was poisoned"))?
+            .insert(csrf_state.secret().into(), pkce_verifier.secret().into());
+
+        Ok(authorize_url.to_string())
+    }
+
+    /// Exchanges the given authorization code for an access token
+    ///
+    /// # Arguments
+    ///
+    /// * `auth_code` - The authorization code that was supplied by the OAuth provider
+    /// * `csrf_token` - The CSRF token that was provided in the original auth request, which is
+    ///   used to prevent CSRF attacks and to correlate the auth code with the original auth
+    ///   request.
+    pub fn exchange_authorization_code(
+        &self,
+        auth_code: String,
+        csrf_token: &str,
+    ) -> Result<Option<UserTokens>, OAuthClientError> {
+        let pkce_verifier = match self
+            .pending_authorizations
+            .lock()
+            .map_err(|_| OAuthClientError::new("pending authorizations lock was poisoned"))?
+            .remove(csrf_token)
+        {
+            Some(pkce_verifier) => PkceCodeVerifier::new(pkce_verifier),
+            None => return Ok(None),
+        };
+
+        let token_response = self
+            .client
+            .exchange_code(AuthorizationCode::new(auth_code))
+            .set_pkce_verifier(pkce_verifier)
+            .request(http_client)
+            .map_err(|err| {
+                OAuthClientError::new(&format!(
+                    "failed to make authorization code exchange request: {}",
+                    err,
+                ))
+            })?;
+
+        Ok(Some(UserTokens::from(token_response)))
+    }
+}
+
+/// User information returned by the OAuth2 client
+pub struct UserTokens {
+    /// The access token to be used for authentication in future requests
+    access_token: String,
+    /// The amount of time (if the provider gives it) until the access token expires and the refresh
+    /// token will need to be used
+    expires_in: Option<Duration>,
+    /// The refresh token (if the provider gives one) for refreshing the access token
+    refresh_token: Option<String>,
+}
+
+impl UserTokens {
+    /// Gets the user's access token
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    /// Gets the amount of time that the user's access token is valid for. Not all providers expire
+    /// access tokens, so this may be `None` for some providers.
+    pub fn expires_in(&self) -> Option<Duration> {
+        self.expires_in
+    }
+
+    /// Gets the user's refresh token. Not all providers use refresh tokens, so this may be `None`
+    /// for some providers.
+    pub fn refresh_token(&self) -> Option<&str> {
+        self.refresh_token.as_deref()
+    }
+}
+
+impl std::fmt::Debug for UserTokens {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("UserTokens")
+            .field("access_token", &"<Redacted>".to_string())
+            .field("expires_in", &self.expires_in)
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_deref().map(|_| "<Redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl From<BasicTokenResponse> for UserTokens {
+    fn from(token_response: BasicTokenResponse) -> Self {
+        Self {
+            access_token: token_response.access_token().secret().into(),
+            expires_in: token_response.expires_in(),
+            refresh_token: token_response
+                .refresh_token()
+                .map(|token| token.secret().into()),
+        }
     }
 }
 

--- a/libsplinter/src/auth/oauth/mod.rs
+++ b/libsplinter/src/auth/oauth/mod.rs
@@ -32,15 +32,32 @@ use oauth2::{
 pub use error::{OAuthClientConfigurationError, OAuthClientError};
 
 /// An OAuth2 client for Splinter
+///
+/// This client currently supports OAuth2 authorization code grants
+/// (<https://tools.ietf.org/html/rfc6749#section-4.1>).
 #[derive(Clone)]
 pub struct OAuthClient {
+    /// The inner OAuth2 client
     client: BasicClient,
     /// List of (CSRF token, PKCE verifier) pairs for pending authorization requests
     pending_authorizations: Arc<Mutex<HashMap<String, String>>>,
+    /// The scopes that will be requested for each user that's authenticated
     scopes: Vec<String>,
 }
 
 impl OAuthClient {
+    /// Creates a new `OAuthClient`
+    ///
+    /// # Arguments
+    ///
+    /// * `client_id` - The OAuth client ID
+    /// * `client_secret` - The OAuth client secret
+    /// * `auth_url` - The provider's authorization endpoint
+    /// * `redirect_url` - The endpoint that the provider will redirect to after it has completed
+    ///   authorization
+    /// * `token_url` - The provider's endpoint for exchanging an authorization code for an access
+    ///   token
+    /// * `scopes` - The scopes that will be requested for each user
     pub fn new(
         client_id: String,
         client_secret: String,

--- a/libsplinter/src/auth/oauth/mod.rs
+++ b/libsplinter/src/auth/oauth/mod.rs
@@ -15,6 +15,8 @@
 //! Support for OAuth2 authorization in Splinter
 
 mod error;
+#[cfg(feature = "rest-api")]
+pub mod rest_api;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
@@ -1,0 +1,68 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `GET /oauth/callback` endpoint for receiving the authorization code from the provider and
+//! exchanging it for an access token.
+
+use actix_web::{web::Query, HttpResponse};
+use futures::future::IntoFuture;
+
+use crate::auth::oauth::{
+    rest_api::resources::callback::{CallbackQuery, CallbackResponse},
+    OAuthClient,
+};
+use crate::protocol;
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+
+pub fn make_callback_route(client: OAuthClient) -> Resource {
+    Resource::build("/oauth/callback")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::OAUTH_CALLBACK_MIN,
+            protocol::OAUTH_PROTOCOL_VERSION,
+        ))
+        .add_method(Method::Get, move |req, _| {
+            Box::new(
+                match Query::<CallbackQuery>::from_query(req.query_string()) {
+                    Ok(query) => {
+                        match client.exchange_authorization_code(query.code.clone(), &query.state) {
+                            Ok(Some(user_tokens)) => {
+                                HttpResponse::Ok().json(CallbackResponse::from(&user_tokens))
+                            }
+                            Ok(None) => {
+                                error!(
+                                "Received OAuth callback request that does not correlate to an \
+                                 open authorization request"
+                            );
+                                HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                                HttpResponse::InternalServerError()
+                                    .json(ErrorResponse::internal_error())
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error!(
+                            "Failed to parse query string in OAuth callback request: {}",
+                            err
+                        );
+                        HttpResponse::InternalServerError().json(ErrorResponse::internal_error())
+                    }
+                }
+                .into_future(),
+            )
+        })
+}

--- a/libsplinter/src/auth/oauth/rest_api/actix/login.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/login.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `GET /oauth/login` endpoint for getting the authorization request URL for the provider.
+
+use actix_web::{http::header::LOCATION, HttpResponse};
+use futures::future::IntoFuture;
+
+use crate::auth::oauth::OAuthClient;
+use crate::protocol;
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+
+pub fn make_login_route(client: OAuthClient) -> Resource {
+    Resource::build("/oauth/login")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::OAUTH_LOGIN_MIN,
+            protocol::OAUTH_PROTOCOL_VERSION,
+        ))
+        .add_method(Method::Get, move |_, _| {
+            Box::new(
+                match client.get_authorization_url() {
+                    Ok(auth_url) => HttpResponse::Found().header(LOCATION, auth_url).finish(),
+                    Err(err) => {
+                        error!("{}", err);
+                        HttpResponse::InternalServerError().json(ErrorResponse::internal_error())
+                    }
+                }
+                .into_future(),
+            )
+        })
+}

--- a/libsplinter/src/auth/oauth/rest_api/actix/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod callback;
+pub(super) mod login;

--- a/libsplinter/src/auth/oauth/rest_api/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/mod.rs
@@ -1,0 +1,71 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! OAuth REST API endpoints
+
+#[cfg(feature = "rest-api-actix")]
+mod actix;
+mod resources;
+
+use crate::rest_api::{Resource, RestResourceProvider};
+
+use super::OAuthClient;
+
+/// Provides the REST API [Resource](../../../rest_api/struct.Resource.html) definitions for OAuth
+/// endpoints. The following endpoints are provided:
+///
+/// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
+/// * `GET /oauth/callback` - Receive the authorization code from the provider
+///
+/// These endpoints are only available if the following REST API backend feature is enabled:
+///
+/// * `rest-api-actix`
+#[derive(Clone)]
+pub struct OAuthResourceProvider {
+    client: OAuthClient,
+}
+
+impl OAuthResourceProvider {
+    /// Creates a new `OAuthResourceProvider`
+    pub fn new(client: OAuthClient) -> Self {
+        Self { client }
+    }
+}
+
+/// `OAuthResourceProvider` provides the following endpoints as REST API resources:
+///
+/// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
+/// * `GET /oauth/callback` - Receive the authorization code from the provider
+///
+/// These endpoints are only available if the following REST API backend feature is enabled:
+///
+/// * `rest-api-actix`
+impl RestResourceProvider for OAuthResourceProvider {
+    fn resources(&self) -> Vec<Resource> {
+        // Allowing unused_mut because resources must be mutable if feature `rest-api-actix` is
+        // enabled
+        #[allow(unused_mut)]
+        let mut resources = Vec::new();
+
+        #[cfg(feature = "rest-api-actix")]
+        {
+            resources.append(&mut vec![
+                actix::login::make_login_route(self.client.clone()),
+                actix::callback::make_callback_route(self.client.clone()),
+            ]);
+        }
+
+        resources
+    }
+}

--- a/libsplinter/src/auth/oauth/rest_api/resources/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/resources/callback.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::auth::oauth::UserTokens;
+
+#[derive(Deserialize)]
+pub struct CallbackQuery {
+    pub code: String,
+    pub state: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct CallbackResponse<'a> {
+    pub access_token: &'a str,
+    pub expires_in: Option<u64>,
+    pub refresh_token: Option<&'a str>,
+}
+
+impl<'a> From<&'a UserTokens> for CallbackResponse<'a> {
+    fn from(tokens: &'a UserTokens) -> Self {
+        Self {
+            access_token: tokens.access_token(),
+            expires_in: tokens.expires_in().map(|duration| duration.as_secs()),
+            refresh_token: tokens.refresh_token(),
+        }
+    }
+}

--- a/libsplinter/src/auth/oauth/rest_api/resources/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/resources/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod callback;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -36,6 +36,14 @@ pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
 #[cfg(feature = "rest-api-actix")]
 pub(crate) const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
 
+#[cfg(feature = "oauth")]
+pub const OAUTH_PROTOCOL_VERSION: u32 = 1;
+
+#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+pub(crate) const OAUTH_CALLBACK_MIN: u32 = 1;
+#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+pub(crate) const OAUTH_LOGIN_MIN: u32 = 1;
+
 #[cfg(feature = "registry")]
 pub const REGISTRY_PROTOCOL_VERSION: u32 = 1;
 

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -472,6 +472,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -257,7 +257,7 @@ mod tests {
     use serde_json::{to_value, Value as JsonValue};
 
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::registry::NodeIter;
     use crate::rest_api::{
         paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
@@ -467,15 +467,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -385,6 +385,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -167,7 +167,7 @@ mod tests {
     use reqwest::{blocking::Client, StatusCode, Url};
 
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::registry::{MetadataPredicate, NodeIter};
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 
@@ -380,15 +380,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -401,7 +401,7 @@ mod tests {
     use tempdir::TempDir;
 
     #[cfg(feature = "oauth")]
-    use crate::auth::oauth::Provider;
+    use crate::auth::oauth::OAuthClient;
     use crate::rest_api::{
         Method, Resource, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
     };
@@ -1103,15 +1103,15 @@ mod tests {
                     .add_resources(resources.clone());
                 #[cfg(feature = "oauth")]
                 {
-                    builder = builder.with_oauth_provider(
-                        Provider::new(
+                    builder = builder.with_oauth_client(
+                        OAuthClient::new(
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )
-                        .expect("Failed to create OAuth provider"),
+                        .expect("Failed to create OAuth client"),
                     );
                 }
                 let result = builder.build().expect("Failed to build REST API").run();

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -1108,6 +1108,7 @@ mod tests {
                             "client_id".into(),
                             "client_secret".into(),
                             "https://provider.com/auth".into(),
+                            "https://localhost/oauth/callback".into(),
                             "https://provider.com/token".into(),
                             vec![],
                         )

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -749,6 +749,7 @@ mod test {
                     "client_id".into(),
                     "client_secret".into(),
                     "https://provider.com/auth".into(),
+                    "https://localhost/oauth/callback".into(),
                     "https://provider.com/token".into(),
                     vec![],
                 )

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -72,7 +72,7 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 
 #[cfg(feature = "oauth")]
-use crate::auth::oauth::Provider as OAuthProvider;
+use crate::auth::oauth::OAuthClient;
 
 pub use errors::{RequestError, ResponseError, RestApiServerError};
 
@@ -468,7 +468,7 @@ pub struct RestApi {
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "oauth")]
-    _oauth_provider: Option<OAuthProvider>,
+    _oauth_client: Option<OAuthClient>,
 }
 
 impl RestApi {
@@ -570,7 +570,7 @@ pub struct RestApiBuilder {
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "oauth")]
-    oauth_provider: Option<OAuthProvider>,
+    oauth_client: Option<OAuthClient>,
 }
 
 impl Default for RestApiBuilder {
@@ -581,7 +581,7 @@ impl Default for RestApiBuilder {
             #[cfg(feature = "rest-api-cors")]
             whitelist: None,
             #[cfg(feature = "oauth")]
-            oauth_provider: None,
+            oauth_client: None,
         }
     }
 }
@@ -613,8 +613,8 @@ impl RestApiBuilder {
     }
 
     #[cfg(feature = "oauth")]
-    pub fn with_oauth_provider(mut self, oauth_provider: OAuthProvider) -> Self {
-        self.oauth_provider = Some(oauth_provider);
+    pub fn with_oauth_client(mut self, oauth_client: OAuthClient) -> Self {
+        self.oauth_client = Some(oauth_client);
         self
     }
 
@@ -628,7 +628,7 @@ impl RestApiBuilder {
             let mut authentication_configured = false;
 
             #[cfg(feature = "oauth")]
-            if self.oauth_provider.is_some() {
+            if self.oauth_client.is_some() {
                 authentication_configured = true;
             }
 
@@ -645,7 +645,7 @@ impl RestApiBuilder {
             #[cfg(feature = "rest-api-cors")]
             whitelist: self.whitelist,
             #[cfg(feature = "oauth")]
-            _oauth_provider: self.oauth_provider,
+            _oauth_client: self.oauth_client,
         })
     }
 }
@@ -744,15 +744,15 @@ mod test {
         #[cfg(feature = "oauth")]
         assert!(RestApiBuilder::new()
             .with_bind("test")
-            .with_oauth_provider(
-                OAuthProvider::new(
+            .with_oauth_client(
+                OAuthClient::new(
                     "client_id".into(),
                     "client_secret".into(),
                     "https://provider.com/auth".into(),
                     "https://provider.com/token".into(),
                     vec![],
                 )
-                .expect("Failed to create OAuth provider")
+                .expect("Failed to create OAuth client")
             )
             .build()
             .is_ok())


### PR DESCRIPTION
Adds OAuth endpoints to the Splinter REST API

This can be tested by checking out https://github.com/ltseeley/splinter/tree/rest-api-oauth-impl-test, which contains two extra commits for testing out authenticating with GitHub and Google.