### PR TITLE
Enable HTTPS REST API in splinterd

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -84,6 +84,7 @@ experimental = [
     "admin-service-event-store",
     "biome-oauth",
     "health",
+    "https-bind",
     "registry-database",
     "service-arg-validation",
     "service-endpoint",
@@ -108,6 +109,7 @@ biome-oauth = [
     "splinter/biome-oauth-user-store-postgres"
 ]
 database = ["splinter/postgres", "splinter/sqlite"]
+https-bind = ["splinter/https-bind"]
 registry-database = ["database", "splinter/registry-database"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -231,6 +231,15 @@ OPTIONS
 : Specifies the path and file name for the server key.
   (Default: `/etc/splinter/certs/server.key`.)
 
+`--tls-rest-api-cert REST-API-CERT`
+: Specifies the path and file name for the REST API certificate, which is used by
+  `splinterd` when it is hosting the REST API over HTTPS.
+  (Default: `/etc/splinter/certs/rest_api.crt`.)
+
+`--tls-rest-api-key REST-API-KEY`
+: Specifies the path and file name for the REST API key.
+  (Default: `/etc/splinter/certs/rest_api.key`.)
+
 `--whitelist WHITELIST` `[,...]`
 : Lists one or more trusted domains for cross-origin resource sharing (CORS).
   This option allows the specified domains to access restricted web resources

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -73,6 +73,15 @@ tls_server_cert = "/etc/splinter/node_012/certs/server.crt"
 # (default "/etc/splinter/certs/private/server.key")
 tls_server_key = "/etc/splinter/node_012/certs/server.key"
 
+# A certificate signed by a certificate authority.
+# Used by the daemon when it is providing a REST API.
+# (default "/etc/splinter/certs/rest_api.crt")
+tls_rest_api_cert = "/etc/splinter/node_012/certs/rest_api.crt"
+
+# Private key used by daemon when it is providing a REST API.
+# (default "/etc/splinter/certs/private/rest_api.key")
+tls_rest_api_key = "/etc/splinter/node_012/certs/rest_api.key"
+
 # Public network endpoint for daemon-to-daemon communication
 # Use a protocol prefix to enforce the connection type, using the format
 # `protocol_prefix://ip:port`

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -92,6 +92,15 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
             })
             .with_state_dir(self.matches.value_of("state_dir").map(String::from));
 
