### PR TITLE
Update required cylinder version to 0.2.1

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -36,7 +36,7 @@ awc = { version = "0.2", optional = true }
 bcrypt = {version = "0.6", optional = true}
 byteorder = "1"
 crossbeam-channel = "0.3"
-cylinder = "0.2"
+cylinder = "0.2.1"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
 futures = { version = "0.1", optional = true }


### PR DESCRIPTION
This is required because libsplinter makes use of features added in
0.2.1 that were not present in 0.2.0.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>