### PR TITLE
Gameroom JWT support

### DIFF
--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -37,7 +37,7 @@ actix-rt = "1.0"
 bcrypt = "0.5"
 clap = "2"
 ctrlc = "3.0"
-cylinder = { version = "0.2", features = ["jwt"] }
+cylinder = { version = "0.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
 flexi_logger = "0.14"

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -37,7 +37,7 @@ actix-rt = "1.0"
 bcrypt = "0.5"
 clap = "2"
 ctrlc = "3.0"
-cylinder = "0.2"
+cylinder = { version = "0.2", features = ["jwt"] }
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
 flexi_logger = "0.14"

--- a/examples/gameroom/daemon/src/authorization_handler/sabre.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/sabre.rs
@@ -51,6 +51,7 @@ pub fn setup_xo(
     private_key: &str,
     scabbard_admin_keys: Vec<String>,
     splinterd_url: &str,
+    authorization: &str,
     circuit_id: &str,
     service_id: &str,
 ) -> Result<Box<dyn Future<Item = (), Error = ()> + Send + 'static>, AppAuthHandlerError> {
@@ -86,6 +87,7 @@ pub fn setup_xo(
             splinterd_url, circuit_id, service_id
         ))
         .method("POST")
+        .header("Authorization", authorization)
         .header(
             "SplinterProtocolVersion",
             protocol::SCABBARD_PROTOCOL_VERSION.to_string(),

--- a/examples/gameroom/daemon/src/config.rs
+++ b/examples/gameroom/daemon/src/config.rs
@@ -27,6 +27,7 @@ pub struct GameroomConfig {
     rest_api_endpoint: String,
     database_url: String,
     splinterd_url: String,
+    key: String,
 }
 
 impl GameroomConfig {
@@ -40,12 +41,17 @@ impl GameroomConfig {
     pub fn splinterd_url(&self) -> &str {
         &self.splinterd_url
     }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
 }
 
 pub struct GameroomConfigBuilder {
     rest_api_endpoint: Option<String>,
     database_url: Option<String>,
     splinterd_url: Option<String>,
+    key: Option<String>,
 }
 
 impl Default for GameroomConfigBuilder {
@@ -56,6 +62,7 @@ impl Default for GameroomConfigBuilder {
                 "postgres://gameroom:gameroom_example@postgres:5432/gameroom".to_owned(),
             ),
             splinterd_url: Some("http://127.0.0.1:8080".to_owned()),
+            key: None,
         }
     }
 }
@@ -77,6 +84,11 @@ impl GameroomConfigBuilder {
                 .value_of("splinterd_url")
                 .map(ToOwned::to_owned)
                 .or_else(|| self.splinterd_url.take()),
+
+            key: matches
+                .value_of("key")
+                .map(ToOwned::to_owned)
+                .or_else(|| self.key.take()),
         }
     }
 
@@ -94,6 +106,10 @@ impl GameroomConfigBuilder {
                 .splinterd_url
                 .take()
                 .ok_or_else(|| ConfigurationError::MissingValue("splinterd_url".to_owned()))?,
+            key: self
+                .key
+                .take()
+                .ok_or_else(|| ConfigurationError::MissingValue("key".to_owned()))?,
         })
     }
 }

--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -29,7 +29,7 @@ mod rest_api;
 
 use std::thread;
 
-use cylinder::{jwt::JsonWebTokenBuilder, secp256k1::Secp256k1Context, Context};
+use cylinder::{jwt::JsonWebTokenBuilder, load_user_key, secp256k1::Secp256k1Context, Context};
 use flexi_logger::{style, DeferredNow, LogSpecBuilder, Logger};
 use gameroom_database::ConnectionPool;
 use log::Record;
@@ -69,6 +69,7 @@ fn run() -> Result<(), GameroomDaemonError> {
         (@arg database_url: --("database-url") +takes_value "Database connection for Gameroom rest API")
         (@arg bind: -b --bind +takes_value "connection endpoint for Gameroom rest API")
         (@arg splinterd_url: --("splinterd-url") +takes_value "connection endpoint to SplinterD rest API")
+        (@arg key: --("key") +takes_value "path to the GameroomD signing key")
     )
     .get_matches();
 
