### PR TITLE
Add event store's `AdminServiceEvent` object, update store to use it

### DIFF
--- a/libsplinter/src/admin/service/event/mod.rs
+++ b/libsplinter/src/admin/service/event/mod.rs
@@ -12,5 +12,77 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Module containing the `AdminServiceEventStore` trait and related implementations.
+//! Defines an `AdminServiceEvent`, stored and returned by the `AdminServiceEventStore`.
+//!
+//! The public interface includes the struct [`AdminServiceEvent`].
+//!
+//! [`AdminServiceEvent`]: struct.AdminServiceEvent.html
+
 pub mod store;
+
+use std::convert::TryFrom;
+
+use crate::admin::service::messages;
+use crate::admin::store as admin_store;
+use crate::error::InvalidStateError;
+
+#[derive(Debug, PartialEq, Eq)]
+/// Representation of an `AdminServiceEvent` defined by the admin messages
+pub struct AdminServiceEvent {
+    pub event_id: i64,
+    pub event_type: EventType,
+    pub proposal: admin_store::CircuitProposal,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// Native representation of the `AdminServiceEvent` enum variants
+pub enum EventType {
+    ProposalSubmitted,
+    ProposalVote { requester: Vec<u8> },
+    ProposalAccepted { requester: Vec<u8> },
+    ProposalRejected { requester: Vec<u8> },
+    CircuitReady,
+}
+
+impl TryFrom<(i64, &messages::AdminServiceEvent)> for AdminServiceEvent {
+    type Error = InvalidStateError;
+
+    fn try_from(
+        (event_id, event): (i64, &messages::AdminServiceEvent),
+    ) -> Result<Self, Self::Error> {
+        let proposal = admin_store::CircuitProposal::try_from(event.proposal())?;
+        match event {
+            messages::AdminServiceEvent::ProposalSubmitted(_) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::ProposalSubmitted,
+                proposal,
+            }),
+            messages::AdminServiceEvent::ProposalVote((_, data)) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::ProposalVote {
+                    requester: data.to_vec(),
+                },
+                proposal,
+            }),
+            messages::AdminServiceEvent::ProposalAccepted((_, data)) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::ProposalAccepted {
+                    requester: data.to_vec(),
+                },
+                proposal,
+            }),
+            messages::AdminServiceEvent::ProposalRejected((_, data)) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::ProposalRejected {
+                    requester: data.to_vec(),
+                },
+                proposal,
+            }),
+            messages::AdminServiceEvent::CircuitReady(_) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::CircuitReady,
+                proposal,
+            }),
+        }
+    }
+}

--- a/libsplinter/src/admin/service/event/store/mod.rs
+++ b/libsplinter/src/admin/service/event/store/mod.rs
@@ -25,10 +25,10 @@ mod error;
 pub mod memory;
 
 pub use self::error::AdminServiceEventStoreError;
-use crate::admin::service::messages::AdminServiceEvent;
+use crate::admin::service::{event::AdminServiceEvent, messages};
 
 /// Return type of the `AdminServiceEventStore` `list_events_*` methods.
