### PR TITLE
Add key flag to Splinter CLI commands

### DIFF
--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -46,6 +46,10 @@ OPTIONS
 : Specifies the output format of the circuit. (default `human`). Possible values
   for formatting are `human` and `csv`.
 
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
 `-m`, `--member` <member>
 : Filter the circuits list by a node ID that is present in the circuits’ members
   list.

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -47,6 +47,10 @@ OPTIONS
   displays the circuit proposals information in a formatted table, while `csv`
   prints the circuit proposals information via comma-separated values.
 
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
 `--management-type` MANAGEMENT-TYPE
 : Filter the circuit proposals by their circuit management type.
 

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -45,6 +45,10 @@ OPTIONS
 : Specifies the output format of the circuit proposal. (default `human`).
   Possible values for formatting are `human` and `csv`.
 
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
 `-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
   `$SPLINTER_REST_API_URL` is set.

--- a/cli/man/splinter-health-status.1.md
+++ b/cli/man/splinter-health-status.1.md
@@ -44,6 +44,10 @@ FLAGS
 OPTIONS
 =======
 
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
 `-U`, `--url URL`
 : Specifies the URL for the node of interest (the URL for the `splinterd`
   REST API on the node). This option is required unless `$SPLINTER_REST_API_URL`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -418,6 +418,14 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .help("Output format")
                         .possible_values(&["human", "csv"])
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("private_key_file")
+                        .value_name("private-key-file")
+                        .short("k")
+                        .long("key")
+                        .takes_value(true)
+                        .help("Name or path of private key"),
                 ),
         )
         .subcommand(
@@ -452,6 +460,14 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .help("Output format")
                         .possible_values(&["human", "yaml", "json"])
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("private_key_file")
+                        .value_name("private-key-file")
+                        .short("k")
+                        .long("key")
+                        .takes_value(true)
+                        .help("Name or path of private key"),
                 ),
         )
         .subcommand(
@@ -498,6 +514,14 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .help("Output format")
                         .possible_values(&["human", "csv"])
                         .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("private_key_file")
+                        .value_name("private-key-file")
+                        .short("k")
+                        .long("key")
+                        .takes_value(true)
+                        .help("Name or path of private key"),
                 ),
         );
 
@@ -578,6 +602,14 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                             .takes_value(true)
                             .multiple(true)
                             .help("Metadata to include with node (<key>=<value>)"),
+                    )
+                    .arg(
+                        Arg::with_name("private_key_file")
+                            .value_name("private-key-file")
+                            .short("k")
+                            .long("key")
+                            .takes_value(true)
+                            .help("Name or path of private key"),
                     ),
             ),
     );
@@ -600,6 +632,14 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .long("url")
                                 .help("URL of the Splinter daemon REST API")
                                 .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("private_key_file")
+                                .value_name("private-key-file")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Name or path of private key"),
                         ),
                 ),
         );


### PR DESCRIPTION
'--key' flag added to all REST API calling Splinter CLI commands. The flag allows the user to specify the path to the file containing the private key.