### PR TITLE
Add re-authentication to OAuth identity provider

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS oauth_user_sessions_timestamp_update;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE FUNCTION update_oauth_user_session_timestamp() RETURNS trigger AS $$
+    BEGIN
+      UPDATE oauth_user_sessions
+      SET last_authenticated = extract(epoch from now())
+      WHERE splinter_access_token = OLD.splinter_access_token;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER oauth_user_sessions_timestamp_update
+  AFTER UPDATE ON oauth_user_sessions
+  FOR EACH ROW EXECUTE PROCEDURE update_oauth_user_session_timestamp();

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS oauth_user_sessions_timestamp_update;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-22-201542_biome_oauth_timestamp_trigger/up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TRIGGER oauth_user_sessions_timestamp_update
+  AFTER UPDATE on oauth_user_sessions
+BEGIN
+  UPDATE oauth_user_sessions
+  SET last_authenticated = strftime('%s','now')
+  WHERE splinter_access_token = old.splinter_access_token;
+END;

--- a/libsplinter/src/oauth/builder/github.rs
+++ b/libsplinter/src/oauth/builder/github.rs
@@ -14,9 +14,8 @@
 
 use crate::oauth::{
     builder::OAuthClientBuilder, error::OAuthClientBuildError, store::InflightOAuthRequestStore,
-    OAuthClient,
+    GithubSubjectProvider, OAuthClient, SubjectProvider,
 };
-use crate::rest_api::auth::identity::{github::GithubUserIdentityProvider, IdentityProvider};
 
 /// Builds a new `OAuthClient` with GitHub's authorization and token URLs.
 pub struct GithubOAuthClientBuilder {
@@ -30,7 +29,7 @@ impl GithubOAuthClientBuilder {
             inner: OAuthClientBuilder::new()
                 .with_auth_url("https://github.com/login/oauth/authorize".into())
                 .with_token_url("https://github.com/login/oauth/access_token".into())
-                .with_identity_provider(Box::new(GithubUserIdentityProvider)),
+                .with_subject_provider(Box::new(GithubSubjectProvider)),
         }
     }
 