@@ -97,9 +98,10 @@ fn run() -> Result<(), GameroomDaemonError> {
     let connection_pool: ConnectionPool =
         gameroom_database::create_connection_pool(config.database_url())?;
 
-    // Generate a public/private key pair
+    // Get the public/private key pair
     let context = Secp256k1Context::new();
-    let private_key = context.new_random_private_key();
+    let private_key = load_user_key(Some(config.key()), "")
+        .map_err(|err| GameroomDaemonError::SigningError(err.to_string()))?;
     let private_key_hex = private_key.as_hex();
     let public_key_hex = context.get_public_key(&private_key)?.as_hex();
 

--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -117,7 +117,7 @@ fn run() -> Result<(), GameroomDaemonError> {
 
     let (rest_api_shutdown_handle, rest_api_join_handle) = rest_api::run(
         config.rest_api_endpoint(),
-        config.splinterd_url(),
+        config.splinterd_url().into(),
         node,
         connection_pool,
         public_key.as_hex(),

--- a/examples/gameroom/daemon/src/rest_api/mod.rs
+++ b/examples/gameroom/daemon/src/rest_api/mod.rs
@@ -32,6 +32,7 @@ use routes::ErrorResponse;
 #[derive(Clone)]
 pub struct GameroomdData {
     pub public_key: String,
+    pub splinterd_url: String,
 }
 
 pub struct RestApiShutdownHandle {
@@ -46,7 +47,7 @@ impl RestApiShutdownHandle {
 
 pub fn run(
     bind_url: &str,
-    splinterd_url: &str,
+    splinterd_url: String,
     node: NodeInfo,
     database_connection: ConnectionPool,
     public_key: String,
@@ -58,8 +59,10 @@ pub fn run(
     RestApiServerError,
 > {
     let bind_url = bind_url.to_owned();
-    let splinterd_url = splinterd_url.to_owned();
-    let gameroomd_data = GameroomdData { public_key };
+    let gameroomd_data = GameroomdData {
+        public_key,
+        splinterd_url,
+    };
     let (tx, rx) = mpsc::channel();
     let join_handle = thread::Builder::new()
         .name("GameroomdRestApi".into())
@@ -70,7 +73,6 @@ pub fn run(
                 App::new()
                     .data(database_connection.clone())
                     .data(Client::new())
-                    .data(splinterd_url.to_owned())
                     .data(node.clone())
                     .data(gameroomd_data.clone())
                     .data(

--- a/examples/gameroom/daemon/src/rest_api/mod.rs
+++ b/examples/gameroom/daemon/src/rest_api/mod.rs
@@ -33,6 +33,7 @@ use routes::ErrorResponse;
 pub struct GameroomdData {
     pub public_key: String,
     pub splinterd_url: String,
+    pub authorization: String,
 }
 
 pub struct RestApiShutdownHandle {
@@ -48,6 +49,7 @@ impl RestApiShutdownHandle {
 pub fn run(
     bind_url: &str,
     splinterd_url: String,
+    authorization: String,
     node: NodeInfo,
     database_connection: ConnectionPool,
     public_key: String,
@@ -62,6 +64,7 @@ pub fn run(
     let gameroomd_data = GameroomdData {
         public_key,
         splinterd_url,
+        authorization,
     };
     let (tx, rx) = mpsc::channel();
     let join_handle = thread::Builder::new()

--- a/examples/gameroom/daemon/src/rest_api/routes/authenticate.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/authenticate.rs
@@ -16,6 +16,8 @@ use actix_web::{client::Client, http::StatusCode, web, Error, HttpResponse};
 use serde::{Deserialize, Serialize};
 use splinter::protocol;
 
+use crate::rest_api::GameroomdData;
+
 use super::{ErrorResponse, SuccessResponse};
 
 #[derive(Debug, Serialize)]
@@ -77,12 +79,12 @@ struct NewKey {
 
 pub async fn login(
     auth_data: web::Json<AuthData>,
-    splinterd_url: web::Data<String>,
     client: web::Data<Client>,
+    gameroomd_data: web::Data<GameroomdData>,
 ) -> Result<HttpResponse, Error> {
     // forward login to splinterd
     let mut login_response = client
-        .post(format!("{}/biome/login", splinterd_url.get_ref()))
+        .post(format!("{}/biome/login", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             protocol::BIOME_PROTOCOL_VERSION.to_string(),
@@ -121,7 +123,7 @@ pub async fn login(
 
     // Get user's key
     let mut key_response = client
-        .get(format!("{}/biome/keys", splinterd_url.get_ref(),))
+        .get(format!("{}/biome/keys", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             protocol::BIOME_PROTOCOL_VERSION.to_string(),
@@ -180,8 +182,8 @@ pub struct UserCreate {
 
 pub async fn register(
     json_wrapper: web::Json<UserCreate>,
-    splinterd_url: web::Data<String>,
     client: web::Data<Client>,
+    gameroomd_data: web::Data<GameroomdData>,
 ) -> Result<HttpResponse, Error> {
     let new_user = json_wrapper.into_inner();
 
@@ -191,7 +193,7 @@ pub async fn register(
     };
 
     let mut registered_response = client
-        .post(format!("{}/biome/register", splinterd_url.get_ref()))
+        .post(format!("{}/biome/register", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             protocol::BIOME_PROTOCOL_VERSION.to_string(),
@@ -220,7 +222,7 @@ pub async fn register(
     };
 
     let mut login_response = client
-        .post(format!("{}/biome/login", splinterd_url.get_ref()))
+        .post(format!("{}/biome/login", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             protocol::BIOME_PROTOCOL_VERSION.to_string(),
@@ -250,7 +252,7 @@ pub async fn register(
 
     // Create Key
     let create_key_response = client
-        .post(format!("{}/biome/keys", splinterd_url.get_ref(),))
+        .post(format!("{}/biome/keys", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             protocol::BIOME_PROTOCOL_VERSION.to_string(),

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -93,7 +93,6 @@ pub async fn propose_gameroom(
     create_gameroom: web::Json<CreateGameroomForm>,
     node_info: web::Data<NodeInfo>,
     client: web::Data<Client>,
-    splinterd_url: web::Data<String>,
     gameroomd_data: web::Data<GameroomdData>,
 ) -> HttpResponse {
     let mut template = match CircuitCreateTemplate::from_yaml_file("gameroom.yaml") {
@@ -104,7 +103,12 @@ pub async fn propose_gameroom(
         }
     };
 
-    let response = fetch_node_information(&create_gameroom.members, &splinterd_url, client).await;
+    let response = fetch_node_information(
+        &create_gameroom.members,
+        &gameroomd_data.splinterd_url,
+        client,
+    )
+    .await;
 
     let nodes = match response {
         Ok(nodes) => nodes,

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -106,6 +106,7 @@ pub async fn propose_gameroom(
     let response = fetch_node_information(
         &create_gameroom.members,
         &gameroomd_data.splinterd_url,
+        &gameroomd_data.authorization,
         client,
     )
     .await;
@@ -210,6 +211,7 @@ pub async fn propose_gameroom(
 async fn fetch_node_information(
     node_ids: &[String],
     splinterd_url: &str,
+    authorization: &str,
     client: web::Data<Client>,
 ) -> Result<Vec<NodeResponse>, RestApiResponseError> {
     let node_ids = node_ids.to_owned();
@@ -219,6 +221,7 @@ async fn fetch_node_information(
             splinterd_url,
             std::i64::MAX
         ))
+        .header("Authorization", authorization)
         .header(
             "SplinterProtocolVersion",
             protocol::ADMIN_PROTOCOL_VERSION.to_string(),

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -31,6 +31,7 @@ pub async fn fetch_node(
             "{}/registry/nodes/{}",
             &gameroomd_data.splinterd_url, identity
         ))
+        .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
             protocol::REGISTRY_PROTOCOL_VERSION.to_string(),
@@ -89,6 +90,7 @@ pub async fn list_nodes(
 
     let mut response = client
         .get(&request_url)
+        .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
             protocol::REGISTRY_PROTOCOL_VERSION.to_string(),
@@ -143,6 +145,10 @@ mod test {
     };
 
     static SPLINTERD_URL: &str = "http://splinterd-node:8085";
+    static AUTHORIZATION: &str = "Bearer Cylinder:eyJhbGciOiJzZWNwMjU2azEiLCJ0eXAiOiJjeWxpbmRlcitq\
+        d3QifQ==.eyJpc3MiOiIwMjc5YmU2NjdlZjlkY2JiYWM1NWEwNjI5NWNlODcwYjA3MDI5YmZjZGIyZGNlMjhkOTU5Z\
+        jI4MTViMTZmODE3OTgifQ==.71Vw3+m9R4b8iZUzhRHOAtX/hO5WYA9PgMe27/CeZ6NhIXFYkBBzreoIGpHbfJ8UxT\
+        +1MLUgjsQB8TISafneRA==";
 
     #[actix_rt::test]
     /// Tests a GET /registry/nodes/{identity} request returns the expected node.
@@ -153,6 +159,7 @@ mod test {
                 .data(GameroomdData {
                     public_key: "".into(),
                     splinterd_url: SPLINTERD_URL.into(),
+                    authorization: AUTHORIZATION.into(),
                 })
                 .service(
                     web::resource("/registry/nodes/{identity}").route(web::get().to(fetch_node)),
@@ -181,6 +188,7 @@ mod test {
                 .data(GameroomdData {
                     public_key: "".into(),
                     splinterd_url: SPLINTERD_URL.into(),
+                    authorization: AUTHORIZATION.into(),
                 })
                 .service(
                     web::resource("/registry/nodes/{identity}").route(web::get().to(fetch_node)),
@@ -206,6 +214,7 @@ mod test {
                 .data(GameroomdData {
                     public_key: "".into(),
                     splinterd_url: SPLINTERD_URL.into(),
+                    authorization: AUTHORIZATION.into(),
                 })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )
@@ -244,6 +253,7 @@ mod test {
                 .data(GameroomdData {
                     public_key: "".into(),
                     splinterd_url: SPLINTERD_URL.into(),
+                    authorization: AUTHORIZATION.into(),
                 })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )
@@ -279,6 +289,7 @@ mod test {
                 .data(GameroomdData {
                     public_key: "".into(),
                     splinterd_url: SPLINTERD_URL.into(),
+                    authorization: AUTHORIZATION.into(),
                 })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -17,18 +17,19 @@ use percent_encoding::utf8_percent_encode;
 use splinter::protocol;
 use std::collections::HashMap;
 
+use crate::rest_api::GameroomdData;
+
 use super::{ErrorResponse, SuccessResponse, DEFAULT_LIMIT, DEFAULT_OFFSET, QUERY_ENCODE_SET};
 
 pub async fn fetch_node(
     identity: web::Path<String>,
     client: web::Data<Client>,
-    splinterd_url: web::Data<String>,
+    gameroomd_data: web::Data<GameroomdData>,
 ) -> Result<HttpResponse, Error> {
     let mut response = client
         .get(&format!(
             "{}/registry/nodes/{}",
-            splinterd_url.get_ref(),
-            identity
+            &gameroomd_data.splinterd_url, identity
         ))
         .header(
             "SplinterProtocolVersion",
@@ -62,10 +63,10 @@ pub async fn fetch_node(
 
 pub async fn list_nodes(
     client: web::Data<Client>,
-    splinterd_url: web::Data<String>,
+    gameroomd_data: web::Data<GameroomdData>,
     query: web::Query<HashMap<String, String>>,
 ) -> Result<HttpResponse, Error> {
-    let mut request_url = format!("{}/registry/nodes", splinterd_url.get_ref());
+    let mut request_url = format!("{}/registry/nodes", &gameroomd_data.splinterd_url);
 
     let offset = query
         .get("offset")
@@ -149,7 +150,10 @@ mod test {
         let mut app = test::init_service(
             App::new()
                 .data(Client::new())
-                .data(SPLINTERD_URL.to_string())
+                .data(GameroomdData {
+                    public_key: "".into(),
+                    splinterd_url: SPLINTERD_URL.into(),
+                })
                 .service(
                     web::resource("/registry/nodes/{identity}").route(web::get().to(fetch_node)),
                 ),
@@ -174,7 +178,10 @@ mod test {
         let mut app = test::init_service(
             App::new()
                 .data(Client::new())
-                .data(SPLINTERD_URL.to_string())
+                .data(GameroomdData {
+                    public_key: "".into(),
+                    splinterd_url: SPLINTERD_URL.into(),
+                })
                 .service(
                     web::resource("/registry/nodes/{identity}").route(web::get().to(fetch_node)),
                 ),
@@ -196,7 +203,10 @@ mod test {
         let mut app = test::init_service(
             App::new()
                 .data(Client::new())
-                .data(SPLINTERD_URL.to_string())
+                .data(GameroomdData {
+                    public_key: "".into(),
+                    splinterd_url: SPLINTERD_URL.into(),
+                })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )
         .await;
@@ -231,7 +241,10 @@ mod test {
         let mut app = test::init_service(
             App::new()
                 .data(Client::new())
-                .data(SPLINTERD_URL.to_string())
+                .data(GameroomdData {
+                    public_key: "".into(),
+                    splinterd_url: SPLINTERD_URL.into(),
+                })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )
         .await;
@@ -263,7 +276,10 @@ mod test {
         let mut app = test::init_service(
             App::new()
                 .data(Client::new())
-                .data(SPLINTERD_URL.to_string())
+                .data(GameroomdData {
+                    public_key: "".into(),
+                    splinterd_url: SPLINTERD_URL.into(),
+                })
                 .service(web::resource("/registry/nodes").route(web::get().to(list_nodes))),
         )
         .await;

--- a/examples/gameroom/daemon/src/rest_api/routes/submit.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/submit.rs
@@ -38,6 +38,7 @@ pub async fn submit_signed_payload(
 ) -> Result<HttpResponse, Error> {
     let mut response = client
         .post(format!("{}/admin/submit", &gameroomd_data.splinterd_url))
+        .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
             ADMIN_PROTOCOL_VERSION.to_string(),
@@ -120,6 +121,7 @@ pub async fn submit_scabbard_payload(
             "{}/scabbard/{}/{}/batches",
             &gameroomd_data.splinterd_url, &circuit_id, &service_id
         ))
+        .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
             SCABBARD_PROTOCOL_VERSION.to_string(),
@@ -169,7 +171,16 @@ pub async fn submit_scabbard_payload(
         }
     };
     let start = Instant::now();
-    match check_batch_status(client, &gameroomd_data.splinterd_url, &link, start, wait).await {
+    match check_batch_status(
+        client,
+        &gameroomd_data.splinterd_url,
+        &gameroomd_data.authorization,
+        &link,
+        start,
+        wait,
+    )
+    .await
+    {
         Ok(batches_info) => {
             let invalid_batches = batches_info
                 .iter()
@@ -265,6 +276,7 @@ fn process_failed_baches(invalid_batches: &[&BatchInfo]) -> String {
 async fn check_batch_status(
     client: web::Data<Client>,
     splinterd_url: &str,
+    authorization: &str,
     link: &str,
     start_time: Instant,
     wait: u64,
@@ -276,6 +288,7 @@ async fn check_batch_status(
         debug!("Checking batch status {}", link);
         let mut response = match client
             .get(format!("{}{}", splinterd_url, link))
+            .header("Authorization", authorization)
             .header(
                 "SplinterProtocolVersion",
                 SCABBARD_PROTOCOL_VERSION.to_string(),

--- a/examples/gameroom/daemon/src/rest_api/routes/submit.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/submit.rs
@@ -27,17 +27,17 @@ use splinter::protocol::ADMIN_PROTOCOL_VERSION;
 use super::{ErrorResponse, SuccessResponse};
 
 use crate::config::NodeInfo;
-use crate::rest_api::RestApiResponseError;
+use crate::rest_api::{GameroomdData, RestApiResponseError};
 
 const DEFAULT_WAIT: u64 = 30; // default wait time in seconds for batch to be commited
 
 pub async fn submit_signed_payload(
     client: web::Data<Client>,
-    splinterd_url: web::Data<String>,
+    gameroomd_data: web::Data<GameroomdData>,
     signed_payload: web::Bytes,
 ) -> Result<HttpResponse, Error> {
     let mut response = client
-        .post(format!("{}/admin/submit", *splinterd_url))
+        .post(format!("{}/admin/submit", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
             ADMIN_PROTOCOL_VERSION.to_string(),
@@ -74,7 +74,7 @@ pub async fn submit_signed_payload(
 
 pub async fn submit_scabbard_payload(
     client: web::Data<Client>,
-    splinterd_url: web::Data<String>,
+    gameroomd_data: web::Data<GameroomdData>,
     pool: web::Data<ConnectionPool>,
     circuit_id: web::Path<String>,
     node_info: web::Data<NodeInfo>,
@@ -118,7 +118,7 @@ pub async fn submit_scabbard_payload(
     let mut response = client
         .post(format!(
             "{}/scabbard/{}/{}/batches",
-            *splinterd_url, &circuit_id, &service_id
+            &gameroomd_data.splinterd_url, &circuit_id, &service_id
         ))
         .header(
             "SplinterProtocolVersion",
@@ -169,7 +169,7 @@ pub async fn submit_scabbard_payload(
         }
     };
     let start = Instant::now();
-    match check_batch_status(client, &splinterd_url, &link, start, wait).await {
+    match check_batch_status(client, &gameroomd_data.splinterd_url, &link, start, wait).await {
         Ok(batches_info) => {
             let invalid_batches = batches_info
                 .iter()

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -24,6 +24,8 @@ networks:
 volumes:
   cargo-registry:
   registry:
+  acme-keys:
+  bubba-keys:
   acme-var:
   bubba-var:
   acme-db:
@@ -121,6 +123,7 @@ services:
           gameroom:
             ipv4_address: 172.28.2.3
         volumes:
+          - acme-keys:/keys
           - cargo-registry:/root/.cargo/registry
         expose:
           - 8000
@@ -144,7 +147,9 @@ services:
 
             gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom &&
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom \
-              -b gameroomd-acme:8000 --splinterd-url http://splinterd-node-acme:8085
+              -b gameroomd-acme:8000 \
+              --splinterd-url http://splinterd-node-acme:8085 \
+              --key /keys/acme.priv
           "
 
     splinterd-node-acme:
@@ -161,10 +166,15 @@ services:
         gameroom:
           ipv4_address: 172.28.2.4
       volumes:
+        - acme-keys:/keys
         - acme-var:/var/lib/splinter
         - ./splinterd-config:/configs
       entrypoint: |
         bash -c "
+          if [ ! -f /keys/acme.priv ]
+          then
+            splinter admin keygen acme -d /keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-acme -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
@@ -235,6 +245,7 @@ services:
           gameroom:
             ipv4_address: 172.28.3.3
         volumes:
+          - bubba-keys:/keys
           - cargo-registry:/root/.cargo/registry
         expose:
           - 8000
@@ -258,7 +269,9 @@ services:
 
             gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom &&
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom \
-              -b gameroomd-bubba:8000 --splinterd-url http://splinterd-node-bubba:8085
+              -b gameroomd-bubba:8000 \
+              --splinterd-url http://splinterd-node-bubba:8085 \
+              --key /keys/bubba.priv
           "
 
     splinterd-node-bubba:
@@ -275,10 +288,15 @@ services:
         gameroom:
           ipv4_address: 172.28.3.4
       volumes:
+        - bubba-keys:/keys
         - ./splinterd-config:/configs
         - bubba-var:/var/lib/splinter
       entrypoint: |
         bash -c "
+          if [ ! -f /keys/bubba.priv ]
+          then
+            splinter admin keygen bubba -d /keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-bubba -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -24,6 +24,8 @@ networks:
 volumes:
   cargo-registry:
   registry:
+  acme-keys:
+  bubba-keys:
   acme-var:
   bubba-var:
   acme-db:
@@ -144,6 +146,7 @@ services:
           gameroom:
             ipv4_address: 172.28.2.3
         volumes:
+          - acme-keys:/keys
           - cargo-registry:/root/.cargo/registry
         expose:
           - 8000
@@ -167,7 +170,9 @@ services:
 
             gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-acme:5432/gameroom \
-              -b gameroomd-acme:8000 --splinterd-url http://splinterd-node-acme:8085
+              -b gameroomd-acme:8000 \
+              --splinterd-url http://splinterd-node-acme:8085 \
+              --key /keys/acme.priv
           "
 
     splinterd-node-acme:
@@ -190,10 +195,15 @@ services:
         gameroom:
           ipv4_address: 172.28.2.4
       volumes:
+        - acme-keys:/keys
         - acme-var:/var/lib/splinter
         - ./splinterd-config:/configs
       entrypoint: |
         bash -c "
+          if [ ! -f /keys/acme.priv ]
+          then
+            splinter admin keygen acme -d /keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-acme -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
@@ -281,6 +291,7 @@ services:
           gameroom:
             ipv4_address: 172.28.3.3
         volumes:
+          - bubba-keys:/keys
           - cargo-registry:/root/.cargo/registry
         expose:
           - 8000
@@ -304,7 +315,9 @@ services:
 
             gameroom -vv database migrate --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom
             gameroomd -vv --database-url postgres://gameroom:gameroom_example@db-bubba:5432/gameroom \
-              -b gameroomd-bubba:8000 --splinterd-url http://splinterd-node-bubba:8085
+              -b gameroomd-bubba:8000 \
+              --splinterd-url http://splinterd-node-bubba:8085 \
+              --key /keys/bubba.priv
           "
 
     splinterd-node-bubba:
@@ -327,10 +340,15 @@ services:
         gameroom:
           ipv4_address: 172.28.3.4
       volumes:
+        - bubba-keys:/keys
         - ./splinterd-config:/configs
         - bubba-var:/var/lib/splinter
       entrypoint: |
         bash -c "
+          if [ ! -f /keys/bubba.priv ]
+          then
+            splinter admin keygen bubba -d /keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-bubba -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -16,6 +16,7 @@ version: "3.7"
 
 volumes:
   cargo-registry:
+  cypress-keys:
 
 services:
 
@@ -57,6 +58,7 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     volumes:
       - cargo-registry:/root/.cargo/registry
+      - cypress-keys:/keys
     expose:
       - 8000
     ports:
@@ -80,7 +82,9 @@ services:
         gameroom -vv database migrate --database-url postgres://gameroom_test:gameroom_test@db-cypress-test:5432/gameroom_test
 
         gameroomd -vv --database-url postgres://gameroom_test:gameroom_test@db-cypress-test:5432/gameroom_test \
-          -b gameroomd-acme:8000 --splinterd-url http://splinterd-node:8085
+          -b gameroomd-acme:8000 \
+          --splinterd-url http://splinterd-node:8085 \
+          --key /keys/cypress.priv
       "
 
   splinterd-node:
@@ -94,6 +98,7 @@ services:
       - 8090:8085
     volumes:
       - ../:/project/tests
+      - cypress-keys:/keys
     build:
       context: ../../../..
       dockerfile: splinterd/Dockerfile-installed-${DISTRO}
@@ -102,6 +107,10 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
+        if [ ! -f /keys/cypress.priv ]
+        then
+          splinter admin keygen cypress -d /keys
+        fi && \
         until PGPASSWORD=admin psql -h splinterd-db-node -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -41,7 +41,6 @@ splinter = { path = "../../../libsplinter" }
 transact = { version = "0.3", features = ["sawtooth-compat"] }
 
 [dev-dependencies]
-cylinder = "0.2"
 tempdir = "0.3"
 transact = { version = "0.3", features = ["family-command", "sawtooth-compat"] }
 


### PR DESCRIPTION
Updates gameroomd to provide a cylinder JWT authorization header in its requests to the splinterd REST API.

Note that this does not make Gameroom fully capable of authorizing with splinterd. Full support is not possible until splinterd authorization is stabilized, since this support would break compatibility with the current stable version of splinterd.