### PR TITLE
Replace OAuthClient constructors with Builder

### DIFF
--- a/libsplinter/src/auth/oauth/builder/github.rs
+++ b/libsplinter/src/auth/oauth/builder/github.rs
@@ -1,0 +1,70 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::auth::oauth::{builder::OAuthClientBuilder, error::OAuthClientBuildError, OAuthClient};
+use crate::auth::rest_api::identity::github::GithubUserIdentityProvider;
+
+/// Builds a new `OAuthClient` with GitHub's authorization and token URLs.
+pub struct GithubOAuthClientBuilder {
+    inner: OAuthClientBuilder,
+}
+
+impl GithubOAuthClientBuilder {
+    /// Constructs a Github OAuthClient builder.
+    pub fn new() -> Self {
+        Self {
+            inner: OAuthClientBuilder::new()
+                .with_auth_url("https://github.com/login/oauth/authorize".into())
+                .with_token_url("https://github.com/login/oauth/access_token".into())
+                .with_identity_provider(Box::new(GithubUserIdentityProvider)),
+        }
+    }
+
+    /// Sets the client ID for the OAuth2 provider.
+    pub fn with_client_id(self, client_id: String) -> Self {
+        Self {
+            inner: self.inner.with_client_id(client_id),
+        }
+    }
+
+    /// Sets the client secret for the OAuth2 provider.
+    pub fn with_client_secret(self, client_secret: String) -> Self {
+        Self {
+            inner: self.inner.with_client_secret(client_secret),
+        }
+    }
+
+    /// Sets the redirect URL for the OAuth2 provider.
+    pub fn with_redirect_url(self, redirect_url: String) -> Self {
+        Self {
+            inner: self.inner.with_redirect_url(redirect_url),
+        }
+    }
+
+    /// Builds an OAuthClient.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OAuthClientBuildError`] if there are required fields missing, or any URL's
+    /// provided are invalid.
+    pub fn build(self) -> Result<OAuthClient, OAuthClientBuildError> {
+        self.inner.build()
+    }
+}
+
+impl Default for GithubOAuthClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libsplinter/src/auth/oauth/builder/mod.rs
+++ b/libsplinter/src/auth/oauth/builder/mod.rs
@@ -1,0 +1,147 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builders for [OAuthClient](crate::auth::oauth::OAuthClient) structs.
+
+#[cfg(feature = "oauth-github")]
+mod github;
+#[cfg(feature = "oauth-openid")]
+mod openid;
+
+use crate::auth::rest_api::identity::IdentityProvider;
+use crate::error::InvalidStateError;
+
+use super::error::OAuthClientBuildError;
+use super::OAuthClient;
+
+#[cfg(feature = "oauth-github")]
+pub use github::GithubOAuthClientBuilder;
+
+#[cfg(feature = "oauth-openid")]
+pub use openid::OpenIdOAuthClientBuilder;
+
+/// A builder for a new [`OAuthClient`].
+///
+/// This builder constructs an [`OAuthClient`] using the most general parameters. Configurations
+/// that set values specific to certain providers may be available, depending on which features
+/// have been enabled at compile time.
+#[derive(Default)]
+pub struct OAuthClientBuilder {
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    auth_url: Option<String>,
+    redirect_url: Option<String>,
+    token_url: Option<String>,
+    scopes: Vec<String>,
+    identity_provider: Option<Box<dyn IdentityProvider>>,
+}
+
+impl OAuthClientBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builds an OAuthClient.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OAuthClientBuildError`] if any of the auth, redirect, or token URLs are
+    /// invalid.
+    pub fn build(self) -> Result<OAuthClient, OAuthClientBuildError> {
+        let client_id = self.client_id.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "A client ID is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        let client_secret = self.client_secret.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "A client secret is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        let auth_url = self.auth_url.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An auth URL is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        let redirect_url = self.redirect_url.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "A redirect URL is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        let token_url = self.token_url.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "A token URL is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        let identity_provider = self.identity_provider.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An identity provider is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+        Ok(OAuthClient::new(
+            client_id,
+            client_secret,
+            auth_url,
+            redirect_url,
+            token_url,
+            self.scopes,
+            identity_provider,
+        )?)
+    }
+
+    /// Sets the client ID for the OAuth2 provider.
+    pub fn with_client_id(mut self, client_id: String) -> Self {
+        self.client_id = Some(client_id);
+        self
+    }
+
+    /// Sets the client secret for the OAuth2 provider.
+    pub fn with_client_secret(mut self, client_secret: String) -> Self {
+        self.client_secret = Some(client_secret);
+        self
+    }
+
+    /// Sets the authorize URL for the OAuth2 provider.
+    pub fn with_auth_url(mut self, auth_url: String) -> Self {
+        self.auth_url = Some(auth_url);
+        self
+    }
+
+    /// Sets the redirect URL for the OAuth2 provider.
+    pub fn with_redirect_url(mut self, redirect_url: String) -> Self {
+        self.redirect_url = Some(redirect_url);
+        self
+    }
+
+    /// Sets the token URL for the OAuth2 provider.
+    pub fn with_token_url(mut self, token_url: String) -> Self {
+        self.token_url = Some(token_url);
+        self
+    }
+
+    /// Sets the scopes to request from the OAuth2 provider.
+    pub fn with_scopes(mut self, scopes: Vec<String>) -> Self {
+        let mut scopes = scopes;
+        self.scopes.append(&mut scopes);
+        self
+    }
+
+    /// Sets the identity provider to use to request a reference to the user's identity, as defined
+    /// by the OAuth2 provider.
+    pub fn with_identity_provider(mut self, identity_provider: Box<dyn IdentityProvider>) -> Self {
+        self.identity_provider = Some(identity_provider);
+        self
+    }
+}

--- a/libsplinter/src/auth/oauth/builder/openid.rs
+++ b/libsplinter/src/auth/oauth/builder/openid.rs
@@ -1,0 +1,128 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use reqwest::blocking::Client;
+
+use crate::auth::oauth::{builder::OAuthClientBuilder, error::OAuthClientBuildError, OAuthClient};
+use crate::auth::rest_api::identity::{openid::OpenIdUserIdentityProvider, IdentityProvider};
+use crate::error::{InternalError, InvalidStateError};
+
+/// Builds a new `OAuthClient` using an OpenID discovery document.
+pub struct OpenIdOAuthClientBuilder {
+    openid_discovery_url: Option<String>,
+    inner: OAuthClientBuilder,
+}
+
+impl OpenIdOAuthClientBuilder {
+    /// Constructs a new [`OpenIdOAuthClientBuilder`].
+    pub fn new() -> Self {
+        Self {
+            openid_discovery_url: None,
+            inner: OAuthClientBuilder::default(),
+        }
+    }
+
+    /// Sets the client ID for the OAuth2 provider.
+    pub fn with_client_id(self, client_id: String) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self.inner.with_client_id(client_id),
+        }
+    }
+
+    /// Sets the client secret for the OAuth2 provider.
+    pub fn with_client_secret(self, client_secret: String) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self.inner.with_client_secret(client_secret),
+        }
+    }
+
+    /// Sets the redirect URL for the OAuth2 provider.
+    pub fn with_redirect_url(self, redirect_url: String) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self.inner.with_redirect_url(redirect_url),
+        }
+    }
+
+    /// Sets the discovery document URL for the OpenID Connect provider.
+    pub fn with_discovery_url(mut self, discovery_url: String) -> Self {
+        self.openid_discovery_url = Some(discovery_url);
+
+        self
+    }
+
+    /// Builds an OAuthClient and an [`IdentityProvider`] based on the OpenID provider's discovery
+    /// document.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OAuthClientBuildError`] if there are required fields missing, if any URL's
+    /// provided are invalid or it is unable to load the discovery document.
+    pub fn build(self) -> Result<(OAuthClient, Box<dyn IdentityProvider>), OAuthClientBuildError> {
+        let discovery_url = self.openid_discovery_url.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An OpenID discovery URL  is required to successfully build an OAuthClient".into(),
+            )
+        })?;
+
+        // make a call to the discovery document
+        let response = Client::new().get(&discovery_url).send().map_err(|err| {
+            InternalError::from_source_with_message(
+                Box::new(err),
+                "Unable to retrieve OpenID discovery document".into(),
+            )
+        })?;
+        // deserialize response
+        let discovery_document_response =
+            response
+                .json::<DiscoveryDocumentResponse>()
+                .map_err(|err| {
+                    InternalError::from_source_with_message(
+                        Box::new(err),
+                        "Unable to deserialize OpenID discovery document".into(),
+                    )
+                })?;
+
+        let userinfo_endpoint = discovery_document_response.userinfo_endpoint;
+
+        Ok((
+            self.inner
+                .with_auth_url(discovery_document_response.authorization_endpoint)
+                .with_token_url(discovery_document_response.token_endpoint)
+                .with_scopes(discovery_document_response.scopes_supported)
+                .with_identity_provider(Box::new(OpenIdUserIdentityProvider::new(
+                    userinfo_endpoint.clone(),
+                )))
+                .build()?,
+            Box::new(OpenIdUserIdentityProvider::new(userinfo_endpoint)),
+        ))
+    }
+}
+
+impl Default for OpenIdOAuthClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Deserializes the OpenId discovery document response
+#[derive(Debug, Deserialize)]
+struct DiscoveryDocumentResponse {
+    authorization_endpoint: String,
+    token_endpoint: String,
+    userinfo_endpoint: String,
+    scopes_supported: Vec<String>,
+}

