### PR TITLE
Add `/oauth/logout` endpoint

### DIFF
--- a/libsplinter/src/auth/oauth/rest_api/actix/logout.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/logout.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `GET /oauth/logout` endpoint for removing a user's tokens.
+
+use actix_web::HttpResponse;
+use futures::future::IntoFuture;
+
+use crate::auth::oauth::rest_api::OAuthUserInfoStore;
+use crate::protocol;
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+
+use crate::biome::rest_api::auth::OAuthUserIdentityRef;
+
+pub fn make_logout_route(user_info_store: Box<dyn OAuthUserInfoStore>) -> Resource {
+    Resource::build("/oauth/logout")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::OAUTH_LOGOUT_MIN,
+            protocol::OAUTH_PROTOCOL_VERSION,
+        ))
+        .add_method(Method::Get, move |req, _| {
+            Box::new(match req.extensions().get::<OAuthUserIdentityRef>() {
+                Some(OAuthUserIdentityRef(identity)) => {
+                    match user_info_store.remove_user_tokens(&identity) {
+                        Ok(()) => HttpResponse::Ok()
+                            .json(json!({
+                                "message": "User successfully logged out"
+                            }))
+                            .into_future(),
+                        Err(err) => {
+                            error!("Unable to remove user tokens: {}", err);
+                            HttpResponse::InternalServerError()
+                                .json(ErrorResponse::internal_error())
+                                .into_future()
+                        }
+                    }
+                }
+                None => HttpResponse::Unauthorized()
+                    .json(ErrorResponse::unauthorized())
+                    .into_future(),
+            })
+        })
+}

--- a/libsplinter/src/auth/oauth/rest_api/actix/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/actix/mod.rs
@@ -14,3 +14,4 @@
 
 pub(super) mod callback;
 pub(super) mod login;
+pub(super) mod logout;

--- a/libsplinter/src/auth/oauth/rest_api/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/mod.rs
@@ -72,6 +72,7 @@ impl OAuthUserInfoStore for OAuthUserInfoStoreNoOp {
 ///
 /// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
 /// * `GET /oauth/callback` - Receive the authorization code from the provider
+/// * `GET /oauth/logout` - Remove the user's access and refresh tokens
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
@@ -96,6 +97,7 @@ impl OAuthResourceProvider {
 ///
 /// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
 /// * `GET /oauth/callback` - Receive the authorization code from the provider
+/// * `GET /oauth/logout` - Remove the user's access and refresh tokens
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
@@ -115,6 +117,7 @@ impl RestResourceProvider for OAuthResourceProvider {
                     self.client.clone(),
                     self.user_info_store.clone(),
                 ),
+                actix::logout::make_logout_route(self.user_info_store.clone()),
             ]);
         }
 

