### PR TITLE
Implement redirect from `oauth/callback`

### DIFF
--- a/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
@@ -15,7 +15,7 @@
 //! The `GET /oauth/callback` endpoint for receiving the authorization code from the provider and
 //! exchanging it for an access token.
 
-use actix_web::{web::Query, HttpResponse};
+use actix_web::{http::header::LOCATION, web::Query, HttpResponse};
 use futures::future::IntoFuture;
 
 use crate::auth::oauth::{
@@ -36,16 +36,39 @@ pub fn make_callback_route(client: OAuthClient) -> Resource {
                 match Query::<CallbackQuery>::from_query(req.query_string()) {
                     Ok(query) => {
                         match client.exchange_authorization_code(query.code.clone(), &query.state) {
-                            Ok(Some(user_tokens)) => {
-                                HttpResponse::Ok().json(CallbackResponse::from(&user_tokens))
+                            Ok(Some((user_tokens, redirect_url))) => {
+                                // Adding the user tokens to the redirect URL, so the client may
+                                // access these values after a redirect
+                                let callback_response = CallbackResponse::from(&user_tokens);
+                                let mut redirect_url = format!(
+                                    "{}?access_token={}",
+                                    redirect_url, callback_response.access_token
+                                );
+                                if let Some(expiry) = callback_response.expires_in {
+                                    redirect_url.push_str(&format!("&expires_in={}", expiry))
+                                };
+                                if let Some(refresh) = callback_response.refresh_token {
+                                    redirect_url.push_str(&format!("&refresh_token={}", refresh))
+                                };
+                                HttpResponse::Found()
+                                    .header(LOCATION, redirect_url)
+                                    .finish()
                             }
                             Ok(None) => {
                                 error!(
                                 "Received OAuth callback request that does not correlate to an \
                                  open authorization request"
-                            );
-                                HttpResponse::InternalServerError()
-                                    .json(ErrorResponse::internal_error())
+                                );
+                                match req.headers().get("referer") {
+                                    Some(referer) => HttpResponse::Found()
+                                        .header(LOCATION, referer.clone())
+                                        .finish(),
+                                    None => {
+                                        HttpResponse::BadRequest().json(ErrorResponse::bad_request(
+                                            "No `redirect_url` supplied, no `referer` found",
+                                        ))
+                                    }
+                                }
                             }
                             Err(err) => {
                                 error!("{}", err);


### PR DESCRIPTION
Adds a `redirect_url` query parameter to the `oauth/login` endpoint,
used to direct the UI once the `oauth/callback` has successfully
exchanged the authorization code for the access token.

This also changes the `oauth/callback` behavior to successfully respond
even when the associated authorization request has expired, but without
an access token, rather than responding with an `Internal Server Error`.

To test: 
Splinter branch with oauth enabled in `splinterd` and the commit from this PR cherry-picked on top: https://github.com/shannynalayna/splinter/tree/shannynalayna-oauth-test, and then use this version of the UI: https://github.com/shannynalayna/splinter-ui/tree/shannynalayna-oauth-login. The UI test branch assumes the splinter and UI repos are at the same level (Splinter is used locally in the UI).

Once the test branches are checked out, run `docker-compose up --build` from within the Splinter-UI directory, go to `localhost:3030` and log-in or register, then navigate to `localhost:3030/oauth-login`, press the button and begin the authentication process. Once you are authorized through GitHub, you should be routed back to `localhost:3030` (which is the functionality implemented in this PR) with the access token information in the page's URL
 