### PR TITLE
Handle display name in splinter CLI

### DIFF
--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -61,18 +61,18 @@ OPTIONS
 EXAMPLES
 ========
 This command displays information about circuits with a default `human`
-formatting, meaning the information is displayed in a table. The `--member` option
-allows for filtering the circuits.
+formatting, meaning the information is displayed in a table. The `--member`
+option allows for filtering the circuits.
 
 The following command does not specify any filters, therefore all circuits
 the local node, `alpha-node-000` is a member of are displayed.
 ```
 $ splinter circuit list \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+ID            NAME      MANAGEMENT    MEMBERS
+01234-ABCDE   -         mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
 The next command specifies a `--member` filter, therefore all circuits
@@ -82,9 +82,9 @@ ID will be listed.
 $ splinter circuit list \
   member gamma-node-000 \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+ID            NAME      MANAGEMENT    MEMBERS
+43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
 Since all of the circuits listed have been accepted by each member, the same
@@ -95,9 +95,9 @@ following with no filters:
 ```
 $ splinter circuit list \
   --url URL-of-gamma-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+ID            NAME      MANAGEMENT    MEMBERS
+43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
 From the perspective of the `beta-node-000` node, this command will display the
@@ -105,8 +105,8 @@ following with no filters:
 ```
 $ splinter circuit list \
   --url URL-of-gamma-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
+ID            NAME  MANAGEMENT    MEMBERS
+01234-ABCDE   -     mgmt001       alpha-node-000;beta-node-000
 ```
 
 ENVIRONMENT VARIABLES

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -18,10 +18,10 @@ DESCRIPTION
 ===========
 Lists all of the circuit proposals that the local node is a proposed member of.
 This command displays abbreviated information pertaining to proposed circuits in
-columns, with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it possible
-to verify that circuit proposals have been successfully proposed as well as being
-able to access the generated circuit ID assigned to a proposal. Circuit proposals
-have not necessarily been voted on by all proposed members.
+columns, with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it
+possible to verify that circuit proposals have been successfully proposed as
+well as being able to access the generated circuit ID assigned to a proposal.
+Circuit proposals have not necessarily been voted on by all proposed members.
 
 FLAGS
 =====
@@ -55,8 +55,8 @@ OPTIONS
 : Filter the circuit proposals by their circuit management type.
 
 `-m`, `--member` MEMBER
-: Filter the circuits list by a node ID that is present in the circuit proposal’s
-  members list.
+: Filter the circuits list by a node ID that is present in the circuit
+  proposal’s members list.
 
 `-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
@@ -68,39 +68,39 @@ This command displays information about circuit proposals with a default `human`
 formatting, meaning the information is displayed in a table. The `--member` and
 `--management-type` options allow for filtering the circuit proposals.
 
-The following command does not specify any filters, therefore all circuit proposals
-the local node, `alpha-node-000` is a part of are displayed.
+The following command does not specify any filters, therefore all circuit
+proposals the local node, `alpha-node-000` is a part of are displayed.
 ```
 $ splinter circuit proposals \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+ID           NAME      MANAGEMENT    MEMBERS
+01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE  -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
 The next command specifies a `--management-type` filter, therefore all circuit
-proposals the local node, `alpha-node-000` is a part of with a `circuit_management_type`
-of `mgmt001` will be listed.
+proposals the local node, `alpha-node-000` is a part of with a
+`circuit_management_type` of `mgmt001` will be listed.
 ```
 $ splinter circuit proposals \
   --management-type mgmt001 \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+ID           NAME      MANAGEMENT    MEMBERS
+01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000
 ```
 
 The next command specifies a `--member` filter, therefore all circuit proposals
