### PR TITLE
Google oauth

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -103,6 +103,7 @@ experimental = [
     "cylinder-jwt",
     "oauth",
     "oauth-github",
+    "oauth-openid",
     "registry-database",
     "service-arg-validation",
     "service-network",
@@ -128,6 +129,7 @@ cylinder-jwt = ["cylinder/jwt"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 oauth = ["auth", "oauth2"]
 oauth-github = ["oauth"]
+oauth-openid = ["oauth", "reqwest"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
 registry-database = ["diesel"]

--- a/libsplinter/src/auth/rest_api/identity/mod.rs
+++ b/libsplinter/src/auth/rest_api/identity/mod.rs
@@ -20,6 +20,8 @@ pub mod biome;
 pub mod cylinder;
 #[cfg(feature = "oauth-github")]
 pub mod github;
+#[cfg(feature = "oauth-openid")]
+pub mod openid;
 
 use std::str::FromStr;
 

--- a/libsplinter/src/auth/rest_api/identity/openid.rs
+++ b/libsplinter/src/auth/rest_api/identity/openid.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest::{blocking::Client, StatusCode};
+
+use crate::error::InternalError;
+
+use super::{Authorization, BearerToken, IdentityProvider};
+
+#[derive(Clone)]
+pub struct OpenIdUserIdentityProvider {
+    userinfo_endpoint: String,
+}
+
+impl OpenIdUserIdentityProvider {
+    pub fn new(userinfo_endpoint: String) -> OpenIdUserIdentityProvider {
+        OpenIdUserIdentityProvider { userinfo_endpoint }
+    }
+}
+
+impl IdentityProvider for OpenIdUserIdentityProvider {
+    fn get_identity(&self, authorization: &Authorization) -> Result<Option<String>, InternalError> {
+        let token = match authorization {
+            Authorization::Bearer(BearerToken::OAuth2(token)) => token,
+            _ => return Ok(None),
+        };
+
+        let response = Client::builder()
+            .build()
+            .map_err(|err| InternalError::from_source(err.into()))?
+            .get(&self.userinfo_endpoint)
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .map_err(|err| InternalError::from_source(err.into()))?;
+
+        if !response.status().is_success() {
+            match response.status() {
+                StatusCode::UNAUTHORIZED => return Ok(None),
+                status_code => {
+                    return Err(InternalError::with_message(format!(
+                        "Received unexpected response code: {}",
+                        status_code
+                    )))
+                }
+            }
+        }
+
+        let email = response
+            .json::<UserResponse>()
+            .map_err(|_| InternalError::with_message("Received unexpected response body".into()))?
+            .email;
+
+        Ok(Some(email))
+    }
+
+    fn clone_box(&self) -> Box<dyn IdentityProvider> {
+        Box::new(self.clone())
+    }
+}
+
+/// Deserializes response
+#[derive(Debug, Deserialize)]
+struct UserResponse {
+    email: String,
+}

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -143,6 +143,7 @@ impl From<OAuthUserModel> for OAuthUser {
             refresh_token,
             provider: match provider_id {
                 ProviderId::Github => OAuthProvider::Github,
+                ProviderId::OpenId => OAuthProvider::OpenId,
             },
         }
     }
@@ -160,6 +161,7 @@ impl<'a> From<&'a OAuthUser> for NewOAuthUserModel<'a> {
             refresh_token: user.refresh_token(),
             provider_id: match user.provider() {
                 OAuthProvider::Github => ProviderId::Github,
+                OAuthProvider::OpenId => ProviderId::OpenId,
             },
         }
     }

--- a/libsplinter/src/biome/oauth/store/diesel/models.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/models.rs
@@ -30,6 +30,7 @@ use super::schema::oauth_user;
 #[derive(Debug, PartialEq, FromSqlRow, Clone, Copy)]
 pub enum ProviderId {
     Github = 1,
+    OpenId = 2,
 }
 
 impl<DB> ToSql<SmallInt, DB> for ProviderId
@@ -66,6 +67,7 @@ where
     fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
         match i16::from_sql(bytes)? {
             1 => Ok(ProviderId::Github),
+            2 => Ok(ProviderId::OpenId),
             int => Err(format!("Invalid provider {}", int).into()),
         }
     }

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -29,6 +29,7 @@ pub use error::OAuthUserStoreError;
 #[derive(Clone, Debug, PartialEq)]
 pub enum OAuthProvider {
     Github,
+    OpenId,
 }
 
 /// Access token assigned to a user when they have been successfully authorized.

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -86,7 +86,7 @@ experimental = [
     "ws-transport",
 ]
 
