### PR TITLE
Auth and OAuth-biome fixes

### DIFF
--- a/libsplinter/src/auth/rest_api/actix.rs
+++ b/libsplinter/src/auth/rest_api/actix.rs
@@ -34,7 +34,7 @@ use crate::rest_api::ErrorResponse;
 
 use super::{
     authorize,
-    identity::{Authorization as IdentityAuthorization, GetByAuthorization, IdentityProvider},
+    identity::{Authorization as IdentityAuthorization, AuthorizationMapping, IdentityProvider},
     AuthorizationResult,
 };
 
@@ -53,12 +53,12 @@ struct IdentityExtension {
 }
 
 impl IdentityExtension {
-    /// Wrap a GetByAuthorization implementation in an IdentityExtension, to provide the ability to
-    /// add a value from the GetByAuthorization trait to the HttpRequest.
+    /// Wrap a AuthorizationMapping implementation in an IdentityExtension, to provide the ability to
+    /// add a value from the AuthorizationMapping trait to the HttpRequest.
     fn new<G, T>(get_by_auth: G) -> Self
     where
         T: 'static,
-        G: GetByAuthorization<T> + Send + Sync + 'static,
+        G: AuthorizationMapping<T> + Send + Sync + 'static,
     {
         Self {
             inner: Box::new(move |extensions, identity_auth| {
@@ -90,14 +90,14 @@ impl Authorization {
         }
     }
 
-    /// Add an authorization mapping, provided by a GetByAuthorization implementation.
-    pub fn with_authorization_mapping<G, T>(mut self, get_by_auth: G) -> Self
+    /// Add an authorization mapping, provided by a AuthorizationMapping implementation.
+    pub fn with_authorization_mapping<M, T>(mut self, auth_mapping: M) -> Self
     where
         T: 'static,
-        G: GetByAuthorization<T> + Send + Sync + 'static,
+        M: AuthorizationMapping<T> + Send + Sync + 'static,
     {
         self.identity_extensions
-            .push(Arc::new(IdentityExtension::new(get_by_auth)));
+            .push(Arc::new(IdentityExtension::new(auth_mapping)));
 
         self
     }

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -53,7 +53,7 @@ impl Clone for Box<dyn IdentityProvider> {
 }
 
 /// A trait that fetches a value based on an Authorization.
-pub trait GetByAuthorization<T> {
+pub trait AuthorizationMapping<T> {
     /// Return a value based on the given authorization value.
     fn get(&self, authorization: &Authorization) -> Result<Option<T>, InternalError>;
 }

--- a/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use diesel::{
-    dsl::insert_into, prelude::*, result::DatabaseErrorKind, result::Error as DieselError,
-};
-
-use crate::error::InternalError;
+use diesel::{dsl::insert_into, prelude::*};
 
 use crate::biome::oauth::store::{
     diesel::{models::NewOAuthUserModel, schema::oauth_user, OAuthUser},
@@ -40,17 +36,7 @@ impl<'a> OAuthUserStoreAddOAuthUserOperation
             .values(new_oauth_user)
             .execute(self.conn)
             .map(|_| ())
-            .map_err(|err| match err {
-                DieselError::DatabaseError(ref kind, _) => match kind {
-                    DatabaseErrorKind::UniqueViolation | DatabaseErrorKind::ForeignKeyViolation => {
-                        OAuthUserStoreError::ConstraintViolation(Box::new(err))
-                    }
-                    _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(
-                        err,
-                    ))),
-                },
-                _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })
+            .map_err(OAuthUserStoreError::from)
     }
 }
 
@@ -65,16 +51,6 @@ impl<'a> OAuthUserStoreAddOAuthUserOperation
             .values(new_oauth_user)
             .execute(self.conn)
             .map(|_| ())
-            .map_err(|err| match err {
-                DieselError::DatabaseError(ref kind, _) => match kind {
-                    DatabaseErrorKind::UniqueViolation | DatabaseErrorKind::ForeignKeyViolation => {
-                        OAuthUserStoreError::ConstraintViolation(Box::new(err))
-                    }
-                    _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(
-                        err,
-                    ))),
-                },
-                _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })
+            .map_err(OAuthUserStoreError::from)
     }
 }

