### PR TITLE
Store OAuth Tokens on login via Biome

### DIFF
--- a/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
@@ -59,7 +59,8 @@ pub fn make_callback_route(
                                         redirect_url.push_str(&format!("&expires_in={}", expiry))
                                     };
                                     if let Some(refresh) = callback_response.refresh_token {
-                                        redirect_url.push_str(&format!("&refresh_token={}", refresh))
+                                        redirect_url
+                                            .push_str(&format!("&refresh_token={}", refresh))
                                     };
                                     HttpResponse::Found()
                                         .header(LOCATION, redirect_url)

--- a/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/callback.rs
@@ -19,13 +19,19 @@ use actix_web::{http::header::LOCATION, web::Query, HttpResponse};
 use futures::future::IntoFuture;
 
 use crate::auth::oauth::{
-    rest_api::resources::callback::{CallbackQuery, CallbackResponse},
+    rest_api::{
+        resources::callback::{CallbackQuery, CallbackResponse},
+        SaveTokensOperation,
+    },
     OAuthClient,
 };
 use crate::protocol;
 use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
-pub fn make_callback_route(client: OAuthClient) -> Resource {
+pub fn make_callback_route(
+    client: OAuthClient,
+    save_token_op: Box<dyn SaveTokensOperation>,
+) -> Resource {
     Resource::build("/oauth/callback")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             protocol::OAUTH_CALLBACK_MIN,
@@ -37,22 +43,28 @@ pub fn make_callback_route(client: OAuthClient) -> Resource {
                     Ok(query) => {
                         match client.exchange_authorization_code(query.code.clone(), &query.state) {
                             Ok(Some((user_tokens, redirect_url))) => {
-                                // Adding the user tokens to the redirect URL, so the client may
-                                // access these values after a redirect
-                                let callback_response = CallbackResponse::from(&user_tokens);
-                                let mut redirect_url = format!(
-                                    "{}?access_token={}",
-                                    redirect_url, callback_response.access_token
-                                );
-                                if let Some(expiry) = callback_response.expires_in {
-                                    redirect_url.push_str(&format!("&expires_in={}", expiry))
-                                };
-                                if let Some(refresh) = callback_response.refresh_token {
-                                    redirect_url.push_str(&format!("&refresh_token={}", refresh))
-                                };
-                                HttpResponse::Found()
-                                    .header(LOCATION, redirect_url)
-                                    .finish()
+                                if let Err(err) = save_token_op.save_tokens(&user_tokens) {
+                                    error!("Unable to store user tokens: {}", err);
+                                    HttpResponse::InternalServerError()
+                                        .json(ErrorResponse::internal_error())
+                                } else {
+                                    // Adding the user tokens to the redirect URL, so the client may
+                                    // access these values after a redirect
+                                    let callback_response = CallbackResponse::from(&user_tokens);
+                                    let mut redirect_url = format!(
+                                        "{}?access_token={}",
+                                        redirect_url, callback_response.access_token
+                                    );
+                                    if let Some(expiry) = callback_response.expires_in {
+                                        redirect_url.push_str(&format!("&expires_in={}", expiry))
+                                    };
+                                    if let Some(refresh) = callback_response.refresh_token {
+                                        redirect_url.push_str(&format!("&refresh_token={}", refresh))
+                                    };
+                                    HttpResponse::Found()
+                                        .header(LOCATION, redirect_url)
+                                        .finish()
+                                }
                             }
                             Ok(None) => {
                                 error!(

--- a/libsplinter/src/auth/oauth/rest_api/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/mod.rs
@@ -18,9 +18,42 @@
 mod actix;
 mod resources;
 
+use crate::error::InternalError;
 use crate::rest_api::{Resource, RestResourceProvider};
 
-use super::OAuthClient;
+use super::{OAuthClient, UserTokens};
+
+/// Perform a save operation on a set of UserTokens.
+pub trait SaveTokensOperation: Sync + Send {
+    /// Execute a save operation on the given UserTokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InternalError, if the implementation produces an error during the save
+    /// operation.
+    fn save_tokens(&self, user_tokens: &UserTokens) -> Result<(), InternalError>;
+
+    fn clone_box(&self) -> Box<dyn SaveTokensOperation>;
+}
+
+impl Clone for Box<dyn SaveTokensOperation> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// A No-Op SaveTokensOperation.
+pub struct SaveTokensToNull;
+
+impl SaveTokensOperation for SaveTokensToNull {
+    fn save_tokens(&self, _user_tokens: &UserTokens) -> Result<(), InternalError> {
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn SaveTokensOperation> {
+        Box::new(SaveTokensToNull)
+    }
+}
 
 /// Provides the REST API [Resource](../../../rest_api/struct.Resource.html) definitions for OAuth
 /// endpoints. The following endpoints are provided:
@@ -34,12 +67,16 @@ use super::OAuthClient;
 #[derive(Clone)]
 pub(crate) struct OAuthResourceProvider {
     client: OAuthClient,
+    save_tokens_operation: Box<dyn SaveTokensOperation>,
 }
 
 impl OAuthResourceProvider {
     /// Creates a new `OAuthResourceProvider`
-    pub fn new(client: OAuthClient) -> Self {
-        Self { client }
+    pub fn new(client: OAuthClient, save_tokens_operation: Box<dyn SaveTokensOperation>) -> Self {
+        Self {
+            client,
+            save_tokens_operation,
+        }
     }
 }
 
@@ -62,7 +99,10 @@ impl RestResourceProvider for OAuthResourceProvider {
         {
             resources.append(&mut vec![
                 actix::login::make_login_route(self.client.clone()),
-                actix::callback::make_callback_route(self.client.clone()),
+                actix::callback::make_callback_route(
+                    self.client.clone(),
+                    self.save_tokens_operation.clone(),
+                ),
             ]);
         }
 

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 pub use error::{AuthorizationParseError, IdentityProviderError};
 
 /// A service that fetches identities from a backing provider
-pub trait IdentityProvider: Send {
+pub trait IdentityProvider: Send + Sync {
     /// Attempts to get the identity that corresponds to the given authorization
     fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError>;
 

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -270,7 +270,7 @@ pub mod tests {
 
         let updated_oauth_user = stored_oauth_user
             .into_update_builder()
-            .with_refresh_token("somerefreshtoken".into())
+            .with_refresh_token(Some("somerefreshtoken".into()))
             .build()
             .expect("Unable to build updated user");
 

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -63,6 +63,12 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::sqlite::SqliteConnection> {
         let connection = self.connection_pool.get()?;
         OAuthUserStoreOperations::new(&*connection).get_by_user_id(user_id)
     }
+
+    fn clone_box(&self) -> Box<dyn OAuthUserStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -88,6 +94,12 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::pg::PgConnection> {
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserStoreOperations::new(&*connection).get_by_user_id(user_id)
+    }
+
+    fn clone_box(&self) -> Box<dyn OAuthUserStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
     }
 }
 

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -78,4 +78,8 @@ impl OAuthUserStore for MemoryOAuthUserStore {
 
         Ok(inner.get(user_id).cloned())
     }
+
+    fn clone_box(&self) -> Box<dyn OAuthUserStore> {
+        Box::new(self.clone())
+    }
 }

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -252,4 +252,13 @@ pub trait OAuthUserStore {
 
     /// Returns the stored OAuth user based on the biome user ID.
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
+
+    /// Clone into a boxed, dynamic dispatched OAuthUserStore.
+    fn clone_box(&self) -> Box<dyn OAuthUserStore>;
+}
+
+impl Clone for Box<dyn OAuthUserStore> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
 }

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -130,8 +130,8 @@ impl OAuthUserBuilder {
     /// Set the OAuth refresh token.
     ///
     /// This field is optional when constructing the final struct.
-    pub fn with_refresh_token(mut self, refresh_token: String) -> Self {
-        self.refresh_token = Some(refresh_token);
+    pub fn with_refresh_token(mut self, refresh_token: Option<String>) -> Self {
+        self.refresh_token = refresh_token;
 
         self
     }
@@ -200,8 +200,8 @@ impl OAuthUserUpdateBuilder {
     /// Set the OAuth refresh token.
     ///
     /// This field is optional when constructing the final struct.
-    pub fn with_refresh_token(mut self, refresh_token: String) -> Self {
-        self.refresh_token = Some(refresh_token);
+    pub fn with_refresh_token(mut self, refresh_token: Option<String>) -> Self {
+        self.refresh_token = refresh_token;
 
         self
     }

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -226,7 +226,7 @@ impl OAuthUserUpdateBuilder {
 }
 
 /// Defines methods for CRUD operations and fetching OAuth user information.
-pub trait OAuthUserStore {
+pub trait OAuthUserStore: Send + Sync {
     /// Add an OAuthUser to the store.
     ///
     /// # Errors

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "biome-oauth")]
+mod oauth;
+
+#[cfg(feature = "biome-oauth")]
+pub use oauth::OAuthUserStoreSaveTokensOperation;

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -1,0 +1,119 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SaveTokenOperation implementation, backed by Biome's OAuthUserStore.
+
+use uuid::Uuid;
+
+use crate::auth::{
+    oauth::{rest_api::SaveTokensOperation, UserTokens},
+    rest_api::identity::{Authorization, BearerToken, IdentityProvider},
+};
+use crate::biome::oauth::store::{OAuthProvider, OAuthUserBuilder, OAuthUserStore};
+use crate::biome::user::store::{User, UserStore};
+use crate::error::InternalError;
+
+/// Biome-backed implementation of the SaveTokensOperation trait.
+///
+/// This implementation stores the UserToken values using the OAuthUserStore provided by Biome.
+#[derive(Clone)]
+pub struct OAuthUserStoreSaveTokensOperation {
+    provider: OAuthProvider,
+    identity_provider: Box<dyn IdentityProvider>,
+    user_store: Box<dyn UserStore>,
+    oauth_user_store: Box<dyn OAuthUserStore>,
+}
+
+impl OAuthUserStoreSaveTokensOperation {
+    /// Construct a new OAuthUserStoreSaveTokensOperation.
+    pub fn new(
+        provider: OAuthProvider,
+        identity_provider: Box<dyn IdentityProvider>,
+        user_store: Box<dyn UserStore>,
+        oauth_user_store: Box<dyn OAuthUserStore>,
+    ) -> Self {
+        Self {
+            provider,
+            identity_provider,
+            user_store,
+            oauth_user_store,
+        }
+    }
+}
+
+impl SaveTokensOperation for OAuthUserStoreSaveTokensOperation {
+    fn save_tokens(&self, user_tokens: &UserTokens) -> Result<(), InternalError> {
+        let authorization =
+            Authorization::Bearer(BearerToken::OAuth2(user_tokens.access_token().to_string()));
+
+        let provider_identity = self
+            .identity_provider
+            .get_identity(&authorization)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        let existing_oauth_user = self
+            .oauth_user_store
+            .get_by_provider_user_ref(&provider_identity)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        if let Some(oauth_user) = existing_oauth_user {
+            let updated_user = oauth_user
+                .into_update_builder()
+                .with_access_token(user_tokens.access_token().into())
+                .with_refresh_token(user_tokens.refresh_token().map(String::from))
+                .build()
+                .map_err(|e| {
+                    InternalError::from_source_with_message(
+                        Box::new(e),
+                        "Failed to properly construct an updated OAuth user".into(),
+                    )
+                })?;
+
+            self.oauth_user_store
+                .update_oauth_user(updated_user)
+                .map_err(|e| InternalError::from_source(Box::new(e)))?;
+        } else {
+            let user_id = Uuid::new_v4().to_string();
+            let user = User::new(&user_id);
+
+            self.user_store
+                .add_user(user)
+                .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+            let oauth_user = OAuthUserBuilder::new()
+                .with_user_id(user_id)
+                .with_provider_user_ref(provider_identity)
+                .with_access_token(user_tokens.access_token().into())
+                .with_refresh_token(user_tokens.refresh_token().map(String::from))
+                .with_provider(self.provider.clone())
+                .build()
+                .map_err(|e| {
+                    InternalError::from_source_with_message(
+                        Box::new(e),
+                        "Failed to properly construct a new OAuth user".into(),
+                    )
+                })?;
+
+            self.oauth_user_store
+                .add_oauth_user(oauth_user)
+                .map_err(|e| InternalError::from_source(Box::new(e)))?;
+        }
+
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn SaveTokensOperation> {
+        Box::new(self.clone())
+    }
+}

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -40,6 +40,8 @@
 
 #[cfg(feature = "rest-api-actix")]
 mod actix;
+#[cfg(feature = "auth")]
+pub mod auth;
 mod config;
 mod error;
 mod resources;

--- a/libsplinter/src/biome/user/store/diesel/mod.rs
+++ b/libsplinter/src/biome/user/store/diesel/mod.rs
@@ -67,6 +67,12 @@ impl UserStore for DieselUserStore<diesel::pg::PgConnection> {
     fn list_users(&self) -> Result<Vec<User>, UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).list_users()
     }
+
+    fn clone_box(&self) -> Box<dyn UserStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -89,6 +95,12 @@ impl UserStore for DieselUserStore<diesel::sqlite::SqliteConnection> {
 
     fn list_users(&self) -> Result<Vec<User>, UserStoreError> {
         UserStoreOperations::new(&*self.connection_pool.get()?).list_users()
+    }
+
+    fn clone_box(&self) -> Box<dyn UserStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
     }
 }
 

--- a/libsplinter/src/biome/user/store/memory.rs
+++ b/libsplinter/src/biome/user/store/memory.rs
@@ -136,4 +136,8 @@ impl UserStore for MemoryUserStore {
 
         Ok(inner.iter().map(|(_, v)| v.clone()).collect())
     }
+
+    fn clone_box(&self) -> Box<dyn UserStore> {
+        Box::new(self.clone())
+    }
 }

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -78,14 +78,12 @@ pub trait UserStore: Send + Sync {
 
     /// List all users from the underlying storage
     fn list_users(&self) -> Result<Vec<User>, UserStoreError>;
+
+    fn clone_box(&self) -> Box<dyn UserStore>;
 }
 
-pub trait CloneBoxUserStore: UserStore {
-    fn clone_box(&self) -> Box<dyn CloneBoxUserStore>;
-}
-
-impl Clone for Box<dyn CloneBoxUserStore> {
-    fn clone(&self) -> Box<dyn CloneBoxUserStore> {
+impl Clone for Box<dyn UserStore> {
+    fn clone(&self) -> Self {
         self.clone_box()
     }
 }
@@ -112,5 +110,9 @@ where
 
     fn list_users(&self) -> Result<Vec<User>, UserStoreError> {
         (**self).list_users()
+    }
+
+    fn clone_box(&self) -> Box<dyn UserStore> {
+        (**self).clone_box()
     }
 }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -87,6 +87,7 @@ auth = ["splinter/oauth-github"]
 biome = ["splinter/biome", "splinter/store-factory", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
 biome-key-management = ["splinter/biome-key-management", "biome"]
+biome-oauth = ["auth", "splinter/biome-oauth"]
 database = ["splinter/postgres", "splinter/sqlite"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [


### PR DESCRIPTION
This PR stores the oauth token values in biome, when enabled.

## Testing

Set up a local environment, with postgres as the backend.

Start a postgreSQL instance:
```bash
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
```
Set up the database tables:
```bash
$ cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
```
Set the following environment variables:
```bash
export OAUTH_PROVIDER="github"
export OAUTH_CLIENT_ID="<your client id>"
export OAUTH_CLIENT_SECRET="<your client secret>"
export OAUTH_REDIRECT_URL="http://localhost:8080/oauth/callback"
```
(Or you could set these as CLI parameters for `splinterd`)

Run splinter:

```bash
$ mkdir -p /tmp/splinter # a splinter home dir for local use
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate --skip
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features auth,biome-oauth -- \
    --database postgres://postgres:mypassword@localhost:5432/splinter \
    --enable-biome \
    --tls-insecure \
    -vv
```

In your browser, navigate to [localhost:8080/oauth/login?redirect_url=http://localhost:8080/status](http://localhost:8080/oauth/login?redirect_url=http://localhost:8080/status). (Note, this will result in a 401, but will return).

After this completes, you can verify that a token has been stored in the table.  To verify the the information has been stored, run (with the password configured above `mypassword`):

```
$ docker run -it --rm --link postgres:postgres postgres psql -h postgres -U postgres
Password for user postgres:
postgres-# \c splinter
You are now connected to database "splinter" as user "postgres".
splinter=# select * from oauth_user;
 id |               user_id                | provider_user_ref |               access_token               | refresh_token | provider_id
----+--------------------------------------+-------------------+------------------------------------------+---------------+-------------
  1 | 88074e7f-18f1-47f7-ab67-65c6968127ba | your_username     | aaaaaaaaaaaaaaaaaaaaaaa00000000000000000 |               |           1
(1 row)
```