-auth = ["splinter/cylinder-jwt", "splinter/oauth-github"]
+auth = ["splinter/cylinder-jwt", "splinter/oauth-github", "splinter/oauth-openid"]
 biome = ["splinter/biome", "splinter/store-factory", "database"]
 biome-credentials = ["splinter/biome-credentials", "biome"]
 biome-key-management = ["splinter/biome-key-management", "biome"]

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -157,10 +157,14 @@ OPTIONS
 : Specifies the client secret for the OAuth provider used by the REST API.
 
 `--oauth-provider OAUTH-PROVIDER`
-: Specifies the OAuth provider used by the REST API. Accepted values: `github`.
+: Specifies the OAuth provider used by the REST API. Accepted values: `github`,
+  `openid`.
 
 `--oauth-redirect-url OAUTH-REDIRECT-URL`
 : Redirect URL for the OAuth provider used by the REST API.
+
+`--oauth-openid-url OAUTH-OPENID-URL`
+: OpenID discovery document URL for the OAuth provider used by the REST API.
 
 `--peers PEER-URL` `[,...]`
 : Specifies one or more Splinter nodes that `splinterd` will automatically
@@ -321,7 +325,7 @@ Biome credentials for the splinter REST API can be enabled using the
 The Splinter daemon provides 4 options for configuring OAuth for the REST API:
 
 * `oauth-provider` for specifying the OAuth provider that splinterd will use to
-  get the client's identity. Currently, only `github` is supported.
+  get the client's identity. Currently, `github` and `openid` are supported.
 
 * `oauth-client-id` for specifying the client ID, which is a public identifier
   for an app that's registered with the chosen OAuth provider.
@@ -388,6 +392,10 @@ ENVIRONMENT VARIABLES
 **OAUTH_REDIRECT_URL**
 : Redirect URL for the OAuth provider used by the REST API. See
   `--oauth-redirect-url`.
+
+**OAUTH_OPENID_URL**
+: URL for the OpenID provider's discovery document used by the REST API. See
+  `--oauth-openid-url`.
 
 FILES
 =====

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -329,6 +329,13 @@ impl ConfigBuilder {
                     None => None,
                 }
             }),
+            #[cfg(feature = "auth")]
+            oauth_openid_url: self.partial_configs.iter().find_map(|p| {
+                match p.oauth_openid_url() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }
+            }),
             strict_ref_counts: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -138,6 +138,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                         .value_of("oauth_redirect_url")
                         .map(String::from),
                 )
+                .with_oauth_openid_url(self.matches.value_of("oauth_openid_url").map(String::from))
         }
 
         Ok(partial_config)

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -33,6 +33,8 @@ const OAUTH_CLIENT_ID_ENV: &str = "OAUTH_CLIENT_ID";
 const OAUTH_CLIENT_SECRET_ENV: &str = "OAUTH_CLIENT_SECRET";
 #[cfg(feature = "auth")]
 const OAUTH_REDIRECT_URL_ENV: &str = "OAUTH_REDIRECT_URL";
+#[cfg(feature = "auth")]
+const OAUTH_OPENID_URL_ENV: &str = "OAUTH_OPENID_URL";
 
 pub struct EnvPartialConfigBuilder;
 
@@ -111,7 +113,8 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
                 .with_oauth_provider(env::var(OAUTH_PROVIDER_ENV).ok())
                 .with_oauth_client_id(env::var(OAUTH_CLIENT_ID_ENV).ok())
                 .with_oauth_client_secret(env::var(OAUTH_CLIENT_SECRET_ENV).ok())
-                .with_oauth_redirect_url(env::var(OAUTH_REDIRECT_URL_ENV).ok());
+                .with_oauth_redirect_url(env::var(OAUTH_REDIRECT_URL_ENV).ok())
+                .with_oauth_openid_url(env::var(OAUTH_OPENID_URL_ENV).ok());
         }
 
         Ok(config)

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -78,6 +78,8 @@ pub struct Config {
     oauth_client_secret: Option<(String, ConfigSource)>,
     #[cfg(feature = "auth")]
     oauth_redirect_url: Option<(String, ConfigSource)>,
+    #[cfg(feature = "auth")]
+    oauth_openid_url: Option<(String, ConfigSource)>,
     strict_ref_counts: (bool, ConfigSource),
 }
 
@@ -238,6 +240,15 @@ impl Config {
         }
     }
 
