### PR TITLE
Add CustomizeConnection to turn on foreign key support for sqlite

### DIFF
--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -20,6 +20,8 @@ pub mod sqlite;
 
 use std::str::FromStr;
 
+#[cfg(feature = "sqlite")]
+use self::sqlite::ForeignKeyCustomizer;
 #[cfg(feature = "diesel")]
 use diesel::r2d2::{ConnectionManager, Pool};
 
@@ -68,7 +70,8 @@ pub fn create_store_factory(
         ConnectionUri::Sqlite(conn_str) => {
             let connection_manager =
                 ConnectionManager::<diesel::sqlite::SqliteConnection>::new(&conn_str);
-            let mut pool_builder = Pool::builder();
+            let mut pool_builder =
+                Pool::builder().connection_customizer(Box::new(ForeignKeyCustomizer::default()));
             // A new database is created for each connection to the in-memory SQLite
             // implementation; to ensure that the resulting stores will operate on the same
             // database, only one connection is allowed.


### PR DESCRIPTION
foreign key support is not turned on by default in SQLite. It can be
turned on by running:

`PRAGMA foreign_keys = ON;`

However this needs to be run on connection creation and using a migration
does not keep it on.

Since we are using a Pool to get Sqlite connections, we need to define a
CustomizeConnection that will turn foreign key support on for the
connection when the connection is required.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>