### PR TITLE
Fix default user dir for keygen CLI

### DIFF
--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -21,7 +21,7 @@ DESCRIPTION
 This command generates secp256k1 public/private keys for Splinter.
 
 If no option is specified, this command generates user keys that are stored in
-the directory `$HOME/splinter/keys`. The `--system` flag generates keys for the
+the directory `$HOME/.splinter/keys`. The `--system` flag generates keys for the
 Splinter daemon (`splinterd`) that are stored in `/etc/splinter/keys`. The
 `--key-dir` option generates keys in the specified directory.
 
@@ -73,8 +73,8 @@ This example generates user keys for a Splinter user who is logged in as
 
 ```
 $ splinter keygen
-writing file: "/Users/paulbunyan/splinter/keys/paulbunyan.priv"
-writing file: "/Users/paulbunyan/splinter/keys/paulbunyan.pub"
+writing file: "/Users/paulbunyan/.splinter/keys/paulbunyan.priv"
+writing file: "/Users/paulbunyan/.splinter/keys/paulbunyan.pub"
 ```
 
 This example generates keys for the user `babe` in the `/tmp` directory:

--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -49,7 +49,7 @@ impl Action for KeyGenAction {
         } else {
             dirs::home_dir()
                 .map(|mut p| {
-                    p.push("splinter/keys");
+                    p.push(".splinter/keys");
                     p
                 })
                 .ok_or_else(|| CliError::EnvironmentError("Home directory not found".into()))?


### PR DESCRIPTION
Updates the `splinter keygen` CLI command to put user keys in the
`~/.splinter/keys` directory by default instead of `~/splinter/keys`,
which was a typo. The other commands in the CLI assume the `.splinter`
directory is the default.

Signed-off-by: Logan Seeley <seeley@bitwise.io>