+    #[cfg(feature = "auth")]
+    pub fn oauth_openid_url(&self) -> Option<&str> {
+        if let Some((openid_url, _)) = &self.oauth_openid_url {
+            Some(openid_url)
+        } else {
+            None
+        }
+    }
+
     pub fn strict_ref_counts(&self) -> bool {
         self.strict_ref_counts.0
     }
@@ -392,6 +403,15 @@ impl Config {
     #[cfg(feature = "auth")]
     pub fn oauth_redirect_url_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.oauth_redirect_url {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "auth")]
+    pub fn oauth_openid_url_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.oauth_openid_url {
             Some(source)
         } else {
             None
@@ -564,6 +584,14 @@ impl Config {
                 debug!(
                     "Config: oauth_redirect_url: {} (source: {:?})",
                     redirect_url, source,
+                );
+            }
+            if let (Some(openid_url), Some(source)) =
+                (self.oauth_openid_url(), self.oauth_openid_url_source())
+            {
+                debug!(
+                    "Config: oauth_openid_url: {} (source: {:?})",
+                    openid_url, source,
                 );
             }
         }

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -71,6 +71,8 @@ pub struct PartialConfig {
     oauth_client_secret: Option<String>,
     #[cfg(feature = "auth")]
     oauth_redirect_url: Option<String>,
+    #[cfg(feature = "auth")]
+    oauth_openid_url: Option<String>,
     strict_ref_counts: Option<bool>,
 }
 
@@ -117,6 +119,8 @@ impl PartialConfig {
             oauth_client_secret: None,
             #[cfg(feature = "auth")]
             oauth_redirect_url: None,
+            #[cfg(feature = "auth")]
+            oauth_openid_url: None,
             strict_ref_counts: None,
         }
     }
