### PR TITLE
Remaining AdminServiceStore derive annotations

### DIFF
--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -20,7 +20,7 @@ use super::error::BuilderError;
 use super::{ProposedCircuit, Service};
 
 /// Native representation of a circuit in state
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Circuit {
     id: String,
     roster: Vec<Service>,
@@ -75,13 +75,13 @@ impl Circuit {
 }
 
 /// What type of authorization the circuit requires
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthorizationType {
     Trust,
 }
 
 /// A circuits message persistence strategy
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PersistenceType {
     Any,
 }
@@ -93,13 +93,13 @@ impl Default for PersistenceType {
 }
 
 /// A circuits durability requirement
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DurabilityType {
     NoDurability,
 }
 
 /// How messages are expected to be routed across a circuit
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RouteType {
     Any,
 }

--- a/libsplinter/src/admin/store/circuit_node.rs
+++ b/libsplinter/src/admin/store/circuit_node.rs
@@ -18,7 +18,7 @@ use super::error::BuilderError;
 use super::ProposedNode;
 
 /// Native representation of a node included in circuit
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CircuitNode {
     id: String,
     endpoints: Vec<String>,

--- a/libsplinter/src/admin/store/circuit_proposal.rs
+++ b/libsplinter/src/admin/store/circuit_proposal.rs
@@ -20,7 +20,7 @@ use super::error::BuilderError;
 use super::ProposedCircuit;
 
 /// Native representation of a circuit proposal
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CircuitProposal {
     proposal_type: ProposalType,
     circuit_id: String,
@@ -258,7 +258,7 @@ impl CircuitProposalBuilder {
 }
 
 // Native representation of a vote record for a proposal
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VoteRecord {
     public_key: Vec<u8>,
     vote: Vote,
@@ -346,14 +346,14 @@ impl VoteRecordBuilder {
 }
 
 /// Represents a vote, either accept or reject, for a circuit proposal
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Vote {
     Accept,
     Reject,
 }
 
 /// Represents the of  type change the circuit proposal is for
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProposalType {
     Create,
     UpdateRoster,

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -22,7 +22,7 @@ use super::{
 };
 
 /// Native representation of a circuit that is being proposed in a proposal
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProposedCircuit {
     circuit_id: String,
     roster: Vec<ProposedService>,

--- a/libsplinter/src/admin/store/proposed_node.rs
+++ b/libsplinter/src/admin/store/proposed_node.rs
@@ -17,7 +17,7 @@
 use super::error::BuilderError;
 
 /// Native representation of a node in a proposed circuit
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProposedNode {
     node_id: String,
     endpoints: Vec<String>,

--- a/libsplinter/src/admin/store/proposed_service.rs
+++ b/libsplinter/src/admin/store/proposed_service.rs
@@ -18,7 +18,7 @@ use crate::admin::messages::is_valid_service_id;
 use super::error::BuilderError;
 
 /// Native representation of a service that is a part of a proposed circuit
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProposedService {
     service_id: String,
     service_type: String,

--- a/libsplinter/src/admin/store/service.rs
+++ b/libsplinter/src/admin/store/service.rs
@@ -20,7 +20,7 @@ use super::error::BuilderError;
 use super::ProposedService;
 
 /// Native representation of a service that is a part of circuit
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Service {
     service_id: String,
     service_type: String,


### PR DESCRIPTION
Remove remaining serialization 'derive' annotations from AdminServiceStore structs at the trait level. Serialization should be
handled in reader/writer implementation.

Add serializable structs to the yaml implementation of AdminServiceStore and implement 'From' for each to allow for conversion between the trait level structs and the yaml structs.