### PR TITLE
Update gameroom and tests to use postgres for circuit state

### DIFF
--- a/examples/gameroom/splinterd-config/splinterd-node-acme.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-acme.toml
@@ -25,9 +25,5 @@ network_endpoints = ["tcps://127.0.0.1:8044"]
 # connect to on start up.
 peers = []
 
-# The type of storage that should be used to store circuit state. Option are
-# currently "yaml" or "memory"
-storage = "yaml"
-
 # Rest api address.
 rest_api_endpoint = "localhost:8085"

--- a/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
+++ b/examples/gameroom/splinterd-config/splinterd-node-bubba.toml
@@ -25,9 +25,5 @@ network_endpoints = ["tcps://127.0.0.1:8044"]
 # connect to on start up.
 peers = []
 
-# The type of storage that should be used to store circuit state. Option are
-# currently "yaml" or "memory"
-storage = "yaml"
-
 # Rest api address.
 rest_api_endpoint = "localhost:8085"

--- a/examples/gameroom/tests/splinterd-node-0-docker.toml
+++ b/examples/gameroom/tests/splinterd-node-0-docker.toml
@@ -28,10 +28,6 @@ network_endpoints = ["127.0.0.1:8044"]
 # connect to on start up.
 peers = []
 
-# The type of storage that should be used to store circuit state. Option are
-# currently "yaml" or "memory"
-storage = "memory"
-
 # Which transport type this splinterd node supports. Options are "raw" or "tls"
 transport = "tls"
 


### PR DESCRIPTION
This commit removes storage from the config files. If storage
is not provided the value passed to --database is used for
admin state. Since a postgres database was provided for
Biome state, this same database is now used for circuits and
proposal state as well.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>