### PR TITLE
Add experimental DieselRegistry support to splinterd

### DIFF
--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -55,6 +55,9 @@ pub trait StoreFactory {
     fn get_oauth_inflight_request_store(
         &self,
     ) -> Box<dyn crate::oauth::store::InflightOAuthRequestStore>;
+
+    #[cfg(feature = "registry-database")]
+    fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -87,4 +87,9 @@ impl StoreFactory for PgStoreFactory {
     ) -> Box<dyn crate::oauth::store::InflightOAuthRequestStore> {
         unimplemented!()
     }
+
+    #[cfg(feature = "registry-database")]
+    fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
+        Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
+    }
 }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -72,6 +72,11 @@ impl StoreFactory for SqliteStoreFactory {
             self.pool.clone(),
         ))
     }
+
+    #[cfg(feature = "registry-database")]
+    fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
+        Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
+    }
 }
 
 #[derive(Default, Debug)]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -83,6 +83,7 @@ experimental = [
     "auth",
     "biome-oauth",
     "health",
+    "registry-database",
     "service-arg-validation",
     "service-endpoint",
     "ws-transport",
@@ -103,6 +104,7 @@ biome-oauth = [
     "splinter/biome-oauth-user-store-postgres"
 ]
 database = ["splinter/postgres", "splinter/sqlite"]
+registry-database = ["database", "splinter/registry-database"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [
     "scabbard/service-arg-validation",


### PR DESCRIPTION
This was tested by inserting a new node view the REST API for both postgres and sqlite. 
Not this PR updates the insert_node method to use diesel instead of a raw SQL query. All other raw SQL queries in the DieselRegistry should be removed before stabilization. 