### PR TITLE
Add 0.6 to accepted input for --compat

### DIFF
--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -55,7 +55,7 @@ OPTIONS
 
 `--compat COMPAT_VERSION`
 : Enforce that the proposed circuit is compatible with a specific version.
-  Accepted values: `0.4`
+  Accepted values: `0.4`, `0.6`
 
 `--display-name DISPLAY-NAME`
 : Add human-readable name for the circuit.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -312,7 +312,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             Arg::with_name("compat_version")
                 .long("compat")
                 .takes_value(true)
-                .possible_values(&["0.4"])
+                .possible_values(&["0.4", "0.6"])
                 .help("Enforce that the proposed circuit is compatible with a specific version"),
         )
         .arg(


### PR DESCRIPTION
This does not currently enforce any extra checks.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>