@@ -74,7 +73,7 @@ impl GithubOAuthClientBuilder {
     ///
     /// Returns an [`OAuthClientBuildError`] if there are required fields missing, or any URL's
     /// provided are invalid.
-    pub fn build(self) -> Result<(OAuthClient, Box<dyn IdentityProvider>), OAuthClientBuildError> {
+    pub fn build(self) -> Result<(OAuthClient, Box<dyn SubjectProvider>), OAuthClientBuildError> {
         self.inner.build()
     }
 }

--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -46,21 +46,21 @@ pub fn make_callback_route(
                                 // Generate a Splinter access token for the new session
                                 let splinter_access_token = new_splinter_access_token();
 
-                                // Adding the token and identity to the redirect URL so the client
+                                // Adding the token and subject to the redirect URL so the client
                                 // may access these values after a redirect
                                 let redirect_url = format!(
                                     "{}?{}",
                                     redirect_url,
                                     generate_redirect_query(
                                         &splinter_access_token,
-                                        user_info.identity()
+                                        user_info.subject()
                                     )
                                 );
 
                                 // Save the new session
                                 match InsertableOAuthUserSessionBuilder::new()
                                     .with_splinter_access_token(splinter_access_token)
-                                    .with_subject(user_info.identity().to_string())
+                                    .with_subject(user_info.subject().to_string())
                                     .with_oauth_access_token(user_info.access_token().to_string())
                                     .with_oauth_refresh_token(
                                         user_info.refresh_token().map(ToOwned::to_owned),

--- a/libsplinter/src/oauth/subject/mod.rs
+++ b/libsplinter/src/oauth/subject/mod.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! APIs and implementations for fetching subject identifiers from OAuth servers
+
+#[cfg(feature = "oauth-github")]
+mod github;
+#[cfg(feature = "oauth-openid")]
+mod openid;
+
+use crate::error::InternalError;
+
+#[cfg(feature = "oauth-github")]
+pub use github::GithubSubjectProvider;
+#[cfg(feature = "oauth-openid")]
+pub use openid::OpenIdSubjectProvider;
+
+/// A service that fetches subject identifiers from a backing OAuth server
+pub trait SubjectProvider: Send + Sync {
+    /// Attempts to get the subject that the given access token is for. This method will return
+    /// `Ok(None)` if the access token could not be resolved to a subject.
+    fn get_subject(&self, access_token: &str) -> Result<Option<String>, InternalError>;
+
+    /// Clone implementation for `SubjectProvider`. The implementation of the `Clone` trait for
+    /// `Box<dyn SubjectProvider>` calls this method.
+    ///
+    /// # Example
+    ///
+    ///```ignore
+    ///  fn clone_box(&self) -> Box<dyn SubjectProvider> {
+    ///     Box::new(self.clone())
+    ///  }
+    ///```
+    fn clone_box(&self) -> Box<dyn SubjectProvider>;
+}
+
+impl Clone for Box<dyn SubjectProvider> {
+    fn clone(&self) -> Box<dyn SubjectProvider> {
+        self.clone_box()
+    }
+}

--- a/libsplinter/src/rest_api/auth/identity/mod.rs
+++ b/libsplinter/src/rest_api/auth/identity/mod.rs
@@ -32,7 +32,7 @@ use super::AuthorizationHeader;
 /// A service that fetches identities from a backing provider
 pub trait IdentityProvider: Send + Sync {
     /// Attempts to get the identity that corresponds to the given authorization header. This method
-    /// will  return `Ok(None)` if the identity provider was not able to resolve the authorization
+    /// will return `Ok(None)` if the identity provider was not able to resolve the authorization
     /// to an identity.
     fn get_identity(
         &self,

--- a/libsplinter/src/rest_api/auth/identity/mod.rs
+++ b/libsplinter/src/rest_api/auth/identity/mod.rs
@@ -18,12 +18,8 @@
 pub mod biome;
 #[cfg(feature = "cylinder-jwt")]
 pub mod cylinder;
-#[cfg(feature = "oauth-github")]
-pub mod github;
 #[cfg(feature = "oauth")]
 pub mod oauth;
-#[cfg(feature = "oauth-openid")]
-pub mod openid;
 
 use crate::error::InternalError;
 

--- a/libsplinter/src/rest_api/auth/identity/oauth.rs
+++ b/libsplinter/src/rest_api/auth/identity/oauth.rs
@@ -14,12 +14,18 @@
 
 //! An identity provider backed by an OAuth server
 
+use std::time::Duration;
+
 use crate::biome::OAuthUserSessionStore;
 use crate::error::InternalError;
 use crate::oauth::SubjectProvider;
 use crate::rest_api::auth::{AuthorizationHeader, BearerToken};
 
 use super::IdentityProvider;
+
+/// The default amount of time since the last authentication for which the identity provider can
+/// assume the session is still valid
+const DEFAULT_REAUTHENTICATION_INTERVAL: Duration = Duration::from_secs(3600); // 1 hour
 
 /// An identity provider, backed by an OAuth server, that returns a user's Biome ID
 ///
@@ -39,8 +45,9 @@ use super::IdentityProvider;
 /// authorizations, and the inner token must be a valid Splinter access token for an OAuth user.
 #[derive(Clone)]
 pub struct OAuthUserIdentityProvider {
-    _subject_provider: Box<dyn SubjectProvider>,
+    subject_provider: Box<dyn SubjectProvider>,
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+    reauthentication_interval: Duration,
 }
 
 impl OAuthUserIdentityProvider {
@@ -51,13 +58,20 @@ impl OAuthUserIdentityProvider {
     /// * `subject_provider` - The OAuth subject provider that calls the OAuth server to check if a
     ///   session is still valid
     /// * `oauth_user_session_store` - The store that tracks users' sessions
+    /// * `reauthentication_interval` - The amount of time since the last authentication for which
+    ///   the identity provider can assume the session is still valid. If this amount of time has
+    ///   elapsed since the last authentication of a session, the session will be re-authenticated
+    ///   by the identity provider. If not provided, the default will be used (1 hour).
     pub fn new(
-        _subject_provider: Box<dyn SubjectProvider>,
+        subject_provider: Box<dyn SubjectProvider>,
         oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+        reauthentication_interval: Option<Duration>,
     ) -> Self {
         Self {
-            _subject_provider: subject_provider,
+            subject_provider,
             oauth_user_session_store,
+            reauthentication_interval: reauthentication_interval
+                .unwrap_or(DEFAULT_REAUTHENTICATION_INTERVAL),
         }
     }
 }
@@ -72,14 +86,311 @@ impl IdentityProvider for OAuthUserIdentityProvider {
             _ => return Ok(None),
         };
 
-        Ok(self
+        let session = match self
             .oauth_user_session_store
             .get_session(token)
             .map_err(|err| InternalError::from_source(err.into()))?
-            .map(|session| session.user().user_id().to_string()))
+        {
+            Some(session) => session,
+            None => return Ok(None),
+        };
+
+        let user_id = session.user().user_id().to_string();
+
+        let time_since_authenticated = session
+            .last_authenticated()
+            .elapsed()
+            .map_err(|err| InternalError::from_source(err.into()))?;
+        if time_since_authenticated >= self.reauthentication_interval {
+            match self
+                .subject_provider
+                .get_subject(session.oauth_access_token())
+            {
+                Ok(Some(_)) => {
+                    let updated_session = session.into_update_builder().build();
+                    self.oauth_user_session_store
+                        .update_session(updated_session)
+                        .map_err(|err| InternalError::from_source(err.into()))?;
+                    Ok(Some(user_id))
+                }
+                Ok(None) => {
+                    self.oauth_user_session_store
+                        .remove_session(token)
+                        .map_err(|err| InternalError::from_source(err.into()))?;
+                    Ok(None)
+                }
+                Err(err) => {
+                    self.oauth_user_session_store
+                        .remove_session(token)
+                        .map_err(|err| InternalError::from_source(err.into()))?;
+                    Err(err)
+                }
+            }
+        } else {
+            Ok(Some(user_id))
+        }
     }
 
     fn clone_box(&self) -> Box<dyn IdentityProvider> {
         Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::biome::oauth::store::InsertableOAuthUserSessionBuilder;
+    use crate::biome::MemoryOAuthUserSessionStore;
+
+    /// Verifies that the `OAuthUserIdentityProvider` returns a cached user identity when a session
+    /// does not need to be re-authenticated.
+    ///
+    /// 1. Create a new `OAuthUserSessionStore`
+    /// 2. Add a session to the store
+    /// 3. Create a new `OAuthUserIdentityProvider` with the session store, a subject provider
+    ///    that always fails (this will verify that the cache is used and this isn't called), and
+    ///    the default re-authentication interval (an hour is long enough to ensure that the session
+    ///    does not expire while this test is running).
+    /// 4. Call the `get_identity` method with the session's access token and verify that the
+    ///    correct identity (the user's Biome ID) is returned.
+    #[test]
+    fn get_identity_cached() {
+        let session_store = Box::new(MemoryOAuthUserSessionStore::new());
+
+        let splinter_access_token = "splinter_access_token";
+        let session = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token.into())
+            .with_subject("subject".into())
+            .with_oauth_access_token("oauth_access_token".into())
+            .build()
+            .expect("Failed to build session");
+        session_store
+            .add_session(session)
+            .expect("Failed to add session");
+        let user_id = session_store
+            .get_session(splinter_access_token)
+            .expect("Failed to get inserted session")
+            .expect("Inserted session not found")
+            .user()
+            .user_id()
+            .to_string();
+
+        let identity_provider =
+            OAuthUserIdentityProvider::new(Box::new(AlwaysErrSubjectProvider), session_store, None);
+
+        let authorization_header =
+            AuthorizationHeader::Bearer(BearerToken::OAuth2(splinter_access_token.into()));
+        let identity = identity_provider
+            .get_identity(&authorization_header)
+            .expect("Failed to get identity")
+            .expect("Identity not found");
+        assert_eq!(identity, user_id);
+    }
+
+    /// Verifies that the `OAuthUserIdentityProvider` returns `None` when the sessions store does
+    /// not have a session for the given token.
+    ///
+    /// 1. Create a new `OAuthUserIdentityProvider` with an empty session store and a subject
+    ///    provider that always succeeds (this will verify that the subject provider isn't called
+    ///    when the session doesn't even exist).
+    /// 2. Call the `get_identity` method and verify that `None` is returned
+    #[test]
+    fn get_identity_no_session() {
+        let identity_provider = OAuthUserIdentityProvider::new(
+            Box::new(AlwaysSomeSubjectProvider),
+            Box::new(MemoryOAuthUserSessionStore::new()),
+            None,
+        );
+
+        let authorization_header =
+            AuthorizationHeader::Bearer(BearerToken::OAuth2("splinter_access_token".into()));
+        assert!(identity_provider
+            .get_identity(&authorization_header)
+            .expect("Failed to get identity")
+            .is_none());
+    }
+
+    /// Verifies that the `OAuthUserIdentityProvider` re-authenticates a session when the
+    /// re-authentication interval has expired for a session.
+    ///
+    /// 1. Create a new `OAuthUserSessionStore`
+    /// 2. Add a session to the store
+    /// 3. Create a new `OAuthUserIdentityProvider` with the session store, a subject provider
+    ///    that always succeeds, and a re-authentication interval of 0 (the session will expire
+    ///    immediately).
+    /// 4. Call the `get_identity` method with the session's access token and verify that the
+    ///    identity is correct.
+    /// 5. Verify that the "last authenticated" time for the session in the session store is more
+    ///    recent than the session's original "last authenticated" time.
+    #[test]
+    fn get_identity_reauthentication_successful() {
+        let session_store = Box::new(MemoryOAuthUserSessionStore::new());
+
+        let splinter_access_token = "splinter_access_token";
+        let session = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token.into())
+            .with_subject("subject".into())
+            .with_oauth_access_token("oauth_access_token".into())
+            .build()
+            .expect("Failed to build session");
+        session_store
+            .add_session(session)
+            .expect("Failed to add session");
+        let original_session = session_store
+            .get_session(splinter_access_token)
+            .expect("Failed to get inserted session")
+            .expect("Inserted session not found");
+
+        let identity_provider = OAuthUserIdentityProvider::new(
+            Box::new(AlwaysSomeSubjectProvider),
+            session_store.clone(),
+            Some(Duration::from_secs(0)),
+        );
+
+        let authorization_header =
+            AuthorizationHeader::Bearer(BearerToken::OAuth2(splinter_access_token.into()));
+        let identity = identity_provider
+            .get_identity(&authorization_header)
+            .expect("Failed to get identity")
+            .expect("Identity not found");
+        assert_eq!(&identity, original_session.user().user_id());
+
+        let new_session = session_store
+            .get_session(splinter_access_token)
+            .expect("Failed to get updated session")
+            .expect("Updated session not found");
+        assert!(new_session.last_authenticated() > original_session.last_authenticated());
+    }
+
+    /// Verifies that the `OAuthUserIdentityProvider` correctly handles the case where the internal
+    /// subect provider returns `Ok(None)` when re-authenticating a session.
+    ///
+    /// 1. Create a new `OAuthUserSessionStore`
+    /// 2. Add a session to the store
+    /// 3. Create a new `OAuthUserIdentityProvider` with the session store, a subject provider
+    ///    that always returns `Ok(None)`, and a re-authentication interval of 0 (the session will
+    ///    expire immediately).
+    /// 4. Call the `get_identity` method with the session's access token and verify that `Ok(None)`
+    ///    is returned.
+    /// 5. Verify that the session has been removed from the store.
+    #[test]
+    fn get_identity_reauthentication_unauthorized() {
+        let session_store = Box::new(MemoryOAuthUserSessionStore::new());
+
+        let splinter_access_token = "splinter_access_token";
+        let session = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token.into())
+            .with_subject("subject".into())
+            .with_oauth_access_token("oauth_access_token".into())
+            .build()
+            .expect("Failed to build session");
+        session_store
+            .add_session(session)
+            .expect("Failed to add session");
+
+        let identity_provider = OAuthUserIdentityProvider::new(
+            Box::new(AlwaysNoneSubjectProvider),
+            session_store.clone(),
+            Some(Duration::from_secs(0)),
+        );
+
+        let authorization_header =
+            AuthorizationHeader::Bearer(BearerToken::OAuth2(splinter_access_token.into()));
+        assert!(identity_provider
+            .get_identity(&authorization_header)
+            .expect("Failed to get identity")
+            .is_none());
+
+        assert!(session_store
+            .get_session(splinter_access_token)
+            .expect("Failed to get session")
+            .is_none());
+    }
+
+    /// Verifies that the `OAuthUserIdentityProvider` correctly handles the case where the internal
+    /// subect provider returns an error when re-authenticating a session.
+    ///
+    /// 1. Create a new `OAuthUserSessionStore`
+    /// 2. Add a session to the store
+    /// 3. Create a new `OAuthUserIdentityProvider` with the session store, a subject provider
+    ///    that always returns an error, and a re-authentication interval of 0 (the session will
+    ///    expire immediately).
+    /// 4. Call the `get_identity` method with the session's access token and verify that an error
+    ///    is returned.
+    /// 5. Verify that the session has been removed from the store.
+    #[test]
+    fn get_identity_reauthentication_failed() {
+        let session_store = Box::new(MemoryOAuthUserSessionStore::new());
+
+        let splinter_access_token = "splinter_access_token";
+        let session = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token.into())
+            .with_subject("subject".into())
+            .with_oauth_access_token("oauth_access_token".into())
+            .build()
+            .expect("Failed to build session");
+        session_store
+            .add_session(session)
+            .expect("Failed to add session");
+
+        let identity_provider = OAuthUserIdentityProvider::new(
+            Box::new(AlwaysErrSubjectProvider),
+            session_store.clone(),
+            Some(Duration::from_secs(0)),
+        );
+
+        let authorization_header =
+            AuthorizationHeader::Bearer(BearerToken::OAuth2(splinter_access_token.into()));
+        assert!(identity_provider
+            .get_identity(&authorization_header)
+            .is_err());
+
+        assert!(session_store
+            .get_session(splinter_access_token)
+            .expect("Failed to get session")
+            .is_none());
+    }
+
+    /// Subject provider that always returns a subject
+    #[derive(Clone)]
+    struct AlwaysSomeSubjectProvider;
+
+    impl SubjectProvider for AlwaysSomeSubjectProvider {
+        fn get_subject(&self, _access_token: &str) -> Result<Option<String>, InternalError> {
+            Ok(Some("subject".into()))
+        }
+
+        fn clone_box(&self) -> Box<dyn SubjectProvider> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// Subject provider that always returns `Ok(None)`
+    #[derive(Clone)]
+    struct AlwaysNoneSubjectProvider;
+
+    impl SubjectProvider for AlwaysNoneSubjectProvider {
+        fn get_subject(&self, _access_token: &str) -> Result<Option<String>, InternalError> {
+            Ok(None)
+        }
+
+        fn clone_box(&self) -> Box<dyn SubjectProvider> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// Subject provider that always returns `Err`
+    #[derive(Clone)]
+    struct AlwaysErrSubjectProvider;
+
+    impl SubjectProvider for AlwaysErrSubjectProvider {
+        fn get_subject(&self, _access_token: &str) -> Result<Option<String>, InternalError> {
+            Err(InternalError::with_message("error".into()))
+        }
+
+        fn clone_box(&self) -> Box<dyn SubjectProvider> {
+            Box::new(self.clone())
+        }
     }
 }

--- a/libsplinter/src/rest_api/auth/identity/oauth.rs
+++ b/libsplinter/src/rest_api/auth/identity/oauth.rs
@@ -64,7 +64,7 @@ impl IdentityProvider for OAuthUserIdentityProvider {
             .oauth_user_session_store
             .get_session(token)
             .map_err(|err| InternalError::from_source(err.into()))?
-            .map(|session| session.user().subject().to_string()))
+            .map(|session| session.user().user_id().to_string()))
     }
 
     fn clone_box(&self) -> Box<dyn IdentityProvider> {

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -89,14 +89,14 @@ use crate::biome::rest_api::BiomeRestResourceManager;
 use crate::biome::{rest_api::auth::GetUserByOAuthAuthorization, OAuthUserSessionStore};
 #[cfg(feature = "auth")]
 use crate::error::InvalidStateError;
-#[cfg(feature = "oauth")]
-use crate::oauth::rest_api::OAuthResourceProvider;
 #[cfg(any(feature = "oauth-github", feature = "oauth-openid"))]
 use crate::oauth::store::InflightOAuthRequestStore;
 #[cfg(feature = "oauth-github")]
 use crate::oauth::GithubOAuthClientBuilder;
 #[cfg(feature = "oauth-openid")]
 use crate::oauth::OpenIdOAuthClientBuilder;
+#[cfg(feature = "oauth")]
+use crate::oauth::{rest_api::OAuthResourceProvider, SubjectProvider};
 #[cfg(all(feature = "auth", feature = "cylinder-jwt"))]
 use auth::identity::cylinder::CylinderKeyIdentityProvider;
 #[cfg(feature = "oauth")]
@@ -932,53 +932,51 @@ impl RestApiBuilder {
                             ));
                         }
 
