### PR TITLE
Implement Add subcommand for node registry CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,12 +74,15 @@ experimental = [
     "health",
     "https-certs",
     "permissions",
+    "registry",
 ]
 
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
 circuit-template = ["splinter/circuit-template"]
+
+registry = []
 
 health = []
 

--- a/cli/man/splinter-registry-add.1.md
+++ b/cli/man/splinter-registry-add.1.md
@@ -1,0 +1,133 @@
+% SPLINTER-REGISTRY-ADD(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-registry-add** — Add a node to the local registry
+
+SYNOPSIS
+========
+
+**splinter registry add** \[**FLAGS**\] \[**OPTIONS**\] IDENTITY
+
+DESCRIPTION
+===========
+
+Add a new node to the local node registry. The node may be entirely new to the
+registry, or it may be copied from the remote registries with the
+`--from-remote` flag. If the `--from-remote` flag is used the `--display-name`,
+`--endpoint`, `--key` and `--metadata` options may not be used to alter the
+node being copied from the remote registry. When run, the command will
+display the resulting changes as confirmation.
+
+FLAGS
+=====
+`--dry-run`
+: Shows the expected changes without submitting the node.
+
+`--from-remote`
+: Copies an existing node definition from the remote registries. 
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decreases verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`--display-name` DISPLAY_NAME
+: Sets a human-readable name for the new node. If not provided, a default value
+based on the node's ID will be used.
+
+`--endpoint ENDPOINT`
+: Adds a network endpoint for the new node. At least one endpoint must be
+provided, and all endpoints must be non-empty and unique in the registry (two
+nodes cannot share the same endpoint). Repeat this option to specify multiple
+endpoints.
+
+`--key-file KEY`
+: Add the public key to the new node. At least one key must be provided, and all
+keys must be non-empty. Repeat this option to specify multiple keys.
+
+`-k`, `--key KEY`
+: Name or path of private key to be used for REST API authorization.
+
+`--metadata METADATA_STRING`
+: Adds the metadata to the new node, using the format
+`METADATA_KEY:METADATA_VALUE`. If an entry for the given `METADATA_KEY` already
+exists, it will be replaced. Repeat this option to specify multiple metadata
+entries.
+
+`-U`, `--url URL`
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+
+`IDENTITY`
+Identity of the new node. Must be unique in the local registry.
+
+EXAMPLES
+========
+
+The simplest use of this command is to create a new node with an identity, a
+single endpoint, and a single key:
+
+```
+splinter registry add example-node-1 \
+  --endpoint tcps://splinterd-node-1:8044 \
+  --key /path/to/public/key/file \
+  --url http://splinterd-rest-api:8085
+```
+
+Multiple endpoints, keys, and metadata entries can be provided by specifying the
+arguments multiple times:
+
+```
+splinter registry add example-node-2 \
+  --endpoint tcps://splinterd-node-2:8044 \
+  --endpoint tcp://splinterd-node-2:8045 \
+  --key /path/to/public/key/file1 \
+  --key /path/to/public/key/file2 \
+  --metadata key1:value1 \
+  --metadata key2:value2 \
+  --url http://splinterd-rest-api:8085
+```
+
+A node that exists in one or more remote registries can be copied to the local
+registry with just the node's identity and the `--from-remote` flag, the
+`--display-name`, `--endpoint`, `--key` and `--metadata` options may not be used
+with this flag:
+
+```
+splinter registry add example-node-3 \
+  --from-remote \
+  --url http://splinterd-rest-api:8085
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/src/action/registry/api.rs
+++ b/cli/src/action/registry/api.rs
@@ -1,0 +1,121 @@
+// Copyright 2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::action::api::{ServerError, SplinterRestClient};
+use crate::error::CliError;
+
+impl SplinterRestClient {
+    /// Adds a new node to the registry.
+    pub fn add_node(&self, node: &RegistryNode) -> Result<(), CliError> {
+        let request = Client::new()
+            .post(&format!("{}/registry/nodes", self.url))
+            .json(&node)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| CliError::ActionError(format!("Failed to add node to registry: {}", err)))
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            CliError::ActionError(format!(
+                                "Registry add node request failed with status code '{}', but error response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(CliError::ActionError(format!(
+                        "Failed to add node to registry: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    /// Retrieves the node with the given identity from the registry.
+    pub fn get_node(&self, identity: &str) -> Result<Option<RegistryNode>, CliError> {
+        let request = Client::new()
+            .get(&format!("{}/registry/nodes/{}", self.url, &identity))
+            .header("Authorization", &self.auth);
+
+        request.send()
+            .map_err(|err| CliError::ActionError(format!("Failed to fetch node: {}", err)))
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<RegistryNode>().map(Some).map_err(|_| {
+                        CliError::ActionError(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            CliError::ActionError(format!(
+                                "Registry get node request failed with status code '{}', but error response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(CliError::ActionError(format!(
+                        "Failed to fetch node: {}",
+                        message
+                    )))
+                }
+            })
+    }
+}
+
+#[cfg(feature = "registry")]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RegistryNode {
+    pub identity: String,
+    pub endpoints: Vec<String>,
+    pub display_name: String,
+    pub keys: Vec<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[cfg(feature = "registry")]
+impl fmt::Display for RegistryNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut display_string = format!("identity: {}\nendpoints:", self.identity);
+        for endpoint in &self.endpoints {
+            display_string += &format!("\n  - {}", endpoint);
+        }
+        display_string += &format!("\ndisplay name: {}\nkeys:", self.display_name);
+        for key in &self.keys {
+            display_string += &format!("\n  - {}", key);
+        }
+        display_string += "\nmetadata:";
+        for (key, value) in &self.metadata {
+            display_string += &format!("\n  {}: {}", key, value);
+        }
+        write!(f, "{}", display_string)
+    }
+}

--- a/cli/src/action/registry/mod.rs
+++ b/cli/src/action/registry/mod.rs
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "registry")]
+mod api;
+
+use clap::ArgMatches;
+use splinter::registry::Node;
+#[cfg(feature = "registry")]
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use clap::ArgMatches;
-use splinter::registry::Node;
-
 use crate::error::CliError;
+#[cfg(feature = "registry")]
+use crate::registry::api::RegistryNode;
 
 use super::api::SplinterRestClientBuilder;
 use super::{
@@ -170,5 +176,124 @@ impl Action for RegistryGenerateAction {
         info!("Added node '{}' to '{}'", node_status.node_id, output_file);
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "registry")]
+pub struct RegistryAddAction;
+
+#[cfg(feature = "registry")]
+impl Action for RegistryAddAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
+
+        let identity = args
+            .value_of("identity")
+            .ok_or_else(|| CliError::ActionError("Identity must be specified".into()))?
+            .to_string();
+
+        let display_name = args
+            .value_of("display_name")
+            .unwrap_or(&identity)
+            .to_string();
+
+        let private_key = args.value_of("private_key_file");
+
+        let client = SplinterRestClientBuilder::new()
+            .with_url(url)
+            .with_auth(create_cylinder_jwt_auth(private_key)?)
+            .build()?;
+
+        let mut node_metadata: HashMap<String, String> = HashMap::new();
+        if let Some(metadata) = args.values_of("metadata") {
+            for pair in metadata {
+                let (key, value) = parse_metadata(pair)?;
+                node_metadata.insert(key, value);
+            }
+        }
+
+        if args.is_present("from_remote") {
+            let remote_node = client.get_node(&identity)?.ok_or_else(|| {
+                CliError::ActionError("Unable to retrieve node from remote".into())
+            })?;
+
+            let node = RegistryNode {
+                identity: remote_node.identity,
+                endpoints: remote_node.endpoints,
+                display_name: remote_node.display_name,
+                keys: remote_node.keys,
+                metadata: remote_node.metadata,
+            };
+
+            if !args.is_present("dry_run") {
+                client.add_node(&node)?;
+            }
+
+            info!("{}", node);
+
+            Ok(())
+        } else {
+            let endpoints: Vec<String> = args
+                .values_of("endpoint")
+                .ok_or_else(|| {
+                    CliError::ActionError("One or more endpoints must be specified".into())
+                })?
+                .map(String::from)
+                .collect::<Vec<String>>();
+
+            let keys: Vec<String> = args
+                .values_of("key_files")
+                .ok_or_else(|| {
+                    CliError::ActionError("One or more key files must be specified".into())
+                })?
+                .map(|key_file| read_private_key(key_file))
+                .collect::<Result<_, _>>()?;
+
+            let node = RegistryNode {
+                identity,
+                endpoints,
+                display_name,
+                keys,
+                metadata: node_metadata,
+            };
+
+            if !args.is_present("dry_run") {
+                client.add_node(&node)?
+            }
+
+            info!("{}", node);
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "registry")]
+fn parse_metadata(metadata: &str) -> Result<(String, String), CliError> {
+    let mut parts = metadata.splitn(2, ':');
+    match (parts.next(), parts.next()) {
+        (Some(key), Some(value)) => match key {
+            "" => Err(CliError::ActionError(
+                "Empty '--metadata' argument detected".into(),
+            )),
+            _ => match value {
+                "" => Err(CliError::ActionError(format!(
+                    "Empty value detected for key: {}",
+                    key
+                ))),
+                _ => Ok((key.to_string(), value.to_string())),
+            },
+        },
+        (Some(key), None) => Err(CliError::ActionError(format!(
+            "Missing value for metadata key '{}'",
+            key
+        ))),
+        _ => unreachable!(), // splitn always returns at least one item
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -659,52 +659,118 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     app = app.subcommand(circuit_command);
 
-    app = app.subcommand(
-        SubCommand::with_name("registry")
-            .about("Splinter registry commands")
-            .setting(AppSettings::SubcommandRequiredElseHelp)
-            .subcommand(
-                SubCommand::with_name("build")
-                    .about("Add a node to a YAML file")
-                    .arg(Arg::with_name("file").long("file").takes_value(true).help(
-                        "Path of registry file to add node to; defaults to \
+    let registry_command = SubCommand::with_name("registry")
+        .about("Splinter registry commands")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            SubCommand::with_name("build")
+                .about("Add a node to a YAML file")
+                .arg(Arg::with_name("file").long("file").takes_value(true).help(
+                    "Path of registry file to add node to; defaults to \
                                 './nodes.yaml'",
-                    ))
-                    .arg(
-                        Arg::with_name("force")
-                            .long("force")
-                            .help("Overwrite node if it already exists"),
-                    )
-                    .arg(
-                        Arg::with_name("status_url")
-                            .takes_value(true)
-                            .help("URL of splinter REST API to query for node data"),
-                    )
-                    .arg(
-                        Arg::with_name("key_files")
-                            .long("key-file")
-                            .takes_value(true)
-                            .multiple(true)
-                            .required(true)
-                            .help("Path of public key file to include with node"),
-                    )
-                    .arg(
-                        Arg::with_name("metadata")
-                            .long("metadata")
-                            .takes_value(true)
-                            .multiple(true)
-                            .help("Metadata to include with node (<key>=<value>)"),
-                    )
-                    .arg(
-                        Arg::with_name("private_key_file")
-                            .value_name("private-key-file")
-                            .short("k")
-                            .long("key")
-                            .takes_value(true)
-                            .help("Name or path of private key"),
-                    ),
+                ))
+                .arg(
+                    Arg::with_name("force")
+                        .long("force")
+                        .help("Overwrite node if it already exists"),
+                )
+                .arg(
+                    Arg::with_name("status_url")
+                        .takes_value(true)
+                        .help("URL of splinter REST API to query for node data"),
+                )
+                .arg(
+                    Arg::with_name("key_files")
+                        .long("key-file")
+                        .takes_value(true)
+                        .multiple(true)
+                        .required(true)
+                        .help("Path of public key file to include with node"),
+                )
+                .arg(
+                    Arg::with_name("metadata")
+                        .long("metadata")
+                        .takes_value(true)
+                        .multiple(true)
+                        .help("Metadata to include with node (<key>=<value>)"),
+                )
+                .arg(
+                    Arg::with_name("private_key_file")
+                        .value_name("private-key-file")
+                        .short("k")
+                        .long("key")
+                        .takes_value(true)
+                        .help("Name or path of private key"),
+                ),
+        );
+
+    #[cfg(feature = "registry")]
+    let registry_command = registry_command.subcommand(
+        SubCommand::with_name("add")
+            .about("Add a node to the local registry")
+            .arg(
+                Arg::with_name("display_name")
+                    .long("display-name")
+                    .takes_value(true)
+                    .help("Human-readable name for the new node"),
+            )
+            .arg(
+                Arg::with_name("dry_run")
+                    .long("dry-run")
+                    .help("Show the expected changes without submitting the node"),
+            )
+            .arg(
+                Arg::with_name("endpoint")
+                    .long("endpoint")
+                    .takes_value(true)
+                    .multiple(true)
+                    .required_unless("from_remote")
+                    .help("Network endpoint for the new node"),
+            )
+            .arg(
+                Arg::with_name("from_remote")
+                    .long("from-remote")
+                    .conflicts_with_all(&["display_name", "endpoint", "key_files", "metadata"])
+                    .help("Copies an existing node definition from the remote registries"),
+            )
+            .arg(
+                Arg::with_name("identity")
+                    .required(true)
+                    .help("Identity of the new node. Must be unique in the local registry"),
+            )
+            .arg(
+                Arg::with_name("key_files")
+                    .long("key-file")
+                    .takes_value(true)
+                    .multiple(true)
+                    .required_unless("from_remote")
+                    .help("Path of public key file to include with node"),
+            )
+            .arg(
+                Arg::with_name("metadata")
+                    .long("metadata")
+                    .takes_value(true)
+                    .multiple(true)
+                    .help("Metadata to include with node (<key>:<value>)"),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Name or path of private key to be used for REST API authorization"),
+            )
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .takes_value(true)
+                    .help("URL of the splinter REST API"),
             ),
     );
+
+    app = app.subcommand(registry_command);
 
     #[cfg(feature = "health")]
     {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1019,10 +1019,13 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     subcommands = subcommands.with_command("circuit", circuit_command);
 
-    subcommands = subcommands.with_command(
-        "registry",
-        SubcommandActions::new().with_command("build", registry::RegistryGenerateAction),
-    );
+    let registry_command =
+        SubcommandActions::new().with_command("build", registry::RegistryGenerateAction);
+
+    #[cfg(feature = "registry")]
+    let registry_command = registry_command.with_command("add", registry::RegistryAddAction);
+
+    subcommands = subcommands.with_command("registry", registry_command);
 
     #[cfg(feature = "health")]
     {

--- a/libsplinter/src/registry/diesel/operations/add_node.rs
+++ b/libsplinter/src/registry/diesel/operations/add_node.rs
@@ -1,0 +1,186 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "add node" operation for the `DieselRegistry`.
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use crate::registry::{
+    check_node_required_fields_are_not_empty,
+    diesel::{
+        models::{NodeEndpointsModel, NodeKeysModel, NodeMetadataModel, NodesModel},
+        schema::{
+            splinter_nodes, splinter_nodes_endpoints, splinter_nodes_keys, splinter_nodes_metadata,
+        },
+    },
+    InvalidNodeError, Node, RegistryError,
+};
+
+use super::RegistryOperations;
+
+pub(in crate::registry::diesel) trait RegistryAddNodeOperation {
+    fn add_node(&self, node: Node) -> Result<(), RegistryError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> RegistryAddNodeOperation for RegistryOperations<'a, diesel::pg::PgConnection> {
+    fn add_node(&self, node: Node) -> Result<(), RegistryError> {
+        // Verify that the node's required fields are non-empty
+        check_node_required_fields_are_not_empty(&node)?;
+
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify that the node's endpoints are unique.
+            let filters = node
+                .endpoints
+                .iter()
+                .map(|endpoint| endpoint.to_string())
+                .collect::<Vec<_>>();
+
+            let duplicate_endpoint = splinter_nodes_endpoints::table
+                .filter(splinter_nodes_endpoints::endpoint.eq_any(filters))
+                .first::<NodeEndpointsModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check for duplicate endpoints",
+                        Box::new(err),
+                    )
+                })?;
+
+            if let Some(endpoint) = duplicate_endpoint {
+                return Err(RegistryError::from(InvalidNodeError::DuplicateEndpoint(
+                    endpoint.endpoint,
+                )));
+            }
+
+            // Add new node
+            insert_into(splinter_nodes::table)
+                .values(NodesModel::from(&node))
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source("Failed to add node", Box::new(err))
+                })?;
+
+            // Add endpoints, keys, and metadata for the node
+            let endpoints: Vec<NodeEndpointsModel> = Vec::from(&node);
+            insert_into(splinter_nodes_endpoints::table)
+                .values(&endpoints)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node endpoints",
+                        Box::new(err),
+                    )
+                })?;
+            let keys: Vec<NodeKeysModel> = Vec::from(&node);
+            insert_into(splinter_nodes_keys::table)
+                .values(&keys)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node keys",
+                        Box::new(err),
+                    )
+                })?;
+            let metadata: Vec<NodeMetadataModel> = Vec::from(&node);
+            insert_into(splinter_nodes_metadata::table)
+                .values(&metadata)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node metadata",
+                        Box::new(err),
+                    )
+                })?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RegistryAddNodeOperation for RegistryOperations<'a, diesel::sqlite::SqliteConnection> {
+    fn add_node(&self, node: Node) -> Result<(), RegistryError> {
+        // Verify that the node's required fields are non-empty
+        check_node_required_fields_are_not_empty(&node)?;
+
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify that the node's endpoints are unique.
+            let filters = node
+                .endpoints
+                .iter()
+                .map(|endpoint| endpoint.to_string())
+                .collect::<Vec<_>>();
+
+            let duplicate_endpoint = splinter_nodes_endpoints::table
+                .filter(splinter_nodes_endpoints::endpoint.eq_any(filters))
+                .first::<NodeEndpointsModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check for duplicate endpoints",
+                        Box::new(err),
+                    )
+                })?;
+
+            if let Some(endpoint) = duplicate_endpoint {
+                return Err(RegistryError::from(InvalidNodeError::DuplicateEndpoint(
+                    endpoint.endpoint,
+                )));
+            }
+
+            // Add new node
+            insert_into(splinter_nodes::table)
+                .values(NodesModel::from(&node))
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source("Failed to add node", Box::new(err))
+                })?;
+
+            // Add endpoints, keys, and metadata for the node
+            let endpoints: Vec<NodeEndpointsModel> = Vec::from(&node);
+            insert_into(splinter_nodes_endpoints::table)
+                .values(&endpoints)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node endpoints",
+                        Box::new(err),
+                    )
+                })?;
+            let keys: Vec<NodeKeysModel> = Vec::from(&node);
+            insert_into(splinter_nodes_keys::table)
+                .values(&keys)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node keys",
+                        Box::new(err),
+                    )
+                })?;
+            let metadata: Vec<NodeMetadataModel> = Vec::from(&node);
+            insert_into(splinter_nodes_metadata::table)
+                .values(&metadata)
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to add node metadata",
+                        Box::new(err),
+                    )
+                })?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/registry/diesel/operations/mod.rs
+++ b/libsplinter/src/registry/diesel/operations/mod.rs
@@ -14,12 +14,14 @@
 
 //! Provides database operations for the `DieselRegistry`.
 
+pub(super) mod add_node;
 pub(super) mod count_nodes;
 pub(super) mod delete_node;
 pub(super) mod fetch_node;
 pub(super) mod has_node;
 pub(super) mod insert_node;
 pub(super) mod list_nodes;
+pub(super) mod update_node;
 
 use diesel::{
     dsl::{exists, not},

--- a/libsplinter/src/registry/diesel/operations/update_node.rs
+++ b/libsplinter/src/registry/diesel/operations/update_node.rs
@@ -1,0 +1,295 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "update node" operation for the `DieselRegistry`.
+
+use diesel::{
+    dsl::{delete, insert_into, update},
+    prelude::*,
+};
+
+use crate::registry::{
+    check_node_required_fields_are_not_empty,
+    diesel::{
+        models::{NodeEndpointsModel, NodeKeysModel, NodeMetadataModel, NodesModel},
+        schema::{
+            splinter_nodes, splinter_nodes_endpoints, splinter_nodes_keys, splinter_nodes_metadata,
+        },
+    },
+    InvalidNodeError, Node, RegistryError,
+};
+
+use super::RegistryOperations;
+
+pub(in crate::registry::diesel) trait RegistryUpdateNodeOperation {
+    fn update_node(&self, node: Node) -> Result<(), RegistryError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> RegistryUpdateNodeOperation for RegistryOperations<'a, diesel::pg::PgConnection> {
+    fn update_node(&self, node: Node) -> Result<(), RegistryError> {
+        // Verify that the node's required fields are non-empty
+        check_node_required_fields_are_not_empty(&node)?;
+
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify that the node's endpoints are unique.
+            let filters = node
+                .endpoints
+                .iter()
+                .map(|endpoint| endpoint.to_string())
+                .collect::<Vec<_>>();
+
+            let duplicate_endpoint = splinter_nodes_endpoints::table
+                .filter(splinter_nodes_endpoints::endpoint.eq_any(filters))
+                .first::<NodeEndpointsModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check for duplicate endpoints",
+                        Box::new(err),
+                    )
+                })?;
+
+            if let Some(endpoint) = duplicate_endpoint {
+                return Err(RegistryError::from(InvalidNodeError::DuplicateEndpoint(
+                    endpoint.endpoint,
+                )));
+            }
+
+            // Check if the node exists
+            let existing_node = splinter_nodes::table
+                .find(&node.identity)
+                .first::<NodesModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check if node already exists",
+                        Box::new(err),
+                    )
+                })?;
+
+            if existing_node.is_some() {
+                // Update existing node
+                update(splinter_nodes::table.find(&node.identity))
+                    .set(splinter_nodes::display_name.eq(&node.display_name))
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node",
+                            Box::new(err),
+                        )
+                    })?;
+                // Remove old endpoints, keys, and metadata for the node
+                delete(
+                    splinter_nodes_endpoints::table
+                        .filter(splinter_nodes_endpoints::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old endpoints",
+                        Box::new(err),
+                    )
+                })?;
+                delete(
+                    splinter_nodes_keys::table
+                        .filter(splinter_nodes_keys::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old keys",
+                        Box::new(err),
+                    )
+                })?;
+                delete(
+                    splinter_nodes_metadata::table
+                        .filter(splinter_nodes_metadata::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old metadata",
+                        Box::new(err),
+                    )
+                })?;
+
+                // Add endpoints, keys, and metadata for the node
+                let endpoints: Vec<NodeEndpointsModel> = Vec::from(&node);
+                insert_into(splinter_nodes_endpoints::table)
+                    .values(&endpoints)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node endpoints",
+                            Box::new(err),
+                        )
+                    })?;
+                let keys: Vec<NodeKeysModel> = Vec::from(&node);
+                insert_into(splinter_nodes_keys::table)
+                    .values(&keys)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node keys",
+                            Box::new(err),
+                        )
+                    })?;
+                let metadata: Vec<NodeMetadataModel> = Vec::from(&node);
+                insert_into(splinter_nodes_metadata::table)
+                    .values(&metadata)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node metadata",
+                            Box::new(err),
+                        )
+                    })?;
+
+                Ok(())
+            } else {
+                Err(RegistryError::general_error("Node does not exist"))
+            }
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RegistryUpdateNodeOperation for RegistryOperations<'a, diesel::sqlite::SqliteConnection> {
+    fn update_node(&self, node: Node) -> Result<(), RegistryError> {
+        // Verify that the node's required fields are non-empty
+        check_node_required_fields_are_not_empty(&node)?;
+
+        self.conn.transaction::<(), _, _>(|| {
+            // Verify that the node's endpoints are unique.
+            let filters = node
+                .endpoints
+                .iter()
+                .map(|endpoint| endpoint.to_string())
+                .collect::<Vec<_>>();
+
+            let duplicate_endpoint = splinter_nodes_endpoints::table
+                .filter(splinter_nodes_endpoints::endpoint.eq_any(filters))
+                .first::<NodeEndpointsModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check for duplicate endpoints",
+                        Box::new(err),
+                    )
+                })?;
+
+            if let Some(endpoint) = duplicate_endpoint {
+                return Err(RegistryError::from(InvalidNodeError::DuplicateEndpoint(
+                    endpoint.endpoint,
+                )));
+            }
+
+            // Check if the node exists
+            let existing_node = splinter_nodes::table
+                .find(&node.identity)
+                .first::<NodesModel>(self.conn)
+                .optional()
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to check if node already exists",
+                        Box::new(err),
+                    )
+                })?;
+
+            if existing_node.is_some() {
+                // Update existing node
+                update(splinter_nodes::table.find(&node.identity))
+                    .set(splinter_nodes::display_name.eq(&node.display_name))
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node",
+                            Box::new(err),
+                        )
+                    })?;
+                // Remove old endpoints, keys, and metadata for the node
+                delete(
+                    splinter_nodes_endpoints::table
+                        .filter(splinter_nodes_endpoints::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old endpoints",
+                        Box::new(err),
+                    )
+                })?;
+                delete(
+                    splinter_nodes_keys::table
+                        .filter(splinter_nodes_keys::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old keys",
+                        Box::new(err),
+                    )
+                })?;
+                delete(
+                    splinter_nodes_metadata::table
+                        .filter(splinter_nodes_metadata::identity.eq(&node.identity)),
+                )
+                .execute(self.conn)
+                .map_err(|err| {
+                    RegistryError::general_error_with_source(
+                        "Failed to remove old metadata",
+                        Box::new(err),
+                    )
+                })?;
+
+                // Add endpoints, keys, and metadata for the node
+                let endpoints: Vec<NodeEndpointsModel> = Vec::from(&node);
+                insert_into(splinter_nodes_endpoints::table)
+                    .values(&endpoints)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node endpoints",
+                            Box::new(err),
+                        )
+                    })?;
+                let keys: Vec<NodeKeysModel> = Vec::from(&node);
+                insert_into(splinter_nodes_keys::table)
+                    .values(&keys)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node keys",
+                            Box::new(err),
+                        )
+                    })?;
+                let metadata: Vec<NodeMetadataModel> = Vec::from(&node);
+                insert_into(splinter_nodes_metadata::table)
+                    .values(&metadata)
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        RegistryError::general_error_with_source(
+                            "Failed to update node metadata",
+                            Box::new(err),
+                        )
+                    })?;
+
+                Ok(())
+            } else {
+                Err(RegistryError::general_error("Node does not exist"))
+            }
+        })
+    }
+}

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -262,7 +262,24 @@ pub trait RegistryWriter: Send + Sync {
     ///
     /// * `node` - The node to be added to or updated in the registry.
     ///
+    #[deprecated(since = "0.5.1", note = "replaced by `add_node` and `update_node`")]
     fn insert_node(&self, node: Node) -> Result<(), RegistryError>;
+
+    /// Adds a new node to the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The node to be added to the registry.
+    ///
+    fn add_node(&self, node: Node) -> Result<(), RegistryError>;
+
+    /// Replaces an existing node with the same identity.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The node to be updated in the registry.
+    ///
+    fn update_node(&self, node: Node) -> Result<(), RegistryError>;
 
     /// Deletes a node with the given identity and returns the node if it was in the registry.
     ///
@@ -320,7 +337,16 @@ where
     NW: RegistryWriter + ?Sized,
 {
     fn insert_node(&self, node: Node) -> Result<(), RegistryError> {
+        #[allow(deprecated)]
         (**self).insert_node(node)
+    }
+
+    fn add_node(&self, node: Node) -> Result<(), RegistryError> {
+        (**self).add_node(node)
+    }
+
+    fn update_node(&self, node: Node) -> Result<(), RegistryError> {
+        (**self).update_node(node)
     }
 
     fn delete_node(&self, identity: &str) -> Result<Option<Node>, RegistryError> {

--- a/libsplinter/src/registry/unified.rs
+++ b/libsplinter/src/registry/unified.rs
@@ -201,7 +201,16 @@ impl RegistryReader for UnifiedRegistry {
 
 impl RegistryWriter for UnifiedRegistry {
     fn insert_node(&self, node: Node) -> Result<(), RegistryError> {
+        #[allow(deprecated)]
         self.internal_source.insert_node(node)
+    }
+
+    fn add_node(&self, node: Node) -> Result<(), RegistryError> {
+        self.internal_source.add_node(node)
+    }
+
+    fn update_node(&self, node: Node) -> Result<(), RegistryError> {
+        self.internal_source.update_node(node)
     }
 
     fn delete_node(&self, identity: &str) -> Result<Option<Node>, RegistryError> {
@@ -230,6 +239,7 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use super::*;
+    use crate::registry::InvalidNodeError;
 
     fn new_node(id: &str, endpoint: &str, metadata: &[(&str, &str)]) -> Node {
         let mut builder = Node::builder(id).with_endpoint(endpoint).with_key("abcd");
@@ -258,17 +268,11 @@ mod test {
         let node3 = new_node("node1", "endpoint3", &[("meta_c", "val_c")]);
 
         let writeable = MemRegistry::default();
-        writeable
-            .insert_node(node1)
-            .expect("Unable to insert node1");
-        writeable
-            .insert_node(node2)
-            .expect("Unable to insert node2");
+        writeable.add_node(node1).expect("Unable to insert node1");
+        writeable.add_node(node2).expect("Unable to insert node2");
 
         let readable = MemRegistry::default();
-        writeable
-            .insert_node(node3)
-            .expect("Unable to insert node3");
+        writeable.add_node(node3).expect("Unable to insert node3");
 
         let unified = UnifiedRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
 
@@ -295,15 +299,11 @@ mod test {
         );
 
         let writeable = MemRegistry::default();
-        writeable
-            .insert_node(node1)
-            .expect("Unable to insert node1");
-        writeable
-            .insert_node(node2)
-            .expect("Unable to insert node2");
+        writeable.add_node(node1).expect("Unable to insert node1");
+        writeable.add_node(node2).expect("Unable to insert node2");
 
         let readable = MemRegistry::default();
-        readable.insert_node(node3).expect("Unable to insert node3");
+        readable.add_node(node3).expect("Unable to insert node3");
 
         let unified = UnifiedRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
 
@@ -325,7 +325,7 @@ mod test {
 
         let readable = MemRegistry::default();
         readable
-            .insert_node(node.clone())
+            .add_node(node.clone())
             .expect("Unable to insert node");
 
         let unified =
@@ -346,7 +346,7 @@ mod test {
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(node.clone())
+            .add_node(node.clone())
             .expect("Unable to insert node");
 
         let unified =
@@ -381,17 +381,17 @@ mod test {
 
         let high_precedence_readable = MemRegistry::default();
         high_precedence_readable
-            .insert_node(high_precedence_node)
+            .add_node(high_precedence_node)
             .expect("Unable to insert high-precedence node");
 
         let med_precedence_readable = MemRegistry::default();
         med_precedence_readable
-            .insert_node(med_precedence_node)
+            .add_node(med_precedence_node)
             .expect("Unable to insert medium-precedence node");
 
         let low_precedence_readable = MemRegistry::default();
         low_precedence_readable
-            .insert_node(low_precedence_node)
+            .add_node(low_precedence_node)
             .expect("Unable to insert low-precedence node");
 
         let unified = UnifiedRegistry::new(
@@ -432,17 +432,17 @@ mod test {
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(high_precedence_node)
+            .add_node(high_precedence_node)
             .expect("Unable to insert high-precedence node");
 
         let med_precedence_readable = MemRegistry::default();
         med_precedence_readable
-            .insert_node(med_precedence_node)
+            .add_node(med_precedence_node)
             .expect("Unable to insert medium-precedence node");
 
         let low_precedence_readable = MemRegistry::default();
         low_precedence_readable
-            .insert_node(low_precedence_node)
+            .add_node(low_precedence_node)
             .expect("Unable to insert low-precedence node");
 
         let unified = UnifiedRegistry::new(
@@ -469,12 +469,12 @@ mod test {
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(node1.clone())
+            .add_node(node1.clone())
             .expect("Unable to insert node");
 
         let readable = MemRegistry::default();
         readable
-            .insert_node(node2.clone())
+            .add_node(node2.clone())
             .expect("Unable to insert node");
 
         let unified = UnifiedRegistry::new(Box::new(writable), vec![Box::new(readable)]);
@@ -533,20 +533,20 @@ mod test {
 
         let writable = MemRegistry::default();
         writable
-            .insert_node(node1_internal)
+            .add_node(node1_internal)
             .expect("Unable to insert internal node1");
 
         let readable_high = MemRegistry::default();
         readable_high
-            .insert_node(node1_read_only)
+            .add_node(node1_read_only)
             .expect("Unable to insert read-only node1");
         readable_high
-            .insert_node(node2_high)
+            .add_node(node2_high)
             .expect("Unable to insert high-precedence node2");
 
         let readable_low = MemRegistry::default();
         readable_low
-            .insert_node(node2_low)
+            .add_node(node2_low)
             .expect("Unable to insert low-precedence node2");
 
         let unified = UnifiedRegistry::new(
@@ -584,14 +584,12 @@ mod test {
 
         let writeable = MemRegistry::default();
         writeable
-            .insert_node(node1.clone())
+            .add_node(node1.clone())
             .expect("Unable to insert node1");
-        writeable
-            .insert_node(node2)
-            .expect("Unable to insert node2");
+        writeable.add_node(node2).expect("Unable to insert node2");
 
         let readable = MemRegistry::default();
-        readable.insert_node(node3).expect("Unable to insert node3");
+        readable.add_node(node3).expect("Unable to insert node3");
 
         let unified = UnifiedRegistry::new(Box::new(writeable), vec![Box::new(readable)]);
 
@@ -617,7 +615,7 @@ mod test {
 
         let readable = MemRegistry::default();
         readable
-            .insert_node(node2.clone())
+            .add_node(node2.clone())
             .expect("Unable to insert node2 into read-only registry");
 
         let unified = UnifiedRegistry::new(
@@ -627,7 +625,7 @@ mod test {
 
         // Verify node1 is only added to writeable
         unified
-            .insert_node(node1.clone())
+            .add_node(node1.clone())
             .expect("Unable to add node1");
         assert!(unified
             .has_node(&node1.identity)
@@ -706,6 +704,30 @@ mod test {
                 .expect("mem registry lock was poisoned")
                 .insert(node.identity.clone(), node);
             Ok(())
+        }
+
+        fn add_node(&self, node: Node) -> Result<(), RegistryError> {
+            self.nodes
+                .lock()
+                .expect("mem registry lock was poisoned")
+                .insert(node.identity.clone(), node);
+            Ok(())
+        }
+
+        fn update_node(&self, node: Node) -> Result<(), RegistryError> {
+            let mut inner = self.nodes.lock().expect("mem registry lock was poisoned");
+
+            if inner.contains_key(&node.identity) {
+                inner.insert(node.identity.clone(), node);
+                Ok(())
+            } else {
+                Err(RegistryError::InvalidNode(
+                    InvalidNodeError::InvalidIdentity(
+                        node.identity,
+                        "Node does not exist in the registry".to_string(),
+                    ),
+                ))
+            }
         }
 
         fn delete_node(&self, identity: &str) -> Result<Option<Node>, RegistryError> {


### PR DESCRIPTION
Add the `add` subcommand including its options and flags to the splinter registry subcommand in splinter cli. 

Add the functionality for adding a node to the registry using the `splinter registry add` command. This includes the addition of a `registry::api` module to handle REST API requests. This is behind an experimental feature `registry-add-node`.

Implement std::fmt::Display for the registry Node struct to allow it to be printed after successfully adding a node to the registry.

## **Testing:**

use keygen to create a private key and add it to the allow_keys file:

from the `splinter/cli` directory run:
```
$ cargo run keygen
$ cat ~/.cylinder/keys/$USER.pub >> /tmp/splinter/data/allow_keys
```

Start splinterd locally

In a separate terminal window, from the `splinter/cli` directory, try the following `splinter registry add` commands:

`$ cargo run --features experimental registry add node1 --key-file <public key file> --key <private key file> --endpoint tcps://splinterd-node-1:8001 --metadata key1:value1`
(the private key should be the same as the one added to `allow_keys`)

This should successfully add a node named "node1" to the local registry

`$ cargo run --features experimental registry add node1 --key-file <public key file> --key <private key file> --endpoint tcps://splinterd-node-1:8002`

This should fail because a node with name "node1" already exists in the registry

`$ cargo run --features experimental registry add node2 --key-file <public key file> --key <private key file> --endpoint tcps://splinterd-node-1:8001`

This should fail because a node with endpoint "tcps://splinterd-node-1:8001" already exists in the registry

`$ cargo run --features experimental registry add node2 --key-file <public key file> --key <private key file> --endpoint tcps://splinterd-node-1:8002 --metadata key1:`

This should fail because the metadata key is missing a value