### PR TITLE
Add admin-service-store-postgres experimental feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -95,6 +95,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "admin-service-store",
+    "admin-service-store-postgres",
     "auth",
     "biome-notifications",
     "biome-user",
@@ -115,6 +116,7 @@ benchmark = []
 
 auth = []
 admin-service-store = []
+admin-service-store-postgres = ["admin-service-store", "postgres"]
 biome = []
 biome-credentials = ["biome", "biome-user", "bcrypt"]
 biome-key-management = ["biome"]

--- a/libsplinter/src/admin/store/diesel/migrations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/migrations/mod.rs
@@ -14,7 +14,7 @@
 
 //! Provides database migrations for the `DieselAdminServiceStore`.
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
@@ -22,7 +22,7 @@ pub mod sqlite;
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 pub use postgres::run_migrations as run_postgres_migrations;
 #[cfg(feature = "sqlite")]
 pub use sqlite::run_migrations as run_sqlite_migrations;

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -74,7 +74,7 @@ impl Clone for DieselAdminServiceStore<diesel::sqlite::SqliteConnection> {
     }
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl Clone for DieselAdminServiceStore<diesel::pg::PgConnection> {
     fn clone(&self) -> Self {
         Self {
@@ -83,7 +83,7 @@ impl Clone for DieselAdminServiceStore<diesel::pg::PgConnection> {
     }
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl AdminServiceStore for DieselAdminServiceStore<diesel::pg::PgConnection> {
     fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
         AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_proposal(proposal)

--- a/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
@@ -38,7 +38,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreAddCircuitOperation {
     ) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl<'a> AdminServiceStoreAddCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
@@ -36,7 +36,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreAddProposalOperation 
     fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl<'a> AdminServiceStoreAddProposalOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -33,7 +33,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateCircuitOperatio
     fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl<'a> AdminServiceStoreUpdateCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -39,7 +39,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateProposalOperati
     fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl<'a> AdminServiceStoreUpdateProposalOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -28,7 +28,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpgradeProposalToCirc
     fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
 impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {


### PR DESCRIPTION
This will guard the postgres implementation of the admin
service store until it can be tested after the AdminServiceStore
is integrated into the admin service.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>