### PR TITLE
Add Cylinder jwt to Scabbard cli

### DIFF
--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -36,7 +36,7 @@ flexi_logger = "0.14"
 log = "0.4"
 sabre-sdk = "0.6"
 transact = { version = "0.3", features = ["contract-archive"] }
-scabbard = { path = "../libscabbard", features = ["client"] }
+scabbard = { path = "../libscabbard", features = ["client", "client-auth"] }
 
 [dev-dependencies]
 serial_test = "0.3"
@@ -52,8 +52,10 @@ experimental = [
   "stable",
   # The following features are experimental:
   "smart-permissions",
+  "scabbard-cli-jwt"
 ]
 
+scabbard-cli-jwt = ["cylinder/jwt", "cylinder/key-load", "scabbard/client-auth"]
 smart-permissions = []
 
 [package.metadata.deb]

--- a/services/scabbard/cli/src/main.rs
+++ b/services/scabbard/cli/src/main.rs
@@ -44,10 +44,12 @@ use sabre_sdk::{
     },
     protos::FromBytes,
 };
-use scabbard::client::{ScabbardClient, ServiceId};
+use scabbard::client::{ScabbardClientBuilder, ServiceId};
 use transact::contract::archive::{default_scar_path, SmartContractArchive};
 
 use error::CliError;
