### PR TITLE
Cylinder JWT auth for Splinter REST API

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -100,6 +100,7 @@ experimental = [
     "auth",
     "biome-notifications",
     "biome-oauth",
+    "cylinder-jwt",
     "oauth",
     "oauth-github",
     "registry-database",
@@ -123,6 +124,7 @@ biome-key-management = ["biome"]
 biome-notifications = ["biome"]
 biome-oauth = ["biome"]
 circuit-template = ["glob"]
+cylinder-jwt = ["cylinder/jwt"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 oauth = ["auth", "oauth2"]
 oauth-github = ["oauth"]

--- a/libsplinter/src/auth/rest_api/identity/cylinder.rs
+++ b/libsplinter/src/auth/rest_api/identity/cylinder.rs
@@ -1,0 +1,61 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An identity provider that extracts the public key from a Cylinder JWT
+
+use std::sync::{Arc, Mutex};
+
+use cylinder::{jwt::JsonWebTokenParser, Verifier};
+
+use super::{Authorization, BearerToken, IdentityProvider, IdentityProviderError};
+
+/// Extracts the public key from a Cylinder JWT
+///
+/// This provider only accepts `Authorization::Bearer(BearerToken::Cylinder(token))` authorizations,
+/// and the inner token must be a valid Cylinder JWT.
+#[derive(Clone)]
+pub struct CylinderKeyIdentityProvider {
+    /// The verifier is wrapped in an `Arc<Mutex<_>>` to ensure this struct is `Sync`
+    verifier: Arc<Mutex<Box<dyn Verifier>>>,
+}
+
+impl CylinderKeyIdentityProvider {
+    /// Creates a new Cylinder key identity provider
+    pub fn new(verifier: Arc<Mutex<Box<dyn Verifier>>>) -> Self {
+        Self { verifier }
+    }
+}
+
+impl IdentityProvider for CylinderKeyIdentityProvider {
+    fn get_identity(&self, authorization: &Authorization) -> Result<String, IdentityProviderError> {
+        let token = match authorization {
+            Authorization::Bearer(BearerToken::Cylinder(token)) => token,
+            _ => return Err(IdentityProviderError::Unauthorized),
+        };
+
+        let parsed_token = JsonWebTokenParser::new(&**self.verifier.lock().map_err(|_| {
+            IdentityProviderError::InternalError(
+                "Cylinder key identity provider's verifier lock poisoned".into(),
+            )
+        })?)
+        .parse(token)
+        .map_err(|_| IdentityProviderError::Unauthorized)?;
+
+        Ok(parsed_token.issuer().as_hex())
+    }
+
+    fn clone_box(&self) -> Box<dyn IdentityProvider> {
+        Box::new(self.clone())
+    }
+}

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -16,6 +16,8 @@
 
 #[cfg(feature = "biome-credentials")]
 pub mod biome;
+#[cfg(feature = "cylinder-jwt")]
+pub mod cylinder;
 mod error;
 #[cfg(feature = "oauth-github")]
 pub mod github;
@@ -89,6 +91,9 @@ pub enum BearerToken {
     #[cfg(feature = "biome-credentials")]
     /// Contains a Biome JWT
     Biome(String),
+    #[cfg(feature = "cylinder-jwt")]
+    /// Contains a Cylinder JWT
+    Cylinder(String),
     #[cfg(feature = "oauth")]
     /// Contains an OAuth2 token
     OAuth2(String),
@@ -104,6 +109,8 @@ impl FromStr for BearerToken {
             (Some(token_type), Some(token)) => match token_type {
                 #[cfg(feature = "biome-credentials")]
                 "Biome" => Ok(BearerToken::Biome(token.to_string())),
+                #[cfg(feature = "cylinder-jwt")]
+                "Cylinder" => Ok(BearerToken::Cylinder(token.to_string())),
                 #[cfg(feature = "oauth")]
                 "OAuth2" => Ok(BearerToken::OAuth2(token.to_string())),
                 other_type => Err(AuthorizationParseError::new(format!(

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -944,6 +944,7 @@ pub enum AuthConfig {
     /// Biome credentials authentication
     #[cfg(feature = "biome-credentials")]
     Biome {
+        /// The resource provider that defines all Biome-related endpoints for the Splinter REST API
         biome_resource_manager: BiomeRestResourceManager,
     },
     /// Cylinder JWT authentication

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -64,10 +64,14 @@ use actix_web::{
     error::ErrorBadRequest, http::header, middleware, web, App, Error as ActixError, HttpRequest,
     HttpResponse, HttpServer,
 };
+#[cfg(all(feature = "auth", feature = "cylinder-jwt"))]
+use cylinder::Verifier;
 use futures::{future::FutureResult, stream::Stream, Future, IntoFuture};
 use percent_encoding::{AsciiSet, CONTROLS};
 use protobuf::{self, Message};
 use std::boxed::Box;
+#[cfg(all(feature = "auth", feature = "cylinder-jwt"))]
+use std::sync::Mutex;
 use std::sync::{mpsc, Arc};
 use std::thread;
 
@@ -76,6 +80,8 @@ use crate::auth::oauth::{
     rest_api::{OAuthResourceProvider, SaveUserInfoOperation, SaveUserInfoToNull},
     OAuthClient,
 };
+#[cfg(all(feature = "auth", feature = "cylinder-jwt"))]
+use crate::auth::rest_api::identity::cylinder::CylinderKeyIdentityProvider;
 #[cfg(feature = "oauth-github")]
 use crate::auth::rest_api::identity::github::GithubUserIdentityProvider;
 #[cfg(feature = "auth")]
@@ -817,6 +823,12 @@ impl RestApiBuilder {
                         self.resources
                             .append(&mut biome_resource_manager.resources());
                     }
+                    #[cfg(feature = "cylinder-jwt")]
+                    AuthConfig::Cylinder { verifier } => {
+                        identity_providers.push(Box::new(CylinderKeyIdentityProvider::new(
+                            Arc::new(Mutex::new(verifier)),
+                        )));
+                    }
                     #[cfg(feature = "oauth")]
                     AuthConfig::OAuth {
                         oauth_config,
@@ -933,6 +945,12 @@ pub enum AuthConfig {
     #[cfg(feature = "biome-credentials")]
     Biome {
         biome_resource_manager: BiomeRestResourceManager,
+    },
+    /// Cylinder JWT authentication
+    #[cfg(feature = "cylinder-jwt")]
+    Cylinder {
+        /// The signature verifier used to validate Cylinder JWTs
+        verifier: Box<dyn Verifier>,
     },
     /// OAuth authentication
     #[cfg(feature = "oauth")]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -85,7 +85,7 @@ experimental = [
     "ws-transport",
 ]
 
-auth = ["splinter/oauth-github"]
+auth = ["splinter/cylinder-jwt", "splinter/oauth-github"]
 biome = ["splinter/biome", "splinter/store-factory", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
 biome-key-management = ["splinter/biome-key-management", "biome"]

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1608,8 +1608,8 @@ components:
       in: header
       description: |
         The client's authorization, which the server resolves to an identity.
-        Currently supports Biome JWT (if Biome credentials is enabled) and OAuth2
-        bearer tokens.
+        Currently supports Biome JWT (if Biome credentials is enabled), Cylinder
+        JWT, and OAuth2 bearer tokens.
       required: true
       schema:
         type: string
@@ -1618,6 +1618,11 @@ components:
             IjoiZjM1YWFjYzEtYTljZC00ZWRhLWI2ZDAtMmVmYWRkZjBjOGE0IiwiaXNzIjoic2V\
             sZi1pc3N1ZWQiLCJleHAiOjE1ODAyMzkyMjh9.P8hA0ru_xriYX7qryl08ZEp86t5HD\
             _AEVPEUXY70Ehc
+          Cylinder: Bearer Cylinder:eyJhbGciOiJzZWNwMjU2azEiLCJ0eXAiOiJjeWxpbmR\
+            lcitqd3QifQ==.eyJpc3MiOiIwMjc5YmU2NjdlZjlkY2JiYWM1NWEwNjI5NWNlODcwY\
+            jA3MDI5YmZjZGIyZGNlMjhkOTU5ZjI4MTViMTZmODE3OTgifQ==.71Vw3+m9R4b8iZU\
+            zhRHOAtX/hO5WYA9PgMe27/CeZ6NhIXFYkBBzreoIGpHbfJ8UxT+1MLUgjsQB8TISaf\
+            neRA==
           OAuth2: Bearer OAuth2:55eeea7ce2b472d69d406990939baa698e34e955
 
     protocol_version:

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -310,9 +310,10 @@ is set to `/tmp/testing` and `SPLINTER_STATE_DIR` is set to
 AUTHORIZATION CONFIGURATION
 ===========================
 
-Currently, splinterd supports two authorization types: Biome credentials and
-OAuth. The REST API requires that one of these authorization providers is
-configured.
+Currently, splinterd supports three authorization types: Biome credentials,
+Cylinder JWT, and OAuth.
+
+Cylinder JWT authorization is enabled by default.
 
 Biome credentials for the splinter REST API can be enabled using the
 `--enable-biome` flag.

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -486,6 +486,11 @@ impl SplinterDaemon {
         {
             let mut auth_configs = vec![];
 
+            // Add Cylinder JWT as an auth provider
+            auth_configs.push(AuthConfig::Cylinder {
+                verifier: Secp256k1Context::new().new_verifier(),
+            });
+
             // Handle OAuth config. If no OAuth config values are provided, just skip this;
             // otherwise, require that all are set.
             let any_oauth_args_provided = self.oauth_provider.is_some()


### PR DESCRIPTION
Adds Cylinder JWT authorization to the Splinter REST API.

### Testing
Run splinterd with experimental features enabled:
```bash
CARGO_ARGS="-- --features experimental" SPLINTERD_ARGS="--enable-cylinder-jwt" docker-compose up --build
```

Verify auth is enabled by checking that this returns a 401 response:
```bash
curl -I http://localhost:8080/status
```

Verify that Cylinder JWT auth works for valid tokens by verifying that this returns the node's info:
```bash
curl http://localhost:8080/status -H "Authorization: Bearer Cylinder:eyJhbGciOi\
JzZWNwMjU2azEiLCJ0eXAiOiJjeWxpbmRlcitqd3QifQ==.eyJpc3MiOiIwMjc5YmU2NjdlZjlkY2Ji\
YWM1NWEwNjI5NWNlODcwYjA3MDI5YmZjZGIyZGNlMjhkOTU5ZjI4MTViMTZmODE3OTgifQ==.71Vw3+\
m9R4b8iZUzhRHOAtX/hO5WYA9PgMe27/CeZ6NhIXFYkBBzreoIGpHbfJ8UxT+1MLUgjsQB8TISafneRA=="
```

Verify invalid tokens are rejected by checking that this returns a 401 response:
```bash
curl http://localhost:8080/status -H "Authorization: Bearer Cylinder:bad_token"
```