### PR TITLE
Inflight OAuth request store

### DIFF
--- a/libsplinter/src/oauth/builder/github.rs
+++ b/libsplinter/src/oauth/builder/github.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::oauth::{builder::OAuthClientBuilder, error::OAuthClientBuildError, OAuthClient};
+use crate::oauth::{
+    builder::OAuthClientBuilder, error::OAuthClientBuildError, InflightOAuthRequestStore,
+    OAuthClient,
+};
 use crate::rest_api::auth::identity::{github::GithubUserIdentityProvider, IdentityProvider};
 
 /// Builds a new `OAuthClient` with GitHub's authorization and token URLs.
@@ -52,7 +55,20 @@ impl GithubOAuthClientBuilder {
         }
     }
 
-    /// Builds an `OAuthClient` and returns it along with the `IdentityProvider` for GitHub.
+    /// Sets the in-flight request store in order to store values between requests to and from the
+    /// OAuth2 provider.
+    pub fn with_inflight_request_store(
+        self,
+        inflight_request_store: Box<dyn InflightOAuthRequestStore>,
+    ) -> Self {
+        Self {
+            inner: self
+                .inner
+                .with_inflight_request_store(inflight_request_store),
+        }
+    }
+
+    /// Builds an OAuthClient.
     ///
     /// # Errors
     ///

--- a/libsplinter/src/oauth/builder/mod.rs
+++ b/libsplinter/src/oauth/builder/mod.rs
@@ -23,7 +23,7 @@ use crate::error::InvalidStateError;
 use crate::rest_api::auth::identity::IdentityProvider;
 
 use super::error::OAuthClientBuildError;
-use super::{InflightOAuthRequestStore, OAuthClient};
+use super::{new_basic_client, InflightOAuthRequestStore, OAuthClient};
 
 #[cfg(feature = "oauth-github")]
 pub use github::GithubOAuthClientBuilder;