-the local node, `alpha-node-000` is a part of including the `gamma-node-000` node
-ID will be listed.
+the local node, `alpha-node-000` is a part of including the `gamma-node-000`
+node ID will be listed.
 ```
 $ splinter circuit proposals \
   member gamma-node-000 \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            MANAGEMENT    MEMBERS
-43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+ID            NAME      MANAGEMENT    MEMBERS
+43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
 ENVIRONMENT VARIABLES

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -53,6 +53,9 @@ OPTIONS
 `--comments COMMENTS`
 : Adds human-readable comments to the circuit proposal.
 
+`--display-name DISPLAY-NAME`
+: Add human-readable name for the circuit.
+
 `-k, --key PRIVATE-KEY-FILE`
 : Specifies the full path to the private key file.
 

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -53,6 +53,10 @@ OPTIONS
 `--comments COMMENTS`
 : Adds human-readable comments to the circuit proposal.
 
+`--compat COMPAT_VERSION`
+: Enforce that the proposed circuit is compatible with a specific version.
+  Accepted values: `0.4`
+
 `--display-name DISPLAY-NAME`
 : Add human-readable name for the circuit.
 

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -82,6 +82,7 @@ the proposal will not be viewable by any nodes.
 $ splinter circuit show 01234-ABCDE \
   ---url URL-of-alpha-node-splinterd-REST-API
 Proposal to create: 01234-ABCDE
+    Display Name: -
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -34,6 +34,7 @@ pub struct CreateCircuitMessageBuilder {
     authorization_type: Option<AuthorizationType>,
     application_metadata: Vec<u8>,
     comments: Option<String>,
+    display_name: Option<String>,
 }
 
 impl CreateCircuitMessageBuilder {
@@ -47,6 +48,7 @@ impl CreateCircuitMessageBuilder {
             authorization_type: None,
             application_metadata: vec![],
             comments: None,
+            display_name: None,
         }
     }
 
@@ -232,6 +234,10 @@ impl CreateCircuitMessageBuilder {
         self.comments = Some(comments.into());
     }
 
+    pub fn set_display_name(&mut self, display_name: &str) {
+        self.display_name = Some(display_name.into());
+    }
+
     pub fn build(mut self) -> Result<CreateCircuit, CliError> {
         let circuit_builder = self.create_circuit_builder();
 
@@ -287,13 +293,17 @@ impl CreateCircuitMessageBuilder {
             comments.push_str(&format!("; {}", builder_comments));
         }
 
-        let create_circuit_builder = self
+        let mut create_circuit_builder = self
             .create_circuit_builder
             .with_members(&self.nodes)
             .with_roster(&services)
             .with_circuit_management_type(&management_type)
             .with_application_metadata(&self.application_metadata)
             .with_comments(&comments);
+
+        if let Some(display_name) = self.display_name {
+            create_circuit_builder = create_circuit_builder.with_display_name(&display_name);
+        }
 
         #[cfg(feature = "circuit-auth-type")]
         let create_circuit_builder = match self.authorization_type {

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -20,6 +20,7 @@ pub mod template;
 
 #[cfg(feature = "circuit-template")]
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fs::File;
 
 use clap::ArgMatches;
@@ -159,9 +160,13 @@ impl Action for CircuitProposeAction {
             builder.set_comments(comments);
         }
 
+        if let Some(comments) = args.value_of("display_name") {
+            builder.set_display_name(comments);
+        }
+
         let create_circuit = builder.build()?;
 
-        let circuit_slice = CircuitSlice::from(&create_circuit);
+        let circuit_slice = CircuitSlice::try_from(&create_circuit)?;
 
         if !args.is_present("dry_run") {
             let url = args
@@ -498,9 +503,11 @@ fn parse_service_type_argument(service_type: &str) -> Result<(String, String), C
     Ok((service_id, service_type))
 }
 
-impl From<&CreateCircuit> for CircuitSlice {
-    fn from(circuit: &CreateCircuit) -> Self {
-        Self {
+impl TryFrom<&CreateCircuit> for CircuitSlice {
+    type Error = CliError;
+
+    fn try_from(circuit: &CreateCircuit) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: circuit.circuit_id.clone(),
             members: circuit
                 .members
@@ -510,21 +517,33 @@ impl From<&CreateCircuit> for CircuitSlice {
             roster: circuit
                 .roster
                 .iter()
-                .map(|service| service.into())
-                .collect(),
+                .map(CircuitServiceSlice::try_from)
+                .collect::<Result<Vec<CircuitServiceSlice>, CliError>>()?,
             management_type: circuit.circuit_management_type.clone(),
-        }
+            display_name: circuit.display_name.clone(),
+        })
     }
 }
 
-impl From<&SplinterService> for CircuitServiceSlice {
-    fn from(service: &SplinterService) -> Self {
-        Self {
+impl TryFrom<&SplinterService> for CircuitServiceSlice {
+    type Error = CliError;
+
+    fn try_from(service: &SplinterService) -> Result<Self, Self::Error> {
+        Ok(Self {
             service_id: service.service_id.clone(),
             service_type: service.service_type.clone(),
-            allowed_nodes: service.allowed_nodes.clone(),
+            node_id: service
+                .allowed_nodes
+                .get(0)
+                .ok_or_else(|| {
+                    CliError::ActionError(format!(
+                        "Service {} is missing node_id",
+                        service.service_id
+                    ))
+                })?
+                .to_string(),
             arguments: service.arguments.iter().cloned().collect(),
-        }
+        })
     }
 }
 
@@ -660,13 +679,25 @@ fn list_circuits(
     let mut data = Vec::new();
     data.push(vec![
         "ID".to_string(),
+        "NAME".to_string(),
         "MANAGEMENT".to_string(),
         "MEMBERS".to_string(),
     ]);
     circuits.data.iter().for_each(|circuit| {
         let members = circuit.members.join(";");
+        let display_name = {
+            if format == "csv" {
+                circuit.display_name.clone().unwrap_or_default()
+            } else {
+                circuit
+                    .display_name
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string())
+            }
+        };
         data.push(vec![
             circuit.id.to_string(),
+            display_name,
             circuit.management_type.to_string(),
             members,
         ]);
@@ -848,11 +879,24 @@ fn list_proposals(
     let mut data = Vec::new();
     data.push(vec![
         "ID".to_string(),
+        "NAME".to_string(),
         "MANAGEMENT".to_string(),
         "MEMBERS".to_string(),
         "COMMENTS".to_string(),
     ]);
     proposals.data.iter().for_each(|proposal| {
+        let display_name = {
+            if format == "csv" {
+                proposal.circuit.display_name.clone().unwrap_or_default()
+            } else {
+                proposal
+                    .circuit
+                    .display_name
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string())
+            }
+        };
+
         let members = proposal
             .circuit
             .members
@@ -862,6 +906,7 @@ fn list_proposals(
             .join(";");
         data.push(vec![
             proposal.circuit_id.to_string(),
+            display_name,
             proposal.circuit.management_type.to_string(),
             members,
             proposal.circuit.comments.to_string(),

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -160,8 +160,13 @@ impl Action for CircuitProposeAction {
             builder.set_comments(comments);
         }
 
-        if let Some(comments) = args.value_of("display_name") {
-            builder.set_display_name(comments);
+        if let Some(display_name) = args.value_of("display_name") {
+            if args.value_of("compat_version") == Some("0.4") {
+                return Err(CliError::ActionError(
+                    "Display name is not compatible with Splinter v0.4".to_string(),
+                ));
+            }
+            builder.set_display_name(display_name);
         }
 
         let create_circuit = builder.build()?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -303,6 +303,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 .help("Add human-readable comments to the proposal"),
         )
         .arg(
+            Arg::with_name("display_name")
+                .long("display-name")
+                .takes_value(true)
+                .help("Add human-readable name for the circuit"),
+        )
+        .arg(
             Arg::with_name("dry_run")
                 .long("dry-run")
                 .short("n")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -309,6 +309,13 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 .help("Add human-readable name for the circuit"),
         )
         .arg(
+            Arg::with_name("compat_version")
+                .long("compat")
+                .takes_value(true)
+                .possible_values(&["0.4"])
+                .help("Enforce that the proposed circuit is compatible with a specific version"),
+        )
+        .arg(
             Arg::with_name("dry_run")
                 .long("dry-run")
                 .short("n")

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1672,7 +1672,7 @@ components:
       required: false
       schema:
         type: integer
-        example: 1
+        example: 2
 
   schemas:
     Error:
@@ -1840,6 +1840,10 @@ components:
         management_type:
           type: string
           example: gameroom
+        display_name:
+          description: Human readable name for the circuit
+          type: string
+          nullable: true
 
     CircuitService:
       type: object
@@ -1850,11 +1854,10 @@ components:
         service_type:
           type: string
           example: scabbard
-        allowed_nodes:
-          description: IDs of the nodes that are allowed to run this service
-          type: array
-          items:
-            type: string
+        node_id:
+          description: The node ID that is allowed to run this service
+          type: string
+          example: alpha-node-000
 
     Proposal:
       type: object
@@ -1896,6 +1899,10 @@ components:
               comments:
                 description: Arbitrary comments to describe the proposed circuit
                 type: string
+              display_name:
+                description: Human readable name for the circuit
+                type: string
+                nullable: true
         votes:
           type: array
           items:
@@ -1928,12 +1935,10 @@ components:
         service_type:
           type: string
           example: scabbard
-        allowed_nodes:
-          description: List of node IDs that are allowed to run this service
-          type: array
-          items:
-            type: string
-            example: alpha-node-000
+        node_id:
+          description: The node ID that is allowed to run this service
+          type: string
+          example: alpha-node-000
         arguments:
           description: |-
             Arbitrary arguments to be passed to this service on initialization,


### PR DESCRIPTION
Help for `splinter circuit propose`:

```
splinter-circuit-propose 
Propose that a new circuit is created

