### PR TITLE
Fix bug in database migrate CLI command

### DIFF
--- a/cli/src/action/database/mod.rs
+++ b/cli/src/action/database/mod.rs
@@ -34,9 +34,10 @@ pub struct MigrateAction;
 impl Action for MigrateAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let url = if let Some(args) = arg_matches {
-            args.value_of("connect")
-                .map(ToOwned::to_owned)
-                .unwrap_or(get_default_database()?)
+            match args.value_of("connect") {
+                Some(url) => url.to_owned(),
+                None => get_default_database()?,
+            }
         } else {
             get_default_database()?
         };


### PR DESCRIPTION
Fixes a small bug in the `splinter database migrate` command where the
`get_default_database` function would always be called, regardless of it
was necessary. This was happening because the `Option::unwrap_or` method
eagerly evaluates its contents.

Signed-off-by: Logan Seeley <seeley@bitwise.io>