### PR TITLE
Replace auth with authorization_type in Circuit

### DIFF
--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -25,7 +25,7 @@ pub struct Circuit {
     id: String,
     roster: Vec<Service>,
     members: Vec<String>,
-    auth: AuthorizationType,
+    authorization_type: AuthorizationType,
     persistence: PersistenceType,
     durability: DurabilityType,
     routes: RouteType,
@@ -49,8 +49,8 @@ impl Circuit {
     }
 
     /// Returns the authorization type of the circuit
-    pub fn auth(&self) -> &AuthorizationType {
-        &self.auth
+    pub fn authorization_type(&self) -> &AuthorizationType {
+        &self.authorization_type
     }
 
     /// Returns the persistence type type of the circuit
@@ -116,7 +116,7 @@ pub struct CircuitBuilder {
     circuit_id: Option<String>,
     roster: Option<Vec<Service>>,
     members: Option<Vec<String>>,
-    auth: Option<AuthorizationType>,
+    authorization_type: Option<AuthorizationType>,
     persistence: Option<PersistenceType>,
     durability: Option<DurabilityType>,
     routes: Option<RouteType>,
@@ -145,8 +145,8 @@ impl CircuitBuilder {
     }
 
     /// Returns the authorization type in the builder
-    pub fn auth(&self) -> Option<AuthorizationType> {
-        self.auth.clone()
+    pub fn authorization_type(&self) -> Option<AuthorizationType> {
+        self.authorization_type.clone()
     }
 
     /// Returns the persistence type in the builder
@@ -203,9 +203,12 @@ impl CircuitBuilder {
     ///
     /// # Arguments
     ///
-    ///  * `auth` - The authorization type for the circuit
-    pub fn with_auth(mut self, auth: &AuthorizationType) -> CircuitBuilder {
-        self.auth = Some(auth.clone());
+    ///  * `authorization_type` - The authorization type for the circuit
+    pub fn with_authorization_type(
+        mut self,
+        authorization_type: &AuthorizationType,
+    ) -> CircuitBuilder {
+        self.authorization_type = Some(authorization_type.clone());
         self
     }
 
@@ -274,7 +277,9 @@ impl CircuitBuilder {
             .members
             .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
 
-        let auth = self.auth.unwrap_or_else(|| AuthorizationType::Trust);
+        let authorization_type = self
+            .authorization_type
+            .unwrap_or_else(|| AuthorizationType::Trust);
 
         let persistence = self.persistence.unwrap_or_else(PersistenceType::default);
 
@@ -292,7 +297,7 @@ impl CircuitBuilder {
             id: circuit_id,
             roster,
             members,
-            auth,
+            authorization_type,
             persistence,
             durability,
             routes,
@@ -313,7 +318,7 @@ impl From<ProposedCircuit> for Circuit {
                 .iter()
                 .map(|node| node.node_id().to_string())
                 .collect(),
-            auth: circuit.authorization_type().clone(),
+            authorization_type: circuit.authorization_type().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),

--- a/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/postgres/migrations/2020-08-18-213009_admin_service_store/up.sql
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS service_argument (
 
 CREATE TABLE IF NOT EXISTS circuit (
     circuit_id                TEXT PRIMARY KEY,
-    auth                      TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
     persistence               TEXT NOT NULL,
     durability                TEXT NOT NULL,
     routes                    TEXT NOT NULL,

--- a/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
+++ b/libsplinter/src/admin/store/diesel/migrations/sqlite/migrations/2020-08-18-213016_admin_service_store/up.sql
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS service_argument (
 
 CREATE TABLE IF NOT EXISTS circuit (
     circuit_id                TEXT PRIMARY KEY,
-    auth                      TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
     persistence               TEXT NOT NULL,
     durability                TEXT NOT NULL,
     routes                    TEXT NOT NULL,

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -304,7 +304,7 @@ impl From<&Circuit> for Vec<ServiceArgumentModel> {
 #[primary_key(circuit_id)]
 pub struct CircuitModel {
     pub circuit_id: String,
-    pub auth: String,
+    pub authorization_type: String,
     pub persistence: String,
     pub durability: String,
     pub routes: String,
@@ -315,7 +315,7 @@ impl From<&Circuit> for CircuitModel {
     fn from(circuit: &Circuit) -> Self {
         CircuitModel {
             circuit_id: circuit.circuit_id().into(),
-            auth: String::from(circuit.auth()),
+            authorization_type: String::from(circuit.authorization_type()),
             persistence: String::from(circuit.persistence()),
             durability: String::from(circuit.durability()),
             routes: String::from(circuit.routes()),

--- a/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
@@ -77,7 +77,9 @@ where
                     .with_circuit_id(&circuit.circuit_id)
                     .with_roster(&services)
                     .with_members(&circuit_member)
-                    .with_auth(&AuthorizationType::try_from(circuit.auth)?)
+                    .with_authorization_type(&AuthorizationType::try_from(
+                        circuit.authorization_type,
+                    )?)
                     .with_persistence(&PersistenceType::try_from(circuit.persistence)?)
                     .with_durability(&DurabilityType::try_from(circuit.durability)?)
                     .with_routes(&RouteType::try_from(circuit.routes)?)

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -209,7 +209,9 @@ where
                 for (id, model) in circuits {
                     let mut circuit_builder = CircuitBuilder::new()
                         .with_circuit_id(&model.circuit_id)
-                        .with_auth(&AuthorizationType::try_from(model.auth)?)
+                        .with_authorization_type(&AuthorizationType::try_from(
+                            model.authorization_type,
+                        )?)
                         .with_persistence(&PersistenceType::try_from(model.persistence)?)
                         .with_durability(&DurabilityType::try_from(model.durability)?)
                         .with_routes(&RouteType::try_from(model.routes)?);

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -58,7 +58,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             let circuit_model = CircuitModel::from(&circuit);
             update(circuit::table.find(circuit.circuit_id()))
                 .set((
-                    circuit::auth.eq(circuit_model.auth),
+                    circuit::authorization_type.eq(circuit_model.authorization_type),
                     circuit::persistence.eq(circuit_model.persistence),
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),
@@ -140,7 +140,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             let circuit_model = CircuitModel::from(&circuit);
             update(circuit::table.find(circuit.circuit_id()))
                 .set((
-                    circuit::auth.eq(circuit_model.auth),
+                    circuit::authorization_type.eq(circuit_model.authorization_type),
                     circuit::persistence.eq(circuit_model.persistence),
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -60,7 +60,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_auth(proposed_circuit.authorization_type())
+                .with_authorization_type(proposed_circuit.authorization_type())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
@@ -115,7 +115,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                         .map(|node| node.node_id().to_string())
                         .collect::<Vec<String>>(),
                 )
-                .with_auth(proposed_circuit.authorization_type())
+                .with_authorization_type(proposed_circuit.authorization_type())
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -97,7 +97,7 @@ table! {
 table! {
     circuit (circuit_id) {
         circuit_id -> Text,
-        auth -> Text,
+        authorization_type -> Text,
         persistence -> Text,
         durability -> Text,
         routes -> Text,

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1040,7 +1040,7 @@ impl TryFrom<YamlCircuit> for Circuit {
                     .collect::<Result<Vec<Service>, BuilderError>>()?,
             )
             .with_members(&circuit.members)
-            .with_auth(&circuit.auth)
+            .with_authorization_type(&circuit.auth)
             .with_persistence(&circuit.persistence)
             .with_durability(&circuit.durability)
             .with_routes(&circuit.routes)
@@ -1059,7 +1059,7 @@ impl From<Circuit> for YamlCircuit {
                 .map(|service| YamlService::from(service.clone()))
                 .collect(),
             members: circuit.members().to_vec(),
-            auth: circuit.auth().clone(),
+            auth: circuit.authorization_type().clone(),
             persistence: circuit.persistence().clone(),
             durability: circuit.durability().clone(),
             routes: circuit.routes().clone(),


### PR DESCRIPTION
Update the AdminServiceStore Circuit struct to have authorization_type instead of auth. This makes the use
of authorization_type consistent between Circuit and ProposedCircuit.

The database migration changes are made in place currently because the migration do not run successfully (this will be fixed in the next PR)