### PR TITLE
Return 401 Unauthorized for invalid auth header

### DIFF
--- a/libsplinter/src/auth/rest_api/actix.rs
+++ b/libsplinter/src/auth/rest_api/actix.rs
@@ -104,19 +104,6 @@ where
         match authorize(req.path(), auth_header, &self.identity_providers) {
             AuthorizationResult::Authorized(_identity) => {}
             AuthorizationResult::NoAuthorizationNecessary => {}
-            AuthorizationResult::InvalidAuthorization(auth_str) => {
-                return Box::new(
-                    req.into_response(
-                        HttpResponse::BadRequest()
-                            .json(ErrorResponse::bad_request(&format!(
-                                "The provided authorization header is not supported: {}",
-                                auth_str
-                            )))
-                            .into_body(),
-                    )
-                    .into_future(),
-                )
-            }
             AuthorizationResult::Unauthorized => {
                 return Box::new(
                     req.into_response(HttpResponse::Unauthorized().finish().into_body())

--- a/libsplinter/src/auth/rest_api/identity/biome.rs
+++ b/libsplinter/src/auth/rest_api/identity/biome.rs
@@ -46,7 +46,7 @@ impl IdentityProvider for BiomeUserIdentityProvider {
     fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError> {
         let token = match authorization {
             Authorization::Bearer(BearerToken::Biome(token)) => token,
-            _ => return Err(IdentityProviderError::UnsupportedAuth),
+            _ => return Err(IdentityProviderError::Unauthorized),
         };
 
         let secret = self

--- a/libsplinter/src/auth/rest_api/identity/error.rs
+++ b/libsplinter/src/auth/rest_api/identity/error.rs
@@ -22,11 +22,8 @@ use std::fmt;
 pub enum IdentityProviderError {
     /// An unrecoverable error that cannot be handled by the caller
     InternalError(String),
-    /// The given authentication variant is supported by this identity provider, but could not be
-    /// resolved to an identity
+    /// The given authentication could not be resolved to an identity by this provider
     Unauthorized,
-    /// The given authentication is not supported by this identity provider
-    UnsupportedAuth,
 }
 
 impl fmt::Display for IdentityProviderError {
@@ -38,9 +35,6 @@ impl fmt::Display for IdentityProviderError {
                 msg,
             ),
             Self::Unauthorized => f.write_str("No identity was found for the given authentication"),
-            Self::UnsupportedAuth => {
-                f.write_str("The given authentication is not supported by this provider")
-            }
         }
     }
 }

--- a/libsplinter/src/auth/rest_api/identity/github.rs
+++ b/libsplinter/src/auth/rest_api/identity/github.rs
@@ -29,7 +29,7 @@ impl IdentityProvider for GithubUserIdentityProvider {
     fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError> {
         let token = match authorization {
             Authorization::Bearer(BearerToken::OAuth2(token)) => token,
-            _ => return Err(IdentityProviderError::UnsupportedAuth),
+            _ => return Err(IdentityProviderError::Unauthorized),
         };
 
         let response = Client::builder()

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -38,12 +38,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Status'
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         500:
@@ -152,12 +146,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Proposal"
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -339,12 +327,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Circuit"
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -487,12 +469,6 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/RegisteredNode"
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -566,12 +542,6 @@ paths:
       responses:
         200:
           description: The node has been deleted from the registry
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -836,12 +806,6 @@ paths:
                 type: array
                 items:
                   type: integer
-        400:
-          description: The request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -1154,12 +1118,6 @@ paths:
                       type: string
                       description: "Internal unique identifier for the user"
                       example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         500:
@@ -1321,12 +1279,6 @@ paths:
                   message:
                     type: string
                     example: "User deleted successfully"
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         404:
@@ -1359,12 +1311,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/BiomeUserKey'
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         500:


### PR DESCRIPTION
Updates the Splinter REST API to return `401 Unauthorized` instead of
`400 Bad Request` when an invalid `Authorization` header is provided.

Signed-off-by: Logan Seeley <seeley@bitwise.io>