### PR TITLE
Skip auth check for biome auth routes

### DIFF
--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -88,6 +88,7 @@ impl FromStr for BearerToken {
         let mut parts = s.splitn(2, ':');
         match (parts.next(), parts.next()) {
             (Some(token_type), Some(token)) => match token_type {
+                #[cfg(feature = "oauth")]
                 "OAuth2" => Ok(BearerToken::OAuth2(token.to_string())),
                 other_type => Err(AuthorizationParseError::new(format!(
                     "unsupported token type: {}",

--- a/libsplinter/src/auth/rest_api/mod.rs
+++ b/libsplinter/src/auth/rest_api/mod.rs
@@ -47,6 +47,10 @@ fn authorize(
 ) -> AuthorizationResult {
     // Authorization isn't necessary when using one of the authorization endpoints
     let mut is_auth_endpoint = false;
+    #[cfg(feature = "biome-credentials")]
+    if endpoint == "/biome/register" || endpoint == "/biome/login" || endpoint == "/biome/token" {
+        is_auth_endpoint = true;
+    }
     #[cfg(feature = "oauth")]
     if endpoint.starts_with("/oauth") {
         is_auth_endpoint = true;


### PR DESCRIPTION
Updates the authorization middleware for the Actix REST API to skip
authorization for the `/biome/register`, `/biome/login`, and
`/biome/token` endpoints, since these endpoints are used to get
authentication credentials.

Signed-off-by: Logan Seeley <seeley@bitwise.io>