### PR TITLE
Represent access tokens with `AccessToken` enum

### DIFF
--- a/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/up.sql
+++ b/libsplinter/src/biome/migrations/diesel/postgres/migrations/2020-11-02-144300_create_oauth_users/up.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS oauth_user (
     id                  BIGSERIAL     PRIMARY KEY,
     user_id             TEXT          NOT NULL UNIQUE,
     provider_user_ref   TEXT          NOT NULL UNIQUE,
-    access_token        TEXT          NOT NULL,
+    access_token        TEXT,
     refresh_token       TEXT,
     provider_id         SMALLINT      NULL,
 

--- a/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/up.sql
+++ b/libsplinter/src/biome/migrations/diesel/sqlite/migrations/2020-10-28-135000/up.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS oauth_user (
     id                  INTEGER       PRIMARY KEY AUTOINCREMENT,
     user_id             TEXT          NOT NULL UNIQUE,
     provider_user_ref   TEXT          NOT NULL UNIQUE,
-    access_token        TEXT          NOT NULL,
+    access_token        TEXT,
     refresh_token       TEXT,
     provider_id         INTEGER       NOT NULL,
 

--- a/libsplinter/src/biome/oauth/store/diesel/models.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/models.rs
@@ -78,7 +78,7 @@ pub struct OAuthUserModel {
     pub id: i64,
     pub user_id: String,
     pub provider_user_ref: String,
-    pub access_token: String,
+    pub access_token: Option<String>,
     pub refresh_token: Option<String>,
     pub provider_id: ProviderId,
 }
@@ -88,7 +88,7 @@ pub struct OAuthUserModel {
 pub struct NewOAuthUserModel<'a> {
     pub user_id: &'a str,
     pub provider_user_ref: &'a str,
-    pub access_token: &'a str,
+    pub access_token: Option<&'a str>,
     pub refresh_token: Option<&'a str>,
     pub provider_id: ProviderId,
 }

--- a/libsplinter/src/biome/oauth/store/diesel/operations/get_by_access_token.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/get_by_access_token.rs
@@ -42,7 +42,7 @@ where
         access_token: &str,
     ) -> Result<Option<OAuthUser>, OAuthUserStoreError> {
         let oauth_user_model = oauth_user::table
-            .filter(oauth_user::access_token.eq(access_token))
+            .filter(oauth_user::access_token.eq(Some(access_token.to_string())))
             .first::<OAuthUserModel>(self.conn)
             .optional()
             .map_err(|err| {

--- a/libsplinter/src/biome/oauth/store/diesel/schema.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/schema.rs
@@ -17,7 +17,7 @@ table! {
         id -> Int8,
         user_id -> Text,
         provider_user_ref -> Text,
-        access_token -> Text,
+        access_token -> Nullable<Text>,
         refresh_token -> Nullable<Text>,
         provider_id -> SmallInt,
     }

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::InternalError;
 
-use super::{OAuthUser, OAuthUserStore, OAuthUserStoreError};
+use super::{AccessToken, OAuthUser, OAuthUserStore, OAuthUserStoreError};
 
 #[derive(Default, Clone)]
 pub struct MemoryOAuthUserStore {
@@ -81,7 +81,9 @@ impl OAuthUserStore for MemoryOAuthUserStore {
 
         Ok(inner
             .values()
-            .find(|oauth_user| oauth_user.access_token() == access_token)
+            .find(|oauth_user| {
+                oauth_user.access_token() == &AccessToken::Authorized(access_token.to_string())
+            })
             .cloned())
     }
 

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -30,6 +30,19 @@ pub enum OAuthProvider {
     Github,
 }
 
+/// Access token assigned to a user when they have been successfully authorized.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AccessToken {
+    Authorized(String),
+    Unauthorized,
+}
+
+impl Default for AccessToken {
+    fn default() -> Self {
+        AccessToken::Unauthorized
+    }
+}
+
 /// A user defined by an OAuth Provider.
 ///
 /// This user is connected to a Biome User, via a user ID.
@@ -38,7 +51,7 @@ pub struct OAuthUser {
     user_id: String,
     provider_user_ref: String,
 
-    access_token: String,
+    access_token: AccessToken,
     refresh_token: Option<String>,
     provider: OAuthProvider,
 }
@@ -57,7 +70,7 @@ impl OAuthUser {
     }
 
     /// Return the user's current access token.
-    pub fn access_token(&self) -> &str {
+    pub fn access_token(&self) -> &AccessToken {
         &self.access_token
     }
 
@@ -96,7 +109,7 @@ pub struct OAuthUserBuilder {
     user_id: Option<String>,
     provider_user_ref: Option<String>,
 
-    access_token: Option<String>,
+    access_token: AccessToken,
     refresh_token: Option<String>,
     provider: Option<OAuthProvider>,
 }
@@ -121,8 +134,8 @@ impl OAuthUserBuilder {
     }
 
     /// Set the OAuth access token.
-    pub fn with_access_token(mut self, access_token: String) -> Self {
-        self.access_token = Some(access_token);
+    pub fn with_access_token(mut self, access_token: AccessToken) -> Self {
+        self.access_token = access_token;
 
         self
     }
@@ -159,11 +172,7 @@ impl OAuthUserBuilder {
                         .into(),
                 )
             })?,
-            access_token: self.access_token.ok_or_else(|| {
-                InvalidStateError(
-                    "An access token is required to successfully build an OAuthUser".into(),
-                )
-            })?,
+            access_token: self.access_token,
             refresh_token: self.refresh_token,
             provider: self.provider.ok_or_else(|| {
                 InvalidStateError(
@@ -185,13 +194,13 @@ pub struct OAuthUserUpdateBuilder {
     provider: OAuthProvider,
 
     // "mutable" items
-    access_token: String,
+    access_token: AccessToken,
     refresh_token: Option<String>,
 }
 
 impl OAuthUserUpdateBuilder {
     /// Set the OAuth access token.
-    pub fn with_access_token(mut self, access_token: String) -> Self {
+    pub fn with_access_token(mut self, access_token: AccessToken) -> Self {
         self.access_token = access_token;
 
         self

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -20,7 +20,7 @@ use crate::auth::{
     oauth::{rest_api::SaveUserInfoOperation, UserInfo},
     rest_api::identity::{Authorization, BearerToken, GetByAuthorization},
 };
-use crate::biome::oauth::store::{OAuthProvider, OAuthUserBuilder, OAuthUserStore};
+use crate::biome::oauth::store::{AccessToken, OAuthProvider, OAuthUserBuilder, OAuthUserStore};
 use crate::biome::user::store::{User, UserStore};
 use crate::error::InternalError;
 
@@ -95,7 +95,9 @@ impl SaveUserInfoOperation for OAuthUserStoreSaveUserInfoOperation {
         if let Some(oauth_user) = existing_oauth_user {
             let updated_user = oauth_user
                 .into_update_builder()
-                .with_access_token(user_info.access_token().into())
+                .with_access_token(AccessToken::Authorized(
+                    user_info.access_token().to_string(),
+                ))
                 .with_refresh_token(user_info.refresh_token().map(String::from))
                 .build()
                 .map_err(|e| {
@@ -119,7 +121,9 @@ impl SaveUserInfoOperation for OAuthUserStoreSaveUserInfoOperation {
             let oauth_user = OAuthUserBuilder::new()
                 .with_user_id(user_id)
                 .with_provider_user_ref(provider_identity)
-                .with_access_token(user_info.access_token().into())
+                .with_access_token(AccessToken::Authorized(
+                    user_info.access_token().to_string(),
+                ))
                 .with_refresh_token(user_info.refresh_token().map(String::from))
                 .with_provider(self.provider.clone())
                 .build()


### PR DESCRIPTION
Adds an enum, `AccessToken`, to represent access tokens in the
OAuthUserStore to allow for the `access_token` field to be represented
by the database as a nullable string. This allows for the access token
field to be `Authorized` with the token string, or `Unauthorized` with
no token string. A user may be `Unauthorized` after logging out, for
example.

Signed-off-by: Shannyn Telander <telander@bitwise.io>