### PR TITLE
AdminServiceStore remove serialization annotations

### DIFF
--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -57,7 +57,7 @@ pub use self::service::{Service, ServiceBuilder};
 
 /// The unique ID of service made up of a circuit ID and the individual service ID.
 /// A service ID is only required to be unique from within a circuit.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ServiceId {
     circuit_id: String,
     service_id: String,


### PR DESCRIPTION
Remove serialization 'derive' annotations from AdminServiceStore structs at the trait level. Serialization should be handled in reader/writer implementation.