### PR TITLE
Modify OpenID OAuth identity provider

### DIFF
--- a/libsplinter/src/rest_api/auth/identity/openid.rs
+++ b/libsplinter/src/rest_api/auth/identity/openid.rs
@@ -56,12 +56,12 @@ impl IdentityProvider for OpenIdUserIdentityProvider {
             }
         }
 
-        let email = response
+        let user_identity = response
             .json::<UserResponse>()
             .map_err(|_| InternalError::with_message("Received unexpected response body".into()))?
-            .email;
+            .sub;
 
-        Ok(Some(email))
+        Ok(Some(user_identity))
     }
 
     fn clone_box(&self) -> Box<dyn IdentityProvider> {
@@ -72,5 +72,5 @@ impl IdentityProvider for OpenIdUserIdentityProvider {
 /// Deserializes response
 #[derive(Debug, Deserialize)]
 struct UserResponse {
-    email: String,
+    sub: String,
 }


### PR DESCRIPTION
Modify the OpenID identity provider to return the 'sub' value from the json object returned by the userinfo_endpoint. This value, the subject identifier, is the unique identifier for End-User accounts. Google and Azure AD both use subject identifiers and all other OpenID providers should as well.