USAGE:
    splinter circuit propose [FLAGS] [OPTIONS] --node <node>... --node-file <node_file> --service <service>... --template <template>

FLAGS:
    -n, --dry-run       Print circuit definition without submitting the proposal
    -h, --help          Prints help information
    -q, --quiet         Do not display output
    -V, --version       Prints version information
    -v                  Log verbosely

OPTIONS:
        --comments <comments>                           Add human-readable comments to the proposal
        --compat <compat_version>
            Enforce that the proposed circuit is compatible with a specific version [possible values: 0.4]
        --display-name <display_name>                   Add human-readable name for the circuit
    -k, --key <private-key-file>                        Path to private key file
        --management <management_type>                  Management type for the circuit
        --metadata <application_metadata>...            Application metadata of the proposal
        --metadata-encoding <metadata_encoding>
            Set encoding of application metadata (default: string) [possible values: json, string]

        --node <node>...
            Node that is part of a circuit (<node_id>::<endpoint1>,<endpoint2>)

        --node-file <node_file>                         File system path or HTTP(S) URL to nodes file
        --service <service>...                          Service ID and allowed nodes (<service-id>::<allowed_nodes>)
        --service-arg <service_argument>...             Pass arguments to a service (<service_id>::<key>=<value>)
        --service-peer-group <service_peer_group>...    List of peer services (comma-separated list)
        --service-type <service_type>...                Service type (<service_id>::<service_type>)
        --template <template>                           Template name to be applied to circuit
        --template-arg <template_arg>...                Arguments for the template argument (<key>=<value>)
    -U, --url <url>                                     URL of Splinter Daemon

