### PR TITLE
Initial `AdminServiceEventStore` trait and diesel support 

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -95,6 +95,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "admin-service-event-store",
     "auth",
     "biome-notifications",
     "biome-oauth",
@@ -115,6 +116,7 @@ experimental = [
 benchmark = []
 
 admin-service = []
+admin-service-event-store = ["admin-service"]
 auth = []
 biome = []
 biome-credentials = ["biome", "bcrypt"]

--- a/libsplinter/src/admin/service/event/mod.rs
+++ b/libsplinter/src/admin/service/event/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing the `AdminServiceEventStore` trait and related implementations.
+pub mod store;

--- a/libsplinter/src/admin/service/event/store/diesel/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/mod.rs
@@ -1,0 +1,92 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database backend support for the `AdminServiceEventStore`, powered by
+//! [`Diesel`](https://crates.io/crates/diesel).
+//!
+//! This module contains the [`DieselAdminServiceStore`].
+//!
+//! [`DieselAdminServiceEventStore`]: struct.DieselAdminServiceEventStore.html
+//! [`AdminServiceEventStore`]: ../trait.AdminServiceEventStore.html
+
+mod models;
+mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+/// A database-backed AdminServiceEventStore, powered by [`Diesel`](https://crates.io/crates/diesel).
+pub struct DieselAdminServiceEventStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselAdminServiceEventStore<C> {
+    /// Creates a new `DieselAdminServiceEventStore`.
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool for the database
+    pub fn _new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselAdminServiceEventStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl Clone for DieselAdminServiceEventStore<diesel::sqlite::SqliteConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Clone for DieselAdminServiceEventStore<diesel::pg::PgConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+pub mod tests {
+    use crate::migrations::run_sqlite_migrations;
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    /// Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection ensures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    #[test]
+    /// Test that the sqlite migrations can be run successfully
+    fn test_admin_service_event_store_sqlite_migrations() {
+        create_connection_pool_and_migrate();
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/models.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/models.rs
@@ -1,0 +1,381 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database representations used to implement a diesel backend for the `AdminServiceEventStore`.
+
+use std::convert::TryFrom;
+use std::time::SystemTime;
+
+use crate::admin::service::event::store::{
+    diesel::schema::{
+        admin_event_circuit_proposal, admin_event_create_circuit, admin_event_entry,
+        admin_event_proposed_node, admin_event_proposed_node_endpoint,
+        admin_event_proposed_service, admin_event_proposed_service_argument,
+        admin_event_proposed_service_node, admin_event_vote_record,
+    },
+    AdminServiceEventStoreError,
+};
+use crate::admin::service::messages::{
+    AdminServiceEvent, AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType,
+    PersistenceType, ProposalType, RouteType, Vote, VoteRecord,
+};
+use crate::error::InvalidStateError;
+
+/// Database model representation of an `EventEntry` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_entry"]
+#[primary_key(id)]
+pub struct AdminEventEntryModel {
+    pub id: i64,
+    pub circuit_id: String,
+    pub event_type: String,
+    pub data: Option<Vec<u8>>,
+    pub timestamp: SystemTime,
+}
+
+#[derive(AsChangeset, Insertable, PartialEq, Debug)]
+#[table_name = "admin_event_entry"]
+pub struct NewAdminEventEntryModel<'a> {
+    pub circuit_id: &'a str,
+    pub event_type: &'a str,
+    pub data: Option<&'a [u8]>,
+    pub timestamp: SystemTime,
+}
+
+/// Wrapper struct for the event's ID, used to filter and access records that correlate to the
+/// `AdminServiceEvent` with the specified ID.
+pub(crate) struct EventId(i64);
+
+/// Database model representation of a `CircuitProposal` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_circuit_proposal"]
+#[belongs_to(AdminEventEntryModel, foreign_key = "event_id")]
+#[primary_key(event_id)]
+pub struct AdminEventCircuitProposalModel {
+    pub event_id: i64,
+    pub proposal_type: String,
+    pub circuit_id: String,
+    pub circuit_hash: String,
+    pub requester: Vec<u8>,
+    pub requester_node_id: String,
+}
+
+impl From<&(CircuitProposal, EventId)> for AdminEventCircuitProposalModel {
+    fn from((proposal, event_id): &(CircuitProposal, EventId)) -> Self {
+        AdminEventCircuitProposalModel {
+            event_id: event_id.0,
+            proposal_type: String::from(&proposal.proposal_type),
+            circuit_id: proposal.circuit_id.to_string(),
+            circuit_hash: proposal.circuit_hash.to_string(),
+            requester: proposal.requester.to_vec(),
+            requester_node_id: proposal.requester_node_id.to_string(),
+        }
+    }
+}
+
+/// Database model representation of a `CreateCircuit` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_create_circuit"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id)]
+pub struct AdminEventCreateCircuitModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub authorization_type: String,
+    pub persistence: String,
+    pub durability: String,
+    pub routes: String,
+    pub circuit_management_type: String,
+    pub application_metadata: Vec<u8>,
+    pub comments: String,
+}
+
+impl From<&(CreateCircuit, EventId)> for AdminEventCreateCircuitModel {
+    fn from((circuit, event_id): &(CreateCircuit, EventId)) -> Self {
+        AdminEventCreateCircuitModel {
+            event_id: event_id.0,
+            circuit_id: circuit.circuit_id.to_string(),
+            authorization_type: String::from(&circuit.authorization_type),
+            persistence: String::from(&circuit.persistence),
+            durability: String::from(&circuit.durability),
+            routes: String::from(&circuit.routes),
+            circuit_management_type: circuit.circuit_management_type.to_string(),
+            application_metadata: circuit.application_metadata.to_vec(),
+            comments: circuit.comments.to_string(),
+        }
+    }
+}
+
+/// Database model representation of a `VoteRecord` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_vote_record"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, voter_node_id)]
+pub struct AdminEventVoteRecordModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub public_key: Vec<u8>,
+    pub vote: String,
+    pub voter_node_id: String,
+}
+
+impl TryFrom<&AdminEventVoteRecordModel> for VoteRecord {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(vote: &AdminEventVoteRecordModel) -> Result<Self, Self::Error> {
+        Ok(VoteRecord {
+            public_key: vote.public_key.to_vec(),
+            vote: Vote::try_from(vote.vote.clone())?,
+            voter_node_id: vote.voter_node_id.to_string(),
+        })
+    }
+}
+
+/// Database model representation of a `AdminEventProposedNode` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_proposed_node"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, node_id)]
+pub struct AdminEventProposedNodeModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub node_id: String,
+}
+
+/// Database model representation of the endpoint values associated with a `ProposedNode` from an
+/// `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_proposed_node_endpoint"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, node_id, endpoint)]
+pub struct AdminEventProposedNodeEndpointModel {
+    pub event_id: i64,
+    pub node_id: String,
+    pub circuit_id: String,
+    pub endpoint: String,
+}
+
+/// Database model representation of a `ProposedService` from an `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_proposed_service"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, service_id)]
+pub struct AdminEventProposedServiceModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub service_id: String,
+    pub service_type: String,
+}
+
+/// Database model representation of the `allowed_nodes` field of a `SplinterService` from an
+/// `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_proposed_service_node"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, service_id, node_id)]
+pub struct AdminEventProposedServiceNodeModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub service_id: String,
+    pub node_id: String,
+}
+
+/// Database model representation of the arguments associated with a `ProposedService` from an
+/// `AdminServiceEvent`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "admin_event_proposed_service_argument"]
+#[belongs_to(AdminEventCircuitProposalModel, foreign_key = "event_id")]
+#[primary_key(event_id, circuit_id, service_id, key)]
+pub struct AdminEventProposedServiceArgumentModel {
+    pub event_id: i64,
+    pub circuit_id: String,
+    pub service_id: String,
+    pub key: String,
+    pub value: String,
+}
+
+// All enums associated with the above structs have TryFrom and From implemented in order to
+// translate the enums to a `Text` representation to be stored in the database.
+
+impl TryFrom<String> for Vote {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Accept" => Ok(Vote::Accept),
+            "Reject" => Ok(Vote::Reject),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message("Unable to convert string to Vote".into()),
+            )),
+        }
+    }
+}
+
+impl From<&Vote> for String {
+    fn from(variant: &Vote) -> Self {
+        match variant {
+            Vote::Accept => String::from("Accept"),
+            Vote::Reject => String::from("Reject"),
+        }
+    }
+}
+
+impl TryFrom<String> for ProposalType {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Create" => Ok(ProposalType::Create),
+            "UpdateRoster" => Ok(ProposalType::UpdateRoster),
+            "AddNode" => Ok(ProposalType::AddNode),
+            "RemoveNode" => Ok(ProposalType::RemoveNode),
+            "Destroy" => Ok(ProposalType::Destroy),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message("Unable to convert string to ProposalType".into()),
+            )),
+        }
+    }
+}
+
+impl From<&ProposalType> for String {
+    fn from(variant: &ProposalType) -> Self {
+        match variant {
+            ProposalType::Create => String::from("Create"),
+            ProposalType::UpdateRoster => String::from("UpdateRoster"),
+            ProposalType::AddNode => String::from("AddNode"),
+            ProposalType::RemoveNode => String::from("RemoveNode"),
+            ProposalType::Destroy => String::from("Destroy"),
+        }
+    }
+}
+
+impl TryFrom<String> for AuthorizationType {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Trust" => Ok(AuthorizationType::Trust),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message(
+                    "Unable to convert string to AuthorizationType".into(),
+                ),
+            )),
+        }
+    }
+}
+
+impl From<&AuthorizationType> for String {
+    fn from(variant: &AuthorizationType) -> Self {
+        match variant {
+            AuthorizationType::Trust => String::from("Trust"),
+        }
+    }
+}
+
+impl TryFrom<String> for PersistenceType {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Any" => Ok(PersistenceType::Any),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message(
+                    "Unable to convert string to PersistenceType".into(),
+                ),
+            )),
+        }
+    }
+}
+
+impl From<&PersistenceType> for String {
+    fn from(variant: &PersistenceType) -> Self {
+        match variant {
+            PersistenceType::Any => String::from("Any"),
+        }
+    }
+}
+
+impl TryFrom<String> for DurabilityType {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "NoDurability" => Ok(DurabilityType::NoDurability),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message(
+                    "Unable to convert string to DurabilityType".into(),
+                ),
+            )),
+        }
+    }
+}
+
+impl From<&DurabilityType> for String {
+    fn from(variant: &DurabilityType) -> Self {
+        match variant {
+            DurabilityType::NoDurability => String::from("NoDurability"),
+        }
+    }
+}
+
+impl TryFrom<String> for RouteType {
+    type Error = AdminServiceEventStoreError;
+    fn try_from(variant: String) -> Result<Self, Self::Error> {
+        match variant.as_ref() {
+            "Any" => Ok(RouteType::Any),
+            _ => Err(AdminServiceEventStoreError::InvalidStateError(
+                InvalidStateError::with_message("Unable to convert string to RouteType".into()),
+            )),
+        }
+    }
+}
+
+impl From<&RouteType> for String {
+    fn from(variant: &RouteType) -> Self {
+        match variant {
+            RouteType::Any => String::from("Any"),
+        }
+    }
+}
+
+impl<'a> From<&'a AdminServiceEvent> for NewAdminEventEntryModel<'a> {
+    fn from(event: &'a AdminServiceEvent) -> Self {
+        match event {
+            AdminServiceEvent::ProposalSubmitted(proposal) => NewAdminEventEntryModel {
+                circuit_id: &proposal.circuit_id,
+                event_type: "ProposalSubmitted",
+                data: None,
+                timestamp: SystemTime::now(),
+            },
+            AdminServiceEvent::ProposalVote((proposal, data)) => NewAdminEventEntryModel {
+                circuit_id: &proposal.circuit_id,
+                event_type: "ProposalVote",
+                data: Some(data),
+                timestamp: SystemTime::now(),
+            },
+            AdminServiceEvent::ProposalAccepted((proposal, data)) => NewAdminEventEntryModel {
+                circuit_id: &proposal.circuit_id,
+                event_type: "ProposalAccepted",
+                data: Some(data),
+                timestamp: SystemTime::now(),
+            },
+            AdminServiceEvent::ProposalRejected((proposal, data)) => NewAdminEventEntryModel {
+                circuit_id: &proposal.circuit_id,
+                event_type: "ProposalRejected",
+                data: Some(data),
+                timestamp: SystemTime::now(),
+            },
+            AdminServiceEvent::CircuitReady(proposal) => NewAdminEventEntryModel {
+                circuit_id: &proposal.circuit_id,
+                event_type: "CircuitReady",
+                data: None,
+                timestamp: SystemTime::now(),
+            },
+        }
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/schema.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/schema.rs
@@ -1,0 +1,114 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    admin_event_entry (id) {
+        id -> Int8,
+        circuit_id -> Text,
+        event_type -> Text,
+        data -> Nullable<Binary>,
+        timestamp -> Timestamp,
+    }
+}
+
+table! {
+    admin_event_circuit_proposal (event_id, circuit_id) {
+        event_id -> Int8,
+        proposal_type -> Text,
+        circuit_id -> Text,
+        circuit_hash -> Text,
+        requester -> Binary,
+        requester_node_id -> Text,
+    }
+}
+
+table! {
+    admin_event_create_circuit (event_id, circuit_id) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        authorization_type -> Text,
+        persistence -> Text,
+        durability -> Text,
+        routes -> Text,
+        circuit_management_type -> Text,
+        application_metadata -> Binary,
+        comments -> Text,
+    }
+}
+
+table! {
+    admin_event_vote_record (event_id, circuit_id, voter_node_id) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        public_key -> Binary,
+        vote -> Text,
+        voter_node_id -> Text,
+    }
+}
+
+table! {
+    admin_event_proposed_node (event_id, circuit_id, node_id) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        node_id -> Text,
+    }
+}
+
+table! {
+    admin_event_proposed_node_endpoint (event_id, circuit_id, node_id, endpoint) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        node_id -> Text,
+        endpoint -> Text,
+    }
+}
+
+table! {
+    admin_event_proposed_service (event_id, circuit_id, service_id) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        service_id -> Text,
+        service_type -> Text,
+        node_id -> Text,
+    }
+}
+
+table! {
+    admin_event_proposed_service_node (event_id, circuit_id, service_id, node_id) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        service_id -> Text,
+        node_id -> Text,
+    }
+}
+
+table! {
+    admin_event_proposed_service_argument (event_id, circuit_id, service_id, key) {
+        event_id -> Int8,
+        circuit_id -> Text,
+        service_id -> Text,
+        key -> Text,
+        value -> Text,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(
+    admin_event_create_circuit,
+    admin_event_proposed_node,
+    admin_event_proposed_node_endpoint,
+    admin_event_proposed_service,
+    admin_event_proposed_service_argument,
+    admin_event_vote_record,
+    admin_event_circuit_proposal,
+);

--- a/libsplinter/src/admin/service/event/store/error.rs
+++ b/libsplinter/src/admin/service/event/store/error.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for errors that can be raised while using an admin service event store
+use std::fmt;
+
+use crate::error::{
+    ConstraintViolationError, InternalError, InvalidStateError, ResourceTemporarilyUnavailableError,
+};
+
+/// Represents AdminServiceEventStoreError errors
+#[derive(Debug)]
+pub enum AdminServiceEventStoreError {
+    /// Represents errors internal to the function.
+    InternalError(InternalError),
+    /// Represents constraint violations on the database's definition
+    ConstraintViolationError(ConstraintViolationError),
+    /// Represents when the underlying resource is unavailable
+    ResourceTemporarilyUnavailableError(ResourceTemporarilyUnavailableError),
+    /// Represents when cab operation cannot be completed because the state of the underlying
+    /// struct is inconsistent.
+    InvalidStateError(InvalidStateError),
+}
+
+impl fmt::Display for AdminServiceEventStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AdminServiceEventStoreError::InternalError(err) => write!(f, "{}", err),
+            AdminServiceEventStoreError::ConstraintViolationError(err) => write!(f, "{}", err),
+            AdminServiceEventStoreError::ResourceTemporarilyUnavailableError(err) => {
+                write!(f, "{}", err)
+            }
+            AdminServiceEventStoreError::InvalidStateError(err) => write!(f, "{}", err),
+        }
+    }
+}

