### PR TITLE
Biome oauth validation

### DIFF
--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -84,6 +84,7 @@ impl FromStr for Authorization {
 }
 
 /// A bearer token of a specific type
+#[non_exhaustive]
 pub enum BearerToken {
     #[cfg(feature = "biome-credentials")]
     /// Contains a Biome JWT

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -22,6 +22,8 @@ pub mod github;
 
 use std::str::FromStr;
 
+use crate::error::InternalError;
+
 pub use error::{AuthorizationParseError, IdentityProviderError};
 
 /// A service that fetches identities from a backing provider
@@ -46,6 +48,12 @@ impl Clone for Box<dyn IdentityProvider> {
     fn clone(&self) -> Box<dyn IdentityProvider> {
         self.clone_box()
     }
+}
+
+/// A trait that fetches a value based on an Authorization.
+pub trait GetByAuthorization<T> {
+    /// Return a value based on the given authorization value.
+    fn get(&self, authorization: &Authorization) -> Result<Option<T>, InternalError>;
 }
 
 /// The authorization that is passed to an `IdentityProvider`

--- a/libsplinter/src/auth/rest_api/mod.rs
+++ b/libsplinter/src/auth/rest_api/mod.rs
@@ -18,12 +18,15 @@
 pub mod actix;
 pub mod identity;
 
-use identity::{IdentityProvider, IdentityProviderError};
+use identity::{Authorization, IdentityProvider, IdentityProviderError};
 
 /// The possible outcomes of attempting to authorize a client
 enum AuthorizationResult {
     /// The client was authorized to the given identity
-    Authorized(String),
+    Authorized {
+        identity: String,
+        authorization: Authorization,
+    },
     /// The requested endpoint does not require authorization
     NoAuthorizationNecessary,
     /// The authorization header is empty or invalid
@@ -70,7 +73,12 @@ fn authorize(
     // Attempt to get the client's identity
     for provider in identity_providers {
         match provider.get_identity(&authorization) {
-            Ok(identity) => return AuthorizationResult::Authorized(identity),
+            Ok(identity) => {
+                return AuthorizationResult::Authorized {
+                    identity,
+                    authorization,
+                }
+            }
             Err(IdentityProviderError::Unauthorized) => {}
             Err(err) => error!("{}", err),
         }

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -24,6 +24,7 @@ use super::{OAuthProvider, OAuthUser, OAuthUserStore, OAuthUserStoreError};
 
 use models::{NewOAuthUserModel, OAuthUserModel, ProviderId};
 use operations::add_oauth_user::OAuthUserStoreAddOAuthUserOperation as _;
+use operations::get_by_access_token::OAuthUserStoreGetByAccessToken as _;
 use operations::get_by_provider_user_ref::OAuthUserStoreGetByProviderUserRef as _;
 use operations::get_by_user_id::OAuthUserStoreGetByUserId as _;
 use operations::update_oauth_user::OAuthUserStoreUpdateOAuthUserOperation as _;
@@ -59,6 +60,14 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::sqlite::SqliteConnection> {
         OAuthUserStoreOperations::new(&*connection).get_by_provider_user_ref(provider_user_ref)
     }
 
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_access_token(access_token)
+    }
+
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserStoreOperations::new(&*connection).get_by_user_id(user_id)
@@ -89,6 +98,14 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::pg::PgConnection> {
     ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserStoreOperations::new(&*connection).get_by_provider_user_ref(provider_user_ref)
+    }
+
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let connection = self.connection_pool.get()?;
+        OAuthUserStoreOperations::new(&*connection).get_by_access_token(access_token)
     }
 
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_access_token.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_access_token.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+use crate::biome::oauth::store::{
+    diesel::{models::OAuthUserModel, schema::oauth_user},
+    OAuthUser, OAuthUserStoreError,
+};
+
+use super::OAuthUserStoreOperations;
+
+pub(in crate::biome::oauth) trait OAuthUserStoreGetByAccessToken {
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
+}
+
+impl<'a, C> OAuthUserStoreGetByAccessToken for OAuthUserStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let oauth_user_model = oauth_user::table
+            .filter(oauth_user::access_token.eq(access_token))
+            .first::<OAuthUserModel>(self.conn)
+            .optional()
+            .map_err(|err| {
+                OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
+
+        Ok(oauth_user_model.map(OAuthUser::from))
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 //! Provides OAuthUserStoreOperations implemented for a diesel backend
 
 pub(super) mod add_oauth_user;
+pub(super) mod get_by_access_token;
 pub(super) mod get_by_provider_user_ref;
 pub(super) mod get_by_user_id;
 pub(super) mod update_oauth_user;

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -69,6 +69,22 @@ impl OAuthUserStore for MemoryOAuthUserStore {
             .cloned())
     }
 
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
+        let inner = self.inner.lock().map_err(|_| {
+            OAuthUserStoreError::InternalError(InternalError::with_message(
+                "Cannot access refresh token store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+
+        Ok(inner
+            .values()
+            .find(|oauth_user| oauth_user.access_token() == access_token)
+            .cloned())
+    }
+
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let inner = self.inner.lock().map_err(|_| {
             OAuthUserStoreError::InternalError(InternalError::with_message(

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -250,6 +250,12 @@ pub trait OAuthUserStore: Send + Sync {
         provider_user_ref: &str,
     ) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
 
+    /// Returns the stored OAuth user based on the access token from the OAuth provider.
+    fn get_by_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
+
     /// Returns the stored OAuth user based on the biome user ID.
     fn get_by_user_id(&self, user_id: &str) -> Result<Option<OAuthUser>, OAuthUserStoreError>;
 

--- a/libsplinter/src/biome/rest_api/auth/credentials.rs
+++ b/libsplinter/src/biome/rest_api/auth/credentials.rs
@@ -1,0 +1,60 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use jsonwebtoken::decode;
+
+use crate::auth::rest_api::identity::{Authorization, BearerToken, GetByAuthorization};
+use crate::biome::rest_api::BiomeRestConfig;
+use crate::biome::user::store::User;
+use crate::error::InternalError;
+use crate::rest_api::secrets::SecretManager;
+use crate::rest_api::sessions::{default_validation, Claims};
+
+pub struct GetUserByBiomeAuthorization {
+    rest_config: Arc<BiomeRestConfig>,
+    secret_manager: Arc<dyn SecretManager>,
+}
+
+impl GetUserByBiomeAuthorization {
+    pub fn new(rest_config: Arc<BiomeRestConfig>, secret_manager: Arc<dyn SecretManager>) -> Self {
+        Self {
+            rest_config,
+            secret_manager,
+        }
+    }
+}
+
+impl GetByAuthorization<User> for GetUserByBiomeAuthorization {
+    fn get(&self, authorization: &Authorization) -> Result<Option<User>, InternalError> {
+        match authorization {
+            Authorization::Bearer(BearerToken::Biome(token)) => {
+                let validation = default_validation(&self.rest_config.issuer());
+                let secret = match self.secret_manager.secret() {
+                    Ok(secret) => secret,
+                    Err(err) => {
+                        return Err(InternalError::from_source(Box::new(err)));
+                    }
+                };
+
+                match decode::<Claims>(&token, secret.as_ref(), &validation) {
+                    Ok(claims) => Ok(Some(User::new(&claims.claims.user_id()))),
+                    Err(err) => Err(InternalError::from_source(Box::new(err))),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "biome-credentials")]
+mod credentials;
 #[cfg(feature = "biome-oauth")]
 mod oauth;
 
+#[cfg(feature = "biome-credentials")]
+pub use credentials::GetUserByBiomeAuthorization;
 #[cfg(feature = "biome-oauth")]
 pub use oauth::GetUserByOAuthAuthorization;
 #[cfg(feature = "biome-oauth")]

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -16,4 +16,6 @@
 mod oauth;
 
 #[cfg(feature = "biome-oauth")]
+pub use oauth::GetUserByOAuthAuthorization;
+#[cfg(feature = "biome-oauth")]
 pub use oauth::OAuthUserStoreSaveTokensOperation;

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -86,6 +86,8 @@ use self::actix::token::make_token_route;
 use self::actix::user::make_user_routes;
 #[cfg(all(feature = "biome-credentials", feature = "rest-api-actix",))]
 use self::actix::{login::make_login_route, user::make_list_route, verify::make_verify_route};
+#[cfg(all(feature = "auth", feature = "biome-credentials"))]
+use self::auth::GetUserByBiomeAuthorization;
 #[cfg(feature = "biome-credentials")]
 use super::credentials::store::CredentialsStore;
 
@@ -138,6 +140,15 @@ impl BiomeRestResourceManager {
         BiomeUserIdentityProvider::new(
             self.token_secret_manager.clone(),
             default_validation(&self.rest_config.issuer()),
+        )
+    }
+
+    /// Creates a new Biome authorization mapping for Users
+    #[cfg(all(feature = "auth", feature = "biome-credentials"))]
+    pub fn get_authorization_mapping(&self) -> GetUserByBiomeAuthorization {
+        GetUserByBiomeAuthorization::new(
+            self.rest_config.clone(),
+            self.token_secret_manager.clone(),
         )
     }
 }

--- a/libsplinter/src/biome/user/store/memory.rs
+++ b/libsplinter/src/biome/user/store/memory.rs
@@ -55,7 +55,7 @@ impl UserStore for MemoryUserStore {
                 source: None,
             })?;
 
-        inner.insert(user.id(), user);
+        inner.insert(user.id().to_string(), user);
         Ok(())
     }
 
@@ -68,8 +68,8 @@ impl UserStore for MemoryUserStore {
                 source: None,
             })?;
 
-        if inner.contains_key(&updated_user.id()) {
-            inner.insert(updated_user.id(), updated_user);
+        if inner.contains_key(updated_user.id()) {
+            inner.insert(updated_user.id().to_string(), updated_user);
             Ok(())
         } else {
             Err(UserStoreError::NotFoundError(format!(

--- a/libsplinter/src/biome/user/store/mod.rs
+++ b/libsplinter/src/biome/user/store/mod.rs
@@ -40,8 +40,8 @@ impl User {
     }
 
     /// Returns the user's id.
-    pub fn id(&self) -> String {
-        self.id.to_string()
+    pub fn id(&self) -> &str {
+        &self.id
     }
 }
 

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -477,7 +477,6 @@ impl RequestGuard for ProtocolVersionRangeGuard {
 }
 
 /// `RestApi` is used to create an instance of a restful web server.
-#[derive(Clone)]
 pub struct RestApi {
     resources: Vec<Resource>,
     bind: String,

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -79,7 +79,10 @@ use crate::auth::oauth::{
 #[cfg(feature = "oauth-github")]
 use crate::auth::rest_api::identity::github::GithubUserIdentityProvider;
 #[cfg(feature = "auth")]
-use crate::auth::rest_api::{actix::Authorization, identity::IdentityProvider};
+use crate::auth::rest_api::{
+    actix::Authorization,
+    identity::{GetByAuthorization, IdentityProvider},
+};
 #[cfg(all(feature = "auth", feature = "biome-credentials"))]
 use crate::biome::rest_api::BiomeRestResourceManager;
 #[cfg(feature = "biome-oauth")]
@@ -476,6 +479,36 @@ impl RequestGuard for ProtocolVersionRangeGuard {
     }
 }
 
+#[cfg(feature = "auth")]
+struct ConfigureAuthorizationMapping {
+    config_fn: Box<dyn FnMut(Authorization) -> Authorization>,
+}
+
+#[cfg(feature = "auth")]
+impl ConfigureAuthorizationMapping {
+    fn new<G, T>(get_by_auth: G) -> Self
+    where
+        T: 'static,
+        G: GetByAuthorization<T> + Send + Sync + 'static,
+    {
+        let mut auth_mapping = Some(get_by_auth);
+        Self {
+            config_fn: Box::new(move |authorization| {
+                if let Some(auth_mapping) = auth_mapping.take() {
+                    debug!("Configuring auth mapping {}", std::any::type_name::<G>());
+                    authorization.with_authorization_mapping(auth_mapping)
+                } else {
+                    authorization
+                }
+            }),
+        }
+    }
+
+    fn configure(&mut self, authorization: Authorization) -> Authorization {
+        (*self.config_fn)(authorization)
+    }
+}
+
 /// `RestApi` is used to create an instance of a restful web server.
 pub struct RestApi {
     resources: Vec<Resource>,
@@ -484,6 +517,8 @@ pub struct RestApi {
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "auth")]
     identity_providers: Vec<Box<dyn IdentityProvider>>,
+    #[cfg(feature = "auth")]
+    authorization_mappings: Vec<ConfigureAuthorizationMapping>,
 }
 
 impl RestApi {
@@ -492,12 +527,22 @@ impl RestApi {
     ) -> Result<(RestApiShutdownHandle, thread::JoinHandle<()>), RestApiServerError> {
         let (tx, rx) = mpsc::channel();
 
+        let bind_url_for_err = self.bind.to_owned();
         let bind_url = self.bind.to_owned();
-        let resources = self.resources.to_owned();
+        let resources = self.resources;
         #[cfg(feature = "rest-api-cors")]
-        let whitelist = self.whitelist.to_owned();
+        let whitelist = self.whitelist;
         #[cfg(feature = "auth")]
-        let authorization = Authorization::new(self.identity_providers.to_owned());
+        let mut authorization = Authorization::new(self.identity_providers.to_owned());
+
+        #[cfg(feature = "auth")]
+        {
+            let mut auth_mappings = self.authorization_mappings;
+            for auth_mapping in auth_mappings.iter_mut() {
+                authorization = auth_mapping.configure(authorization);
+            }
+        }
+
         let join_handle = thread::Builder::new()
             .name("SplinterDRestApi".into())
             .spawn(move || {
@@ -555,7 +600,7 @@ impl RestApi {
             .map_err(|err| {
                 RestApiServerError::BindError(format!(
                     "Failed to bind to URL {}: {}",
-                    self.bind, err
+                    bind_url_for_err, err
                 ))
             })?;
 
@@ -676,6 +721,8 @@ pub struct RestApiBuilder {
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "auth")]
     auth_configs: Vec<AuthConfig>,
+    #[cfg(feature = "auth")]
+    authorization_mappings: Vec<ConfigureAuthorizationMapping>,
 }
 
 impl Default for RestApiBuilder {
@@ -687,6 +734,8 @@ impl Default for RestApiBuilder {
             whitelist: None,
             #[cfg(feature = "auth")]
             auth_configs: Vec::new(),
+            #[cfg(feature = "auth")]
+            authorization_mappings: vec![],
         }
     }
 }
@@ -720,6 +769,19 @@ impl RestApiBuilder {
     #[cfg(feature = "auth")]
     pub fn with_auth_configs(mut self, auth_configs: Vec<AuthConfig>) -> Self {
         self.auth_configs = auth_configs;
+        self
+    }
+
+    #[cfg(feature = "auth")]
+    pub fn with_authorization_mapping<G, T>(mut self, authorization_mapping: G) -> Self
+    where
+        T: 'static,
+        G: GetByAuthorization<T> + Send + Sync + 'static,
+    {
+        debug!("Adding auth mapping {}", std::any::type_name::<G>());
+        self.authorization_mappings
+            .push(ConfigureAuthorizationMapping::new(authorization_mapping));
+
         self
     }
 
@@ -840,6 +902,8 @@ impl RestApiBuilder {
             whitelist: self.whitelist,
             #[cfg(feature = "auth")]
             identity_providers,
+            #[cfg(feature = "auth")]
+            authorization_mappings: self.authorization_mappings,
         })
     }
 
@@ -857,6 +921,8 @@ impl RestApiBuilder {
             whitelist: self.whitelist,
             #[cfg(feature = "auth")]
             identity_providers: vec![],
+            #[cfg(feature = "auth")]
+            authorization_mappings: self.authorization_mappings,
         })
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -29,6 +29,8 @@ use scabbard::service::ScabbardArgValidator;
 use scabbard::service::ScabbardFactory;
 use splinter::admin::rest_api::CircuitResourceProvider;
 use splinter::admin::service::{admin_service_id, AdminService};
+#[cfg(feature = "biome-oauth")]
+use splinter::biome::rest_api::auth::GetUserByOAuthAuthorization;
 #[cfg(feature = "biome")]
 use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
 use splinter::circuit::directory::CircuitDirectory;
@@ -526,6 +528,12 @@ impl SplinterDaemon {
                         user_store: store_factory.get_biome_user_store(),
                         oauth_user_store: store_factory.get_biome_oauth_user_store(),
                     };
+
+                    rest_api_builder = rest_api_builder.with_authorization_mapping(
+                        GetUserByOAuthAuthorization::new(
+                            store_factory.get_biome_oauth_user_store(),
+                        ),
+                    );
                 }
 
                 auth_configs.push(AuthConfig::OAuth {
@@ -538,9 +546,13 @@ impl SplinterDaemon {
             // is configured. This informs the REST API that Biome is providing auth.
             #[cfg(feature = "biome-credentials")]
             if self.enable_biome {
+                let biome_resource_manager = build_biome_routes(&*store_factory)?;
+                let authorization_mapping = biome_resource_manager.get_authorization_mapping();
                 auth_configs.push(AuthConfig::Biome {
-                    biome_resource_manager: build_biome_routes(&*store_factory)?,
+                    biome_resource_manager,
                 });
+                rest_api_builder =
+                    rest_api_builder.with_authorization_mapping(authorization_mapping);
             }
 
             rest_api_builder = rest_api_builder.with_auth_configs(auth_configs);


### PR DESCRIPTION
This PR stores the oauth token values in biome, when enabled.

## Testing

Set up a local environment, with postgres as the backend.

Start a postgreSQL instance:
```bash
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
```
Set up the database tables:
```bash
$ cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
```
Set the following environment variables:
```bash
export OAUTH_PROVIDER="github"
export OAUTH_CLIENT_ID="<your client id>"
export OAUTH_CLIENT_SECRET="<your client secret>"
export OAUTH_REDIRECT_URL="http://localhost:8080/oauth/callback"
```
(Or you could set these as CLI parameters for `splinterd`)

Run splinter:

```bash
$ mkdir -p /tmp/splinter # a splinter home dir for local use
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate --skip
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features auth,biome-oauth -- \
    --database postgres://postgres:mypassword@localhost:5432/splinter \
    --enable-biome \
    --tls-insecure \
    -vv
```

In your browser, navigate to [localhost:8080/oauth/login?redirect_url=http://localhost:8080/status](http://localhost:8080/oauth/login?redirect_url=http://localhost:8080/status). (Note, this will result in a 401, but will return).

After this completes, you can verify that a token has been stored in the table.  To verify the the information has been stored, run (with the password configured above `mypassword`):

```
$ docker run -it --rm --link postgres:postgres postgres psql -h postgres -U postgres
Password for user postgres:
postgres-# \c splinter
You are now connected to database "splinter" as user "postgres".
splinter=# select * from oauth_user;
 id |               user_id                | provider_user_ref |               access_token               | refresh_token | provider_id
----+--------------------------------------+-------------------+------------------------------------------+---------------+-------------
  1 | 88074e7f-18f1-47f7-ab67-65c6968127ba | your_username     | aaaaaaaaaaaaaaaaaaaaaaa00000000000000000 |               |           1
(1 row)
```

Taking the value from the `access_token` column, make the following curl requests:

```
$ curl --header "Authorization: Bearer OAuth2:$ACCESS_TOKEN" http://localhost:8080/status
{"node_id":"n64708","display_name":"Node n64708","service_endpoint":"tcp://127.0.0.1:8043","network_endpoints":["tcps://127.0.0.1:8044"],"advertised_endpoints":["tcps://127.0.0.1:8044"],"version":"0.5.1"}
$ curl --header "Authorization: Bearer OAuth2:$ACCESS_TOKEN" http://localhost:8080/biome/keys
{"data": []}
```
Use any alternative token value, and you should get a 401