### PR TITLE
Update ServiceStartError to take a String instead of Box<dyn Error + Send>

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -257,7 +257,9 @@ impl AdminService {
                 ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
             })?
             .get_circuits()
-            .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+            .map_err(|err| {
+                ServiceStartError::Internal(format!("Unable to get circuits: {}", err))
+            })?;
 
         let nodes = self
             .admin_service_shared
@@ -266,7 +268,7 @@ impl AdminService {
                 ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
             })?
             .get_nodes()
-            .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+            .map_err(|err| ServiceStartError::Internal(format!("Unable to get nodes: {}", err)))?;
 
         let orchestrator = self.orchestrator.lock().map_err(|_| {
             ServiceStartError::PoisonedLock("the admin orchestrator lock was poisoned".into())
@@ -400,7 +402,10 @@ impl Service for AdminService {
             self.admin_service_shared.clone(),
             self.coordinator_timeout,
         )
-        .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+        .map_err(|err| {
+            ServiceStartError::Internal(format!("Unable to start consensus: {}", err))
+        })?;
+
         let proposal_sender = consensus.proposal_update_sender();
 
         self.consensus = Some(consensus);
@@ -420,7 +425,9 @@ impl Service for AdminService {
                 ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
             })?
             .add_services_to_directory()
-            .map_err(|err| ServiceStartError::Internal(Box::new(err)))?;
+            .map_err(|err| {
+                ServiceStartError::Internal(format!("Unable to add services to directory: {}", err))
+            })?;
 
         self.admin_service_shared
             .lock()

--- a/libsplinter/src/circuit/routing/error.rs
+++ b/libsplinter/src/circuit/routing/error.rs
@@ -28,6 +28,19 @@ pub enum RoutingTableReaderError {
     InvalidStateError(InvalidStateError),
 }
 
+impl RoutingTableReaderError {
+    /// Reduces the `RoutingTableReaderError to the display string
+    ///
+    /// If the error is `InternalError` and includes a source, the debug format will be logged to
+    /// provide information that may be lost on the conversion.
+    pub fn reduce_to_string(self) -> String {
+        match self {
+            RoutingTableReaderError::InternalError(err) => err.reduce_to_string(),
+            _ => self.to_string(),
+        }
+    }
+}
+
 impl Error for RoutingTableReaderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {

--- a/libsplinter/src/error/internal.rs
+++ b/libsplinter/src/error/internal.rs
@@ -126,6 +126,18 @@ impl InternalError {
             source: None,
         }
     }
+
+    /// Reduces the `InternalError` to the display string
+    ///
+    /// If the error includes a source, the debug format will be logged to provide
+    /// information that may be lost on the conversion.
+    pub fn reduce_to_string(self) -> String {
+        if self.source.is_some() {
+            debug!("{:?}", self);
+        }
+
+        self.to_string()
+    }
 }
 
 impl error::Error for InternalError {

--- a/libsplinter/src/service/error.rs
+++ b/libsplinter/src/service/error.rs
@@ -103,7 +103,7 @@ impl std::fmt::Display for ServiceDisconnectionError {
 pub enum ServiceStartError {
     AlreadyStarted,
     UnableToConnect(ServiceConnectionError),
-    Internal(Box<dyn Error + Send>),
+    Internal(String),
     PoisonedLock(String),
 }
 
@@ -112,7 +112,7 @@ impl Error for ServiceStartError {
         match self {
             ServiceStartError::AlreadyStarted => None,
             ServiceStartError::UnableToConnect(err) => Some(err),
-            ServiceStartError::Internal(err) => Some(&**err),
+            ServiceStartError::Internal(_) => None,
             ServiceStartError::PoisonedLock(_) => None,
         }
     }
@@ -125,7 +125,7 @@ impl std::fmt::Display for ServiceStartError {
             ServiceStartError::UnableToConnect(err) => {
                 write!(f, "unable to connect on start: {}", err)
             }
-            ServiceStartError::Internal(err) => write!(f, "unable to start service: {}", err),
+            ServiceStartError::Internal(msg) => write!(f, "unable to start service: {}", msg),
             ServiceStartError::PoisonedLock(msg) => write!(f, "a lock was poisoned: {}", msg),
         }
     }

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -260,7 +260,9 @@ impl Service for Scabbard {
                 self.state.clone(),
                 self.coordinator_timeout,
             )
-            .map_err(|err| ServiceStartError::Internal(Box::new(ScabbardError::from(err))))?,
+            .map_err(|err| {
+                ServiceStartError::Internal(format!("Unable to start consensus: {}", err))
+            })?,
         );
 
         Ok(())


### PR DESCRIPTION
If a component is using the top level InternalError, that error can not be passed as Box<dyn Error + Send>. Instead we provide a function to InternalError to be reduce the error to a string that can be passed that to ServiceStartError.