### PR TITLE
Enable biome for splinterd in gameroom test

### DIFF
--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -65,8 +65,16 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
+        until PGPASSWORD=gameroom_test psql -h db-test -U gameroom_test -c '\q'; do
+            >&2 echo \"Database is unavailable - sleeping\"
+            sleep 1
+        done &&
+        splinter database migrate -C postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test &&
         splinter cert generate --skip &&
-        splinterd -c ./project/tests/splinterd-node-0-docker.toml --tls-insecure -vv
+        splinterd -c ./project/tests/splinterd-node-0-docker.toml -vv \
+            --database postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test \
+            --tls-insecure \
+            --enable-biome
       "
 
   db-test:


### PR DESCRIPTION
Updates the gameroom test docker compose file to enable Biome for
splinterd. This is required to provide an auth implementation for the
Splinter REST API when experimental features are enabled.

Signed-off-by: Logan Seeley <seeley@bitwise.io>