DETAILS:
    One or more nodes must be specified using the --node and/or --node-file arguments. These
    arguments can be used on their own or together, but at least one of them is required.

    The --node-file argument must be a valid YAML file. A valid YAML file will be a list of nodes,
    where each node has an 'identity' or 'node_id' field, as well as an 'endpoints' field. Example:
        ---
        - identity: 'node-1'
          endpoints:
            - tcps://node-1-endpoint:8044
        - node_id: 'node-2'
          endpoints:
            - tcps://node-2-endpoint:8045

    For the --service-arg, --service-peer-group, and --service-type options, service IDs can be
    wildcarded with '*' to match multiple services. For example, '--service-type *::scabbard' match
    all services, and '--service-type sc*::scabbard' will match all services with IDs that start
    with 'sc'.

    With '--metadata-encoding string' (the default), the --metadata option takes a single string
    value and the --metadata option can be used only once. With '--metadata-encoding json', the
    --metadata option takes a key/value pair in the format '<key>=<value>', where '<value>' is a
    simple string, a JSON array, or a JSON object; the --metadata option can be used multiple times
    with JSON encoding.
```

Update for list/show proposals:

```
splinter circuit proposals
ID          NAME         MANAGEMENT MEMBERS                      COMMENTS 
kTu1A-34swL test_display test       acme-node-000;bubba-node-000          
iuYK1-98ZJk -            test       acme-node-000;bubba-node-000                 
```

show proposal with display name and without
```
Proposal to create: kTu1A-34swL
    Display Name: test_display
    Management Type: test

    acme-node-000 (["tcps://splinterd-node-acme:8044"])
        Vote: ACCEPT (implied as requester):
            03b6b074eec971e4601e4981bf43bb9c5e56906ef5ec1d28da75633e8f23ac9d9f
        Service (scabbard): a000
            admin_keys:
                PRIVATE-KEY-FILE
            peer_services:
                a001

    bubba-node-000 (["tcps://splinterd-node-bubba:8044"])
        Vote: PENDING
        Service (scabbard): a001
            admin_keys:
                PRIVATE-KEY-FILE
            peer_services:
                a000

Proposal to create: iuYK1-98ZJk
    Display Name: -
    Management Type: test

    acme-node-000 (["tcps://splinterd-node-acme:8044"])
        Vote: ACCEPT (implied as requester):
            03b6b074eec971e4601e4981bf43bb9c5e56906ef5ec1d28da75633e8f23ac9d9f
        Service (scabbard): a000
            admin_keys:
                PRIVATE-KEY-FILE
            peer_services:
                a001

    bubba-node-000 (["tcps://splinterd-node-bubba:8044"])
        Vote: PENDING
        Service (scabbard): a001
            admin_keys:
                PRIVATE-KEY-FILE
            peer_services:
                a000
```

circuit list:
```
splinter circuit list
ID          NAME         MANAGEMENT MEMBERS                      
kTu1A-34swL test_display test       acme-node-000;bubba-node-000 
iuYK1-98ZJk -            test       acme-node-000;bubba-node-000 
```

circuit show with and without display name:

```
Circuit: kTu1A-34swL
    Display Name: test_display
    Management Type: test

    acme-node-000
        Service (scabbard): a000
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a001

    bubba-node-000
        Service (scabbard): a001
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a000

Circuit: iuYK1-98ZJk
    Display Name: -
    Management Type: test

    acme-node-000
        Service (scabbard): a000
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a001

    bubba-node-000
        Service (scabbard): a001
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a000


```