### PR TITLE
RoleBasedAuthorizationStore Diesel implementation

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -109,6 +109,7 @@ experimental = [
     "oauth-openid",
     "oauth-inflight-request-store-postgres",
     "registry-database",
+    "role-based-authorization-store-postgres",
     "service-arg-validation",
     "service-network",
     "ws-transport",
@@ -151,6 +152,7 @@ rest-api = [
 ]
 rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
 rest-api-cors = []
+role-based-authorization-store-postgres = ["authorization", "postgres"]
 service-arg-validation = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-30-115400_add_roles_and_assignments/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-30-115400_add_roles_and_assignments/down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS role_permissions;
+DROP TABLE IF EXISTS assignments;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS identities;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-30-115400_add_roles_and_assignments/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-30-115400_add_roles_and_assignments/up.sql
@@ -1,0 +1,38 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS roles (
+    id           TEXT    PRIMARY KEY,
+    display_name TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id      TEXT    NOT NULL,
+    permission   TEXT    NOT NULL,
+    PRIMARY KEY(role_id, permission),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS identities (
+    identity      TEXT    PRIMARY KEY,
+    identity_type INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+    identity     TEXT    NOT NULL,
+    role_id      TEXT    NOT NULL,
+    PRIMARY KEY(identity, role_id),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-30-115400_add_roles_and_assignments/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-30-115400_add_roles_and_assignments/down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS role_permissions;
+DROP TABLE IF EXISTS assignments;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS identities;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-30-115400_add_roles_and_assignments/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-30-115400_add_roles_and_assignments/up.sql
@@ -1,0 +1,38 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS roles (
+    id           TEXT    PRIMARY KEY,
+    display_name TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id      TEXT    NOT NULL,
+    permission   TEXT    NOT NULL,
+    PRIMARY KEY(role_id, permission),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS identities (
+    identity      TEXT    PRIMARY KEY,
+    identity_type INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+    identity     TEXT    NOT NULL,
+    role_id      TEXT    NOT NULL,
+    PRIMARY KEY(identity, role_id),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
@@ -166,6 +166,118 @@ impl RoleBasedAuthorizationStore
     }
 }
 
+#[cfg(feature = "role-based-authorization-store-postgres")]
+impl RoleBasedAuthorizationStore for DieselRoleBasedAuthorizationStore<diesel::pg::PgConnection> {
+    /// Returns the role for the given ID, if one exists.
+    fn get_role(&self, id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).get_role(id)
+    }
+
+    /// Lists all roles.
+    fn list_roles(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).list_roles()
+    }
+
+    /// Adds a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConstraintViolation` error if a duplicate role ID is added.
+    fn add_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).add_role(role)
+    }
+
+    /// Updates a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the role does not exist.
+    fn update_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).update_role(role)
+    }
+
+    /// Removes a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the role does not exist.
+    fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).remove_role(role_id)
+    }
+
+    /// Returns the role for the given Identity, if one exists.
+    fn get_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<Option<Assignment>, RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).get_assignment(identity)
+    }
+
+    /// Lists all assignments.
+    fn list_assignments(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Assignment>>, RoleBasedAuthorizationStoreError>
+    {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).list_assignments()
+    }
+
+    /// Adds an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConstraintViolation` error if there is a duplicate assignment of a role to an
+    /// identity.
+    fn add_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).add_assignment(assignment)
+    }
+
+    /// Updates an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the assignment does not exist.
+    fn update_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).update_assignment(assignment)
+    }
+
+    /// Removes an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the assignment does not exist.
+    fn remove_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let connection = self.connection_pool.get()?;
+        RoleBasedAuthorizationStoreOperations::new(&*connection).remove_assignment(identity)
+    }
+
+    /// Clone into a boxed, dynamically dispatched store
+    fn clone_box(&self) -> Box<dyn RoleBasedAuthorizationStore> {
+        Box::new(DieselRoleBasedAuthorizationStore {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
+}
+
 impl From<Role> for (models::RoleModel, Vec<models::RolePermissionModel>) {
     fn from(role: Role) -> Self {
         let (id, display_name, permissions) = role.into_parts();

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod models;
+mod schema;

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/mod.rs
@@ -14,3 +14,125 @@
 
 mod models;
 mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::{
+    Assignment, Identity, Role, RoleBasedAuthorizationStore, RoleBasedAuthorizationStoreError,
+    RoleBuilder,
+};
+
+/// A database-backed [RoleBasedAuthorizationStore], powered by [diesel].
+pub struct DieselRoleBasedAuthorizationStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection + 'static> DieselRoleBasedAuthorizationStore<C> {
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        Self { connection_pool }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl RoleBasedAuthorizationStore
+    for DieselRoleBasedAuthorizationStore<diesel::sqlite::SqliteConnection>
+{
+    /// Returns the role for the given ID, if one exists.
+    fn get_role(&self, id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Lists all roles.
+    fn list_roles(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Adds a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConstraintViolation` error if a duplicate role ID is added.
+    fn add_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Updates a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the role does not exist.
+    fn update_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Removes a role.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the role does not exist.
+    fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Returns the role for the given Identity, if one exists.
+    fn get_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<Option<Assignment>, RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Lists all assignments.
+    fn list_assignments(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Assignment>>, RoleBasedAuthorizationStoreError>
+    {
+        todo!()
+    }
+
+    /// Adds an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ConstraintViolation` error if there is a duplicate assignment of a role to an
+    /// identity.
+    fn add_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Updates an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the assignment does not exist.
+    fn update_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Removes an assignment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `InvalidState` error if the assignment does not exist.
+    fn remove_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        todo!()
+    }
+
+    /// Clone into a boxed, dynamically dispatched store
+    fn clone_box(&self) -> Box<dyn RoleBasedAuthorizationStore> {
+        Box::new(DieselRoleBasedAuthorizationStore {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/models.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/models.rs
@@ -1,0 +1,106 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use diesel::{
+    backend::Backend,
+    deserialize::{self, FromSql},
+    expression::{helper_types::AsExprOf, AsExpression},
+    serialize::{self, Output, ToSql},
+    sql_types::SmallInt,
+};
+
+use super::schema::{assignments, identities, role_permissions, roles};
+
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
+#[table_name = "roles"]
+#[primary_key(id)]
+pub(super) struct RoleModel {
+    pub id: String,
+    pub display_name: String,
+}
+
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
+#[table_name = "role_permissions"]
+#[belongs_to(RoleModel, foreign_key = "role_id")]
+#[primary_key(role_id, permission)]
+pub(super) struct RolePermissionModel {
+    pub role_id: String,
+    pub permission: String,
+}
+
+#[repr(i16)]
+#[derive(Debug, Copy, Clone, PartialEq, FromSqlRow)]
+pub(super) enum IdentityModelType {
+    Key = 1,
+    User = 2,
+}
+
+impl<DB> ToSql<SmallInt, DB> for IdentityModelType
+where
+    DB: Backend,
+    i16: ToSql<SmallInt, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        (*self as i16).to_sql(out)
+    }
+}
+
+impl AsExpression<SmallInt> for IdentityModelType {
+    type Expression = AsExprOf<i16, SmallInt>;
+
+    fn as_expression(self) -> Self::Expression {
+        <i16 as AsExpression<SmallInt>>::as_expression(self as i16)
+    }
+}
+
+impl<'a> AsExpression<SmallInt> for &'a IdentityModelType {
+    type Expression = AsExprOf<i16, SmallInt>;
+
+    fn as_expression(self) -> Self::Expression {
+        <i16 as AsExpression<SmallInt>>::as_expression((*self) as i16)
+    }
+}
+
+impl<DB> FromSql<SmallInt, DB> for IdentityModelType
+where
+    DB: Backend,
+    i16: FromSql<SmallInt, DB>,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        match i16::from_sql(bytes)? {
+            1 => Ok(IdentityModelType::Key),
+            2 => Ok(IdentityModelType::User),
+            int => Err(format!("Invalid identity type {}", int).into()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
+#[table_name = "identities"]
+#[primary_key(identity)]
+pub(super) struct IdentityModel {
+    pub identity: String,
+    pub identity_type: IdentityModelType,
+}
+
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
+#[table_name = "assignments"]
+#[belongs_to(IdentityModel, foreign_key = "identity")]
+#[primary_key(identity, role_id)]
+pub(super) struct AssignmentModel {
+    pub identity: String,
+    pub role_id: String,
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_assignment.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{AssignmentModel, IdentityModel},
+        schema::{assignments, identities},
+    },
+    Assignment, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreAddAssignment {
+    fn add_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreAddAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let (identity, assignments): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
+        self.conn.transaction::<_, _, _>(|| {
+            insert_into(identities::table)
+                .values(identity)
+                .execute(self.conn)?;
+
+            insert_into(assignments::table)
+                .values(assignments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_assignment.rs
@@ -53,3 +53,26 @@ impl<'a> RoleBasedAuthorizationStoreAddAssignment
         })
     }
 }
+
+#[cfg(feature = "role-based-authorization-store-postgres")]
+impl<'a> RoleBasedAuthorizationStoreAddAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let (identity, assignments): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
+        self.conn.transaction::<_, _, _>(|| {
+            insert_into(identities::table)
+                .values(identity)
+                .execute(self.conn)?;
+
+            insert_into(assignments::table)
+                .values(assignments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_role.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/add_role.rs
@@ -1,0 +1,48 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{RoleModel, RolePermissionModel},
+        schema::{role_permissions, roles},
+    },
+    Role, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreAddRole {
+    fn add_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreAddRole
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
+
+        self.conn.transaction::<_, _, _>(|| {
+            insert_into(roles::table).values(role).execute(self.conn)?;
+
+            insert_into(role_permissions::table)
+                .values(permissions)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/get_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/get_assignment.rs
@@ -1,0 +1,69 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+
+use diesel::prelude::*;
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{AssignmentModel, IdentityModel},
+        schema::identities,
+    },
+    Assignment, Identity, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreGetAssignment {
+    fn get_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<Option<Assignment>, RoleBasedAuthorizationStoreError>;
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreGetAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+{
+    fn get_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<Option<Assignment>, RoleBasedAuthorizationStoreError> {
+        let search_identity = match identity {
+            Identity::Key(ref key) => key,
+            Identity::User(ref user_id) => user_id,
+        };
+        self.conn.transaction(|| {
+            let identities = identities::table
+                .filter(identities::identity.eq(search_identity))
+                .load::<IdentityModel>(self.conn)?;
+
+            let assignments = AssignmentModel::belonging_to(&identities)
+                .load::<AssignmentModel>(self.conn)?
+                .grouped_by(&identities);
+
+            identities
+                .into_iter()
+                .zip(assignments)
+                .next()
+                .map(|model| model.try_into())
+                .transpose()
+                .map_err(RoleBasedAuthorizationStoreError::from)
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/get_role.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/get_role.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+
+use diesel::prelude::*;
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{RoleModel, RolePermissionModel},
+        schema::roles,
+    },
+    Role, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreGetRole {
+    fn get_role(&self, search_id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError>;
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreGetRole for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_role(&self, search_id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError> {
+        self.conn.transaction(|| {
+            let roles = roles::table
+                .filter(roles::id.eq(search_id))
+                .load::<RoleModel>(self.conn)?;
+
+            let perms = RolePermissionModel::belonging_to(&roles)
+                .load::<RolePermissionModel>(self.conn)?
+                .grouped_by(&roles);
+
+            roles
+                .into_iter()
+                .zip(perms)
+                .next()
+                .map(|models| models.try_into())
+                .transpose()
+                .map_err(RoleBasedAuthorizationStoreError::from)
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/list_assignments.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/list_assignments.rs
@@ -1,0 +1,65 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+
+use diesel::prelude::*;
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{AssignmentModel, IdentityModel},
+        schema::identities,
+    },
+    Assignment, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreListAssignments {
+    fn list_assignments(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Assignment>>, RoleBasedAuthorizationStoreError>;
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreListAssignments
+    for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+{
+    fn list_assignments(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Assignment>>, RoleBasedAuthorizationStoreError>
+    {
+        self.conn
+            .transaction::<Box<dyn ExactSizeIterator<Item = Assignment>>, _, _>(|| {
+                let identities = identities::table.load::<IdentityModel>(self.conn)?;
+
+                let assignments = AssignmentModel::belonging_to(&identities)
+                    .load::<AssignmentModel>(self.conn)?
+                    .grouped_by(&identities);
+
+                Ok(Box::new(
+                    identities
+                        .into_iter()
+                        .zip(assignments)
+                        .map(|models| models.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(RoleBasedAuthorizationStoreError::from)?
+                        .into_iter(),
+                ))
+            })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/list_roles.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/list_roles.rs
@@ -1,0 +1,62 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+
+use diesel::prelude::*;
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{RoleModel, RolePermissionModel},
+        schema::roles,
+    },
+    Role, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreListRoles {
+    fn list_roles(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError>;
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreListRoles for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn list_roles(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError> {
+        self.conn
+            .transaction::<Box<dyn ExactSizeIterator<Item = Role>>, _, _>(|| {
+                let roles = roles::table.load::<RoleModel>(self.conn)?;
+
+                let perms = RolePermissionModel::belonging_to(&roles)
+                    .load::<RolePermissionModel>(self.conn)?
+                    .grouped_by(&roles);
+
+                Ok(Box::new(
+                    roles
+                        .into_iter()
+                        .zip(perms)
+                        .map(|models| models.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(RoleBasedAuthorizationStoreError::from)?
+                        .into_iter(),
+                ))
+            })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod add_role;
 pub(super) mod get_role;
 pub(super) mod list_roles;
+pub(super) mod update_role;
 
 pub(super) struct RoleBasedAuthorizationStoreOperations<'a, C> {
     conn: &'a C,

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod add_assignment;
 pub(super) mod add_role;
 pub(super) mod get_assignment;
 pub(super) mod get_role;
+pub(super) mod list_assignments;
 pub(super) mod list_roles;
 pub(super) mod remove_role;
 pub(super) mod update_role;

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -1,0 +1,29 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod add_role;
+pub(super) mod get_role;
+
+pub(super) struct RoleBasedAuthorizationStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        Self { conn }
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -19,6 +19,7 @@ pub(super) mod get_role;
 pub(super) mod list_assignments;
 pub(super) mod list_roles;
 pub(super) mod remove_role;
+pub(super) mod update_assignment;
 pub(super) mod update_role;
 
 pub(super) struct RoleBasedAuthorizationStoreOperations<'a, C> {

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod add_role;
 pub(super) mod get_role;
 pub(super) mod list_roles;
+pub(super) mod remove_role;
 pub(super) mod update_role;
 
 pub(super) struct RoleBasedAuthorizationStoreOperations<'a, C> {

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_role;
 pub(super) mod get_role;
+pub(super) mod list_roles;
 
 pub(super) struct RoleBasedAuthorizationStoreOperations<'a, C> {
     conn: &'a C,

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(super) mod add_assignment;
 pub(super) mod add_role;
+pub(super) mod get_assignment;
 pub(super) mod get_role;
 pub(super) mod list_roles;
 pub(super) mod remove_role;

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/mod.rs
@@ -18,6 +18,7 @@ pub(super) mod get_assignment;
 pub(super) mod get_role;
 pub(super) mod list_assignments;
 pub(super) mod list_roles;
+pub(super) mod remove_assignment;
 pub(super) mod remove_role;
 pub(super) mod update_assignment;
 pub(super) mod update_role;

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_assignment.rs
@@ -28,9 +28,11 @@ pub trait RoleBasedAuthorizationStoreRemoveAssignment {
     ) -> Result<(), RoleBasedAuthorizationStoreError>;
 }
 
-#[cfg(feature = "sqlite")]
-impl<'a> RoleBasedAuthorizationStoreRemoveAssignment
-    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+impl<'a, C> RoleBasedAuthorizationStoreRemoveAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
     fn remove_assignment(
         &self,

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_assignment.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{dsl::delete, prelude::*};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::schema::{assignments, identities},
+    Identity, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreRemoveAssignment {
+    fn remove_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreRemoveAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn remove_assignment(
+        &self,
+        identity: &Identity,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let search_identity = match identity {
+            Identity::Key(ref key) => key,
+            Identity::User(ref user_id) => user_id,
+        };
+        self.conn.transaction::<_, _, _>(|| {
+            delete(assignments::table.filter(assignments::identity.eq(search_identity)))
+                .execute(self.conn)?;
+            delete(identities::table.filter(identities::identity.eq(search_identity)))
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_role.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_role.rs
@@ -25,9 +25,10 @@ pub trait RoleBasedAuthorizationStoreRemoveRole {
     fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError>;
 }
 
-#[cfg(feature = "sqlite")]
-impl<'a> RoleBasedAuthorizationStoreRemoveRole
-    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+impl<'a, C> RoleBasedAuthorizationStoreRemoveRole for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
     fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError> {
         self.conn.transaction::<_, _, _>(|| {

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_role.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/remove_role.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{dsl::delete, prelude::*};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::schema::{role_permissions, roles},
+    RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreRemoveRole {
+    fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreRemoveRole
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            delete(role_permissions::table.filter(role_permissions::role_id.eq(role_id)))
+                .execute(self.conn)?;
+
+            delete(roles::table.filter(roles::id.eq(role_id))).execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/update_assignment.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/update_assignment.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{
+    dsl::{delete, insert_into},
+    prelude::*,
+};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{AssignmentModel, IdentityModel},
+        schema::assignments,
+    },
+    Assignment, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreUpdateAssignment {
+    fn update_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_assignment(
+        &self,
+        assignment: Assignment,
+    ) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let (identity, roles): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
+        self.conn.transaction::<_, _, _>(|| {
+            delete(assignments::table.filter(assignments::identity.eq(&identity.identity)))
+                .execute(self.conn)?;
+
+            insert_into(assignments::table)
+                .values(roles)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/operations/update_role.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/operations/update_role.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::{
+    dsl::{delete, insert_into, update},
+    prelude::*,
+};
+
+use crate::rest_api::auth::roles::store::{
+    diesel::{
+        models::{RoleModel, RolePermissionModel},
+        schema::{role_permissions, roles},
+    },
+    Role, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreUpdateRole {
+    fn update_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> RoleBasedAuthorizationStoreUpdateRole
+    for RoleBasedAuthorizationStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
+        let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
+
+        self.conn.transaction::<_, _, _>(|| {
+            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
+                .execute(self.conn)?;
+
+            update(roles::table.find(&role.id))
+                .set(roles::display_name.eq(&role.display_name))
+                .execute(self.conn)?;
+
+            insert_into(role_permissions::table)
+                .values(permissions)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/diesel/schema.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/diesel/schema.rs
@@ -1,0 +1,44 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+   roles (id) {
+        id -> Text,
+        display_name -> Text,
+    }
+}
+
+table! {
+    role_permissions (role_id, permission) {
+        role_id -> Text,
+        permission -> Text,
+    }
+}
+
+joinable!(role_permissions -> roles (role_id));
+allow_tables_to_appear_in_same_query!(roles, role_permissions);
+
+table! {
+    identities (identity) {
+        identity -> Text,
+        identity_type -> SmallInt,
+    }
+}
+
+table! {
+    assignments (identity, role_id) {
+        identity -> Text,
+        role_id -> Text,
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/error.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/error.rs
@@ -43,3 +43,21 @@ impl Error for RoleBasedAuthorizationStoreError {
         }
     }
 }
+
+impl From<InternalError> for RoleBasedAuthorizationStoreError {
+    fn from(err: InternalError) -> Self {
+        RoleBasedAuthorizationStoreError::InternalError(err)
+    }
+}
+
+impl From<InvalidStateError> for RoleBasedAuthorizationStoreError {
+    fn from(err: InvalidStateError) -> Self {
+        RoleBasedAuthorizationStoreError::InvalidState(err)
+    }
+}
+
+impl From<ConstraintViolationError> for RoleBasedAuthorizationStoreError {
+    fn from(err: ConstraintViolationError) -> Self {
+        RoleBasedAuthorizationStoreError::ConstraintViolation(err)
+    }
+}

--- a/libsplinter/src/rest_api/auth/roles/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/mod.rs
@@ -25,7 +25,6 @@ pub use self::diesel::DieselRoleBasedAuthorizationStore;
 
 pub use error::RoleBasedAuthorizationStoreError;
 
-
 /// A Role is a named set of permissions.
 pub struct Role {
     id: String,
@@ -56,6 +55,12 @@ impl Role {
             display_name: Some(self.display_name),
             permissions: self.permissions,
         }
+    }
+
+    /// Converts this role into it's constituent parts.  These parts are in the tuple:
+    /// `(id, display_name, permissions)`.
+    pub fn into_parts(self) -> (String, String, Vec<String>) {
+        (self.id, self.display_name, self.permissions)
     }
 }
 
@@ -216,6 +221,12 @@ impl Assignment {
     pub fn into_update_builder(self) -> AssignmentUpdateBuilder {
         let Assignment { identity, roles } = self;
         AssignmentUpdateBuilder { identity, roles }
+    }
+
+    /// Converts this assignment into it's constituent parts.  These parts are in the tuple:
+    /// `(identity, roles)`.
+    pub fn into_parts(self) -> (Identity, Vec<String>) {
+        (self.identity, self.roles)
     }
 }
 

--- a/libsplinter/src/rest_api/auth/roles/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/mod.rs
@@ -181,6 +181,7 @@ impl RoleUpdateBuilder {
 }
 
 /// An identity that may be assigned roles.
+#[derive(Debug, PartialEq)]
 pub enum Identity {
     /// A public key-based identity.
     Key(String),

--- a/libsplinter/src/rest_api/auth/roles/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/mod.rs
@@ -14,6 +14,8 @@
 
 //! This module defines the store trait for roles and their assignments to identities.
 
+#[cfg(feature = "diesel")]
+mod diesel;
 mod error;
 
 use crate::error::InvalidStateError;

--- a/libsplinter/src/rest_api/auth/roles/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/roles/store/mod.rs
@@ -20,7 +20,11 @@ mod error;
 
 use crate::error::InvalidStateError;
 
+#[cfg(feature = "diesel")]
+pub use self::diesel::DieselRoleBasedAuthorizationStore;
+
 pub use error::RoleBasedAuthorizationStoreError;
+
 
 /// A Role is a named set of permissions.
 pub struct Role {

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -58,6 +58,11 @@ pub trait StoreFactory {
 
     #[cfg(feature = "registry-database")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry>;
+
+    #[cfg(feature = "authorization")]
+    fn get_role_based_authorization_store(
+        &self,
+    ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -95,7 +95,21 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "authorization")]
+    #[cfg(feature = "role-based-authorization-store-postgres")]
+    fn get_role_based_authorization_store(
+        &self,
+    ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
+        Box::new(
+            crate::rest_api::auth::roles::store::DieselRoleBasedAuthorizationStore::new(
+                self.pool.clone(),
+            ),
+        )
+    }
+
+    #[cfg(all(
+        feature = "authorization",
+        not(feature = "role-based-authorization-store-postgres")
+    ))]
     fn get_role_based_authorization_store(
         &self,
     ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -94,4 +94,11 @@ impl StoreFactory for PgStoreFactory {
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }
+
+    #[cfg(feature = "authorization")]
+    fn get_role_based_authorization_store(
+        &self,
+    ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
+        unimplemented!()
+    }
 }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -79,6 +79,17 @@ impl StoreFactory for SqliteStoreFactory {
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }
+
+    #[cfg(feature = "authorization")]
+    fn get_role_based_authorization_store(
+        &self,
+    ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
+        Box::new(
+            crate::rest_api::auth::roles::store::DieselRoleBasedAuthorizationStore::new(
+                self.pool.clone(),
+            ),
+        )
+    }
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
This PR implements the Diesel-backed `RoleBasedAuthorizationStore`. 

It only provides the SQLite implementation and tests.  ~PostgreSQL implementation will be included in a future PR.~ It also now includes the PostgreSQL implementation, but there are currently no tests for this.