--- a/libsplinter/src/admin/service/event/store/mod.rs
+++ b/libsplinter/src/admin/service/event/store/mod.rs
@@ -1,0 +1,64 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data store for maintaining ordered records of `AdminServiceEvent`s.
+//!
+//! The [`AdminServiceEventStore`] trait provides the public interface for storing
+//! `AdminServiceEvent`s.
+//!
+//! [`AdminServiceEventStore`]: trait.AdminServiceEventStore.html
+
+mod error;
+
+use std::time::SystemTime;
+
+pub use self::error::AdminServiceEventStoreError;
+use crate::admin::service::messages::AdminServiceEvent;
+
+/// Interface for performing CRUD operations on `AdminServiceEvent`s.
+pub trait AdminServiceEventStore: Send + Sync {
+    /// Add an event to the `AdminServiceEventStore`.  Returns the recorded event time and a copy
+    /// of the event.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - the `AdminServiceEvent` to be added to the store
+    fn add(
+        &self,
+        event: AdminServiceEvent,
+    ) -> Result<(SystemTime, AdminServiceEvent), AdminServiceEventStoreError>;
+
+    /// List `AdminServiceEvent`s that have been added to the store since the provided start index.
+    ///
+    /// # Arguments
+    ///
+    /// * `start` - index used to filter events
+    fn iter_since(
+        &self,
+        start: i64,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = AdminServiceEvent>>, AdminServiceEventStoreError>;
+
+    /// List `AdminServiceEvent`s, with a corresponding `CircuitProposal` that has the specified
+    /// `management_type`, that have been added to the store since the provided start index.
+    ///
+    /// # Arguments
+    ///
+    /// * `management_type` - management type used to filter `CircuitProposal`s
+    /// * `start` - index used to filter events
+    fn iter_with_management_type_since(
+        &self,
+        management_type: String,
+        start: i64,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = AdminServiceEvent>>, AdminServiceEventStoreError>;
+}

--- a/libsplinter/src/admin/service/event/store/mod.rs
+++ b/libsplinter/src/admin/service/event/store/mod.rs
@@ -19,6 +19,8 @@
 //!
 //! [`AdminServiceEventStore`]: trait.AdminServiceEventStore.html
 
+#[cfg(feature = "diesel")]
+mod diesel;
 mod error;
 
 use std::time::SystemTime;

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -14,6 +14,8 @@
 
 mod consensus;
 pub(crate) mod error;
+#[cfg(feature = "admin-service-event-store")]
+pub mod event;
 mod mailbox;
 pub(crate) mod messages;
 pub(super) mod proposal_store;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-11-24-125000_admin_service_event_store/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-11-24-125000_admin_service_event_store/down.sql
@@ -1,0 +1,24 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS admin_event_entry;
+DROP TABLE IF EXISTS admin_event_circuit_proposal;
+DROP TABLE IF EXISTS admin_event_create_circuit;
+DROP TABLE IF EXISTS admin_event_proposed_node;
+DROP TABLE IF EXISTS admin_event_proposed_node_endpoint;
+DROP TABLE IF EXISTS admin_event_proposed_service;
+DROP TABLE IF EXISTS admin_event_proposed_service_argument;
+DROP TABLE IF EXISTS admin_event_proposed_service_node;
+DROP TABLE IF EXISTS admin_event_vote_record;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-11-24-125000_admin_service_event_store/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-11-24-125000_admin_service_event_store/up.sql
@@ -1,0 +1,102 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS admin_event_entry (
+    id                       BIGSERIAL PRIMARY KEY,
+    circuit_id               TEXT NOT NULL,
+    event_type               TEXT NOT NULL,
+    data                     BYTEA,
+    timestamp                TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_circuit_proposal (
+    event_id                  INTEGER PRIMARY KEY,
+    proposal_type             TEXT NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    circuit_hash              TEXT NOT NULL,
+    requester                 BYTEA NOT NULL,
+    requester_node_id         TEXT NOT NULL,
+    FOREIGN KEY (event_id) REFERENCES admin_event_entry(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_vote_record (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    public_key                BYTEA NOT NULL,
+    vote                      TEXT NOT NULL,
+    voter_node_id             TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, voter_node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_create_circuit (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL,
+    application_metadata      BYTEA NOT NULL,
+    comments                  TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_node (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_node_endpoint (
+    event_id               INTEGER NOT NULL,
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    circuit_id             TEXT NOT NULL,
+    PRIMARY KEY (event_id, node_id, endpoint),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service_argument (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id, key),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service_node (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id, node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-11-24-125000_admin_service_event_store/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-11-24-125000_admin_service_event_store/down.sql
@@ -1,0 +1,24 @@
+--- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS admin_event_entry;
+DROP TABLE IF EXISTS admin_event_circuit_proposal;
+DROP TABLE IF EXISTS admin_event_create_circuit;
+DROP TABLE IF EXISTS admin_event_proposed_node;
+DROP TABLE IF EXISTS admin_event_proposed_node_endpoint;
+DROP TABLE IF EXISTS admin_event_proposed_service;
+DROP TABLE IF EXISTS admin_event_proposed_service_argument;
+DROP TABLE IF EXISTS admin_event_proposed_service_node;
+DROP TABLE IF EXISTS admin_event_vote_record;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-11-24-125000_admin_service_event_store/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-11-24-125000_admin_service_event_store/up.sql
@@ -1,0 +1,103 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS admin_event_entry (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id               TEXT NOT NULL,
+    event_type               TEXT NOT NULL,
+    data                     BINARY,
+    timestamp                TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_circuit_proposal (
+    event_id                  INTEGER NOT NULL,
+    proposal_type             TEXT NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    circuit_hash              TEXT NOT NULL,
+    requester                 BINARY NOT NULL,
+    requester_node_id         TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_entry(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_vote_record (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    public_key                BINARY NOT NULL,
+    vote                      TEXT NOT NULL,
+    voter_node_id             TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, voter_node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_create_circuit (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    authorization_type        TEXT NOT NULL,
+    persistence               TEXT NOT NULL,
+    durability                TEXT NOT NULL,
+    routes                    TEXT NOT NULL,
+    circuit_management_type   TEXT NOT NULL,
+    application_metadata      BINARY NOT NULL,
+    comments                  TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_node (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_node_endpoint (
+    event_id               INTEGER NOT NULL,
+    node_id                TEXT NOT NULL,
+    endpoint               TEXT NOT NULL,
+    circuit_id             TEXT NOT NULL,
+    PRIMARY KEY (event_id, node_id, endpoint),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service_argument (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id, key),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS admin_event_proposed_service_node (
+    event_id                  INTEGER NOT NULL,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    node_id                   TEXT NOT NULL,
+    PRIMARY KEY (event_id, circuit_id, service_id, node_id),
+    FOREIGN KEY (event_id) REFERENCES admin_event_circuit_proposal(event_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
This adds the initial structure (models, schemas, and migrations, too) for the database backend for the admin service's `Mailbox`. 

Testing:
To run the SQLite migration test, run 
```
$ cargo test --features experimental test_admin_service_event_store_sqlite_migrations
```

Otherwise, create a local postgres instance: 
```
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
```

Then, run the migrations:
```
$ cargo run --manifest-path cli/Cargo.toml --features experimental -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
```

These should complete successfully. To verify these migrations have been applied, docker exec into the postgres container created above:
```
$ docker run -it --rm --link postgres:postgres postgres psql -h postgres -U postgres
Password for user postgres:
postgres-# \c splinter
You are now connected to database "splinter" as user "postgres".
splinter=# select * from admin_event_entry;
...
```
