### PR TITLE
libsplinter: Support HTTPS bind

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -101,6 +101,7 @@ experimental = [
     "biome-oauth",
     "biome-oauth-user-store-postgres",
     "cylinder-jwt",
+    "https-bind",
     "oauth",
     "oauth-github",
     "oauth-openid",
@@ -126,6 +127,7 @@ biome-oauth-user-store-postgres = ["biome-oauth", "postgres"]
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
+https-bind = ["actix-web/ssl"]
 oauth = ["auth", "oauth2"]
 oauth-github = ["oauth"]
 oauth-inflight-request-store-postgres = ["oauth", "postgres"]

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -221,9 +221,7 @@ mod tests {
         DurabilityType, PersistenceType, RouteType, ServiceBuilder,
     };
     use crate::migrations::run_sqlite_migrations;
-    use crate::rest_api::{
-        paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
-    };
+    use crate::rest_api::{paging::Paging, RestApiBuilder, RestApiShutdownHandle};
 
     #[test]
     /// Tests a GET /admin/circuits request with no filters returns the expected circuits.
@@ -580,23 +578,23 @@ mod tests {
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 }

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -118,7 +118,7 @@ mod tests {
         DurabilityType, PersistenceType, RouteType, ServiceBuilder,
     };
     use crate::migrations::run_sqlite_migrations;
-    use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
+    use crate::rest_api::{RestApiBuilder, RestApiShutdownHandle};
 
     #[test]
     /// Tests a GET /admin/circuit/{circuit_id} request returns the expected circuit.
@@ -320,23 +320,23 @@ mod tests {
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 }

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -125,7 +125,7 @@ mod tests {
         service::proposal_store::{ProposalIter, ProposalStoreError},
         store::CircuitPredicate,
     };
-    use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
+    use crate::rest_api::{RestApiBuilder, RestApiShutdownHandle};
 
     #[test]
     /// Tests a GET /admin/proposals/{circuit_id} request returns the expected proposal.
@@ -272,23 +272,23 @@ mod tests {
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 }

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -492,8 +492,13 @@ mod tests {
 
         let mut rest_api_builder = RestApiBuilder::new();
 
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
         rest_api_builder = rest_api_builder
-            .with_bind("127.0.0.1:0")
+            .with_bind(bind)
             .add_resources(resource_manager.resources());
 
         #[cfg(feature = "auth")]

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -257,9 +257,7 @@ mod tests {
     use serde_json::{to_value, Value as JsonValue};
 
     use crate::registry::NodeIter;
-    use crate::rest_api::{
-        paging::Paging, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
-    };
+    use crate::rest_api::{paging::Paging, RestApiBuilder, RestApiShutdownHandle};
 
     #[test]
     /// Tests a GET /registry/nodes request with no filters returns the expected nodes.
@@ -457,24 +455,24 @@ mod tests {
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 
     fn create_test_paging_response(

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -167,7 +167,7 @@ mod tests {
     use reqwest::{blocking::Client, StatusCode, Url};
 
     use crate::registry::{MetadataPredicate, NodeIter};
-    use crate::rest_api::{RestApiBuilder, RestApiServerError, RestApiShutdownHandle};
+    use crate::rest_api::{RestApiBuilder, RestApiShutdownHandle};
 
     #[test]
     /// Tests a GET /registry/nodes/{identity} request returns the expected node.
@@ -370,24 +370,24 @@ mod tests {
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 
     fn get_node_1() -> Node {

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -400,9 +400,7 @@ mod tests {
     use futures::future::IntoFuture;
     use tempdir::TempDir;
 
-    use crate::rest_api::{
-        Method, Resource, RestApiBuilder, RestApiServerError, RestApiShutdownHandle,
-    };
+    use crate::rest_api::{Method, Resource, RestApiBuilder, RestApiShutdownHandle};
 
     /// Verifies that a remote file that contains two nodes with the same identity is rejected (not
     /// loaded).
@@ -1088,28 +1086,26 @@ mod tests {
         (shutdown, join, format!("http://{}/registry.yaml", url))
     }
 
-    /// Runs a REST API with the given `resources` on an open port. Returned string is the URL the
-    /// REST API is bound to.
     fn run_rest_api_on_open_port(
         resources: Vec<Resource>,
     ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
-        (10000..20000)
-            .find_map(|port| {
-                let bind_url = format!("127.0.0.1:{}", port);
-                let result = RestApiBuilder::new()
-                    .with_bind(&bind_url)
-                    .add_resources(resources.clone())
-                    .build_insecure()
-                    .expect("Failed to build REST API")
-                    .run_insecure();
-                match result {
-                    Ok((shutdown_handle, join_handle)) => {
-                        Some((shutdown_handle, join_handle, bind_url))
-                    }
-                    Err(RestApiServerError::BindError(_)) => None,
-                    Err(err) => panic!("Failed to run REST API: {}", err),
-                }
-            })
-            .expect("No port available")
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
     }
 }

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -114,3 +114,10 @@ impl fmt::Display for RequestError {
         }
     }
 }
+
+#[cfg(feature = "https-bind")]
+impl From<openssl::error::ErrorStack> for RestApiServerError {
+    fn from(err: openssl::error::ErrorStack) -> Self {
+        RestApiServerError::InternalError(InternalError::from_source(Box::new(err)))
+    }
+}

--- a/libsplinter/src/rest_api/errors.rs
+++ b/libsplinter/src/rest_api/errors.rs
@@ -17,7 +17,7 @@ use std::fmt;
 
 use actix_web::Error as ActixError;
 
-use crate::error::InvalidStateError;
+use crate::error::{InternalError, InvalidStateError};
 
 /// Error module for `rest_api`.
 #[derive(Debug)]
@@ -27,6 +27,7 @@ pub enum RestApiServerError {
     MissingField(String),
     StdError(std::io::Error),
     InvalidStateError(InvalidStateError),
+    InternalError(InternalError),
 }
 
 impl From<std::io::Error> for RestApiServerError {
@@ -43,6 +44,7 @@ impl Error for RestApiServerError {
             RestApiServerError::StdError(err) => Some(err),
             RestApiServerError::MissingField(_) => None,
             RestApiServerError::InvalidStateError(err) => Some(err),
+            RestApiServerError::InternalError(err) => Some(err),
         }
     }
 }
@@ -57,6 +59,7 @@ impl fmt::Display for RestApiServerError {
                 write!(f, "Missing required field: {}", field)
             }
             RestApiServerError::InvalidStateError(e) => write!(f, "{}", e),
+            RestApiServerError::InternalError(e) => write!(f, "{}", e),
         }
     }
 }

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -43,9 +43,14 @@
 //!
 //! let index_resource = IndexResource { name: "Taco".to_string() };
 //!
+//! #[cfg(not(feature = "https-bind"))]
+//! let bind = "localhost:8080";
+//! #[cfg(feature = "https-bind")]
+//! let bind = splinter::rest_api::RestApiBind::Insecure("localhost:8080".into());
+//!
 //! RestApiBuilder::new()
 //!     .add_resources(index_resource.resources())
-//!     .with_bind("localhost:8080")
+//!     .with_bind(bind)
 //!     .build()
 //!     .unwrap()
 //!     .run();
@@ -519,10 +524,34 @@ impl ConfigureAuthorizationMapping {
     }
 }
 
+/// Bind configuration for the REST API.
+#[derive(Clone)]
+pub enum RestApiBind {
+    #[cfg(feature = "https-bind")]
+    /// A secure binding, including certificate and key paths.
+    Secure {
+        bind: String,
+        cert_path: String,
+        key_path: String,
+    },
+    /// A insecure binding.
+    Insecure(String),
+}
+
+impl std::fmt::Display for RestApiBind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "https-bind")]
+            RestApiBind::Secure { bind, .. } => write!(f, "https://{}", bind),
+            RestApiBind::Insecure(bind) => write!(f, "http://{}", bind),
+        }
+    }
+}
+
 /// `RestApi` is used to create an instance of a restful web server.
 pub struct RestApi {
     resources: Vec<Resource>,
-    bind: String,
+    bind: RestApiBind,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "auth")]
@@ -537,8 +566,7 @@ impl RestApi {
     ) -> Result<(RestApiShutdownHandle, thread::JoinHandle<()>), RestApiServerError> {
         let (tx, rx) = mpsc::channel();
 
-        let bind_url_for_err = self.bind.to_owned();
-        let bind_url = self.bind.to_owned();
+        let bind_config_for_err = self.bind.clone();
         let resources = self.resources;
         #[cfg(feature = "rest-api-cors")]
         let whitelist = self.whitelist;
@@ -559,11 +587,32 @@ impl RestApi {
             None => cors::Cors::new_allow_any(),
         };
 
+        #[cfg(feature = "https-bind")]
+        let bind_info = match self.bind {
+            RestApiBind::Secure {
+                bind,
+                cert_path,
+                key_path,
+            } => {
+                let mut acceptor =
+                    openssl::ssl::SslAcceptor::mozilla_modern(openssl::ssl::SslMethod::tls())?;
+                acceptor.set_private_key_file(key_path, openssl::ssl::SslFiletype::PEM)?;
+                acceptor.set_certificate_chain_file(&cert_path)?;
+                acceptor.check_private_key()?;
+
+                (bind, Some(acceptor))
+            }
+            RestApiBind::Insecure(bind) => (bind, None),
+        };
+
+        #[cfg(not(feature = "https-bind"))]
+        let RestApiBind::Insecure(bind_info) = self.bind;
+
         let join_handle = thread::Builder::new()
             .name("SplinterDRestApi".into())
             .spawn(move || {
                 let sys = actix::System::new("SplinterD-Rest-API");
-                let mut server = HttpServer::new(move || {
+                let server = HttpServer::new(move || {
                     let app = App::new();
 
                     #[cfg(feature = "rest-api-cors")]
@@ -580,7 +629,22 @@ impl RestApi {
                     app
                 });
 
-                server = match server.bind(&bind_url) {
+                #[cfg(feature = "https-bind")]
+                let (bind_url, opt_acceptor) = bind_info;
+                #[cfg(not(feature = "https-bind"))]
+                let bind_url = bind_info;
+
+                #[cfg(feature = "https-bind")]
+                let server = if let Some(acceptor) = opt_acceptor {
+                    server.bind_ssl(&bind_url, acceptor)
+                } else {
+                    server.bind(&bind_url)
+                };
+
+                #[cfg(not(feature = "https-bind"))]
+                let server = server.bind(&bind_url);
+
+                let server = match server {
                     Ok(server) => server,
                     Err(err) => {
                         let error_msg = format!("Invalid REST API bind {}: {}", bind_url, err);
@@ -614,7 +678,7 @@ impl RestApi {
             .map_err(|err| {
                 RestApiServerError::BindError(format!(
                     "Failed to bind to URL {}: {}",
-                    bind_url_for_err, err
+                    bind_config_for_err, err
                 ))
             })?;
 
@@ -644,7 +708,16 @@ impl RestApi {
     ) -> Result<(RestApiShutdownHandle, thread::JoinHandle<()>), RestApiServerError> {
         let (tx, rx) = mpsc::channel();
 
-        let bind_url = self.bind.to_owned();
+        #[cfg(feature = "https-bind")]
+        let bind_url = match self.bind.clone() {
+            RestApiBind::Secure { bind, .. } => bind,
+
+            RestApiBind::Insecure(bind) => bind,
+        };
+
+        #[cfg(not(feature = "https-bind"))]
+        let RestApiBind::Insecure(bind_url) = self.bind.clone();
+
         let resources = self.resources.to_owned();
         #[cfg(feature = "rest-api-cors")]
         let whitelist = self.whitelist.to_owned();
@@ -734,7 +807,7 @@ impl RestApi {
 /// Builder `struct` for `RestApi`.
 pub struct RestApiBuilder {
     resources: Vec<Resource>,
-    bind: Option<String>,
+    bind: Option<RestApiBind>,
     #[cfg(feature = "rest-api-cors")]
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "auth")]
@@ -763,8 +836,15 @@ impl RestApiBuilder {
         Self::default()
     }
 
+    #[cfg(not(feature = "https-bind"))]
     pub fn with_bind(mut self, value: &str) -> Self {
-        self.bind = Some(value.to_string());
+        self.bind = Some(RestApiBind::Insecure(value.to_string()));
+        self
+    }
+
+    #[cfg(feature = "https-bind")]
+    pub fn with_bind(mut self, value: RestApiBind) -> Self {
+        self.bind = Some(value);
         self
     }
 
@@ -971,6 +1051,12 @@ impl RestApiBuilder {
             .bind
             .ok_or_else(|| RestApiServerError::MissingField("bind".to_string()))?;
 
+        let bind = match bind {
+            #[cfg(feature = "https-bind")]
+            RestApiBind::Secure { bind, .. } => RestApiBind::Insecure(bind),
+            insecure @ RestApiBind::Insecure(_) => insecure,
+        };
+
         Ok(RestApi {
             bind,
             resources: self.resources,
@@ -1149,9 +1235,16 @@ mod test {
     /// provided.
     #[test]
     fn rest_api_builder_successful() {
-        // Allowing unused_mut because builder must be mutable if feature auth is enabled
-        #[allow(unused_mut)]
-        let mut builder = RestApiBuilder::new().with_bind("test");
+        let mut builder = RestApiBuilder::new();
+
+        #[cfg(not(feature = "https-bind"))]
+        {
+            builder = builder.with_bind("test");
+        }
+        #[cfg(feature = "https-bind")]
+        {
+            builder = builder.with_bind(RestApiBind::Insecure("test".into()));
+        }
 
         #[cfg(feature = "auth")]
         {
@@ -1170,8 +1263,15 @@ mod test {
     #[test]
     #[cfg(feature = "auth")]
     fn rest_api_builder_no_auth() {
+        #[cfg(feature = "https-bind")]
+        let result = RestApiBuilder::new()
+            .with_bind(RestApiBind::Insecure("test".into()))
+            .build();
+        #[cfg(not(feature = "https-bind"))]
+        let result = RestApiBuilder::new().with_bind("test").build();
+
         assert!(matches!(
-            RestApiBuilder::new().with_bind("test").build(),
+            result,
             Err(RestApiServerError::InvalidStateError(_))
         ));
     }


### PR DESCRIPTION
This PR includes the changes to libsplinter to support HTTPS bind in the REST API.  It adds a new feature `"https-bind"` to the library and modifies the `RestApiBulder` struct to take additional fields for a certificate and key.

With this feature enabled, the builder assumes HTTPS as the default expectation on a bind string.