### PR TITLE
Guard items with biome-credentials only

### DIFF
--- a/libsplinter/src/biome/rest_api/resources/mod.rs
+++ b/libsplinter/src/biome/rest_api/resources/mod.rs
@@ -14,7 +14,7 @@
 
 //! Provides structures for the REST resources.
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials"))]
+#[cfg(feature = "biome-credentials")]
 pub(in crate::biome::rest_api) mod authorize;
 #[cfg(feature = "biome-credentials")]
 pub(in crate::biome::rest_api) mod credentials;

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -18,7 +18,7 @@ mod claims;
 mod error;
 mod token_issuer;
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
+#[cfg(feature = "biome-credentials")]
 use jsonwebtoken::Validation;
 use serde::Serialize;
 
@@ -26,7 +26,7 @@ pub use claims::{Claims, ClaimsBuilder};
 pub use error::{ClaimsBuildError, TokenIssuerError, TokenValidationError};
 pub use token_issuer::AccessTokenIssuer;
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
+#[cfg(feature = "biome-credentials")]
 const DEFAULT_LEEWAY: i64 = 10; // default leeway in seconds.
 
 /// Implementers can issue JWT tokens
@@ -38,7 +38,7 @@ pub trait TokenIssuer<T: Serialize> {
     fn issue_refresh_token_with_claims(&self, claims: T) -> Result<String, TokenIssuerError>;
 }
 
-#[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
+#[cfg(feature = "biome-credentials")]
 pub(crate) fn default_validation(issuer: &str) -> Validation {
     let mut validation = Validation::default();
     validation.leeway = DEFAULT_LEEWAY;


### PR DESCRIPTION
This change guard modules, structs and fns with biome-credentials only, essentially separating it from the key-management configuration.  This allows splinterd to be compiled without biome-credentials, but the rest of biome (i.e. key-management) without any warnings.

This removes warnings when compiled without `biome-credentials`:

```
$ cargo run --manifest-path splinterd/Cargo.toml --no-default-features \
    --features biome,biome-key-management,auth,biome-oauth,rest-api-cors -- \
    --database postgres://postgres:mypassword@localhost:5432/splinter \
    --tls-insecure \
    --enable-biome  \
    -vv
```

OAuth continues to work with biome key management in this configuration.