### PR TITLE
Point dockerhub bubba node to point to correct database

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -304,7 +304,7 @@ services:
           splinter database migrate -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
-              --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
+              --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-bubba:8044 \
               --rest-api-endpoint 0.0.0.0:8085 \


### PR DESCRIPTION
Before bubba's splinterd node was pointing towards acme's
database.

Issue was found because both would try to add a circuit to the
database and it would cause an unique constraint error.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>