### PR TITLE
Namespace Biome user IDs

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -59,7 +59,7 @@ serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
 tungstenite = { version = "0.10", optional = true }
 url = "1.7.1"
-uuid = { version = "0.7", features = ["v4"]}
+uuid = { version = "0.8", features = ["v4", "v5"] }
 zmq = { version = "0.9", optional = true }
 
 [dev-dependencies]

--- a/libsplinter/src/biome/rest_api/actix/register.rs
+++ b/libsplinter/src/biome/rest_api/actix/register.rs
@@ -25,6 +25,12 @@ use crate::futures::{Future, IntoFuture};
 use crate::protocol;
 use crate::rest_api::{into_bytes, ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
 
+/// This is the UUID namespace for Biome user IDs generated for users that register with Biome
+/// credentials. This will prevent collisions with Biome user IDs generated for users that login
+/// with OAuth. The `u128` was calculated by creating a v5 UUID with the nil namespace and the name
+/// `b"biome credentials"`.
+const UUID_NAMESPACE: Uuid = Uuid::from_u128(140899893353887994607859851180695869034);
+
 /// Defines a REST endpoint to add a user and credentials to the database
 ///
 /// The payload should be in the JSON format:
@@ -57,7 +63,7 @@ pub fn make_register_route(
                             .into_future();
                     }
                 };
-                let user_id = Uuid::new_v4().to_string();
+                let user_id = Uuid::new_v5(&UUID_NAMESPACE, Uuid::new_v4().as_bytes()).to_string();
                 let credentials_builder = CredentialsBuilder::default();
                 let credentials = match credentials_builder
                     .with_user_id(&user_id)

--- a/libsplinter/src/biome/rest_api/auth/oauth.rs
+++ b/libsplinter/src/biome/rest_api/auth/oauth.rs
@@ -25,6 +25,12 @@ use crate::error::InternalError;
 use crate::oauth::{rest_api::OAuthUserInfoStore, UserInfo};
 use crate::rest_api::auth::identity::{Authorization, AuthorizationMapping, BearerToken};
 
+/// This is the UUID namespace for Biome user IDs generated for users that login with OAuth. This
+/// will prevent collisions with Biome user IDs generated for users that register with Biome
+/// credentials. The `u128` was calculated by creating a v5 UUID with the nil namespace and the
+/// name `b"biome oauth"`.
+const UUID_NAMESPACE: Uuid = Uuid::from_u128(187643141867173602676740887132833008173);
+
 /// An `AuthorizationMapping` implementation that returns an `User`.
 pub struct GetUserByOAuthAuthorization {
     oauth_user_store: Box<dyn OAuthUserStore>,
@@ -114,7 +120,7 @@ impl OAuthUserInfoStore for BiomeOAuthUserInfoStore {
             oauth_user.user_id().to_string()
         } else {
             // otherwise, create a new user
-            Uuid::new_v4().to_string()
+            Uuid::new_v5(&UUID_NAMESPACE, Uuid::new_v4().as_bytes()).to_string()
         };
 
         let oauth_user = NewOAuthUserAccessBuilder::new()


### PR DESCRIPTION
Updates Biome user IDs to be namespaced based on authentication method.
Without a central user store, the Biome credentials and OAuth REST API
endpoints are not able to explicitly guarantee that their generated
UUIDs are unique because the two authentication methods store users in
different tables. By using a different UUID namespace between them, we
can ensure that there is no collision.

Signed-off-by: Logan Seeley <seeley@bitwise.io>