### PR TITLE
Documentation updates for biome oauth

### DIFF
--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -59,7 +59,7 @@ impl RestResourceProvider for AdminService {
     }
 }
 
-/// Provides the REST API [Resource](splinter::rest_api::Resource) definitions for
+/// Provides the REST API [`Resource`](crate::rest_api::Resource) definitions for
 /// listing and fetching the circuits in the splinter node's state.
 ///
 /// The following endpoints are provided:

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Database backend support for the OAuthUserStore, powered by
+//! [`Diesel`](https://crates.io/crates/diesel).
+
 pub(in crate::biome) mod models;
 mod operations;
 pub(in crate::biome) mod schema;
@@ -33,6 +36,8 @@ use operations::get_by_user_id::OAuthUserStoreGetByUserId as _;
 use operations::update_oauth_user::OAuthUserStoreUpdateOAuthUserOperation as _;
 use operations::OAuthUserStoreOperations;
 
+/// A database-backed [`OAuthUserStore`](`crate::biome::oauth::store::OAuthUserStore`), powered by
+/// [`Diesel`](https://crates.io/crates/diesel).
 pub struct DieselOAuthUserStore<C: diesel::Connection + 'static> {
     connection_pool: Pool<ConnectionManager<C>>,
 }

--- a/libsplinter/src/biome/rest_api/auth/credentials.rs
+++ b/libsplinter/src/biome/rest_api/auth/credentials.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! An AuthorizationMapping implementation for use with Biome bearer tokens.
+
 use std::sync::Arc;
 
 use jsonwebtoken::decode;

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! SaveTokenOperation implementation, backed by Biome's OAuthUserStore.
+//! SaveTokenOperation implementation, backed by Biome's OAuthUserStore. It also includes
+//! an AuthorizationMapping implementation for use with OAuth2 bearer tokens.
 
 use uuid::Uuid;
 


### PR DESCRIPTION
Additionally:

- Fixes a link using incorrect rust path linkage.