### PR TITLE
Remove raw SQL from the DieselRegistry

### DIFF
--- a/libsplinter/src/registry/diesel/models.rs
+++ b/libsplinter/src/registry/diesel/models.rs
@@ -14,8 +14,6 @@
 
 //! Provides database models for the `DieselRegistry`.
 
-use diesel::sql_types::BigInt;
-
 use crate::registry::Node;
 
 use super::schema::{
@@ -56,14 +54,6 @@ pub struct NodeMetadataModel {
     pub identity: String,
     pub key: String,
     pub value: String,
-}
-
-/// This is required to execute a `SELECT COUNT(_)` query using the `sql_query` function, like when
-/// metadata predicates are passed to `count_nodes`.
-#[derive(QueryableByName)]
-pub struct Count {
-    #[sql_type = "BigInt"]
-    pub count: i64,
 }
 
 impl From<&Node> for NodesModel {

--- a/libsplinter/src/registry/diesel/schema.rs
+++ b/libsplinter/src/registry/diesel/schema.rs
@@ -42,3 +42,10 @@ table! {
         value -> Text,
     }
 }
+
+allow_tables_to_appear_in_same_query!(
+    splinter_nodes,
+    splinter_nodes_endpoints,
+    splinter_nodes_keys,
+    splinter_nodes_metadata
+);


### PR DESCRIPTION
Using raw SQL queries is error prone and makes the database
vulnerable to SQL injection attack. These issues are fixed
by instead using diesel queries, which can be dynamically build
just as easily as a string.

This PR also add sqlite unit tests for the DieselRegistry