### PR TITLE
Add separate protocol version for AdminService

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -33,7 +33,7 @@ use crate::hex::to_hex;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::{ServiceDefinition, ServiceOrchestrator};
 use crate::peer::{PeerManagerConnector, PeerRef};
-use crate::protocol::{ADMIN_PROTOCOL_VERSION, ADMIN_SERVICE_PROTOCOL_MIN};
+use crate::protocol::{ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION};
 #[cfg(feature = "service-arg-validation")]
 use crate::protos::admin::SplinterService;
 use crate::protos::admin::{
@@ -746,7 +746,7 @@ impl AdminServiceShared {
                 );
                 let mut request = ServiceProtocolVersionRequest::new();
                 request.set_protocol_min(ADMIN_SERVICE_PROTOCOL_MIN);
-                request.set_protocol_max(ADMIN_PROTOCOL_VERSION);
+                request.set_protocol_max(ADMIN_SERVICE_PROTOCOL_VERSION);
                 let mut msg = AdminMessage::new();
                 msg.set_message_type(AdminMessage_Type::SERVICE_PROTOCOL_VERSION_REQUEST);
                 msg.set_protocol_request(request);
@@ -1141,7 +1141,7 @@ impl AdminServiceShared {
             );
             let mut request = ServiceProtocolVersionRequest::new();
             request.set_protocol_min(ADMIN_SERVICE_PROTOCOL_MIN);
-            request.set_protocol_max(ADMIN_PROTOCOL_VERSION);
+            request.set_protocol_max(ADMIN_SERVICE_PROTOCOL_VERSION);
             let mut msg = AdminMessage::new();
             msg.set_message_type(AdminMessage_Type::SERVICE_PROTOCOL_VERSION_REQUEST);
             msg.set_protocol_request(request);

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -18,12 +18,11 @@ pub mod authorization;
 pub mod component;
 pub mod service;
 
+// Admin REST API protocol versions
 pub const ADMIN_PROTOCOL_VERSION: u32 = 1;
 
 #[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
 pub(crate) const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
-#[cfg(feature = "admin-service")]
-pub(crate) const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
 #[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
 pub(crate) const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
 
@@ -36,6 +35,12 @@ pub(crate) const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
 #[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
 pub(crate) const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
+
+// Admin Service protocol versions
+pub const ADMIN_SERVICE_PROTOCOL_VERSION: u32 = 1;
+
+#[cfg(feature = "admin-service")]
+pub(crate) const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(feature = "oauth")]
 pub const OAUTH_PROTOCOL_VERSION: u32 = 1;


### PR DESCRIPTION
Before the admin service used the same protocol version
as the admin service REST API. However, the REST API and
the protobuf messages have different protocols and should
be treated as such.

The AdminService has also been updated to properly handle
different admin protocol version and min version, and return
the correct protocol version that can be agreed upon.
Before it only worked if the admin protocol version and min
were the same. It also would always returned the admin
protocol version.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>