+#[cfg(feature = "scabbard-cli-jwt")]
+use key::create_cylinder_jwt_auth;
 
 fn main() {
     if let Err(e) = run() {
@@ -749,7 +751,19 @@ fn run() -> Result<(), CliError> {
         ("contract", Some(matches)) => match matches.subcommand() {
             ("upload", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
+                let key = matches
+                    .value_of("key")
+                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -764,9 +778,6 @@ fn run() -> Result<(), CliError> {
                         CliError::InvalidArgument("'wait' argument must be a valid integer".into())
                     })?;
 
-                let key = matches
-                    .value_of("key")
-                    .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
 
                 let scar = matches
@@ -800,7 +811,17 @@ fn run() -> Result<(), CliError> {
             }
             ("list", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    let key = matches.value_of("key");
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(key)?);
+                }
+
+                let client = builder.build()?;
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -850,7 +871,17 @@ fn run() -> Result<(), CliError> {
             }
             ("show", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    let key = matches.value_of("key");
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(key)?);
+                }
+
+                let client = builder.build()?;
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -895,7 +926,6 @@ fn run() -> Result<(), CliError> {
         },
         ("exec", Some(matches)) => {
             let url = matches.value_of("url").expect("default not set for --url");
-            let client = ScabbardClient::new(url);
 
             let full_service_id = matches
                 .value_of("service-id")
@@ -914,6 +944,16 @@ fn run() -> Result<(), CliError> {
                 .value_of("key")
                 .ok_or_else(|| CliError::MissingArgument("key".into()))?;
             let signer = key::load_signer(key)?;
+
+            let mut builder = ScabbardClientBuilder::new();
+            builder = builder.with_url(url);
+
+            #[cfg(feature = "scabbard-cli-jwt")]
+            {
+                builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+            }
+
+            let client = builder.build()?;
 
             let contract = matches
                 .value_of("contract")
@@ -955,7 +995,6 @@ fn run() -> Result<(), CliError> {
         ("ns", Some(matches)) => match matches.subcommand() {
             ("create", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -974,6 +1013,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let namespace = matches
                     .value_of("namespace")
@@ -996,7 +1045,6 @@ fn run() -> Result<(), CliError> {
             }
             ("update", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1015,6 +1063,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let namespace = matches
                     .value_of("namespace")
@@ -1037,7 +1095,6 @@ fn run() -> Result<(), CliError> {
             }
             ("delete", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1057,6 +1114,16 @@ fn run() -> Result<(), CliError> {
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
 
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
+
                 let namespace = matches
                     .value_of("namespace")
                     .ok_or_else(|| CliError::MissingArgument("namespace".into()))?;
@@ -1074,7 +1141,6 @@ fn run() -> Result<(), CliError> {
         },
         ("perm", Some(matches)) => {
             let url = matches.value_of("url").expect("default not set for --url");
-            let client = ScabbardClient::new(url);
 
             let full_service_id = matches
                 .value_of("service-id")
@@ -1093,6 +1159,16 @@ fn run() -> Result<(), CliError> {
                 .value_of("key")
                 .ok_or_else(|| CliError::MissingArgument("key".into()))?;
             let signer = key::load_signer(key)?;
+
+            let mut builder = ScabbardClientBuilder::new();
+            builder = builder.with_url(url);
+
+            #[cfg(feature = "scabbard-cli-jwt")]
+            {
+                builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+            }
+
+            let client = builder.build()?;
 
             let namespace = matches
                 .value_of("namespace")
@@ -1127,7 +1203,6 @@ fn run() -> Result<(), CliError> {
         ("cr", Some(matches)) => match matches.subcommand() {
             ("create", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1146,6 +1221,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let name = matches
                     .value_of("name")
@@ -1168,7 +1253,6 @@ fn run() -> Result<(), CliError> {
             }
             ("update", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1187,6 +1271,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let name = matches
                     .value_of("name")
@@ -1209,7 +1303,6 @@ fn run() -> Result<(), CliError> {
             }
             ("delete", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1228,6 +1321,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let name = matches
                     .value_of("name")
@@ -1247,7 +1350,6 @@ fn run() -> Result<(), CliError> {
         ("sp", Some(matches)) => match matches.subcommand() {
             ("create", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1266,6 +1368,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let org_id = matches
                     .value_of("org_id")
@@ -1291,7 +1403,6 @@ fn run() -> Result<(), CliError> {
             }
             ("update", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1310,6 +1421,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let org_id = matches
                     .value_of("org_id")
@@ -1335,7 +1456,6 @@ fn run() -> Result<(), CliError> {
             }
             ("delete", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
 
                 let full_service_id = matches
                     .value_of("service-id")
@@ -1354,6 +1474,16 @@ fn run() -> Result<(), CliError> {
                     .value_of("key")
                     .ok_or_else(|| CliError::MissingArgument("key".into()))?;
                 let signer = key::load_signer(key)?;
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(Some(key))?);
+                }
+
+                let client = builder.build()?;
 
                 let org_id = matches
                     .value_of("org_id")
@@ -1377,7 +1507,17 @@ fn run() -> Result<(), CliError> {
         ("state", Some(matches)) => match matches.subcommand() {
             ("root", Some(matches)) => {
                 let url = matches.value_of("url").expect("default not set for --url");
-                let client = ScabbardClient::new(url);
+
+                let mut builder = ScabbardClientBuilder::new();
+                builder = builder.with_url(url);
+
+                #[cfg(feature = "scabbard-cli-jwt")]
+                {
+                    let key = matches.value_of("key");
+                    builder = builder.with_auth(&create_cylinder_jwt_auth(key)?);
+                }
+
+                let client = builder.build()?;
 
                 let full_service_id = matches
                     .value_of("service-id")

--- a/services/scabbard/cli/src/main.rs
+++ b/services/scabbard/cli/src/main.rs
@@ -150,6 +150,11 @@ fn run() -> Result<(), CliError> {
                                 .takes_value(true)
                                 .possible_values(&["human", "csv"])
                                 .default_value("human"),
+                            Arg::with_name("key")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Name or path of private key"),
                         ]),
                 )
                 .subcommand(
@@ -177,6 +182,11 @@ fn run() -> Result<(), CliError> {
                                 )
                                 .takes_value(true)
                                 .required(true),
+                            Arg::with_name("key")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Name or path of private key"),
                         ]),
                 ),
         )
@@ -575,6 +585,11 @@ fn run() -> Result<(), CliError> {
                                 .long("service-id")
                                 .takes_value(true)
                                 .required(true),
+                            Arg::with_name("key")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Name or path of private key"),
                         ]),
                 ),
         );

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -64,10 +64,12 @@ experimental = [
   # The experimental feature extends stable:
   "stable",
   # The following features are experimental:
+  "client-auth"
 ]
 
 client = ["reqwest"]
 events = ["splinter/events"]
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
+client-auth = []
 service-arg-validation = ["splinter/service-arg-validation"]

--- a/services/scabbard/libscabbard/src/client/builder.rs
+++ b/services/scabbard/libscabbard/src/client/builder.rs
@@ -21,6 +21,8 @@ use super::ScabbardClient;
 #[derive(Default)]
 pub struct ScabbardClientBuilder {
     url: Option<String>,
+    #[cfg(feature = "client-auth")]
+    auth: Option<String>,
 }
 
 impl ScabbardClientBuilder {
@@ -40,16 +42,33 @@ impl ScabbardClientBuilder {
         self
     }
 
+    /// Sets the `auth` field of the `ScabbardClientBuilder`. The `auth` string will be
+    /// submitted to the Splinter REST API in an Authorization header.
+    ///
+    /// # Arguments
+    ///
+    /// * `auth` - The authorization string to be submitted to the Splinter REST API.
+    #[cfg(feature = "client-auth")]
+    pub fn with_auth(mut self, auth: &str) -> Self {
+        self.auth = Some(auth.into());
+        self
+    }
+
     /// Builds a `ScabbardClient`.
     ///
     /// # Errors
     ///
     /// Returns an error in any of the following cases:
     /// * Returns an error if url is not set
+    /// * Returns an error if the client-auth feature is enabled and auth is not set
     pub fn build(self) -> Result<ScabbardClient, ScabbardClientError> {
         Ok(ScabbardClient {
             url: self.url.ok_or_else(|| {
                 ScabbardClientError::new("Failed to build client, url not provided")
+            })?,
+            #[cfg(feature = "client-auth")]
+            auth: self.auth.ok_or_else(|| {
+                ScabbardClientError::new("Failed to build client, jwt authorization not provided")
             })?,
         })
     }

--- a/services/scabbard/libscabbard/src/client/builder.rs
+++ b/services/scabbard/libscabbard/src/client/builder.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A convenient client for interacting with scabbard services on a Splinter node.
+
+use super::error::ScabbardClientError;
+use super::ScabbardClient;
+
+/// Builder for building a [`ScabbardClient`](crate::client::ScabbardClient).
+#[derive(Default)]
+pub struct ScabbardClientBuilder {
+    url: Option<String>,
+}
+
+impl ScabbardClientBuilder {
+    /// Creates a new `ScabbardClientBuilder`.
+    pub fn new() -> Self {
+        ScabbardClientBuilder::default()
+    }
+
+    /// Sets the `url` field of the `ScabbardClientBuilder`. The url will be used
+    /// as the bind endpoint for the Splinter REST API.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the bind endpoint of the Splinter REST API.
+    pub fn with_url(mut self, url: &str) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Builds a `ScabbardClient`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error in any of the following cases:
+    /// * Returns an error if url is not set
+    pub fn build(self) -> Result<ScabbardClient, ScabbardClientError> {
+        Ok(ScabbardClient {
+            url: self.url.ok_or_else(|| {
+                ScabbardClientError::new("Failed to build client, url not provided")
+            })?,
+        })
+    }
+}

--- a/services/scabbard/libscabbard/src/client/mod.rs
+++ b/services/scabbard/libscabbard/src/client/mod.rs
@@ -14,6 +14,7 @@
 
 //! A convenient client for interacting with scabbard services on a Splinter node.
 
+mod builder;
 mod error;
 
 use std::time::{Duration, Instant, SystemTime};
@@ -27,6 +28,7 @@ use transact::{protocol::batch::Batch, protos::IntoBytes};
 use super::hex::parse_hex;
 use super::protocol::SCABBARD_PROTOCOL_VERSION;
 
+pub use builder::ScabbardClientBuilder;
 pub use error::ScabbardClientError;
 
 /// A client that can be used to interact with scabbard services on a Splinter node.
@@ -35,12 +37,6 @@ pub struct ScabbardClient {
 }
 
 impl ScabbardClient {
-    /// Create a new `ScabbardClient` with the given base `url`. The URL should be the bind endpoint
-    /// of the Splinter REST API; it should not include the path to the scabbard service itself.
-    pub fn new(url: &str) -> Self {
-        Self { url: url.into() }
-    }
-
     /// Submit the given `batches` to the scabbard service with the given `service_id`. If a `wait`
     /// time is specified, wait the given amount of time for the batches to commit.
     ///
@@ -533,7 +529,12 @@ mod tests {
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(resource_manager.resources());
 
-        let client = ScabbardClient::new(&format!("http://{}", bind_url));
+        let mut builder = ScabbardClientBuilder::new();
+
+        builder = builder.with_url(&format!("http://{}", bind_url));
+
+        let client = builder.build().expect("unable to build client");
+
         let service_id = ServiceId::new(MOCK_CIRCUIT_ID, MOCK_SERVICE_ID);
 
         // Verify that a basic batch submission with no wait time is successful
@@ -547,9 +548,11 @@ mod tests {
             .expect("Failed to submit batches with wait");
 
         // Verify that an invalid URL results in an error being returned
-        assert!(ScabbardClient::new("not a valid URL")
-            .submit(&service_id, vec![], None,)
-            .is_err());
+        let mut invalid_builder = ScabbardClientBuilder::new();
+        invalid_builder = invalid_builder.with_url("not a valid URL");
+
+        let client = invalid_builder.build().expect("unable to build client");
+        assert!(client.submit(&service_id, vec![], None,).is_err());
 
         // Verify that an error response code results in an error being returned
         resource_manager.internal_server_error(true);
@@ -584,7 +587,11 @@ mod tests {
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(resource_manager.resources());
 
-        let client = ScabbardClient::new(&format!("http://{}", bind_url));
+        let mut builder = ScabbardClientBuilder::new();
+
+        builder = builder.with_url(&format!("http://{}", bind_url));
+
+        let client = builder.build().expect("unable to build client");
         let service_id = ServiceId::new(MOCK_CIRCUIT_ID, MOCK_SERVICE_ID);
 
         // Verify that a request for an existing entry is successful and returns the right value
@@ -600,9 +607,11 @@ mod tests {
         assert_eq!(value, None);
 
         // Verify that an invalid URL results in an error being returned
-        assert!(ScabbardClient::new("not a valid URL")
-            .get_state_at_address(&service_id, &mock_state_entry().address)
-            .is_err());
+        let mut invalid_builder = ScabbardClientBuilder::new();
+        invalid_builder = invalid_builder.with_url("not a valid URL");
+
+        let client = invalid_builder.build().expect("unable to build client");
+        assert!(client.submit(&service_id, vec![], None,).is_err());
 
         // Verify that an invalid address results in an error being returned
         assert!(client
@@ -629,7 +638,11 @@ mod tests {
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(resource_manager.resources());
 
-        let client = ScabbardClient::new(&format!("http://{}", bind_url));
+        let mut builder = ScabbardClientBuilder::new();
+
+        builder = builder.with_url(&format!("http://{}", bind_url));
+
+        let client = builder.build().expect("unable to build client");
         let service_id = ServiceId::new(MOCK_CIRCUIT_ID, MOCK_SERVICE_ID);
 
         // Verify that a request with no prefix is successful and returns the right value
@@ -653,9 +666,11 @@ mod tests {
         assert_eq!(entries, vec![]);
 
         // Verify that an invalid URL results in an error being returned
-        assert!(ScabbardClient::new("not a valid URL")
-            .get_state_with_prefix(&service_id, None)
-            .is_err());
+        let mut invalid_builder = ScabbardClientBuilder::new();
+        invalid_builder = invalid_builder.with_url("not a valid URL");
+
+        let client = invalid_builder.build().expect("unable to build client");
+        assert!(client.submit(&service_id, vec![], None,).is_err());
 
         // Verify that an invalid address prefix results in an error being returned
         assert!(client
@@ -680,7 +695,11 @@ mod tests {
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(resource_manager.resources());
 
-        let client = ScabbardClient::new(&format!("http://{}", bind_url));
+        let mut builder = ScabbardClientBuilder::new();
+
+        builder = builder.with_url(&format!("http://{}", bind_url));
+
+        let client = builder.build().expect("unable to build client");
         let service_id = ServiceId::new(MOCK_CIRCUIT_ID, MOCK_SERVICE_ID);
 
         // Verify that a request returns the right value


### PR DESCRIPTION
- Create `ScabbardClientBuilder` for building scabbard clients. Has a `with_url` function to set the url field and a `with_auth` function to set the auth field. `with_auth` is behind the experimental feature `client-jwt`.

- Modifies client functions to submit the string stored in the `auth` field in an authorization header when the `client-jwt` feature is enabled and requests are made to the REST API.

- Add a `create_cylinder_jwt_auth` function to create the auth string that is submitted to the REST API in an "Authorization" header. The auth string contains a json web token created and signed using cylinder jwt. The function is behind an experimental feature scabbard-cli-jwt.

- Add a `--key` option to the scabbard cli subcommands that don't already have it.

- Use ScabbardClientBuilder to create clients in scabbard cli, when the scabbard-cli-jwt feature is enabled create an auth string containing a json web token and call the builder's `with_auth` function.

**Testing:** 

run gameroom (or other node + smart contract setup) so scabbard cli can be used to interact with a smart contract
`docker-compose -f examples/gameroom/docker-compose.yaml up --build`

Set up a circuit in gameroom

from the splinter/cli directory get the circuit ID of the game room circuit
`cargo run --features splinter-cli-jwt circuit list --url http://localhost:8088`

from the splinter/cli directory get the service ID of the acme node
`cargo run --features splinter-cli-jwt circuit show --url http://localhost:8088 <circuit ID>`

from the scabbard/cli directory run a scabbard command with a valid key name (or no key name to use default key in home directory)
` cargo run --features scabbard-cli-jwt contract list --url http://localhost:8088 --service-id <circuit_ID>::<service_ID> --key <key_name>`

verify command was successful and the xo contract is printed in table format

run a scabbard command with an invalid key name
` cargo run --features scabbard-cli-jwt contract list --url http://localhost:8088 --service-id <circuit_ID>::<service_ID> --key bad_key`

verify command fails and gives an error message stating the key could not be found