@@ -251,6 +255,11 @@ impl PartialConfig {
     #[cfg(feature = "auth")]
     pub fn oauth_redirect_url(&self) -> Option<String> {
         self.oauth_redirect_url.clone()
+    }
+
+    #[cfg(feature = "auth")]
+    pub fn oauth_openid_url(&self) -> Option<String> {
+        self.oauth_openid_url.clone()
     }
 
     pub fn strict_ref_counts(&self) -> Option<bool> {
@@ -601,6 +610,18 @@ impl PartialConfig {
     ///
     pub fn with_oauth_redirect_url(mut self, oauth_redirect_url: Option<String>) -> Self {
         self.oauth_redirect_url = oauth_redirect_url;
+        self
+    }
+
+    #[cfg(feature = "auth")]
+    /// Adds an `with_oauth_openid_url` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `with_oauth_openid_url` - Add OAuth OpenID URL to the REST API OAuth configuration
+    ///
+    pub fn with_oauth_openid_url(mut self, oauth_openid_url: Option<String>) -> Self {
+        self.oauth_openid_url = oauth_openid_url;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -61,6 +61,8 @@ struct TomlConfig {
     oauth_client_secret: Option<String>,
     #[cfg(feature = "auth")]
     oauth_redirect_url: Option<String>,
+    #[cfg(feature = "auth")]
+    oauth_openid_url: Option<String>,
 
     // Deprecated values
     cert_dir: Option<String>,
@@ -163,7 +165,8 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_oauth_provider(self.toml_config.oauth_provider)
                 .with_oauth_client_id(self.toml_config.oauth_client_id)
                 .with_oauth_client_secret(self.toml_config.oauth_client_secret)
-                .with_oauth_redirect_url(self.toml_config.oauth_redirect_url);
+                .with_oauth_redirect_url(self.toml_config.oauth_redirect_url)
+                .with_oauth_openid_url(self.toml_config.oauth_openid_url);
         }
 
         // deprecated values, only set if the current value was not set

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -121,6 +121,8 @@ pub struct SplinterDaemon {
     oauth_client_secret: Option<String>,
     #[cfg(feature = "auth")]
     oauth_redirect_url: Option<String>,
+    #[cfg(feature = "auth")]
+    oauth_openid_url: Option<String>,
     heartbeat: u64,
     strict_ref_counts: bool,
 }
@@ -514,6 +516,16 @@ impl SplinterDaemon {
                         client_secret,
                         redirect_url,
                     },
+                    "openid" => OAuthConfig::OpenId {
+                        client_id,
+                        client_secret,
+                        redirect_url,
+                        oauth_openid_url: self.oauth_openid_url.clone().ok_or_else(|| {
+                            StartError::RestApiError(
+                                "missing OAuth OpenID discovery document URL configuration".into(),
+                            )
+                        })?,
+                    },
                     other_provider => {
                         return Err(StartError::RestApiError(format!(
                             "invalid OAuth provider: {}",
@@ -855,6 +867,8 @@ pub struct SplinterDaemonBuilder {
     oauth_client_secret: Option<String>,
     #[cfg(feature = "auth")]
     oauth_redirect_url: Option<String>,
+    #[cfg(feature = "auth")]
+    oauth_openid_url: Option<String>,
     strict_ref_counts: Option<bool>,
 }
 
@@ -976,6 +990,12 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    #[cfg(feature = "auth")]
+    pub fn with_oauth_openid_url(mut self, value: Option<String>) -> Self {
+        self.oauth_openid_url = value;
+        self
+    }
+
     pub fn with_strict_ref_counts(mut self, strict_ref_counts: bool) -> Self {
         self.strict_ref_counts = Some(strict_ref_counts);
         self
@@ -1079,6 +1099,8 @@ impl SplinterDaemonBuilder {
             oauth_client_secret: self.oauth_client_secret,
             #[cfg(feature = "auth")]
             oauth_redirect_url: self.oauth_redirect_url,
+            #[cfg(feature = "auth")]
+            oauth_openid_url: self.oauth_openid_url,
             heartbeat,
             strict_ref_counts,
         })

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -336,7 +336,7 @@ fn main() {
                 .long("oauth-provider")
                 .long_help("The OAuth provider used by the REST API")
                 .takes_value(true)
-                .possible_values(&["github"]),
+                .possible_values(&["github", "openid"]),
         )
         .arg(
             Arg::with_name("oauth_client_id")
@@ -354,6 +354,12 @@ fn main() {
             Arg::with_name("oauth_redirect_url")
                 .long("oauth-redirect-url")
                 .long_help("Redirect URL for the OAuth provider used by the REST API")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("oauth_openid_url")
+                .long("oauth-openid-url")
+                .long_help("URL for the OAuth provider's discovery document used by the REST API")
                 .takes_value(true),
         );
 
@@ -479,7 +485,8 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
             .with_oauth_provider(config.oauth_provider().map(ToOwned::to_owned))
             .with_oauth_client_id(config.oauth_client_id().map(ToOwned::to_owned))
             .with_oauth_client_secret(config.oauth_client_secret().map(ToOwned::to_owned))
-            .with_oauth_redirect_url(config.oauth_redirect_url().map(ToOwned::to_owned));
+            .with_oauth_redirect_url(config.oauth_redirect_url().map(ToOwned::to_owned))
+            .with_oauth_openid_url(config.oauth_openid_url().map(ToOwned::to_owned));
     }
 
     let mut node = daemon_builder.build().map_err(|err| {


### PR DESCRIPTION
Adds a new_openid() function to OAuthClient for creating a client for OpenID. Adds an OpenID implementation of the IdentityProvider trait for determining the user's identity. Adds OpenID to the OAuthProvider and the OAuthConfig enums. This is behind a new experimental feature, `oauth-openid`.

Adds the appropriate environment variables and splinterd command line arguments to allow for splinter daemon to build using an OpenID provider for OAuth. Uses the libsplinter `oauth-openid` feature. These changes are behind the existing experimental `auth` feature 

### **Testing:**
Add the following to the docker-compose file
```
    --oauth-client-secret Lj4cszgL9TqJSgfWRZe_LsVf \
    --oauth-client-id 116864774510-j2qt6rchlj85n5k1aj8deiis48akjplt.apps.googleusercontent.com \
    --oauth-redirect-url http://localhost:8080/oauth/callback \
    --oauth-openid-url  https://accounts.google.com/.well-known/openid-configuration \
```
from the root of the repository run 
`CARGO_ARGS="-- --features experimental" docker-compose up --build`

Then go to
`http://localhost:8080/oauth/login?redirect_url=redirect`

### **Testing with splinter admin UI:**
checkout this splinter branch https://github.com/isabeltomb/splinter/tree/test-google-oauth-splinter-admin which has these commits plus a commit to modify splinterd/cargo.toml 

and checkout this splinter-ui branch https://github.com/isabeltomb/splinter-ui/tree/test-oauth-openid which has the necessary docker-compose modifications to run splinter admin ui locally with Google OpenID OAuth 

run `docker-compose -f docker-compose-oauth.yaml up --build` from the root directory of the splinter-ui branch

go to http://localhost:3030