### PR TITLE
Add Memory, SQLite, and PostgreSQL implementations of OAuthUserStore

### DIFF
--- a/examples/gameroom/tests/cypress/scripts/clear_db.sh
+++ b/examples/gameroom/tests/cypress/scripts/clear_db.sh
@@ -14,4 +14,4 @@
 
 PGPASSWORD=admin psql -h splinterd-db-node -U admin -d splinter -c \
     'TRUNCATE keys, notification_properties, notifications, refresh_tokens,
-    splinter_user, user_credentials, user_notifications';
+    splinter_user, user_credentials, user_notifications, oauth_user';

--- a/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/down.sql
+++ b/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/down.sql
@@ -1,0 +1,18 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_oauth_user_access_token;
+DROP INDEX IF EXISTS idx_oauth_user_provider_user_ref;
+DROP TABLE IF EXISTS oauth_user;

--- a/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/up.sql
+++ b/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/up.sql
@@ -1,0 +1,33 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS oauth_user (
+    id                  BIGSERIAL     PRIMARY KEY,
+    user_id             TEXT          NOT NULL UNIQUE,
+    provider_user_ref   TEXT          NOT NULL UNIQUE,
+    access_token        TEXT          NOT NULL,
+    refresh_token       TEXT,
+    provider_id         SMALLINT      NULL,
+
+    FOREIGN KEY (user_id) REFERENCES splinter_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_user_access_token ON oauth_user (
+    access_token
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_user_provider_user_ref ON oauth_user (
+    provider_user_ref
+);

--- a/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/down.sql
+++ b/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/down.sql
@@ -1,0 +1,18 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_oauth_user_access_token;
+DROP INDEX IF EXISTS idx_oauth_user_provider_user_ref;
+DROP TABLE IF EXISTS oauth_user;

--- a/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/up.sql
+++ b/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/up.sql
@@ -1,0 +1,33 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS oauth_user (
+    id                  INTEGER       PRIMARY KEY AUTOINCREMENT,
+    user_id             TEXT          NOT NULL UNIQUE,
+    provider_user_ref   TEXT          NOT NULL UNIQUE,
+    access_token        TEXT          NOT NULL,
+    refresh_token       TEXT,
+    provider_id         INTEGER       NOT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES splinter_user(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_user_access_token ON oauth_user (
+    access_token
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_user_provider_user_ref ON oauth_user (
+    provider_user_ref
+);

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -61,6 +61,8 @@ pub use key_management::store::memory::MemoryKeyStore;
 pub use key_management::store::KeyStore;
 
 #[cfg(feature = "biome-oauth")]
+pub use oauth::store::memory::MemoryOAuthUserStore;
+#[cfg(feature = "biome-oauth")]
 pub use oauth::store::OAuthUserStore;
 
 #[cfg(all(feature = "biome-credentials", feature = "diesel"))]

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -60,6 +60,8 @@ pub use key_management::store::memory::MemoryKeyStore;
 #[cfg(feature = "biome-key-management")]
 pub use key_management::store::KeyStore;
 
+#[cfg(all(feature = "biome-oauth", feature = "diesel"))]
+pub use oauth::store::diesel::DieselOAuthUserStore;
 #[cfg(feature = "biome-oauth")]
 pub use oauth::store::memory::MemoryOAuthUserStore;
 #[cfg(feature = "biome-oauth")]

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -65,6 +65,32 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::sqlite::SqliteConnection> {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl OAuthUserStore for DieselOAuthUserStore<diesel::pg::PgConnection> {
+    fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).add_oauth_user(oauth_user)
+    }
+
+    fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).update_oauth_user(oauth_user)
+    }
+
+    fn get_by_provider_user_ref(
+        &self,
+        provider_user_ref: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_provider_user_ref(provider_user_ref)
+    }
+
+    fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_user_id(user_id)
+    }
+}
+
 impl From<OAuthUserModel> for OAuthUser {
     fn from(model: OAuthUserModel) -> Self {
         let OAuthUserModel {

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -1,0 +1,267 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(in crate::biome) mod models;
+mod operations;
+pub(in crate::biome) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::error::InternalError;
+
+use super::{OAuthProvider, OAuthUser, OAuthUserStore, OAuthUserStoreError};
+
+use models::{NewOAuthUserModel, OAuthUserModel, ProviderId};
+use operations::add_oauth_user::OAuthUserStoreAddOAuthUserOperation as _;
+use operations::get_by_provider_user_ref::OAuthUserStoreGetByProviderUserRef as _;
+use operations::get_by_user_id::OAuthUserStoreGetByUserId as _;
+use operations::update_oauth_user::OAuthUserStoreUpdateOAuthUserOperation as _;
+use operations::OAuthUserStoreOperations;
+
+pub struct DieselOAuthUserStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection + 'static> DieselOAuthUserStore<C> {
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        Self { connection_pool }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl OAuthUserStore for DieselOAuthUserStore<diesel::sqlite::SqliteConnection> {
+    fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).add_oauth_user(oauth_user)
+    }
+
+    fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).update_oauth_user(oauth_user)
+    }
+
+    fn get_by_provider_user_ref(
+        &self,
+        provider_user_ref: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_provider_user_ref(provider_user_ref)
+    }
+
+    fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_user_id(user_id)
+    }
+}
+
+impl From<OAuthUserModel> for OAuthUser {
+    fn from(model: OAuthUserModel) -> Self {
+        let OAuthUserModel {
+            id: _,
+            user_id,
+            provider_user_ref,
+            access_token,
+            refresh_token,
+            provider_id,
+        } = model;
+        Self {
+            user_id,
+            provider_user_ref,
+            access_token,
+            refresh_token,
+            provider: match provider_id {
+                ProviderId::Github => OAuthProvider::Github,
+            },
+        }
+    }
+}
+
+impl<'a> From<&'a OAuthUser> for NewOAuthUserModel<'a> {
+    fn from(user: &'a OAuthUser) -> Self {
+        NewOAuthUserModel {
+            user_id: user.user_id(),
+            provider_user_ref: user.provider_user_ref(),
+            access_token: user.access_token(),
+            refresh_token: user.refresh_token(),
+            provider_id: match user.provider() {
+                OAuthProvider::Github => ProviderId::Github,
+            },
+        }
+    }
+}
+
+impl From<diesel::r2d2::PoolError> for OAuthUserStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> Self {
+        OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err)))
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+pub mod tests {
+    use super::*;
+
+    use crate::biome::migrations::run_sqlite_migrations;
+    use crate::biome::oauth::store::OAuthUserBuilder;
+    use crate::biome::user::store::{diesel::DieselUserStore, User, UserStore};
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    /// Verify that a SQLite-backed `DieselOAuthUserStore` correctly supports fetching
+    /// an oauth user by provider user ref.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create a `DieselUserStore` and a `DieselOAuthUserStore`.
+    /// 3. Add a User and an OAuthUser
+    /// 4. Verify that the `get_by_provider_user_ref` method returns correct values for the
+    ///    existing OAuth User.
+    /// 5. Verify that the `get_by_provider_user_ref` method returns `None` for
+    ///    for non-existent provider_user_ref.
+    /// 6. Verify that a duplicate entry can't be added (results in a ConstraintViolation).
+    #[test]
+    fn sqlite_add_and_fetch_by_provider_user_ref() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_store = DieselUserStore::new(pool.clone());
+        let oauth_user_store = DieselOAuthUserStore::new(pool);
+
+        let user_id = "test_biome_user_id";
+        user_store
+            .add_user(User::new(user_id))
+            .expect("unable to insert user");
+
+        let oauth_user = OAuthUserBuilder::new()
+            .with_user_id(user_id.into())
+            .with_provider_user_ref("TestUser".into())
+            .with_access_token("someaccesstoken".into())
+            .with_provider(OAuthProvider::Github)
+            .build()
+            .expect("Unable to construct oauth user");
+
+        oauth_user_store
+            .add_oauth_user(oauth_user)
+            .expect("Unable to store oauth user");
+
+        let stored_oauth_user = oauth_user_store
+            .get_by_provider_user_ref("TestUser")
+            .expect("Unable to look up oath user");
+
+        let stored_oauth_user = stored_oauth_user.expect("Did not find the oauth user (was None)");
+
+        assert_eq!("test_biome_user_id", stored_oauth_user.user_id());
+        assert_eq!("TestUser", stored_oauth_user.provider_user_ref());
+        assert_eq!("someaccesstoken", stored_oauth_user.access_token());
+        assert_eq!(None, stored_oauth_user.refresh_token());
+        assert_eq!(&OAuthProvider::Github, stored_oauth_user.provider());
+
+        let unknown_oauth_user = oauth_user_store
+            .get_by_provider_user_ref("NonExistentUserRef".into())
+            .expect("Could not query non-existent oauth user");
+        assert!(unknown_oauth_user.is_none());
+
+        // Create another user and try to connect it to the same user id.
+        let oauth_user = OAuthUserBuilder::new()
+            .with_user_id(user_id.into())
+            .with_provider_user_ref("TestUser2".into())
+            .with_access_token("someotheraccesstoken".into())
+            .with_provider(OAuthProvider::Github)
+            .build()
+            .expect("Unable to construct oauth user");
+
+        let err = oauth_user_store
+            .add_oauth_user(oauth_user)
+            .expect_err("Did not return an error");
+
+        assert!(matches!(err, OAuthUserStoreError::ConstraintViolation(_)));
+    }
+
+    /// Verify that a SQLite-backed `DieselOAuthUserStore` correctly supports updating an
+    /// OAuthUser.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create a `DieselUserStore` and a `DieselOAuthUserStore`.
+    /// 3. Add a User and an OAuthUser
+    /// 4. Verify that the `get_by_user_id` method returns correct values for the
+    ///    existing OAuth User.
+    /// 5. Update the user to have a refresh token.
+    /// 6. Verify that the `get_by_user_id` method returns correct values for the
+    ///    updated OAuth User.
+    #[test]
+    fn sqlite_update_oauth_user() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_store = DieselUserStore::new(pool.clone());
+        let oauth_user_store = DieselOAuthUserStore::new(pool);
+
+        let user_id = "test_biome_user_id";
+        user_store
+            .add_user(User::new(user_id))
+            .expect("unable to insert user");
+
+        let oauth_user = OAuthUserBuilder::new()
+            .with_user_id(user_id.into())
+            .with_provider_user_ref("TestUser".into())
+            .with_access_token("someaccesstoken".into())
+            .with_provider(OAuthProvider::Github)
+            .build()
+            .expect("Unable to construct oauth user");
+
+        oauth_user_store
+            .add_oauth_user(oauth_user)
+            .expect("Unable to store oauth user");
+
+        let stored_oauth_user = oauth_user_store
+            .get_by_user_id("test_biome_user_id")
+            .expect("Unable to look up oath user")
+            .expect("Did not find the oauth user (was None)");
+
+        assert_eq!(None, stored_oauth_user.refresh_token());
+
+        let updated_oauth_user = stored_oauth_user
+            .into_update_builder()
+            .with_refresh_token("somerefreshtoken".into())
+            .build()
+            .expect("Unable to build updated user");
+
+        oauth_user_store
+            .update_oauth_user(updated_oauth_user)
+            .expect("Unable to update the oauth user");
+
+        // Verify that the user was updated
+        let stored_oauth_user = oauth_user_store
+            .get_by_user_id("test_biome_user_id")
+            .expect("Unable to look up oath user")
+            .expect("Did not find the oauth user (was None)");
+
+        assert_eq!(Some("somerefreshtoken"), stored_oauth_user.refresh_token());
+    }
+
+    /// Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection insures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/models.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/models.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use diesel::{
+    backend::Backend,
+    deserialize::{self, FromSql},
+    expression::{helper_types::AsExprOf, AsExpression},
+    serialize::{self, Output, ToSql},
+    sql_types::SmallInt,
+};
+
+use crate::biome::user::store::diesel::models::UserModel;
+
+use super::schema::oauth_user;
+
+#[repr(i16)]
+#[derive(Debug, PartialEq, FromSqlRow, Clone, Copy)]
+pub enum ProviderId {
+    Github = 1,
+}
+
+impl<DB> ToSql<SmallInt, DB> for ProviderId
+where
+    DB: Backend,
+    i16: ToSql<SmallInt, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        (*self as i16).to_sql(out)
+    }
+}
+
+impl AsExpression<SmallInt> for ProviderId {
+    type Expression = AsExprOf<i16, SmallInt>;
+
+    fn as_expression(self) -> Self::Expression {
+        <i16 as AsExpression<SmallInt>>::as_expression(self as i16)
+    }
+}
+
+impl<'a> AsExpression<SmallInt> for &'a ProviderId {
+    type Expression = AsExprOf<i16, SmallInt>;
+
+    fn as_expression(self) -> Self::Expression {
+        <i16 as AsExpression<SmallInt>>::as_expression((*self) as i16)
+    }
+}
+
+impl<DB> FromSql<SmallInt, DB> for ProviderId
+where
+    DB: Backend,
+    i16: FromSql<SmallInt, DB>,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        match i16::from_sql(bytes)? {
+            1 => Ok(ProviderId::Github),
+            int => Err(format!("Invalid provider {}", int).into()),
+        }
+    }
+}
+
+#[derive(Queryable, Identifiable, Associations, PartialEq, Debug)]
+#[table_name = "oauth_user"]
+#[belongs_to(UserModel, foreign_key = "user_id")]
+pub struct OAuthUserModel {
+    pub id: i64,
+    pub user_id: String,
+    pub provider_user_ref: String,
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub provider_id: ProviderId,
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "oauth_user"]
+pub struct NewOAuthUserModel<'a> {
+    pub user_id: &'a str,
+    pub provider_user_ref: &'a str,
+    pub access_token: &'a str,
+    pub refresh_token: Option<&'a str>,
+    pub provider_id: ProviderId,
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{
+    dsl::insert_into, prelude::*, result::DatabaseErrorKind, result::Error as DieselError,
+};
+
+use crate::error::InternalError;
+
+use crate::biome::oauth::store::{
+    diesel::{models::NewOAuthUserModel, schema::oauth_user, OAuthUser},
+    OAuthUserStoreError,
+};
+
+use super::OAuthUserStoreOperations;
+
+pub(in crate::biome::oauth) trait OAuthUserStoreAddOAuthUserOperation {
+    fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> OAuthUserStoreAddOAuthUserOperation
+    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let new_oauth_user = NewOAuthUserModel::from(&oauth_user);
+
+        insert_into(oauth_user::table)
+            .values(new_oauth_user)
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|err| match err {
+                DieselError::DatabaseError(ref kind, _) => match kind {
+                    DatabaseErrorKind::UniqueViolation | DatabaseErrorKind::ForeignKeyViolation => {
+                        OAuthUserStoreError::ConstraintViolation(Box::new(err))
+                    }
+                    _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    ))),
+                },
+                _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err))),
+            })
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_provider_user_ref.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_provider_user_ref.rs
@@ -1,0 +1,51 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+use crate::biome::oauth::store::{
+    diesel::{models::OAuthUserModel, schema::oauth_user},
+    OAuthUser, OAuthUserStoreError,
+};
+
+use super::OAuthUserStoreOperations;
+
+pub(in crate::biome::oauth) trait OAuthUserStoreGetByProviderUserRef {
+    fn get_by_provider_user_ref(
+        &self,
+        provider_user_ref: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> OAuthUserStoreGetByProviderUserRef
+    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_by_provider_user_ref(
+        &self,
+        provider_user_ref: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let oauth_user_model = oauth_user::table
+            .filter(oauth_user::provider_user_ref.eq(provider_user_ref))
+            .first::<OAuthUserModel>(self.conn)
+            .optional()
+            .map_err(|err| {
+                OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+        Ok(oauth_user_model.map(OAuthUser::from))
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_provider_user_ref.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_provider_user_ref.rs
@@ -30,9 +30,12 @@ pub(in crate::biome::oauth) trait OAuthUserStoreGetByProviderUserRef {
     ) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
 }
 
-#[cfg(feature = "sqlite")]
-impl<'a> OAuthUserStoreGetByProviderUserRef
-    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+impl<'a, C> OAuthUserStoreGetByProviderUserRef for OAuthUserStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
     fn get_by_provider_user_ref(
         &self,

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_user_id.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_user_id.rs
@@ -27,9 +27,12 @@ pub(in crate::biome::oauth) trait OAuthUserStoreGetByUserId {
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
 }
 
-#[cfg(feature = "sqlite")]
-impl<'a> OAuthUserStoreGetByUserId
-    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+impl<'a, C> OAuthUserStoreGetByUserId for OAuthUserStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let oauth_user_model = oauth_user::table

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_user_id.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_user_id.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+use crate::biome::oauth::store::{
+    diesel::{models::OAuthUserModel, schema::oauth_user},
+    OAuthUser, OAuthUserStoreError,
+};
+
+use super::OAuthUserStoreOperations;
+
+pub(in crate::biome::oauth) trait OAuthUserStoreGetByUserId {
+    fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> OAuthUserStoreGetByUserId
+    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let oauth_user_model = oauth_user::table
+            .filter(oauth_user::user_id.eq(user_id))
+            .first::<OAuthUserModel>(self.conn)
+            .optional()
+            .map_err(|err| {
+                OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+        Ok(oauth_user_model.map(OAuthUser::from))
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides OAuthUserStoreOperations implemented for a diesel backend
+
+pub(super) mod add_oauth_user;
+pub(super) mod get_by_provider_user_ref;
+pub(super) mod get_by_user_id;
+pub(super) mod update_oauth_user;
+
+pub(super) struct OAuthUserStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> OAuthUserStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        OAuthUserStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
@@ -24,9 +24,9 @@ pub(in crate::biome::oauth) trait OAuthUserStoreUpdateOAuthUserOperation {
     fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError>;
 }
 
-#[cfg(feature = "sqlite")]
-impl<'a> OAuthUserStoreUpdateOAuthUserOperation
-    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+impl<'a, C> OAuthUserStoreUpdateOAuthUserOperation for OAuthUserStoreOperations<'a, C>
+where
+    C: diesel::Connection,
 {
     fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
         update(oauth_user::table.filter(oauth_user::user_id.eq(oauth_user.user_id())))

--- a/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
@@ -1,0 +1,51 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{dsl::update, prelude::*, result::DatabaseErrorKind, result::Error as DieselError};
+
+use crate::error::InternalError;
+
+use crate::biome::oauth::store::{diesel::schema::oauth_user, OAuthUser, OAuthUserStoreError};
+
+use super::OAuthUserStoreOperations;
+
+pub(in crate::biome::oauth) trait OAuthUserStoreUpdateOAuthUserOperation {
+    fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> OAuthUserStoreUpdateOAuthUserOperation
+    for OAuthUserStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        update(oauth_user::table.filter(oauth_user::user_id.eq(oauth_user.user_id())))
+            .set((
+                oauth_user::access_token.eq(oauth_user.access_token()),
+                oauth_user::refresh_token.eq(&oauth_user.refresh_token()),
+            ))
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|err| match err {
+                DieselError::DatabaseError(ref kind, _) => match kind {
+                    DatabaseErrorKind::UniqueViolation | DatabaseErrorKind::ForeignKeyViolation => {
+                        OAuthUserStoreError::ConstraintViolation(Box::new(err))
+                    }
+                    _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(
+                        err,
+                    ))),
+                },
+                _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err))),
+            })
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/schema.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/schema.rs
@@ -1,0 +1,24 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    oauth_user (id) {
+        id -> Int8,
+        user_id -> Text,
+        provider_user_ref -> Text,
+        access_token -> Text,
+        refresh_token -> Nullable<Text>,
+        provider_id -> SmallInt,
+    }
+}

--- a/libsplinter/src/biome/oauth/store/error.rs
+++ b/libsplinter/src/biome/oauth/store/error.rs
@@ -17,7 +17,8 @@
 use std::error::Error;
 use std::fmt;
 
-type InternalError = Box<dyn Error>;
+use crate::error::InternalError;
+
 type ConstraintViolation = Box<dyn Error>;
 
 /// Errors that may occur during OAuthUserStore operations.

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -1,0 +1,81 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::error::InternalError;
+
+use super::{OAuthUser, OAuthUserStore, OAuthUserStoreError};
+
+#[derive(Default, Clone)]
+pub struct MemoryOAuthUserStore {
+    inner: Arc<Mutex<HashMap<String, OAuthUser>>>,
+}
+
+impl MemoryOAuthUserStore {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl OAuthUserStore for MemoryOAuthUserStore {
+    fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            OAuthUserStoreError::InternalError(InternalError::with_message(
+                "Cannot access refresh token store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        inner.insert(oauth_user.user_id().to_string(), oauth_user);
+        Ok(())
+    }
+
+    fn update_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            OAuthUserStoreError::InternalError(InternalError::with_message(
+                "Cannot access refresh token store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        inner.insert(oauth_user.user_id().to_string(), oauth_user);
+        Ok(())
+    }
+
+    fn get_by_provider_user_ref(
+        &self,
+        provider_user_ref: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let inner = self.inner.lock().map_err(|_| {
+            OAuthUserStoreError::InternalError(InternalError::with_message(
+                "Cannot access refresh token store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+
+        Ok(inner
+            .values()
+            .find(|oauth_user| oauth_user.provider_user_ref() == provider_user_ref)
+            .cloned())
+    }
+
+    fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let inner = self.inner.lock().map_err(|_| {
+            OAuthUserStoreError::InternalError(InternalError::with_message(
+                "Cannot access refresh token store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+
+        Ok(inner.get(user_id).cloned())
+    }
+}

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -16,6 +16,8 @@
 //!
 //! The OAuth user can be considered an extension of the base Biome user.
 
+#[cfg(feature = "diesel")]
+pub(in crate::biome) mod diesel;
 mod error;
 pub(in crate::biome) mod memory;
 

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -17,11 +17,13 @@
 //! The OAuth user can be considered an extension of the base Biome user.
 
 mod error;
+pub(in crate::biome) mod memory;
 
 pub use error::InvalidStateError;
 pub use error::OAuthUserStoreError;
 
 /// The set of supported OAuth providers.
+#[derive(Clone, Debug, PartialEq)]
 pub enum OAuthProvider {
     Github,
 }
@@ -29,6 +31,7 @@ pub enum OAuthProvider {
 /// A user defined by an OAuth Provider.
 ///
 /// This user is connected to a Biome User, via a user ID.
+#[derive(Clone)]
 pub struct OAuthUser {
     user_id: String,
     provider_user_ref: String,

--- a/libsplinter/src/store/memory.rs
+++ b/libsplinter/src/store/memory.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "biome-oauth")]
+use crate::biome::MemoryOAuthUserStore;
 #[cfg(feature = "biome-credentials")]
 use crate::biome::{
     CredentialsStore, MemoryCredentialsStore, MemoryRefreshTokenStore, RefreshTokenStore,
@@ -32,6 +34,8 @@ pub struct MemoryStoreFactory {
     #[cfg(feature = "biome-credentials")]
     biome_refresh_token_store: MemoryRefreshTokenStore,
     biome_user_store: MemoryUserStore,
+    #[cfg(feature = "biome-oauth")]
+    biome_oauth_user_store: MemoryOAuthUserStore,
 }
 
 impl MemoryStoreFactory {
@@ -49,6 +53,9 @@ impl MemoryStoreFactory {
         #[cfg(not(feature = "biome-credentials"))]
         let biome_user_store = MemoryUserStore::new();
 
+        #[cfg(feature = "biome-oauth")]
+        let biome_oauth_user_store = MemoryOAuthUserStore::new();
+
         Self {
             #[cfg(feature = "biome-credentials")]
             biome_credentials_store,
@@ -57,6 +64,8 @@ impl MemoryStoreFactory {
             #[cfg(feature = "biome-credentials")]
             biome_refresh_token_store: MemoryRefreshTokenStore::new(),
             biome_user_store,
+            #[cfg(feature = "biome-oauth")]
+            biome_oauth_user_store,
         }
     }
 }
@@ -79,5 +88,10 @@ impl StoreFactory for MemoryStoreFactory {
 
     fn get_biome_user_store(&self) -> Box<dyn UserStore> {
         Box::new(self.biome_user_store.clone())
+    }
+
+    #[cfg(feature = "biome-oauth")]
+    fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore> {
+        Box::new(self.biome_oauth_user_store.clone())
     }
 }

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -37,6 +37,10 @@ pub trait StoreFactory {
     #[cfg(feature = "biome-credentials")]
     fn get_biome_refresh_token_store(&self) -> Box<dyn crate::biome::RefreshTokenStore>;
 
+    /// Get a new `OAuthUserStore`
+    #[cfg(feature = "biome-oauth")]
+    fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore>;
+
     /// Get a new `UserStore`
     fn get_biome_user_store(&self) -> Box<dyn crate::biome::UserStore>;
 }

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -51,4 +51,9 @@ impl StoreFactory for PgStoreFactory {
     fn get_biome_user_store(&self) -> Box<dyn crate::biome::UserStore> {
         Box::new(crate::biome::DieselUserStore::new(self.pool.clone()))
     }
+
+    #[cfg(feature = "biome-oauth")]
+    fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore> {
+        Box::new(crate::biome::DieselOAuthUserStore::new(self.pool.clone()))
+    }
 }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -51,4 +51,9 @@ impl StoreFactory for SqliteStoreFactory {
     fn get_biome_user_store(&self) -> Box<dyn crate::biome::UserStore> {
         Box::new(crate::biome::DieselUserStore::new(self.pool.clone()))
     }
+
+    #[cfg(feature = "biome-oauth")]
+    fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore> {
+        Box::new(crate::biome::DieselOAuthUserStore::new(self.pool.clone()))
+    }
 }


### PR DESCRIPTION
This PR implements two versions of the `OAuthUserStore`: Memory and Diesel (with both the SQLite and PostgreSQL back-ends).  The SQLite version includes database migrations and tests.

Additionally, it replaces the `InternalError` placeholder type def with the one from `splinter::error`