### PR TITLE
Modify error Debug implmentations to use DebugStruct builder

### DIFF
--- a/libsplinter/src/error/constraint_violation.rs
+++ b/libsplinter/src/error/constraint_violation.rs
@@ -126,20 +126,15 @@ impl fmt::Display for ConstraintViolationError {
 
 impl fmt::Debug for ConstraintViolationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const TYPE_NAME: &str = "ConstraintViolationError";
+        let mut debug_struct = f.debug_struct("ConstraintViolationError");
 
-        match &self.source {
-            Some(s) => write!(
-                f,
-                "{} {{ source: {:?}, violation_type: {:?} }}",
-                TYPE_NAME, s, &self.violation_type
-            ),
-            None => write!(
-                f,
-                "{} {{ violation_type: {:?} }}",
-                TYPE_NAME, &self.violation_type
-            ),
+        debug_struct.field("violation_type", &self.violation_type);
+
+        if let Some(source) = &self.source {
+            debug_struct.field("source", source);
         }
+
+        debug_struct.finish()
     }
 }
 
@@ -162,7 +157,7 @@ pub mod tests {
     /// `format!("ConstraintViolationError { source: {:?}, violation_type: {:?} }", source, type)`.
     #[test]
     fn test_debug_from_source_with_violation_type() {
-        let debug = "ConstraintViolationError { source: ConstraintViolationError { violation_type: Unique }, violation_type: Unique }";
+        let debug = "ConstraintViolationError { violation_type: Unique, source: ConstraintViolationError { violation_type: Unique } }";
         let err = ConstraintViolationError::from_source_with_violation_type(
             ConstraintViolationType::Unique,
             Box::new(ConstraintViolationError::with_violation_type(

--- a/libsplinter/src/error/internal.rs
+++ b/libsplinter/src/error/internal.rs
@@ -154,29 +154,21 @@ impl fmt::Display for InternalError {
 
 impl fmt::Debug for InternalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const TYPE_NAME: &str = "InternalError";
+        let mut debug_struct = f.debug_struct("InternalError");
 
-        match &self.message {
-            Some(m) => match &self.source {
-                Some(s) => write!(
-                    f,
-                    "{} {{ message: {:?}, source: {:?} }}",
-                    TYPE_NAME, m, s.source
-                ),
-                None => write!(f, "{} {{ message: {:?} }}", TYPE_NAME, m),
-            },
-            None => match &self.source {
-                Some(s) => match &s.prefix {
-                    Some(p) => write!(
-                        f,
-                        "{} {{ prefix: {:?}, source: {:?} }}",
-                        TYPE_NAME, p, s.source
-                    ),
-                    None => write!(f, "{} {{ source: {:?} }}", TYPE_NAME, s.source),
-                },
-                None => write!(f, "{}", TYPE_NAME),
-            },
+        if let Some(message) = &self.message {
+            debug_struct.field("message", message);
         }
+
+        if let Some(source) = &self.source {
+            if let Some(prefix) = &source.prefix {
+                debug_struct.field("prefix", prefix);
+            }
+
+            debug_struct.field("source", &source.source);
+        }
+
+        debug_struct.finish()
     }
 }
 


### PR DESCRIPTION
Simplifies the implementation and supports "{:#?}", etc.