### PR TITLE
Retrieve user's identity before returning tokens

### DIFF
--- a/libsplinter/src/auth/oauth/rest_api/resources/callback.rs
+++ b/libsplinter/src/auth/oauth/rest_api/resources/callback.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::auth::oauth::UserTokens;
+use crate::auth::oauth::UserInfo;
 
 #[derive(Deserialize)]
 pub struct CallbackQuery {
@@ -20,13 +20,14 @@ pub struct CallbackQuery {
     pub state: String,
 }
 
-/// Serializes the given user tokens as a query string to pass to the client
-pub fn user_tokens_to_query_string(user_tokens: &UserTokens) -> String {
-    let mut query_string = format!("access_token=OAuth2:{}", user_tokens.access_token());
-    if let Some(duration) = user_tokens.expires_in() {
+/// Serializes the given user information as a query string to pass to the client
+pub fn user_info_to_query_string(user_info: &UserInfo) -> String {
+    let mut query_string = format!("access_token=OAuth2:{}", user_info.access_token());
+    query_string.push_str(&format!("&display_name={}", user_info.identity()));
+    if let Some(duration) = user_info.expires_in() {
         query_string.push_str(&format!("&expires_in={}", duration.as_secs()))
     };
-    if let Some(refresh) = user_tokens.refresh_token() {
+    if let Some(refresh) = user_info.refresh_token() {
         query_string.push_str(&format!("&refresh_token={}", refresh))
     };
     query_string

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -22,4 +22,4 @@ pub use credentials::GetUserByBiomeAuthorization;
 #[cfg(feature = "biome-oauth")]
 pub use oauth::GetUserByOAuthAuthorization;
 #[cfg(feature = "biome-oauth")]
-pub use oauth::OAuthUserStoreSaveTokensOperation;
+pub use oauth::OAuthUserStoreSaveUserInfoOperation;

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -60,7 +60,7 @@ use splinter::registry::{
     UnifiedRegistry,
 };
 #[cfg(feature = "auth")]
-use splinter::rest_api::{AuthConfig, OAuthConfig, TokenSaveConfig};
+use splinter::rest_api::{AuthConfig, OAuthConfig, UserInfoSaveConfig};
 use splinter::rest_api::{
     Method, Resource, RestApiBuilder, RestApiServerError, RestResourceProvider,
 };
@@ -518,13 +518,13 @@ impl SplinterDaemon {
                     }
                 };
 
-                // Allowing unused_mut because token_save_config must be mutable if feature
+                // Allowing unused_mut because user_info_save_config must be mutable if feature
                 // biome-oauth is enabled
                 #[allow(unused_mut)]
-                let mut token_save_config = TokenSaveConfig::NoOp;
+                let mut user_info_save_config = UserInfoSaveConfig::NoOp;
                 #[cfg(feature = "biome-oauth")]
                 if self.enable_biome {
-                    token_save_config = TokenSaveConfig::Biome {
+                    user_info_save_config = UserInfoSaveConfig::Biome {
                         user_store: store_factory.get_biome_user_store(),
                         oauth_user_store: store_factory.get_biome_oauth_user_store(),
                     };
@@ -538,7 +538,7 @@ impl SplinterDaemon {
 
                 auth_configs.push(AuthConfig::OAuth {
                     oauth_config,
-                    token_save_config,
+                    user_info_save_config,
                 });
             }
 


### PR DESCRIPTION
Adds a call using the `IdentityProvider` to retrieve the user's identity to be used for the UI's `display_name` value.

TESTING:

Set these environment variables or in the docker-compose file:
 
```
export OAUTH_PROVIDER="github"
export OAUTH_CLIENT_ID="<your client ID>"
export OAUTH_CLIENT_SECRET="<your client secret>"
export OAUTH_REDIRECT_URL="http://localhost:8080/oauth/callback"
``` 
Or, in the docker-compose: 
```
            --oauth-provider github \
            --oauth-client-secret <your client secret> \
            --oauth-client-id <your client ID> \
            --oauth-redirect-url http://localhost:8080/oauth/callback \
```

Run `docker-compose up --build` from the root splinter directory, and go to `http://localhost:8080/oauth/login?redirect_url=redirect`. 

Note, the `redirect_url` isn't valid so you'll hit a 404 when the callback returns, but you should be able to see the returned data in the URL it attempted to hit. So, with `redirect`, the final URL should look something like: `redirect?access_token=1234&display_name=<your GitHub username>` but the web page doesn't exist so you'll get a 404. This is the point that the oauth login sapling handles the data in the URL and would redirect to the base sapling after creating the Canopy user with the data in the URL. 