@@ -99,11 +99,7 @@ impl OAuthClientBuilder {
         })?;
         Ok((
             OAuthClient::new(
-                client_id,
-                client_secret,
-                auth_url,
-                redirect_url,
-                token_url,
+                new_basic_client(client_id, client_secret, auth_url, redirect_url, token_url)?,
                 self.scopes,
                 identity_provider.clone(),
                 inflight_request_store,

--- a/libsplinter/src/oauth/builder/openid.rs
+++ b/libsplinter/src/oauth/builder/openid.rs
@@ -15,7 +15,10 @@
 use reqwest::blocking::Client;
 
 use crate::error::{InternalError, InvalidStateError};
-use crate::oauth::{builder::OAuthClientBuilder, error::OAuthClientBuildError, OAuthClient};
+use crate::oauth::{
+    builder::OAuthClientBuilder, error::OAuthClientBuildError, InflightOAuthRequestStore,
+    OAuthClient,
+};
 use crate::rest_api::auth::identity::{openid::OpenIdUserIdentityProvider, IdentityProvider};
 
 /// Builds a new `OAuthClient` using an OpenID discovery document.
@@ -46,6 +49,20 @@ impl OpenIdOAuthClientBuilder {
         Self {
             openid_discovery_url: self.openid_discovery_url,
             inner: self.inner.with_client_secret(client_secret),
+        }
+    }
+
+    /// Sets the in-flight request store in order to store values between requests to and from the
+    /// OAuth2 provider.
+    pub fn with_inflight_request_store(
+        self,
+        inflight_request_store: Box<dyn InflightOAuthRequestStore>,
+    ) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self
+                .inner
+                .with_inflight_request_store(inflight_request_store),
         }
     }
 

--- a/libsplinter/src/oauth/store/memory.rs
+++ b/libsplinter/src/oauth/store/memory.rs
@@ -1,0 +1,97 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Memory-backed InflightOAuthRequestStore implementation.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::collections::TtlMap;
+use crate::error::InternalError;
+use crate::oauth::{InflightOAuthRequestStore, PendingAuthorization};
+
+/// The amount of time before a pending authorization expires and a new request must be made
+const PENDING_AUTHORIZATION_EXPIRATION_SECS: u64 = 3600; // 1 hour
+
+/// A memory-backed implementation of InflightOAuthRequestStore.
+///
+/// Values in this store expire after an hour.
+#[derive(Clone)]
+pub struct MemoryInflightOAuthRequestStore {
+    pending_authorizations: Arc<Mutex<TtlMap<String, PendingAuthorization>>>,
+}
+
+impl MemoryInflightOAuthRequestStore {
+    /// Constructs a new instance.
+    pub fn new() -> Self {
+        Self {
+            pending_authorizations: Arc::new(Mutex::new(TtlMap::new(Duration::from_secs(
+                PENDING_AUTHORIZATION_EXPIRATION_SECS,
+            )))),
+        }
+    }
+}
+
+impl Default for MemoryInflightOAuthRequestStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InflightOAuthRequestStore for MemoryInflightOAuthRequestStore {
+    fn insert_request(
+        &self,
+        request_id: String,
+        pending_authorization: PendingAuthorization,
+    ) -> Result<(), InternalError> {
+        self.pending_authorizations
+            .lock()
+            .map_err(|_| {
+                InternalError::with_message("pending authorizations lock was poisoned".into())
+            })?
+            .insert(request_id, pending_authorization);
+
+        Ok(())
+    }
+
+    fn remove_request(
+        &self,
+        request_id: &str,
+    ) -> Result<Option<PendingAuthorization>, InternalError> {
+        Ok(self
+            .pending_authorizations
+            .lock()
+            .map_err(|_| {
+                InternalError::with_message("pending authorizations lock was poisoned".into())
+            })?
+            .remove(request_id))
+    }
+
+    fn clone_box(&self) -> Box<dyn InflightOAuthRequestStore> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::oauth::tests::test_request_store_insert_and_remove;
+
+    #[test]
+    fn memory_insert_request_and_remove() {
+        let inflight_request_store = MemoryInflightOAuthRequestStore::new();
+        test_request_store_insert_and_remove(&inflight_request_store);
+    }
+}

--- a/libsplinter/src/oauth/store/mod.rs
+++ b/libsplinter/src/oauth/store/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementations for the InflightOAuthRequestStore.
+
+mod memory;
+
+pub use memory::MemoryInflightOAuthRequestStore;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -92,6 +92,8 @@ use crate::biome::{
 use crate::error::InvalidStateError;
 #[cfg(feature = "oauth")]
 use crate::oauth::rest_api::{OAuthResourceProvider, OAuthUserInfoStore, OAuthUserInfoStoreNoOp};
+#[cfg(any(feature = "oauth-github", feature = "oauth-openid"))]
+use crate::oauth::store::MemoryInflightOAuthRequestStore;
 #[cfg(feature = "oauth-github")]
 use crate::oauth::GithubOAuthClientBuilder;
 #[cfg(feature = "oauth-openid")]
@@ -870,6 +872,9 @@ impl RestApiBuilder {
                                 .with_client_id(client_id.into())
                                 .with_client_secret(client_secret.into())
                                 .with_redirect_url(redirect_url.into())
+                                .with_inflight_request_store(Box::new(
+                                    MemoryInflightOAuthRequestStore::new(),
+                                ))
                                 .build()
                                 .map_err(|err| {
                                     RestApiServerError::InvalidStateError(
@@ -890,6 +895,9 @@ impl RestApiBuilder {
                                 .with_client_id(client_id.into())
                                 .with_client_secret(client_secret.into())
                                 .with_redirect_url(redirect_url.into())
+                                .with_inflight_request_store(Box::new(
+                                    MemoryInflightOAuthRequestStore::new(),
+                                ))
                                 .build()
                                 .map_err(|err| {
                                     RestApiServerError::InvalidStateError(


### PR DESCRIPTION
This PR refactors the in-flight state saved between the initiation of an OAuth2 request and the receipt of the callback. It places the original memory implementation behind a trait, and updates the builders to take a trait implementation. 

Additionally, 

- Adding a new parameter create a clippy error with the OAuthClient constructor. As this is a private method, it has been decomposed into two functions