### PR TITLE
Guard OAuthUserStore postgres backend explicitly

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -99,6 +99,7 @@ experimental = [
     "auth",
     "biome-notifications",
     "biome-oauth",
+    "biome-oauth-user-store-postgres",
     "cylinder-jwt",
     "oauth",
     "oauth-github",
@@ -121,6 +122,7 @@ biome-credentials = ["biome", "bcrypt"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
 biome-oauth = ["biome"]
+biome-oauth-user-store-postgres = ["biome-oauth", "postgres"]
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -83,7 +83,7 @@ impl OAuthUserStore for DieselOAuthUserStore<diesel::sqlite::SqliteConnection> {
     }
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "biome-oauth-user-store-postgres")]
 impl OAuthUserStore for DieselOAuthUserStore<diesel::pg::PgConnection> {
     fn add_oauth_user(&self, oauth_user: OAuthUser) -> Result<(), OAuthUserStoreError> {
         let connection = self.connection_pool.get()?;

--- a/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/add_oauth_user.rs
@@ -40,7 +40,7 @@ impl<'a> OAuthUserStoreAddOAuthUserOperation
     }
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "biome-oauth-user-store-postgres")]
 impl<'a> OAuthUserStoreAddOAuthUserOperation
     for OAuthUserStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! The OAuth user can be considered an extension of the base Biome user.
 
-#[cfg(feature = "diesel")]
+#[cfg(any(feature = "biome-oauth-user-store-postgres", feature = "sqlite"))]
 pub(in crate::biome) mod diesel;
 mod error;
 pub(in crate::biome) mod memory;

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -52,8 +52,15 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::biome::DieselUserStore::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "biome-oauth")]
+    #[cfg(feature = "biome-oauth-user-store-postgres")]
     fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore> {
         Box::new(crate::biome::DieselOAuthUserStore::new(self.pool.clone()))
+    }
+
+    #[cfg(all(feature = "biome-oauth", not(feature = "postgres")))]
+    fn get_biome_oauth_user_store(&self) -> Box<dyn crate::biome::OAuthUserStore> {
+        // This configuration cannot be reached within this implementation as the whole struct is
+        // guarded by "postgres". It merely satisfies the compiler.
+        unreachable!()
     }
 }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -90,7 +90,11 @@ auth = ["splinter/cylinder-jwt", "splinter/oauth-github"]
 biome = ["splinter/biome", "splinter/store-factory", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
 biome-key-management = ["splinter/biome-key-management", "biome"]
-biome-oauth = ["auth", "splinter/biome-oauth"]
+biome-oauth = [
+    "auth",
+    "splinter/biome-oauth",
+    "splinter/biome-oauth-user-store-postgres"
+]
 database = ["splinter/postgres", "splinter/sqlite"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [


### PR DESCRIPTION
This change adds a feature which guards the postgres backend of the OAuthUserStore with a separate feature,
"biome-oauth-user-store-postgres".  This allows this postgres implementation to stabilize at different rate then the rest of the biome-oauth feature.
