### PR TITLE
Add authentication/authorization to Splinter REST API

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -100,6 +100,7 @@ experimental = [
     "biome-notifications",
     "biome-user",
     "oauth",
+    "oauth-github",
     "registry-database",
     "routing-table",
     "service-arg-validation",
@@ -123,6 +124,7 @@ biome-user = ["biome"]
 circuit-template = ["glob"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 oauth = ["auth", "oauth2"]
+oauth-github = ["oauth"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
 registry-database = ["diesel"]

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -81,8 +81,6 @@ mod tests {
     use reqwest::{blocking::Client, StatusCode, Url};
     use serde_json::{to_value, Value as JsonValue};
 
-    #[cfg(feature = "oauth")]
-    use crate::auth::oauth::OAuthClient;
     use crate::circuit::{
         directory::CircuitDirectory, AuthorizationType, Circuit, DurabilityType, PersistenceType,
         RouteType, ServiceDefinition, SplinterState,
@@ -207,24 +205,12 @@ mod tests {
         (10000..20000)
             .find_map(|port| {
                 let bind_url = format!("127.0.0.1:{}", port);
-                let mut builder = RestApiBuilder::new()
+                let result = RestApiBuilder::new()
                     .with_bind(&bind_url)
-                    .add_resources(resources.clone());
-                #[cfg(feature = "oauth")]
-                {
-                    builder = builder.with_oauth_client(
-                        OAuthClient::new(
-                            "client_id".into(),
-                            "client_secret".into(),
-                            "https://provider.com/auth".into(),
-                            "https://localhost/oauth/callback".into(),
-                            "https://provider.com/token".into(),
-                            vec![],
-                        )
-                        .expect("Failed to create OAuth client"),
-                    );
-                }
-                let result = builder.build().expect("Failed to build REST API").run();
+                    .add_resources(resources.clone())
+                    .build_insecure()
+                    .expect("Failed to build REST API")
+                    .run_insecure();
                 match result {
                     Ok((shutdown_handle, join_handle)) => {
                         Some((shutdown_handle, join_handle, bind_url))

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -90,8 +90,6 @@ mod tests {
         },
         service::proposal_store::{ProposalFilter, ProposalIter, ProposalStoreError},
     };
-    #[cfg(feature = "oauth")]
-    use crate::auth::oauth::OAuthClient;
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 
     #[test]
@@ -203,24 +201,12 @@ mod tests {
         (10000..20000)
             .find_map(|port| {
                 let bind_url = format!("127.0.0.1:{}", port);
-                let mut builder = RestApiBuilder::new()
+                let result = RestApiBuilder::new()
                     .with_bind(&bind_url)
-                    .add_resources(resources.clone());
-                #[cfg(feature = "oauth")]
-                {
-                    builder = builder.with_oauth_client(
-                        OAuthClient::new(
-                            "client_id".into(),
-                            "client_secret".into(),
-                            "https://provider.com/auth".into(),
-                            "https://localhost/oauth/callback".into(),
-                            "https://provider.com/token".into(),
-                            vec![],
-                        )
-                        .expect("Failed to create OAuth client"),
-                    );
-                }
-                let result = builder.build().expect("Failed to build REST API").run();
+                    .add_resources(resources.clone())
+                    .build_insecure()
+                    .expect("Failed to build REST API")
+                    .run_insecure();
                 match result {
                     Ok((shutdown_handle, join_handle)) => {
                         Some((shutdown_handle, join_handle, bind_url))

--- a/libsplinter/src/auth/mod.rs
+++ b/libsplinter/src/auth/mod.rs
@@ -16,3 +16,5 @@
 
 #[cfg(feature = "oauth")]
 pub mod oauth;
+#[cfg(feature = "rest-api")]
+pub mod rest_api;

--- a/libsplinter/src/auth/oauth/mod.rs
+++ b/libsplinter/src/auth/oauth/mod.rs
@@ -93,6 +93,30 @@ impl OAuthClient {
         })
     }
 
+    /// Creates a new `OAuthClient` with GitHub's authorization and token URLs.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_id` - The GitHub OAuth client ID
+    /// * `client_secret` - The GitHub OAuth client secret
+    /// * `redirect_url` - The endpoint that GitHub will redirect to after it has completed
+    ///   authorization
+    #[cfg(feature = "oauth-github")]
+    pub fn new_github(
+        client_id: String,
+        client_secret: String,
+        redirect_url: String,
+    ) -> Result<Self, OAuthClientConfigurationError> {
+        Self::new(
+            client_id,
+            client_secret,
+            "https://github.com/login/oauth/authorize".into(),
+            redirect_url,
+            "https://github.com/login/oauth/access_token".into(),
+            vec![],
+        )
+    }
+
     /// Generates the URL that the end user should be redirected to for authorization
     pub fn get_authorization_url(&self) -> Result<String, OAuthClientError> {
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();

--- a/libsplinter/src/auth/oauth/rest_api/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/mod.rs
@@ -32,7 +32,7 @@ use super::OAuthClient;
 ///
 /// * `rest-api-actix`
 #[derive(Clone)]
-pub struct OAuthResourceProvider {
+pub(crate) struct OAuthResourceProvider {
     client: OAuthClient,
 }
 

--- a/libsplinter/src/auth/rest_api/actix.rs
+++ b/libsplinter/src/auth/rest_api/actix.rs
@@ -1,0 +1,130 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Authorization middleware for the Actix REST API
+
+use actix_web::dev::*;
+use actix_web::{Error as ActixError, HttpResponse};
+use futures::{
+    future::{ok, FutureResult},
+    Future, IntoFuture, Poll,
+};
+
+use crate::rest_api::ErrorResponse;
+
+use super::{authorize, identity::IdentityProvider, AuthorizationResult};
+
+/// Wrapper for the authorization middleware
+#[derive(Clone)]
+pub struct Authorization {
+    identity_providers: Vec<Box<dyn IdentityProvider>>,
+}
+
+impl Authorization {
+    pub fn new(identity_providers: Vec<Box<dyn IdentityProvider>>) -> Self {
+        Self { identity_providers }
+    }
+}
+
+impl<S, B> Transform<S> for Authorization
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = ActixError>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = S::Error;
+    type InitError = ();
+    type Transform = AuthorizationMiddleware<S>;
+    type Future = FutureResult<Self::Transform, Self::InitError>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(AuthorizationMiddleware {
+            identity_providers: self.identity_providers.clone(),
+            service,
+        })
+    }
+}
+
+/// Authorization middleware for the Actix REST API
+pub struct AuthorizationMiddleware<S> {
+    identity_providers: Vec<Box<dyn IdentityProvider>>,
+    service: S,
+}
+
+impl<S, B> Service for AuthorizationMiddleware<S>
+where
+    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = ActixError>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Request = ServiceRequest;
+    type Response = ServiceResponse<B>;
+    type Error = S::Error;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.service.poll_ready()
+    }
+
+    fn call(&mut self, req: ServiceRequest) -> Self::Future {
+        let auth_header =
+            match req
+                .headers()
+                .get("Authorization")
+                .map(|auth| auth.to_str())
+                .transpose()
+            {
+                Ok(opt) => opt,
+                // Not including the error since it could leak secrets from the Authorization header
+                Err(_) => return Box::new(
+                    req.into_response(
+                        HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(
+                                "Authorization header must contain only visible ASCII characters",
+                            ))
+                            .into_body(),
+                    )
+                    .into_future(),
+                ),
+            };
+
+        match authorize(req.path(), auth_header, &self.identity_providers) {
+            AuthorizationResult::Authorized(_identity) => {}
+            AuthorizationResult::NoAuthorizationNecessary => {}
+            AuthorizationResult::InvalidAuthorization(auth_str) => {
+                return Box::new(
+                    req.into_response(
+                        HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&format!(
+                                "The provided authorization header is not supported: {}",
+                                auth_str
+                            )))
+                            .into_body(),
+                    )
+                    .into_future(),
+                )
+            }
+            AuthorizationResult::Unauthorized => {
+                return Box::new(
+                    req.into_response(HttpResponse::Unauthorized().finish().into_body())
+                        .into_future(),
+                )
+            }
+        }
+
+        Box::new(self.service.call(req))
+    }
+}

--- a/libsplinter/src/auth/rest_api/identity/error.rs
+++ b/libsplinter/src/auth/rest_api/identity/error.rs
@@ -1,0 +1,69 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Errors that can occur when dealing with identities
+
+use std::error::Error;
+use std::fmt;
+
+/// An error that can occur when using an identity provider
+#[derive(Debug)]
+pub enum IdentityProviderError {
+    /// An unrecoverable error that cannot be handled by the caller
+    InternalError(String),
+    /// The given authentication variant is supported by this identity provider, but could not be
+    /// resolved to an identity
+    Unauthorized,
+    /// The given authentication is not supported by this identity provider
+    UnsupportedAuth,
+}
+
+impl fmt::Display for IdentityProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::InternalError(msg) => write!(
+                f,
+                "Identity provider encountered an unrecoverable error: {}",
+                msg,
+            ),
+            Self::Unauthorized => f.write_str("No identity was found for the given authentication"),
+            Self::UnsupportedAuth => {
+                f.write_str("The given authentication is not supported by this provider")
+            }
+        }
+    }
+}
+
+impl Error for IdentityProviderError {}
+
+/// An error that can occur when parsing an `Authorization`
+#[derive(Debug)]
+pub struct AuthorizationParseError {
+    message: String,
+}
+
+impl AuthorizationParseError {
+    /// Creates a new error
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl fmt::Display for AuthorizationParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for AuthorizationParseError {}

--- a/libsplinter/src/auth/rest_api/identity/github.rs
+++ b/libsplinter/src/auth/rest_api/identity/github.rs
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An identity provider that looks up GitHub usernames
+
+use reqwest::{blocking::Client, StatusCode};
+
+use super::{Authorization, BearerToken, IdentityProvider, IdentityProviderError};
+
+/// Retrieves a GitHub username from the GitHub servers
+///
+/// This provider only accepts `Authorization::Bearer(BearerToken::OAuth2(token))` authorizations,
+/// and the inner token must be a valid GitHub OAuth2 access token.
+#[derive(Clone)]
+pub struct GithubUserIdentityProvider;
+
+impl IdentityProvider for GithubUserIdentityProvider {
+    fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError> {
+        let token = match authorization {
+            Authorization::Bearer(BearerToken::OAuth2(token)) => token,
+        };
+
+        let response = Client::builder()
+            .build()
+            .map_err(|err| IdentityProviderError::InternalError(err.to_string()))?
+            .get("https://api.github.com/user")
+            .header("Authorization", format!("Bearer {}", token))
+            .header("User-Agent", "splinter")
+            .send()
+            .map_err(|err| IdentityProviderError::InternalError(err.to_string()))?;
+
+        if !response.status().is_success() {
+            match response.status() {
+                StatusCode::UNAUTHORIZED => return Err(IdentityProviderError::Unauthorized),
+                status_code => {
+                    return Err(IdentityProviderError::InternalError(format!(
+                        "Received unexpected response code: {}",
+                        status_code
+                    )))
+                }
+            }
+        }
+
+        let username = response
+            .json::<UserResponse>()
+            .map_err(|_| {
+                IdentityProviderError::InternalError("Received unexpected response body".into())
+            })?
+            .login;
+
+        Ok(username)
+    }
+
+    fn clone_box(&self) -> Box<dyn IdentityProvider> {
+        Box::new(self.clone())
+    }
+}
+
+/// Deserializes the GitHub response
+#[derive(Debug, Deserialize)]
+struct UserResponse {
+    login: String,
+}

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -15,6 +15,8 @@
 //! Tools for identifying clients and users
 
 mod error;
+#[cfg(feature = "oauth-github")]
+pub mod github;
 
 use std::str::FromStr;
 

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -1,0 +1,99 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tools for identifying clients and users
+
+mod error;
+
+use std::str::FromStr;
+
+pub use error::{AuthorizationParseError, IdentityProviderError};
+
+/// A service that fetches identities from a backing provider
+pub trait IdentityProvider: Send {
+    /// Attempts to get the identity that corresponds to the given authorization
+    fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError>;
+
+    /// Clones implementation for `IdentityProvider`. The implementation of the `Clone` trait for
+    /// `Box<dyn IdentityProvider>` calls this method.
+    ///
+    /// # Example
+    ///
+    ///```ignore
+    ///  fn clone_box(&self) -> Box<dyn IdentityProvider> {
+    ///     Box::new(self.clone())
+    ///  }
+    ///```
+    fn clone_box(&self) -> Box<dyn IdentityProvider>;
+}
+
+impl Clone for Box<dyn IdentityProvider> {
+    fn clone(&self) -> Box<dyn IdentityProvider> {
+        self.clone_box()
+    }
+}
+
+/// The authorization that is passed to an `IdentityProvider`
+pub enum Authorization {
+    Bearer(BearerToken),
+}
+
+/// Parses an authorization string, which must be in the format "<scheme> <value>"
+impl FromStr for Authorization {
+    type Err = AuthorizationParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(2, ' ');
+        match (parts.next(), parts.next()) {
+            (Some(auth_scheme), Some(token)) => match auth_scheme {
+                "Bearer" => Ok(Authorization::Bearer(token.parse()?)),
+                other_scheme => Err(AuthorizationParseError::new(format!(
+                    "unsupported authorization scheme: {}",
+                    other_scheme
+                ))),
+            },
+            (Some(_), None) => Err(AuthorizationParseError::new(
+                "malformed authorization".into(),
+            )),
+            _ => unreachable!(), // splitn always returns at least one item
+        }
+    }
+}
+
+/// A bearer token of a specific type
+pub enum BearerToken {
+    #[cfg(feature = "oauth")]
+    /// Contains an OAuth2 token
+    OAuth2(String),
+}
+
+/// Parses a bearer token string, which must be in the format "<type>:<value>"
+impl FromStr for BearerToken {
+    type Err = AuthorizationParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(2, ':');
+        match (parts.next(), parts.next()) {
+            (Some(token_type), Some(token)) => match token_type {
+                "OAuth2" => Ok(BearerToken::OAuth2(token.to_string())),
+                other_type => Err(AuthorizationParseError::new(format!(
+                    "unsupported token type: {}",
+                    other_type
+                ))),
+            },
+            (Some(_), None) => Err(AuthorizationParseError::new("malformed token".into())),
+            _ => unreachable!(), // splitn always returns at least one item
+        }
+    }
+}

--- a/libsplinter/src/auth/rest_api/mod.rs
+++ b/libsplinter/src/auth/rest_api/mod.rs
@@ -1,0 +1,86 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Authentication and authorization tools for the Splinter REST API
+
+#[cfg(feature = "rest-api-actix")]
+pub mod actix;
+pub mod identity;
+
+use identity::{IdentityProvider, IdentityProviderError};
+
+/// The possible outcomes of attempting to authorize a client
+enum AuthorizationResult {
+    /// The client was authorized to the given identity
+    Authorized(String),
+    /// The given authorization header isn't supported by any of the configured identity providers
+    InvalidAuthorization(String),
+    /// The requested endpoint does not require authorization
+    NoAuthorizationNecessary,
+    /// The authorization header is empty or invalid
+    Unauthorized,
+}
+
+/// Uses the given identity providers to check authorization for the request. This function is
+/// backend-agnostic and intended as a helper for the backend REST API implementations.
+///
+/// # Arguments
+///
+/// * `endpoint` - The endpoint that is being requested. Example: "/endpoint/path"
+/// * `auth_header` - The value of the Authorization HTTP header for the request
+/// * `identity_providers` - The identity providers that will be used to check the client's identity
+fn authorize(
+    endpoint: &str,
+    auth_header: Option<&str>,
+    identity_providers: &[Box<dyn IdentityProvider>],
+) -> AuthorizationResult {
+    // Authorization isn't necessary when using one of the authorization endpoints
+    let mut is_auth_endpoint = false;
+    #[cfg(feature = "oauth")]
+    if endpoint.starts_with("/oauth") {
+        is_auth_endpoint = true;
+    }
+    if is_auth_endpoint {
+        return AuthorizationResult::NoAuthorizationNecessary;
+    }
+
+    // Parse the auth header
+    let auth_str = match auth_header {
+        Some(auth_str) => auth_str,
+        None => return AuthorizationResult::Unauthorized,
+    };
+    let authorization = match auth_str.parse() {
+        Ok(auth) => auth,
+        Err(_) => return AuthorizationResult::InvalidAuthorization(auth_str.into()),
+    };
+
+    // Attempt to get the client's identity
+    let mut authorization_supported = false;
+    for provider in identity_providers {
+        match provider.get_identity(&authorization) {
+            Ok(identity) => return AuthorizationResult::Authorized(identity),
+            Err(IdentityProviderError::Unauthorized) => authorization_supported = true,
+            Err(IdentityProviderError::UnsupportedAuth) => {}
+            Err(err) => error!("{}", err),
+        }
+    }
+
+    // If no auth was successful, determine if it was an unsupported type or just not
+    // valid for any of the providers
+    if authorization_supported {
+        AuthorizationResult::Unauthorized
+    } else {
+        AuthorizationResult::InvalidAuthorization(auth_str.into())
+    }
+}

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -256,8 +256,6 @@ mod tests {
     use reqwest::{blocking::Client, StatusCode, Url};
     use serde_json::{to_value, Value as JsonValue};
 
-    #[cfg(feature = "oauth")]
-    use crate::auth::oauth::OAuthClient;
     use crate::registry::NodeIter;
     use crate::rest_api::{
         paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
@@ -462,24 +460,12 @@ mod tests {
         (10000..20000)
             .find_map(|port| {
                 let bind_url = format!("127.0.0.1:{}", port);
-                let mut builder = RestApiBuilder::new()
+                let result = RestApiBuilder::new()
                     .with_bind(&bind_url)
-                    .add_resources(resources.clone());
-                #[cfg(feature = "oauth")]
-                {
-                    builder = builder.with_oauth_client(
-                        OAuthClient::new(
-                            "client_id".into(),
-                            "client_secret".into(),
-                            "https://provider.com/auth".into(),
-                            "https://localhost/oauth/callback".into(),
-                            "https://provider.com/token".into(),
-                            vec![],
-                        )
-                        .expect("Failed to create OAuth client"),
-                    );
-                }
-                let result = builder.build().expect("Failed to build REST API").run();
+                    .add_resources(resources.clone())
+                    .build_insecure()
+                    .expect("Failed to build REST API")
+                    .run_insecure();
                 match result {
                     Ok((shutdown_handle, join_handle)) => {
                         Some((shutdown_handle, join_handle, bind_url))

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -166,8 +166,6 @@ mod tests {
 
     use reqwest::{blocking::Client, StatusCode, Url};
 
-    #[cfg(feature = "oauth")]
-    use crate::auth::oauth::OAuthClient;
     use crate::registry::{MetadataPredicate, NodeIter};
     use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
 
@@ -375,24 +373,12 @@ mod tests {
         (10000..20000)
             .find_map(|port| {
                 let bind_url = format!("127.0.0.1:{}", port);
-                let mut builder = RestApiBuilder::new()
+                let result = RestApiBuilder::new()
                     .with_bind(&bind_url)
-                    .add_resources(resources.clone());
-                #[cfg(feature = "oauth")]
-                {
-                    builder = builder.with_oauth_client(
-                        OAuthClient::new(
-                            "client_id".into(),
-                            "client_secret".into(),
-                            "https://provider.com/auth".into(),
-                            "https://localhost/oauth/callback".into(),
-                            "https://provider.com/token".into(),
-                            vec![],
-                        )
-                        .expect("Failed to create OAuth client"),
-                    );
-                }
-                let result = builder.build().expect("Failed to build REST API").run();
+                    .add_resources(resources.clone())
+                    .build_insecure()
+                    .expect("Failed to build REST API")
+                    .run_insecure();
                 match result {
                     Ok((shutdown_handle, join_handle)) => {
                         Some((shutdown_handle, join_handle, bind_url))

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -400,8 +400,6 @@ mod tests {
     use futures::future::IntoFuture;
     use tempdir::TempDir;
 
-    #[cfg(feature = "oauth")]
-    use crate::auth::oauth::OAuthClient;
     use crate::rest_api::{
         Method, Resource, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
     };
@@ -1098,24 +1096,12 @@ mod tests {
         (10000..20000)
             .find_map(|port| {
                 let bind_url = format!("127.0.0.1:{}", port);
-                let mut builder = RestApiBuilder::new()
+                let result = RestApiBuilder::new()
                     .with_bind(&bind_url)
-                    .add_resources(resources.clone());
-                #[cfg(feature = "oauth")]
-                {
-                    builder = builder.with_oauth_client(
-                        OAuthClient::new(
-                            "client_id".into(),
-                            "client_secret".into(),
-                            "https://provider.com/auth".into(),
-                            "https://localhost/oauth/callback".into(),
-                            "https://provider.com/token".into(),
-                            vec![],
-                        )
-                        .expect("Failed to create OAuth client"),
-                    );
-                }
-                let result = builder.build().expect("Failed to build REST API").run();
+                    .add_resources(resources.clone())
+                    .build_insecure()
+                    .expect("Failed to build REST API")
+                    .run_insecure();
                 match result {
                     Ok((shutdown_handle, join_handle)) => {
                         Some((shutdown_handle, join_handle, bind_url))

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -488,18 +488,15 @@ impl RestApi {
             .spawn(move || {
                 let sys = actix::System::new("SplinterD-Rest-API");
                 let mut server = HttpServer::new(move || {
-                    // Actix's type definitions require this to be chained, otherwise, the generic
-                    // type of App is changed as the values are returned.
+                    let app = App::new();
+
                     #[cfg(feature = "rest-api-cors")]
-                    let cors = match &whitelist {
+                    let app = app.wrap(match &whitelist {
                         Some(list) => cors::Cors::new(list.to_vec()),
                         None => cors::Cors::new_allow_any(),
-                    };
-                    #[cfg(feature = "rest-api-cors")]
-                    let mut app = App::new().wrap(middleware::Logger::default()).wrap(cors);
+                    });
 
-                    #[cfg(not(feature = "rest-api-cors"))]
-                    let mut app = App::new().wrap(middleware::Logger::default());
+                    let mut app = app.wrap(middleware::Logger::default());
 
                     #[cfg(feature = "oauth")]
                     if let Some(resource_provider) = &oauth_resource_provider {


### PR DESCRIPTION
Adds the Authorization middleware to the Actix REST API

This PR can be tested by checking out the test branch (https://github.com/ltseeley/splinter/tree/rest-api-auth-guard-test) and running `docker-compose up --build` from the root of the repository.