-pub type EventIter = Box<dyn ExactSizeIterator<Item = (i64, AdminServiceEvent)> + Send>;
+pub type EventIter = Box<dyn ExactSizeIterator<Item = AdminServiceEvent> + Send>;
 
 /// Interface for performing CRUD operations on `AdminServiceEvent`s.
 pub trait AdminServiceEventStore: Send + Sync {
@@ -40,8 +40,8 @@ pub trait AdminServiceEventStore: Send + Sync {
     /// * `event` - the `AdminServiceEvent` to be added to the store
     fn add_event(
         &self,
-        event: AdminServiceEvent,
-    ) -> Result<(i64, AdminServiceEvent), AdminServiceEventStoreError>;
+        event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError>;
 
     /// List `AdminServiceEvent`s that have been added to the store since the provided index.
     ///

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -78,8 +78,7 @@ pub trait AdminServiceEventSubscriber: Send {
     #[cfg(feature = "admin-service-event-store")]
     fn handle_event(
         &self,
-        admin_service_event: &messages::AdminServiceEvent,
-        event_id: &i64,
+        admin_service_event: &event::AdminServiceEvent,
     ) -> Result<(), AdminSubscriberError>;
 }
 
@@ -168,12 +167,12 @@ impl Iterator for Events {
 
 #[cfg(feature = "admin-service-event-store")]
 pub struct Events {
-    inner: Box<dyn ExactSizeIterator<Item = (i64, messages::AdminServiceEvent)> + Send>,
+    inner: Box<dyn ExactSizeIterator<Item = event::AdminServiceEvent> + Send>,
 }
 
 #[cfg(feature = "admin-service-event-store")]
 impl Iterator for Events {
-    type Item = (i64, messages::AdminServiceEvent);
+    type Item = event::AdminServiceEvent;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -60,8 +60,9 @@ use super::{
     Events,
 };
 #[cfg(feature = "admin-service-event-store")]
-use crate::admin::service::event::store::{
-    memory::MemoryAdminServiceEventStore, AdminServiceEventStore,
+use crate::admin::service::event::{
+    self,
+    store::{memory::MemoryAdminServiceEventStore, AdminServiceEventStore},
 };
 
 static VOTER_ROLE: &str = "voter";
@@ -141,24 +142,19 @@ impl SubscriberMap {
     }
 
     #[cfg(feature = "admin-service-event-store")]
-    fn broadcast_by_type(
-        &self,
-        event_type: &str,
-        admin_service_event: &messages::AdminServiceEvent,
-        event_id: &i64,
-    ) {
+    fn broadcast_by_type(&self, event_type: &str, admin_service_event: &event::AdminServiceEvent) {
         let mut subscribers_by_type = self.subscribers_by_type.borrow_mut();
         if let Some(subscribers) = subscribers_by_type.get_mut(event_type) {
-            subscribers.retain(|subscriber| {
-                match subscriber.handle_event(admin_service_event, event_id) {
+            subscribers.retain(
+                |subscriber| match subscriber.handle_event(admin_service_event) {
                     Ok(()) => true,
                     Err(AdminSubscriberError::Unsubscribe) => false,
                     Err(AdminSubscriberError::UnableToHandleEvent(msg)) => {
                         error!("Unable to send event: {}", msg);
                         true
                     }
-                }
-            });
+                },
+            );
         }
     }
 
@@ -1102,7 +1098,9 @@ impl AdminServiceShared {
                 *since_event_id,
             )
             .map_err(|err| AdminSharedError::UnableToAddSubscriber(err.to_string()))?;
-        Ok(Events { inner: events })
+        Ok(Events {
+            inner: Box::new(events),
+        })
     }
 
     pub fn add_subscriber(
@@ -1140,8 +1138,8 @@ impl AdminServiceShared {
         circuit_management_type: &str,
         event: messages::AdminServiceEvent,
     ) {
-        let (event_id, event) = match self.admin_event_store.add_event(event) {
-            Ok((id, event)) => (id, event),
+        let admin_event = match self.admin_event_store.add_event(event) {
+            Ok(admin_event) => admin_event,
             Err(err) => {
                 error!("Unable to store admin event: {}", err);
                 return;
@@ -1149,7 +1147,7 @@ impl AdminServiceShared {
         };
 
         self.event_subscribers
-            .broadcast_by_type(&circuit_management_type, &event, &event_id);
+            .broadcast_by_type(&circuit_management_type, &admin_event);
     }
 
     pub fn remove_all_event_subscribers(&mut self) {

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -14,7 +14,7 @@
 
 //! Structs for building circuits
 
-use crate::admin::messages::is_valid_circuit_id;
+use crate::admin::messages::{self, is_valid_circuit_id};
 use crate::error::InvalidStateError;
 
 use super::{ProposedCircuit, Service};
@@ -86,6 +86,14 @@ pub enum AuthorizationType {
     Trust,
 }
 
+impl From<&messages::AuthorizationType> for AuthorizationType {
+    fn from(message_enum: &messages::AuthorizationType) -> Self {
+        match *message_enum {
+            messages::AuthorizationType::Trust => AuthorizationType::Trust,
+        }
+    }
+}
+
 /// A circuits message persistence strategy
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PersistenceType {
@@ -98,10 +106,26 @@ impl Default for PersistenceType {
     }
 }
 
+impl From<&messages::PersistenceType> for PersistenceType {
+    fn from(message_enum: &messages::PersistenceType) -> Self {
+        match *message_enum {
+            messages::PersistenceType::Any => PersistenceType::Any,
+        }
+    }
+}
+
 /// A circuits durability requirement
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DurabilityType {
     NoDurability,
+}
+
+impl From<&messages::DurabilityType> for DurabilityType {
+    fn from(message_enum: &messages::DurabilityType) -> Self {
+        match *message_enum {
+            messages::DurabilityType::NoDurability => DurabilityType::NoDurability,
+        }
+    }
 }
 
 /// How messages are expected to be routed across a circuit
@@ -113,6 +137,14 @@ pub enum RouteType {
 impl Default for RouteType {
     fn default() -> Self {
         RouteType::Any
+    }
+}
+
+impl From<&messages::RouteType> for RouteType {
+    fn from(message_enum: &messages::RouteType) -> Self {
+        match *message_enum {
+            messages::RouteType::Any => RouteType::Any,
+        }
     }
 }
 

--- a/libsplinter/src/admin/store/proposed_node.rs
+++ b/libsplinter/src/admin/store/proposed_node.rs
@@ -14,6 +14,7 @@
 
 //! Structs for building proposed nodes
 
+use crate::admin::messages;
 use crate::error::InvalidStateError;
 use crate::protos::admin;
 
@@ -114,5 +115,14 @@ impl ProposedNodeBuilder {
         let node = ProposedNode { node_id, endpoints };
 
         Ok(node)
+    }
+}
+
+impl From<&messages::SplinterNode> for ProposedNode {
+    fn from(admin_node: &messages::SplinterNode) -> ProposedNode {
+        ProposedNode {
+            node_id: admin_node.node_id.to_string(),
+            endpoints: admin_node.endpoints.to_vec(),
+        }
     }
 }


### PR DESCRIPTION
Makes a quick update to the `AdminServiceEventStore` to use a newly defined `AdminServiceEvent` that accurately represents the `CircuitProposal` as it is defined across the admin service. The definition of the `CircuitProposal` from the admin::service::messages::AdminServiceEvent did not match this definition, as the `SplinterService` had an `allowed_nodes` field now represented as just a `node_id` field in the admin service `ProposedService` struct (equivalent to the message's `SplinterService`)