### PR TITLE
Compiler warning fixes for sqlite, postgres use

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,6 +54,7 @@ default = [
     "circuit-template",
     "database",
     "database-migrate-biome",
+    "postgres",
 ]
 
 stable = [
@@ -64,9 +65,8 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "health",
-    "postgres",
     "circuit-auth-type",
+    "health",
 ]
 
 circuit-auth-type = []
@@ -75,7 +75,7 @@ database-migrate-biome = ["splinter/biome"]
 
 health = []
 
-database = ["splinter/postgres", "diesel", "postgres"]
+database = ["diesel"]
 postgres = [
     "diesel/postgres",
     "splinter/postgres",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -67,6 +67,7 @@ experimental = [
     # The following features are experimental:
     "circuit-auth-type",
     "health",
+    "sqlite",
 ]
 
 circuit-auth-type = []
@@ -79,6 +80,10 @@ database = ["diesel"]
 postgres = [
     "diesel/postgres",
     "splinter/postgres",
+]
+sqlite = [
+    "diesel/sqlite",
+    "splinter/sqlite",
 ]
 
 [package.metadata.deb]

--- a/libsplinter/src/admin/store/diesel/migrations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/migrations/mod.rs
@@ -14,7 +14,7 @@
 
 //! Provides database migrations for the `DieselAdminServiceStore`.
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
@@ -22,7 +22,7 @@ pub mod sqlite;
 use std::error::Error;
 use std::fmt;
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 pub use postgres::run_migrations as run_postgres_migrations;
 #[cfg(feature = "sqlite")]
 pub use sqlite::run_migrations as run_sqlite_migrations;

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -74,7 +74,7 @@ impl Clone for DieselAdminServiceStore<diesel::sqlite::SqliteConnection> {
     }
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl Clone for DieselAdminServiceStore<diesel::pg::PgConnection> {
     fn clone(&self) -> Self {
         Self {
@@ -83,7 +83,7 @@ impl Clone for DieselAdminServiceStore<diesel::pg::PgConnection> {
     }
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl AdminServiceStore for DieselAdminServiceStore<diesel::pg::PgConnection> {
     fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError> {
         AdminServiceStoreOperations::new(&*self.connection_pool.get()?).add_proposal(proposal)

--- a/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
@@ -40,7 +40,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreAddCircuitOperation {
     ) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl<'a> AdminServiceStoreAddCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
@@ -38,7 +38,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreAddProposalOperation 
     fn add_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl<'a> AdminServiceStoreAddProposalOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -34,7 +34,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateCircuitOperatio
     fn update_circuit(&self, circuit: Circuit) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl<'a> AdminServiceStoreUpdateCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -40,7 +40,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpdateProposalOperati
     fn update_proposal(&self, proposal: CircuitProposal) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl<'a> AdminServiceStoreUpdateProposalOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -29,7 +29,7 @@ pub(in crate::admin::store::diesel) trait AdminServiceStoreUpgradeProposalToCirc
     fn upgrade_proposal_to_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError>;
 }
 
-#[cfg(all(feature = "admin-service-store-postgres", feature = "postgres"))]
+#[cfg(feature = "admin-service-store-postgres")]
 impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
     for AdminServiceStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/admin/store/error.rs
+++ b/libsplinter/src/admin/store/error.rs
@@ -16,9 +16,10 @@
 use std::error::Error;
 use std::fmt;
 
+#[cfg(feature = "diesel")]
+use crate::error::ConstraintViolationType;
 use crate::error::{
-    ConstraintViolationError, ConstraintViolationType, InternalError, InvalidStateError,
-    ResourceTemporarilyUnavailableError,
+    ConstraintViolationError, InternalError, InvalidStateError, ResourceTemporarilyUnavailableError,
 };
 
 /// Represents AdminServiceStore errors

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -30,7 +30,7 @@
 mod circuit;
 mod circuit_node;
 mod circuit_proposal;
-#[cfg(feature = "diesel")]
+#[cfg(any(feature = "admin-service-store-postgres", feature = "sqlite"))]
 pub mod diesel;
 pub mod error;
 mod proposed_circuit;


### PR DESCRIPTION
This cleans up some use of sqlite, postgres features to prevent warnings when we stabilize other features.