--- a/libsplinter/src/auth/oauth/error.rs
+++ b/libsplinter/src/auth/oauth/error.rs
@@ -1,0 +1,64 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::{InternalError, InvalidArgumentError, InvalidStateError};
+
+/// An error that may occur when building an OAuthClient
+#[derive(Debug)]
+pub enum OAuthClientBuildError {
+    InvalidStateError(InvalidStateError),
+    InvalidArgumentError(InvalidArgumentError),
+    InternalError(InternalError),
+}
+
+impl fmt::Display for OAuthClientBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OAuthClientBuildError::InvalidStateError(err) => f.write_str(&err.to_string()),
+            OAuthClientBuildError::InvalidArgumentError(err) => f.write_str(&err.to_string()),
+            OAuthClientBuildError::InternalError(err) => f.write_str(&err.to_string()),
+        }
+    }
+}
+
+impl Error for OAuthClientBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            OAuthClientBuildError::InvalidStateError(err) => Some(err),
+            OAuthClientBuildError::InvalidArgumentError(err) => Some(err),
+            OAuthClientBuildError::InternalError(err) => Some(err),
+        }
+    }
+}
+
+impl From<InvalidStateError> for OAuthClientBuildError {
+    fn from(err: InvalidStateError) -> Self {
+        OAuthClientBuildError::InvalidStateError(err)
+    }
+}
+
+impl From<InvalidArgumentError> for OAuthClientBuildError {
+    fn from(err: InvalidArgumentError) -> Self {
+        OAuthClientBuildError::InvalidArgumentError(err)
+    }
+}
+
+impl From<InternalError> for OAuthClientBuildError {
+    fn from(err: InternalError) -> Self {
+        OAuthClientBuildError::InternalError(err)
+    }
+}


### PR DESCRIPTION
This change replaces the OAuthClient constructors with builders. A general builder maps to the generic constructor, and a Github-specific builder for its configuration.

It also introduces an error module, as the builder requires an enum error for the three types of errors that may occur at construction time.

The original constructor has been made private, and `new_github`, `new_openid` removed entirely.