### PR TITLE
Update format of OPTIONS in splinter-database-migrate man page

### DIFF
--- a/cli/man/splinter-database-migrate.1.md
+++ b/cli/man/splinter-database-migrate.1.md
@@ -45,7 +45,7 @@ FLAGS
 OPTIONS
 =======
 
-`-C` *CONNECTION-STRING*
+`-C` CONNECT
 : Specifies the connection string or URI for the database server.
 
 EXAMPLES


### PR DESCRIPTION
The man page had asterisks around the string passed to the option
when it should have none. Also said connection string when the CLI
says connect.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>