-                        let (oauth_client, oauth_identity_provider): (
-                            _,
-                            Box<dyn IdentityProvider>,
-                        ) = match oauth_config {
-                            #[cfg(feature = "oauth-github")]
-                            OAuthConfig::GitHub {
-                                client_id,
-                                client_secret,
-                                redirect_url,
-                                inflight_request_store,
-                            } => GithubOAuthClientBuilder::new()
-                                .with_client_id(client_id)
-                                .with_client_secret(client_secret)
-                                .with_redirect_url(redirect_url)
-                                .with_inflight_request_store(inflight_request_store)
-                                .build()
-                                .map_err(|err| {
-                                    RestApiServerError::InvalidStateError(
-                                        InvalidStateError::with_message(format!(
-                                            "Invalid GitHub OAuth config provided: {}",
-                                            err
-                                        )),
-                                    )
-                                })?,
-                            #[cfg(feature = "oauth-openid")]
-                            OAuthConfig::OpenId {
-                                client_id,
-                                client_secret,
-                                redirect_url,
-                                oauth_openid_url,
-                                inflight_request_store,
-                            } => OpenIdOAuthClientBuilder::new()
-                                .with_discovery_url(oauth_openid_url)
-                                .with_client_id(client_id)
-                                .with_client_secret(client_secret)
-                                .with_redirect_url(redirect_url)
-                                .with_inflight_request_store(inflight_request_store)
-                                .build()
-                                .map_err(|err| {
-                                    RestApiServerError::InvalidStateError(
-                                        InvalidStateError::with_message(format!(
-                                            "Invalid OpenID OAuth config provided: {}",
-                                            err
-                                        )),
-                                    )
-                                })?,
-                        };
+                        let (oauth_client, subject_provider): (_, Box<dyn SubjectProvider>) =
+                            match oauth_config {
+                                #[cfg(feature = "oauth-github")]
+                                OAuthConfig::GitHub {
+                                    client_id,
+                                    client_secret,
+                                    redirect_url,
+                                    inflight_request_store,
+                                } => GithubOAuthClientBuilder::new()
+                                    .with_client_id(client_id)
+                                    .with_client_secret(client_secret)
+                                    .with_redirect_url(redirect_url)
+                                    .with_inflight_request_store(inflight_request_store)
+                                    .build()
+                                    .map_err(|err| {
+                                        RestApiServerError::InvalidStateError(
+                                            InvalidStateError::with_message(format!(
+                                                "Invalid GitHub OAuth config provided: {}",
+                                                err
+                                            )),
+                                        )
+                                    })?,
+                                #[cfg(feature = "oauth-openid")]
+                                OAuthConfig::OpenId {
+                                    client_id,
+                                    client_secret,
+                                    redirect_url,
+                                    oauth_openid_url,
+                                    inflight_request_store,
+                                } => OpenIdOAuthClientBuilder::new()
+                                    .with_discovery_url(oauth_openid_url)
+                                    .with_client_id(client_id)
+                                    .with_client_secret(client_secret)
+                                    .with_redirect_url(redirect_url)
+                                    .with_inflight_request_store(inflight_request_store)
+                                    .build()
+                                    .map_err(|err| {
+                                        RestApiServerError::InvalidStateError(
+                                            InvalidStateError::with_message(format!(
+                                                "Invalid OpenID OAuth config provided: {}",
+                                                err
+                                            )),
+                                        )
+                                    })?,
+                            };
 
                         // Add the configuration mapping for the Biome User value.
                         self.authorization_mappings
@@ -987,7 +985,7 @@ impl RestApiBuilder {
                             ));
 
                         identity_providers.push(Box::new(OAuthUserIdentityProvider::new(
-                            oauth_identity_provider,
+                            subject_provider,
                             oauth_user_session_store.clone(),
                         )));
                         self.resources.append(

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -987,6 +987,7 @@ impl RestApiBuilder {
                         identity_providers.push(Box::new(OAuthUserIdentityProvider::new(
                             subject_provider,
                             oauth_user_session_store.clone(),
+                            None,
                         )));
                         self.resources.append(
                             &mut OAuthResourceProvider::new(oauth_client, oauth_user_session_store)


### PR DESCRIPTION
Updates the `OAuthUserIdentityProvider` to re-authenticate users'
sessions when a configurable amount of time has elapsed since the last
time the session was authenticated with the OAuth server.