--- a/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/update_oauth_user.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use diesel::{dsl::update, prelude::*, result::DatabaseErrorKind, result::Error as DieselError};
-
-use crate::error::InternalError;
+use diesel::{dsl::update, prelude::*};
 
 use crate::biome::oauth::store::{diesel::schema::oauth_user, OAuthUser, OAuthUserStoreError};
 
@@ -36,16 +34,6 @@ where
             ))
             .execute(self.conn)
             .map(|_| ())
-            .map_err(|err| match err {
-                DieselError::DatabaseError(ref kind, _) => match kind {
-                    DatabaseErrorKind::UniqueViolation | DatabaseErrorKind::ForeignKeyViolation => {
-                        OAuthUserStoreError::ConstraintViolation(Box::new(err))
-                    }
-                    _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(
-                        err,
-                    ))),
-                },
-                _ => OAuthUserStoreError::InternalError(InternalError::from_source(Box::new(err))),
-            })
+            .map_err(OAuthUserStoreError::from)
     }
 }

--- a/libsplinter/src/biome/oauth/store/error.rs
+++ b/libsplinter/src/biome/oauth/store/error.rs
@@ -17,15 +17,13 @@
 use std::error::Error;
 use std::fmt;
 
-use crate::error::InternalError;
-
-type ConstraintViolation = Box<dyn Error>;
+use crate::error::{ConstraintViolationError, InternalError};
 
 /// Errors that may occur during OAuthUserStore operations.
 #[derive(Debug)]
 pub enum OAuthUserStoreError {
     InternalError(InternalError),
-    ConstraintViolation(ConstraintViolation),
+    ConstraintViolation(ConstraintViolationError),
 }
 
 impl Error for OAuthUserStoreError {

--- a/libsplinter/src/biome/rest_api/actix/authorize.rs
+++ b/libsplinter/src/biome/rest_api/actix/authorize.rs
@@ -105,13 +105,10 @@ pub(crate) fn get_authorized_user(
 ) -> Result<User, ErrorHttpResponse> {
     match request.extensions().get::<User>().cloned() {
         Some(user) => Ok(user),
-        None => {
-            error!("Biome routes have not been wrapped in an authorization middleware");
-            Err(Box::new(
-                HttpResponse::InternalServerError()
-                    .json(ErrorResponse::internal_error())
-                    .into_future(),
-            ))
-        }
+        None => Err(Box::new(
+            HttpResponse::Unauthorized()
+                .json(ErrorResponse::unauthorized())
+                .into_future(),
+        )),
     }
 }

--- a/libsplinter/src/biome/rest_api/auth/credentials.rs
+++ b/libsplinter/src/biome/rest_api/auth/credentials.rs
@@ -23,12 +23,17 @@ use crate::error::InternalError;
 use crate::rest_api::secrets::SecretManager;
 use crate::rest_api::sessions::{default_validation, Claims};
 
+/// An `AuthorizationMapping` implementation that returns an `User`.
+///
+/// This mapping gets a User based on a Biome authorization token.
 pub struct GetUserByBiomeAuthorization {
     rest_config: Arc<BiomeRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
 }
 
 impl GetUserByBiomeAuthorization {
+    /// Constructs a new `GetUserByBiomeAuthorization` with the REST configuation and a secret
+    /// manager.
     pub fn new(rest_config: Arc<BiomeRestConfig>, secret_manager: Arc<dyn SecretManager>) -> Self {
         Self {
             rest_config,

--- a/libsplinter/src/biome/rest_api/auth/credentials.rs
+++ b/libsplinter/src/biome/rest_api/auth/credentials.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use jsonwebtoken::decode;
 
-use crate::auth::rest_api::identity::{Authorization, BearerToken, GetByAuthorization};
+use crate::auth::rest_api::identity::{Authorization, AuthorizationMapping, BearerToken};
 use crate::biome::rest_api::BiomeRestConfig;
 use crate::biome::user::store::User;
 use crate::error::InternalError;
@@ -37,7 +37,7 @@ impl GetUserByBiomeAuthorization {
     }
 }
 
-impl GetByAuthorization<User> for GetUserByBiomeAuthorization {
+impl AuthorizationMapping<User> for GetUserByBiomeAuthorization {
     fn get(&self, authorization: &Authorization) -> Result<Option<User>, InternalError> {
         match authorization {
             Authorization::Bearer(BearerToken::Biome(token)) => {

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -18,13 +18,13 @@ use uuid::Uuid;
 
 use crate::auth::{
     oauth::{rest_api::SaveUserInfoOperation, UserInfo},
-    rest_api::identity::{Authorization, BearerToken, GetByAuthorization},
+    rest_api::identity::{Authorization, AuthorizationMapping, BearerToken},
 };
 use crate::biome::oauth::store::{OAuthProvider, OAuthUserBuilder, OAuthUserStore};
 use crate::biome::user::store::{User, UserStore};
 use crate::error::InternalError;
 
-/// A `GetByAuthorization` implementation that returns an `User`.
+/// An `AuthorizationMapping` implementation that returns an `User`.
 pub struct GetUserByOAuthAuthorization {
     oauth_user_store: Box<dyn OAuthUserStore>,
 }
@@ -36,7 +36,7 @@ impl GetUserByOAuthAuthorization {
     }
 }
 
-impl GetByAuthorization<User> for GetUserByOAuthAuthorization {
+impl AuthorizationMapping<User> for GetUserByOAuthAuthorization {
     fn get(&self, authorization: &Authorization) -> Result<Option<User>, InternalError> {
         match authorization {
             Authorization::Bearer(BearerToken::OAuth2(access_token)) => {

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -41,7 +41,7 @@
 #[cfg(feature = "rest-api-actix")]
 mod actix;
 #[cfg(feature = "auth")]
-pub mod auth;
+pub(crate) mod auth;
 mod config;
 mod error;
 mod resources;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -502,7 +502,6 @@ impl ConfigureAuthorizationMapping {
         Self {
             config_fn: Box::new(move |authorization| {
                 if let Some(auth_mapping) = auth_mapping.take() {
-                    debug!("Configuring auth mapping {}", std::any::type_name::<G>());
                     authorization.with_authorization_mapping(auth_mapping)
                 } else {
                     authorization
@@ -793,7 +792,6 @@ impl RestApiBuilder {
         T: 'static,
         M: AuthorizationMapping<T> + Send + Sync + 'static,
     {
-        debug!("Adding auth mapping {}", std::any::type_name::<G>());
         self.authorization_mappings
             .push(ConfigureAuthorizationMapping::new(authorization_mapping));
 

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -87,7 +87,7 @@ use crate::auth::rest_api::identity::github::GithubUserIdentityProvider;
 #[cfg(feature = "auth")]
 use crate::auth::rest_api::{
     actix::Authorization,
-    identity::{GetByAuthorization, IdentityProvider},
+    identity::{AuthorizationMapping, IdentityProvider},
 };
 #[cfg(all(feature = "auth", feature = "biome-credentials"))]
 use crate::biome::rest_api::BiomeRestResourceManager;
@@ -493,12 +493,12 @@ struct ConfigureAuthorizationMapping {
 
 #[cfg(feature = "auth")]
 impl ConfigureAuthorizationMapping {
-    fn new<G, T>(get_by_auth: G) -> Self
+    fn new<M, T>(auth_mapping: M) -> Self
     where
         T: 'static,
-        G: GetByAuthorization<T> + Send + Sync + 'static,
+        M: AuthorizationMapping<T> + Send + Sync + 'static,
     {
-        let mut auth_mapping = Some(get_by_auth);
+        let mut auth_mapping = Some(auth_mapping);
         Self {
             config_fn: Box::new(move |authorization| {
                 if let Some(auth_mapping) = auth_mapping.take() {
@@ -788,10 +788,10 @@ impl RestApiBuilder {
     }
 
     #[cfg(feature = "auth")]
-    pub fn with_authorization_mapping<G, T>(mut self, authorization_mapping: G) -> Self
+    pub fn with_authorization_mapping<M, T>(mut self, authorization_mapping: M) -> Self
     where
         T: 'static,
-        G: GetByAuthorization<T> + Send + Sync + 'static,
+        M: AuthorizationMapping<T> + Send + Sync + 'static,
     {
         debug!("Adding auth mapping {}", std::any::type_name::<G>());
         self.authorization_mappings

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -549,6 +549,12 @@ impl RestApi {
             }
         }
 
+        #[cfg(feature = "rest-api-cors")]
+        let cors = match &whitelist {
+            Some(list) => cors::Cors::new(list.to_vec()),
+            None => cors::Cors::new_allow_any(),
+        };
+
         let join_handle = thread::Builder::new()
             .name("SplinterDRestApi".into())
             .spawn(move || {
@@ -557,10 +563,8 @@ impl RestApi {
                     let app = App::new();
 
                     #[cfg(feature = "rest-api-cors")]
-                    let app = app.wrap(match &whitelist {
-                        Some(list) => cors::Cors::new(list.to_vec()),
-                        None => cors::Cors::new_allow_any(),
-                    });
+                    let app = app.wrap(cors.clone());
+
                     #[cfg(feature = "auth")]
                     let app = app.wrap(authorization.clone());
 
@@ -640,6 +644,13 @@ impl RestApi {
         let resources = self.resources.to_owned();
         #[cfg(feature = "rest-api-cors")]
         let whitelist = self.whitelist.to_owned();
+
+        #[cfg(feature = "rest-api-cors")]
+        let cors = match &whitelist {
+            Some(list) => cors::Cors::new(list.to_vec()),
+            None => cors::Cors::new_allow_any(),
+        };
+
         let join_handle = thread::Builder::new()
             .name("SplinterDRestApi".into())
             .spawn(move || {
@@ -648,10 +659,7 @@ impl RestApi {
                     let app = App::new();
 
                     #[cfg(feature = "rest-api-cors")]
-                    let app = app.wrap(match &whitelist {
-                        Some(list) => cors::Cors::new(list.to_vec()),
-                        None => cors::Cors::new_allow_any(),
-                    });
+                    let app = app.wrap(cors.clone());
 
                     let mut app = app.wrap(middleware::Logger::default());
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -30,8 +30,6 @@ use scabbard::service::ScabbardArgValidator;
 use scabbard::service::ScabbardFactory;
 use splinter::admin::rest_api::CircuitResourceProvider;
 use splinter::admin::service::{admin_service_id, AdminService};
-#[cfg(feature = "biome-oauth")]
-use splinter::biome::rest_api::auth::GetUserByOAuthAuthorization;
 #[cfg(feature = "biome")]
 use splinter::biome::rest_api::{BiomeRestResourceManager, BiomeRestResourceManagerBuilder};
 use splinter::circuit::directory::CircuitDirectory;
@@ -534,12 +532,6 @@ impl SplinterDaemon {
                         user_store: store_factory.get_biome_user_store(),
                         oauth_user_store: store_factory.get_biome_oauth_user_store(),
                     };
-
-                    rest_api_builder = rest_api_builder.with_authorization_mapping(
-                        GetUserByOAuthAuthorization::new(
-                            store_factory.get_biome_oauth_user_store(),
-                        ),
-                    );
                 }
 
                 auth_configs.push(AuthConfig::OAuth {
@@ -553,12 +545,9 @@ impl SplinterDaemon {
             #[cfg(feature = "biome-credentials")]
             if self.enable_biome {
                 let biome_resource_manager = build_biome_routes(&*store_factory)?;
-                let authorization_mapping = biome_resource_manager.get_authorization_mapping();
                 auth_configs.push(AuthConfig::Biome {
                     biome_resource_manager,
                 });
-                rest_api_builder =
-                    rest_api_builder.with_authorization_mapping(authorization_mapping);
             }
 
             rest_api_builder = rest_api_builder.with_auth_configs(auth_configs);


### PR DESCRIPTION
This PR includes a number of minor fixes for Auth and biome-oauth features

- Configuring the AuthorizationMappings in the rest builder
- returning Unauthorized if no user has been supplied via the authorization
- renaming `GetByAuthorization` to `AuthorizationMapping`
- Add some docs
- Replace the placeholder `ConstraintViolation` with the real deal
- remove some debug statements left over from development time

Additionally,

- Reduce the creation of the CORS middleware to once, which results in a single log message