+        #[cfg(feature = "https-bind")]
+        {
+            partial_config = partial_config
+                .with_tls_rest_api_cert(
+                    self.matches.value_of("tls_rest_api_cert").map(String::from),
+                )
+                .with_tls_rest_api_key(self.matches.value_of("tls_rest_api_key").map(String::from));
+        }
+
         #[cfg(feature = "service-endpoint")]
         {
             partial_config = partial_config
@@ -157,6 +166,10 @@ mod tests {
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
     static EXAMPLE_SERVER_CERT: &str = "certs/server.crt";
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
+    #[cfg(feature = "https-bind")]
+    static EXAMPLE_REST_API_CERT: &str = "certs/rest_api.crt";
+    #[cfg(feature = "https-bind")]
+    static EXAMPLE_REST_API_KEY: &str = "certs/rest_api.key";
     #[cfg(feature = "service-endpoint")]
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NETWORK_ENDPOINT: &str = "127.0.0.1:8044";
@@ -186,6 +199,17 @@ mod tests {
             config.tls_server_key(),
             Some(EXAMPLE_SERVER_KEY.to_string())
         );
+        #[cfg(feature = "https-bind")]
+        {
+            assert_eq!(
+                config.tls_rest_api_cert(),
+                Some(EXAMPLE_REST_API_CERT.to_string())
+            );
+            assert_eq!(
+                config.tls_rest_api_key(),
+                Some(EXAMPLE_REST_API_KEY.to_string())
+            );
+        }
         #[cfg(feature = "service-endpoint")]
         assert_eq!(
             config.service_endpoint(),
@@ -220,28 +244,59 @@ mod tests {
 
     /// Creates an `ArgMatches` object to be used to construct a `ClapPartialConfigBuilder` object.
     fn create_arg_matches(args: Vec<&str>) -> ArgMatches<'static> {
-        clap_app!(configtest =>
-            (version: crate_version!())
-            (about: "Config-Test")
-            (@arg config: -c --config +takes_value)
-            (@arg node_id: --("node-id") +takes_value)
-            (@arg display_name: --("display-name") +takes_value)
-            (@arg storage: --("storage") +takes_value)
-            (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
-            (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
-            (@arg service_endpoint: --("service-endpoint") +takes_value)
-            (@arg peers: --peers +takes_value +multiple)
-            (@arg tls_ca_file: --("tls-ca-file") +takes_value)
-            (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
-            (@arg tls_client_cert: --("tls-client-cert") +takes_value)
-            (@arg tls_server_cert: --("tls-server-cert") +takes_value)
-            (@arg tls_server_key:  --("tls-server-key") +takes_value)
-            (@arg tls_client_key:  --("tls-client-key") +takes_value)
-            (@arg rest_api_endpoint: --("rest-api-endpoint") +takes_value)
-            (@arg tls_insecure: --("tls-insecure"))
-            (@arg no_tls: --("no-tls"))
-            (@arg state_dir: --("state-dir") + takes_value))
-        .get_matches_from(args)
+        #[cfg(not(feature = "https-bind"))]
+        {
+            clap_app!(configtest =>
+                (version: crate_version!())
+                (about: "Config-Test")
+                (@arg config: -c --config +takes_value)
+                (@arg node_id: --("node-id") +takes_value)
+                (@arg display_name: --("display-name") +takes_value)
+                (@arg storage: --("storage") +takes_value)
+                (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
+                (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
+                (@arg service_endpoint: --("service-endpoint") +takes_value)
+                (@arg peers: --peers +takes_value +multiple)
+                (@arg tls_ca_file: --("tls-ca-file") +takes_value)
+                (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
+                (@arg tls_client_cert: --("tls-client-cert") +takes_value)
+                (@arg tls_server_cert: --("tls-server-cert") +takes_value)
+                (@arg tls_server_key:  --("tls-server-key") +takes_value)
+                (@arg tls_client_key:  --("tls-client-key") +takes_value)
+                (@arg rest_api_endpoint: --("rest-api-endpoint") +takes_value)
+                (@arg tls_insecure: --("tls-insecure"))
+                (@arg no_tls: --("no-tls"))
+                (@arg state_dir: --("state-dir") + takes_value))
+            .get_matches_from(args)
+        }
+
+        #[cfg(feature = "https-bind")]
+        {
+            clap_app!(configtest =>
+                (version: crate_version!())
+                (about: "Config-Test")
+                (@arg config: -c --config +takes_value)
+                (@arg node_id: --("node-id") +takes_value)
+                (@arg display_name: --("display-name") +takes_value)
+                (@arg storage: --("storage") +takes_value)
+                (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
+                (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
+                (@arg service_endpoint: --("service-endpoint") +takes_value)
+                (@arg peers: --peers +takes_value +multiple)
+                (@arg tls_ca_file: --("tls-ca-file") +takes_value)
+                (@arg tls_cert_dir: --("tls-cert-dir") +takes_value)
+                (@arg tls_client_cert: --("tls-client-cert") +takes_value)
+                (@arg tls_client_key:  --("tls-client-key") +takes_value)
+                (@arg tls_server_cert: --("tls-server-cert") +takes_value)
+                (@arg tls_server_key:  --("tls-server-key") +takes_value)
+                (@arg tls_rest_api_cert: --("tls-rest-api-cert") +takes_value)
+                (@arg tls_rest_api_key:  --("tls-rest-api-key") +takes_value)
+                (@arg rest_api_endpoint: --("rest-api-endpoint") +takes_value)
+                (@arg tls_insecure: --("tls-insecure"))
+                (@arg no_tls: --("no-tls"))
+                (@arg state_dir: --("state-dir") + takes_value))
+            .get_matches_from(args)
+        }
     }
 
     #[test]
@@ -283,6 +338,14 @@ mod tests {
             EXAMPLE_SERVER_CERT,
             "--tls-server-key",
             EXAMPLE_SERVER_KEY,
+            #[cfg(feature = "https-bind")]
+            "--tls-rest-api-cert",
+            #[cfg(feature = "https-bind")]
+            EXAMPLE_REST_API_CERT,
+            #[cfg(feature = "https-bind")]
+            "--tls-rest-api-key",
+            #[cfg(feature = "https-bind")]
+            EXAMPLE_REST_API_KEY,
             "--tls-insecure",
             "--no-tls",
             "--state-dir",

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -24,6 +24,10 @@ const TLS_CLIENT_CERT: &str = "client.crt";
 const TLS_CLIENT_KEY: &str = "private/client.key";
 const TLS_SERVER_CERT: &str = "server.crt";
 const TLS_SERVER_KEY: &str = "private/server.key";
+#[cfg(feature = "https-bind")]
+const TLS_REST_API_CERT: &str = "rest_api.crt";
+#[cfg(feature = "https-bind")]
+const TLS_REST_API_KEY: &str = "private/rest_api.key";
 const TLS_CA_FILE: &str = "ca.pem";
 
 const REST_API_ENDPOINT: &str = "127.0.0.1:8080";
@@ -72,6 +76,13 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_no_tls(Some(false))
             .with_strict_ref_counts(Some(false));
 
+        #[cfg(feature = "https-bind")]
+        {
+            partial_config = partial_config
+                .with_tls_rest_api_cert(Some(String::from(TLS_REST_API_CERT)))
+                .with_tls_rest_api_key(Some(String::from(TLS_REST_API_KEY)));
+        }
+
         #[cfg(feature = "service-endpoint")]
         {
             partial_config =
@@ -112,6 +123,17 @@ mod tests {
             Some(String::from(TLS_SERVER_CERT))
         );
         assert_eq!(config.tls_server_key(), Some(String::from(TLS_SERVER_KEY)));
+        #[cfg(feature = "https-bind")]
+        {
+            assert_eq!(
+                config.tls_rest_api_cert(),
+                Some(String::from(TLS_REST_API_CERT))
+            );
+            assert_eq!(
+                config.tls_rest_api_key(),
+                Some(String::from(TLS_REST_API_KEY))
+            );
+        }
         #[cfg(feature = "service-endpoint")]
         assert_eq!(
             config.service_endpoint(),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -48,6 +48,10 @@ pub struct Config {
     tls_client_key: (String, ConfigSource),
     tls_server_cert: (String, ConfigSource),
     tls_server_key: (String, ConfigSource),
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_cert: (String, ConfigSource),
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_key: (String, ConfigSource),
     #[cfg(feature = "service-endpoint")]
     service_endpoint: (String, ConfigSource),
     network_endpoints: (Vec<String>, ConfigSource),
@@ -118,6 +122,16 @@ impl Config {
 
     pub fn tls_server_key(&self) -> &str {
         &self.tls_server_key.0
+    }
+
+    #[cfg(feature = "https-bind")]
+    pub fn tls_rest_api_cert(&self) -> &str {
+        &self.tls_rest_api_cert.0
+    }
+
+    #[cfg(feature = "https-bind")]
+    pub fn tls_rest_api_key(&self) -> &str {
+        &self.tls_rest_api_key.0
     }
 
     #[cfg(feature = "service-endpoint")]
@@ -291,6 +305,16 @@ impl Config {
 
     fn tls_server_key_source(&self) -> &ConfigSource {
         &self.tls_server_key.1
+    }
+
+    #[cfg(feature = "https-bind")]
+    fn tls_rest_api_cert_source(&self) -> &ConfigSource {
+        &self.tls_rest_api_cert.1
+    }
+
+    #[cfg(feature = "https-bind")]
+    fn tls_rest_api_key_source(&self) -> &ConfigSource {
+        &self.tls_rest_api_key.1
     }
 
     #[cfg(feature = "service-endpoint")]
@@ -471,6 +495,19 @@ impl Config {
             self.tls_server_key(),
             self.tls_server_key_source()
         );
+        #[cfg(feature = "https-bind")]
+        {
+            debug!(
+                "Config: tls_rest_api_cert: {} (source: {:?})",
+                self.tls_rest_api_cert(),
+                self.tls_rest_api_cert_source()
+            );
+            debug!(
+                "Config: tls_rest_api_key: {} (source: {:?})",
+                self.tls_rest_api_key(),
+                self.tls_rest_api_key_source()
+            );
+        }
         #[cfg(feature = "service-endpoint")]
         debug!(
             "Config: service_endpoint: {} (source: {:?})",

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -41,6 +41,10 @@ pub struct PartialConfig {
     tls_client_key: Option<String>,
     tls_server_cert: Option<String>,
     tls_server_key: Option<String>,
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_cert: Option<String>,
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_key: Option<String>,
     #[cfg(feature = "service-endpoint")]
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
@@ -89,6 +93,10 @@ impl PartialConfig {
             tls_client_key: None,
             tls_server_cert: None,
             tls_server_key: None,
+            #[cfg(feature = "https-bind")]
+            tls_rest_api_cert: None,
+            #[cfg(feature = "https-bind")]
+            tls_rest_api_key: None,
             #[cfg(feature = "service-endpoint")]
             service_endpoint: None,
             network_endpoints: None,
@@ -159,6 +167,16 @@ impl PartialConfig {
 
     pub fn tls_server_key(&self) -> Option<String> {
         self.tls_server_key.clone()
+    }
+
+    #[cfg(feature = "https-bind")]
+    pub fn tls_rest_api_cert(&self) -> Option<String> {
+        self.tls_rest_api_cert.clone()
+    }
+
+    #[cfg(feature = "https-bind")]
+    pub fn tls_rest_api_key(&self) -> Option<String> {
+        self.tls_rest_api_key.clone()
     }
 
     #[cfg(feature = "service-endpoint")]
@@ -353,6 +371,31 @@ impl PartialConfig {
     ///
     pub fn with_tls_server_key(mut self, tls_server_key: Option<String>) -> Self {
         self.tls_server_key = tls_server_key;
+        self
+    }
+
+    /// Adds a `tls_rest_api_cert` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `tls_rest_api_cert` - A certificate signed by a certificate authority. Used by the daemon
+    ///                   when it is acting as a rest_api, receiving messages.
+    ///
+    #[cfg(feature = "https-bind")]
+    pub fn with_tls_rest_api_cert(mut self, tls_rest_api_cert: Option<String>) -> Self {
+        self.tls_rest_api_cert = tls_rest_api_cert;
+        self
+    }
+
+    /// Adds a `tls_rest_api_key` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `tls_rest_api_key` - Private key used by daemon when it is acting as a rest_api.
+    ///
+    #[cfg(feature = "https-bind")]
+    pub fn with_tls_rest_api_key(mut self, tls_rest_api_key: Option<String>) -> Self {
+        self.tls_rest_api_key = tls_rest_api_key;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -35,6 +35,10 @@ struct TomlConfig {
     tls_client_key: Option<String>,
     tls_server_cert: Option<String>,
     tls_server_key: Option<String>,
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_cert: Option<String>,
+    #[cfg(feature = "https-bind")]
+    tls_rest_api_key: Option<String>,
     #[cfg(feature = "service-endpoint")]
     service_endpoint: Option<String>,
     network_endpoints: Option<Vec<String>>,
@@ -144,6 +148,13 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_heartbeat(self.toml_config.heartbeat)
             .with_admin_timeout(self.toml_config.admin_timeout);
 
+        #[cfg(feature = "https-bind")]
+        {
+            partial_config = partial_config
+                .with_tls_rest_api_cert(self.toml_config.tls_rest_api_cert)
+                .with_tls_rest_api_key(self.toml_config.tls_rest_api_key);
+        }
+
         #[cfg(feature = "service-endpoint")]
         {
             partial_config = partial_config.with_service_endpoint(self.toml_config.service_endpoint)
@@ -230,6 +241,10 @@ mod tests {
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
     static EXAMPLE_SERVER_CERT: &str = "certs/server.crt";
     static EXAMPLE_SERVER_KEY: &str = "certs/server.key";
+    #[cfg(feature = "https-bind")]
+    static EXAMPLE_REST_API_CERT: &str = "certs/rest_api.crt";
+    #[cfg(feature = "https-bind")]
+    static EXAMPLE_REST_API_KEY: &str = "certs/rest_api.key";
     #[cfg(feature = "service-endpoint")]
     static EXAMPLE_SERVICE_ENDPOINT: &str = "127.0.0.1:8043";
     static EXAMPLE_NODE_ID: &str = "012";
@@ -254,6 +269,16 @@ mod tests {
                 EXAMPLE_SERVER_CERT.to_string(),
             ),
             ("tls_server_key".to_string(), EXAMPLE_SERVER_KEY.to_string()),
+            #[cfg(feature = "https-bind")]
+            (
+                "tls_rest_api_cert".to_string(),
+                EXAMPLE_REST_API_CERT.to_string(),
+            ),
+            #[cfg(feature = "https-bind")]
+            (
+                "tls_rest_api_key".to_string(),
+                EXAMPLE_REST_API_KEY.to_string(),
+            ),
             #[cfg(feature = "service-endpoint")]
             (
                 "service_endpoint".to_string(),
@@ -331,6 +356,17 @@ mod tests {
             config.tls_server_key(),
             Some(EXAMPLE_SERVER_KEY.to_string())
         );
+        #[cfg(feature = "https-bind")]
+        {
+            assert_eq!(
+                config.tls_rest_api_cert(),
+                Some(EXAMPLE_REST_API_CERT.to_string())
+            );
+            assert_eq!(
+                config.tls_rest_api_key(),
+                Some(EXAMPLE_REST_API_KEY.to_string())
+            );
+        }
         #[cfg(feature = "service-endpoint")]
         assert_eq!(
             config.service_endpoint(),

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -324,6 +324,24 @@ fn main() {
             .long_help("Enable the biome subsystem"),
     );
 
+    #[cfg(feature = "https-bind")]
+    let app = app.arg(
+        Arg::with_name("tls_rest_api_cert")
+            .long("tls-rest-api-cert")
+            .help("File path to the certificate for the node's REST API.")
+            .takes_value(true)
+            .alias("rest-api-cert"),
+    );
+
+    #[cfg(feature = "https-bind")]
+    let app = app.arg(
+        Arg::with_name("tls_rest_api_key")
+            .long("tls-rest-api-key")
+            .help("File path to the key for the node's REST API.")
+            .takes_value(true)
+            .alias("rest-api-key"),
+    );
+
     #[cfg(feature = "rest-api-cors")]
     let app = app.arg(
         Arg::with_name("whitelist")

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -399,6 +399,8 @@ fn main() {
     log_spec_builder.default(log_level);
     log_spec_builder.module("hyper", log::LevelFilter::Warn);
     log_spec_builder.module("tokio", log::LevelFilter::Warn);
+    #[cfg(feature = "https-bind")]
+    log_spec_builder.module("h2", log::LevelFilter::Warn);
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
@@ -471,6 +473,13 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
         .with_heartbeat(config.heartbeat())
         .with_admin_timeout(admin_timeout)
         .with_strict_ref_counts(config.strict_ref_counts());
+
+    #[cfg(feature = "https-bind")]
+    {
+        daemon_builder = daemon_builder
+            .with_rest_api_server_cert(config.tls_rest_api_cert().to_string())
+            .with_rest_api_server_key(config.tls_rest_api_key().to_string());
+    }
 
     #[cfg(feature = "service-endpoint")]
     {


### PR DESCRIPTION
To test:

If this is a new splinter setup, be sure to migrate the database:

```
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- database migrate
```

Then generate certs:

```
$ SPLINTER_HOME=/tmp/splinter cargo --manifest-path cli/Cargo.toml -- cert generate
```

If PR #1094 is not merged, copy the server cert files as rest api cert files:

```
$ cp /tmp/splinter/cert/server.crt /tmp/splintercert/rest_api.crt
$ cp /tmp/splinter/cert/private/server.key /tmp/splintercert/private/rest_api.key
``` 

Finally, start splinterd as normal:

```
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- --tls-insecure -vv
```

To verify the https:

```
$ curl -sv --insecure https://localhost:8080/status
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=localhost
*  start date: Dec 22 21:13:18 2020 GMT
*  expire date: Dec 22 21:13:18 2021 GMT
*  issuer: CN=generated_ca
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fe43180f600)
> GET /status HTTP/2
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 4294967295)!
< HTTP/2 401
< content-length: 51
< content-type: application/json
< date: Wed, 23 Dec 2020 01:22:20 GMT
<
* Connection #0 to host localhost left intact
{"code":"401","message":"Client is not authorized"}* Closing connection 0
```

The TLS handshake is successful (the 401 is expected, as the endpoint requires an auth token of some sort).