--- a/libsplinter/src/auth/oauth/rest_api/mod.rs
+++ b/libsplinter/src/auth/oauth/rest_api/mod.rs
@@ -28,6 +28,9 @@ pub trait OAuthUserInfoStore: Sync + Send {
     /// Executes a save operation on the given user info.
     fn save_user_info(&self, user_info: &UserInfo) -> Result<(), InternalError>;
 
+    /// Executes an update operation to remove the user's tokens.
+    fn remove_user_tokens(&self, identity: &str) -> Result<(), InternalError>;
+
     /// Clone implementation for `OAuthUserInfoStore`. The implementation of the `Clone` trait
     /// for `Box<dyn OAuthUserInfoStore>` calls this method.
     ///
@@ -52,6 +55,10 @@ pub struct OAuthUserInfoStoreNoOp;
 
 impl OAuthUserInfoStore for OAuthUserInfoStoreNoOp {
     fn save_user_info(&self, _user_info: &UserInfo) -> Result<(), InternalError> {
+        Ok(())
+    }
+
+    fn remove_user_tokens(&self, _identity: &str) -> Result<(), InternalError> {
         Ok(())
     }
 

--- a/libsplinter/src/auth/rest_api/mod.rs
+++ b/libsplinter/src/auth/rest_api/mod.rs
@@ -53,7 +53,7 @@ fn authorize(
         is_auth_endpoint = true;
     }
     #[cfg(feature = "oauth")]
-    if endpoint.starts_with("/oauth") {
+    if endpoint == "/oauth/login" || endpoint == "/oauth/callback" {
         is_auth_endpoint = true;
     }
     if is_auth_endpoint {

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -20,6 +20,6 @@ mod oauth;
 #[cfg(feature = "biome-credentials")]
 pub use credentials::GetUserByBiomeAuthorization;
 #[cfg(feature = "biome-oauth")]
-pub use oauth::GetUserByOAuthAuthorization;
+pub use oauth::BiomeOAuthUserInfoStore;
 #[cfg(feature = "biome-oauth")]
-pub use oauth::OAuthUserStoreSaveUserInfoOperation;
+pub use oauth::GetUserByOAuthAuthorization;

--- a/libsplinter/src/biome/rest_api/auth/mod.rs
+++ b/libsplinter/src/biome/rest_api/auth/mod.rs
@@ -23,3 +23,7 @@ pub use credentials::GetUserByBiomeAuthorization;
 pub use oauth::BiomeOAuthUserInfoStore;
 #[cfg(feature = "biome-oauth")]
 pub use oauth::GetUserByOAuthAuthorization;
+#[cfg(feature = "biome-oauth")]
+pub use oauth::GetUserIdentityByOAuthAuthorization;
+#[cfg(feature = "biome-oauth")]
+pub use oauth::OAuthUserIdentityRef;

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -18,7 +18,7 @@
 use uuid::Uuid;
 
 use crate::auth::{
-    oauth::{rest_api::SaveUserInfoOperation, UserInfo},
+    oauth::{rest_api::OAuthUserInfoStore, UserInfo},
     rest_api::identity::{Authorization, AuthorizationMapping, BearerToken},
 };
 use crate::biome::oauth::store::{AccessToken, OAuthProvider, OAuthUserBuilder, OAuthUserStore};
@@ -59,18 +59,18 @@ impl AuthorizationMapping<User> for GetUserByOAuthAuthorization {
     }
 }
 
-/// Biome-backed implementation of the SaveUserInfoOperation trait.
+/// Biome-backed implementation of the `OAuthUserInfoStore` trait.
 ///
-/// This implementation stores the UserToken values using the OAuthUserStore provided by Biome.
+/// This implementation uses the `OAuthUserStore` provided by Biome.
 #[derive(Clone)]
-pub struct OAuthUserStoreSaveUserInfoOperation {
+pub struct BiomeOAuthUserInfoStore {
     provider: OAuthProvider,
     user_store: Box<dyn UserStore>,
     oauth_user_store: Box<dyn OAuthUserStore>,
 }
 
-impl OAuthUserStoreSaveUserInfoOperation {
-    /// Construct a new OAuthUserStoreSaveUserInfoOperation.
+impl BiomeOAuthUserInfoStore {
+    /// Construct a new `BiomeOAuthUserInfoStore`.
     pub fn new(
         provider: OAuthProvider,
         user_store: Box<dyn UserStore>,
@@ -84,7 +84,7 @@ impl OAuthUserStoreSaveUserInfoOperation {
     }
 }
 
-impl SaveUserInfoOperation for OAuthUserStoreSaveUserInfoOperation {
+impl OAuthUserInfoStore for BiomeOAuthUserInfoStore {
     fn save_user_info(&self, user_info: &UserInfo) -> Result<(), InternalError> {
         let provider_identity = user_info.identity().to_string();
 
@@ -143,7 +143,7 @@ impl SaveUserInfoOperation for OAuthUserStoreSaveUserInfoOperation {
         Ok(())
     }
 
-    fn clone_box(&self) -> Box<dyn SaveUserInfoOperation> {
+    fn clone_box(&self) -> Box<dyn OAuthUserInfoStore> {
         Box::new(self.clone())
     }
 }

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -59,6 +59,46 @@ impl AuthorizationMapping<User> for GetUserByOAuthAuthorization {
     }
 }
 
+/// A wrapper struct for an `OAuthUser`'s identity.
+pub struct OAuthUserIdentityRef(pub String);
+
+/// An `AuthorizationMapping` implementation that returns  an `OAuthUser`'s identity.
+pub struct GetUserIdentityByOAuthAuthorization {
+    oauth_user_store: Box<dyn OAuthUserStore>,
+}
+
+impl GetUserIdentityByOAuthAuthorization {
+    /// Construct a new `GetUserIdentityByOAuthAuthorization` over an `OAuthUserStore` implementation.
+    pub fn new(oauth_user_store: Box<dyn OAuthUserStore>) -> Self {
+        Self { oauth_user_store }
+    }
+}
+
+impl AuthorizationMapping<OAuthUserIdentityRef> for GetUserIdentityByOAuthAuthorization {
+    fn get(
+        &self,
+        authorization: &Authorization,
+    ) -> Result<Option<OAuthUserIdentityRef>, InternalError> {
+        match authorization {
+            Authorization::Bearer(BearerToken::OAuth2(access_token)) => self
+                .oauth_user_store
+                .get_by_access_token(&access_token)
+                .map(|opt_oauth_user| {
+                    opt_oauth_user.map(|oauth_user| {
+                        OAuthUserIdentityRef(oauth_user.provider_user_ref().to_string())
+                    })
+                })
+                .map_err(|e| {
+                    InternalError::from_source_with_message(
+                        Box::new(e),
+                        "Unable to load oauth user".into(),
+                    )
+                }),
+            _ => Ok(None),
+        }
+    }
+}
+
 /// Biome-backed implementation of the `OAuthUserInfoStore` trait.
 ///
 /// This implementation uses the `OAuthUserStore` provided by Biome.

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -44,6 +44,8 @@ pub const OAUTH_PROTOCOL_VERSION: u32 = 1;
 pub(crate) const OAUTH_CALLBACK_MIN: u32 = 1;
 #[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
 pub(crate) const OAUTH_LOGIN_MIN: u32 = 1;
+#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+pub(crate) const OAUTH_LOGOUT_MIN: u32 = 1;
 
 #[cfg(feature = "registry")]
 pub const REGISTRY_PROTOCOL_VERSION: u32 = 1;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -96,7 +96,9 @@ use crate::biome::rest_api::BiomeRestResourceManager;
 #[cfg(feature = "biome-oauth")]
 use crate::biome::{
     oauth::store::OAuthProvider,
-    rest_api::auth::{BiomeOAuthUserInfoStore, GetUserByOAuthAuthorization},
+    rest_api::auth::{
+        BiomeOAuthUserInfoStore, GetUserByOAuthAuthorization, GetUserIdentityByOAuthAuthorization,
+    },
     OAuthUserStore, UserStore,
 };
 #[cfg(feature = "auth")]
@@ -919,6 +921,13 @@ impl RestApiBuilder {
                                     self.authorization_mappings.push(
                                         ConfigureAuthorizationMapping::new(
                                             GetUserByOAuthAuthorization::new(
+                                                oauth_user_store.clone(),
+                                            ),
+                                        ),
+                                    );
+                                    self.authorization_mappings.push(
+                                        ConfigureAuthorizationMapping::new(
+                                            GetUserIdentityByOAuthAuthorization::new(
                                                 oauth_user_store.clone(),
                                             ),
                                         ),

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1601,6 +1601,44 @@ paths:
                 schema:
                   $ref: '#/components/schemas/Error'
 
+  /oauth/logout:
+    get:
+      tags:
+        - OAuth
+      description: Removes a user's access and refresh tokens from storage.
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "User successfully logged out"
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: The client is unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/Error'
+
 components:
   parameters:
     auth:

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -59,7 +59,7 @@ use splinter::registry::{
     UnifiedRegistry,
 };
 #[cfg(feature = "auth")]
-use splinter::rest_api::{AuthConfig, OAuthConfig, UserInfoSaveConfig};
+use splinter::rest_api::{AuthConfig, OAuthConfig, OAuthUserInfoStoreConfig};
 use splinter::rest_api::{
     Method, Resource, RestApiBuilder, RestApiServerError, RestResourceProvider,
 };
@@ -534,13 +534,13 @@ impl SplinterDaemon {
                     }
                 };
 
-                // Allowing unused_mut because user_info_save_config must be mutable if feature
+                // Allowing unused_mut because `user_info_store_config` must be mutable if feature
                 // biome-oauth is enabled
                 #[allow(unused_mut)]
-                let mut user_info_save_config = UserInfoSaveConfig::NoOp;
+                let mut user_info_store_config = OAuthUserInfoStoreConfig::NoOp;
                 #[cfg(feature = "biome-oauth")]
                 if self.enable_biome {
-                    user_info_save_config = UserInfoSaveConfig::Biome {
+                    user_info_store_config = OAuthUserInfoStoreConfig::Biome {
                         user_store: store_factory.get_biome_user_store(),
                         oauth_user_store: store_factory.get_biome_oauth_user_store(),
                     };
@@ -548,7 +548,7 @@ impl SplinterDaemon {
 
                 auth_configs.push(AuthConfig::OAuth {
                     oauth_config,
-                    user_info_save_config,
+                    user_info_store_config,
                 });
             }
 


### PR DESCRIPTION
Adds an `/oauth/logout` endpoint that removes a user's access and refresh tokens from Biome-backed `OAuthUserStore` and adds a no-op implementation. 

Using docker, could probably just run `docker-compose up --build` and try to hit the endpoints as mentioned below.

Local testing: 
Setting up postgres backend:

```
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
```

Set up the tables:
```
$ cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
```

Run Splinter: 
```
$ mkdir -p /tmp/splinter # a splinter home dir for local use
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate --skip
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features auth,biome-oauth -- \
    --database postgres://postgres:mypassword@localhost:5432/splinter \
    --enable-biome \
    --tls-insecure \
    --OAUTH_PROVIDER github \
    --OAUTH_CLIENT_ID <your client id> \
    --OAUTH_CLIENT_SECRET <your client secret> \
    --OAUTH_REDIRECT_URL http://localhost:8080/oauth/callback \
    -vv
```

In a browser, go to `localhost:8080/oauth/login?redirect_url=redirect`. (Note, you'll get a 404 because this URL does not exist, but you should see an access token and display name in the final URL that 404'd.

Check the database tables to make sure the `OAuthUser` has been stored: 
```
$ docker run -it --rm --link postgres:postgres postgres psql -h postgres -U postgres
Password for user postgres:
postgres-# \c splinter
You are now connected to database "splinter" as user "postgres".
splinter=# select * from oauth_user;
 id |               user_id                | provider_user_ref |               access_token               | refresh_token | provider_id
----+--------------------------------------+-------------------+------------------------------------------+---------------+-------------
  1 | 88074e7f-18f1-47f7-ab67-65c6968127ba | your_username     | aaaaaaaaaaaaaaaaaaaaaaa00000000000000000 |               |           1
(1 row)
```

Then, after taking the value from the `access_token` column, make the following curl request: 

```
$ curl --header "Authorization: Bearer OAuth2:$ACCESS_TOKEN" http://localhost:8080/oauth/logout
{"message": "User successfully logged out"}
```

You can go back to the postgres container and run `select * from oauth_user;` to verify the tokens have been removed from the oauth user's entry.
 