### PR TITLE
Add diesel implementation for `AdminServiceEventStore`

### DIFF
--- a/libsplinter/src/admin/service/event/store/diesel/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/mod.rs
@@ -32,6 +32,11 @@ use crate::admin::service::event::{
 };
 use crate::admin::service::messages;
 
+use operations::add_event::AdminServiceEventStoreAddEventOperation as _;
+use operations::list_events_by_management_type_since::AdminServiceEventStoreListEventsByManagementTypeSinceOperation as _;
+use operations::list_events_since::AdminServiceEventStoreListEventsSinceOperation as _;
+use operations::AdminServiceEventStoreOperations;
+
 /// A database-backed AdminServiceEventStore, powered by [`Diesel`](https://crates.io/crates/diesel).
 pub struct DieselAdminServiceEventStore<C: diesel::Connection + 'static> {
     connection_pool: Pool<ConnectionManager<C>>,
@@ -61,21 +66,23 @@ impl Clone for DieselAdminServiceEventStore<diesel::sqlite::SqliteConnection> {
 impl AdminServiceEventStore for DieselAdminServiceEventStore<diesel::sqlite::SqliteConnection> {
     fn add_event(
         &self,
-        _event: messages::AdminServiceEvent,
+        event: messages::AdminServiceEvent,
     ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
-        unimplemented!()
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?).add_event(event)
     }
 
-    fn list_events_since(&self, _start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
-        unimplemented!()
+    fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?)
+            .list_events_since(start)
     }
 
     fn list_events_by_management_type_since(
         &self,
-        _management_type: String,
-        _start: i64,
+        management_type: String,
+        start: i64,
     ) -> Result<EventIter, AdminServiceEventStoreError> {
-        unimplemented!()
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?)
+            .list_events_by_management_type_since(management_type, start)
     }
 }
 
@@ -92,20 +99,375 @@ impl Clone for DieselAdminServiceEventStore<diesel::pg::PgConnection> {
 impl AdminServiceEventStore for DieselAdminServiceEventStore<diesel::pg::PgConnection> {
     fn add_event(
         &self,
-        _event: messages::AdminServiceEvent,
+        event: messages::AdminServiceEvent,
     ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
-        unimplemented!()
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?).add_event(event)
     }
 
-    fn list_events_since(&self, _start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
-        unimplemented!()
+    fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?)
+            .list_events_since(start)
     }
 
     fn list_events_by_management_type_since(
         &self,
-        _management_type: String,
-        _start: i64,
+        management_type: String,
+        start: i64,
     ) -> Result<EventIter, AdminServiceEventStoreError> {
-        unimplemented!()
+        AdminServiceEventStoreOperations::new(&*self.connection_pool.get()?)
+            .list_events_by_management_type_since(management_type, start)
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+pub mod tests {
+    use super::*;
+
+    use crate::admin::service::event::EventType;
+    use crate::admin::store::{
+        CircuitProposal, CircuitProposalBuilder, ProposalType, ProposedCircuitBuilder,
+        ProposedNodeBuilder, ProposedServiceBuilder,
+    };
+    use crate::hex::parse_hex;
+    use crate::migrations::run_sqlite_migrations;
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    #[test]
+    /// Verify that an event can be added to the store correctly and then returned by the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create a `messages::AdminServiceEvent`
+    /// 4. Add the previously created event to store
+    /// 5. List all the events from the store by calling `list_events_since(0)`, which should
+    ///    return all events with an ID greater than 0, so all events in the store.
+    /// 6. Validate event returned in the list matches the expected values
+    fn test_add_list_one_event() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event = create_proposal_submitted_messages_event("test");
+        store.add_event(event).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_since(0)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert only the event added is returned
+        assert_eq!(events.len(), 1);
+        // Assert the event returned matches the expected values
+        assert_eq!(events, vec![create_proposal_submitted_event(1, "test")],);
+    }
+
+    #[test]
+    /// Verify that events can be added to the store correctly and then returned by the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create two `messages::AdminServiceEvent`s
+    /// 4. Add the previously created events to store
+    /// 5. List all the events from the store by calling `list_events_since(0)`, which should
+    ///    return all events with an ID greater than 0, so all events in the store.
+    /// 6. Validate the events returned in the list match the expected values
+    fn test_list_since_multiple_events() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event_1 = create_proposal_submitted_messages_event("test");
+        store.add_event(event_1).expect("Unable to add event");
+
+        let event_2 = create_circuit_ready_messages_event("test");
+        store.add_event(event_2).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_since(0)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert the expected number of events are returned
+        assert_eq!(events.len(), 2);
+        // Assert the event returned matches the expected values
+        assert_eq!(
+            events,
+            vec![
+                create_proposal_submitted_event(1, "test"),
+                create_circuit_ready_event(2, "test")
+            ],
+        );
+    }
+
+    #[test]
+    /// Verify that events can be added to the store correctly and then returned by the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create three `messages::AdminServiceEvent`s
+    /// 4. Add the previously created events to store
+    /// 5. List the events in the store since the event with an ID of 1
+    /// 6. Validate the events returned in the list match the expected values, and the event with
+    ///    the ID of 1 is not included
+    fn test_list_since() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event_1 = create_proposal_submitted_messages_event("test");
+        store.add_event(event_1).expect("Unable to add event");
+        let event_2 = create_circuit_ready_messages_event("test");
+        store.add_event(event_2).expect("Unable to add event");
+        let event_3 = create_proposal_vote_messages_event("test");
+        store.add_event(event_3).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_since(1)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert the expected number of events are returned
+        assert_eq!(events.len(), 2);
+        // Assert the event returned matches the expected values
+        assert_eq!(
+            events,
+            vec![
+                create_circuit_ready_event(2, "test"),
+                create_proposal_vote_event(3, "test")
+            ],
+        );
+    }
+
+    #[test]
+    /// Verify that events can be added to the store correctly and then returned by the store with
+    /// the correct `circuit_management_type`.
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create three `messages::AdminServiceEvent`s
+    /// 4. Add the previously created events to store
+    /// 5. List the events in the store since the event with an ID of 0 with a
+    ///    `circuit_management_type` equal to "not-test".
+    /// 6. Validate event returned in the list matches the expected values, including the
+    ///    `CircuitProposal` management type.
+    fn test_list_one_event_by_management_type() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event = create_proposal_submitted_messages_event("test");
+        store.add_event(event).expect("Unable to add event");
+
+        let event_2 = create_circuit_ready_messages_event("not-test");
+        store.add_event(event_2).expect("Unable to add event");
+        let event_3 = create_proposal_vote_messages_event("test");
+        store.add_event(event_3).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_by_management_type_since("not-test".to_string(), 0)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert one event is returned
+        assert_eq!(events.len(), 1);
+        // Assert the event returned matches the expected values, with the "not-test" management type
+        assert_eq!(events, vec![create_circuit_ready_event(2, "not-test")],);
+    }
+
+    #[test]
+    /// Verify that events can be added to the store correctly and then returned by the store with
+    /// the correct `circuit_management_type`.
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create three `messages::AdminServiceEvent`s
+    /// 4. Add the previously created events to store
+    /// 5. List the events in the store since the event with an ID of 1 with a
+    ///    `circuit_management_type` equal to "not-test".
+    /// 6. Validate event returned in the list matches the expected values, including verifying the
+    ///    `CircuitProposal`'s `circuit_management_type` and the event ID is not equal or less than
+    ///    2.
+    fn test_list_event_by_management_type_since() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event = create_proposal_submitted_messages_event("test");
+        store.add_event(event).expect("Unable to add event");
+        let event_2 = create_circuit_ready_messages_event("not-test");
+        store.add_event(event_2).expect("Unable to add event");
+        let event_3 = create_proposal_vote_messages_event("test");
+        store.add_event(event_3).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_by_management_type_since("not-test".to_string(), 1)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert one event is returned
+        assert_eq!(events.len(), 1);
+        // Assert the event returned matches the expected values, with the "not-test" management type
+        assert_eq!(events, vec![create_circuit_ready_event(2, "not-test")],);
+    }
+
+    #[test]
+    /// Verify that events can be added to the store correctly and then returned by the store with
+    /// the correct `circuit_management_type`.
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselAdminServiceEventStore
+    /// 3. Create three `messages::AdminServiceEvent`s
+    /// 4. Add the previously created events to store
+    /// 5. List the events in the store since the event with an ID of 0 with a
+    ///    `circuit_management_type` equal to "test".
+    /// 6. Validate the events returned in the list match the expected values, including the
+    ///    `CircuitProposal`'s `circuit_management_type`.
+    fn test_list_multiple_events_by_management_type() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselAdminServiceEventStore::_new(pool);
+        let event = create_proposal_submitted_messages_event("test");
+        store.add_event(event).expect("Unable to add event");
+        let event_2 = create_circuit_ready_messages_event("not-test");
+        store.add_event(event_2).expect("Unable to add event");
+        let event_3 = create_proposal_vote_messages_event("test");
+        store.add_event(event_3).expect("Unable to add event");
+
+        let events: Vec<AdminServiceEvent> = store
+            .list_events_by_management_type_since("test".to_string(), 0)
+            .expect("Unable to get events from store")
+            .collect();
+        // Assert the expected number of events is returned
+        assert_eq!(events.len(), 2);
+        // Assert the event returned matches the expected values, with the "test" management type
+        assert_eq!(
+            events,
+            vec![
+                create_proposal_submitted_event(1, "test"),
+                create_proposal_vote_event(3, "test")
+            ],
+        );
+    }
+
+    fn create_proposal_submitted_event(event_id: i64, management_type: &str) -> AdminServiceEvent {
+        AdminServiceEvent {
+            event_id,
+            event_type: EventType::ProposalSubmitted,
+            proposal: create_proposal(management_type),
+        }
+    }
+
+    fn create_proposal_submitted_messages_event(
+        management_type: &str,
+    ) -> messages::AdminServiceEvent {
+        messages::AdminServiceEvent::ProposalSubmitted(messages::CircuitProposal::from(
+            create_proposal(management_type),
+        ))
+    }
+
+    fn create_circuit_ready_event(event_id: i64, management_type: &str) -> AdminServiceEvent {
+        AdminServiceEvent {
+            event_id,
+            event_type: EventType::CircuitReady,
+            proposal: create_proposal(management_type),
+        }
+    }
+
+    fn create_circuit_ready_messages_event(management_type: &str) -> messages::AdminServiceEvent {
+        messages::AdminServiceEvent::CircuitReady(messages::CircuitProposal::from(create_proposal(
+            management_type,
+        )))
+    }
+
+    fn create_proposal_vote_event(event_id: i64, management_type: &str) -> AdminServiceEvent {
+        let requester =
+            &parse_hex("0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482")
+                .unwrap();
+
+        AdminServiceEvent {
+            event_id,
+            event_type: EventType::ProposalVote {
+                requester: requester.to_vec(),
+            },
+            proposal: create_proposal(management_type),
+        }
+    }
+
+    fn create_proposal_vote_messages_event(management_type: &str) -> messages::AdminServiceEvent {
+        let requester =
+            &parse_hex("0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482")
+                .unwrap();
+
+        messages::AdminServiceEvent::ProposalVote((
+            messages::CircuitProposal::from(create_proposal(management_type)),
+            requester.to_vec(),
+        ))
+    }
+
+    fn create_proposal(management_type: &str) -> CircuitProposal {
+        CircuitProposalBuilder::default()
+            .with_proposal_type(&ProposalType::Create)
+            .with_circuit_id("WBKLF-BBBBB")
+            .with_circuit_hash(
+                "7ddc426972710adc0b2ecd49e89a9dd805fb9206bf516079724c887bedbcdf1d")
+            .with_circuit(
+                &ProposedCircuitBuilder::default()
+                    .with_circuit_id("WBKLF-BBBBB")
+                    .with_roster(&vec![
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a000")
+                            .with_service_type("scabbard")
+                            .with_node_id(&"acme-node-000")
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a001\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service"),
+                        ProposedServiceBuilder::default()
+                            .with_service_id("a001")
+                            .with_service_type("scabbard")
+                            .with_node_id(&"bubba-node-000")
+                            .with_arguments(&vec![
+                                ("peer_services".into(), "[\"a000\"]".into()),
+                                ("admin_keys".into(),
+                               "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                            ])
+                            .build().expect("Unable to build service")
+                        ])
+
+                    .with_members(
+                        &vec![
+                        ProposedNodeBuilder::default()
+                            .with_node_id("bubba-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-bubba:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ProposedNodeBuilder::default()
+                            .with_node_id("acme-node-000".into())
+                            .with_endpoints(&vec!["tcps://splinterd-node-acme:8044".into()])
+                            .build().expect("Unable to build node"),
+                        ]
+                    )
+                    .with_application_metadata(b"test")
+                    .with_comments("This is a test")
+                    .with_circuit_management_type(management_type)
+                    .with_display_name("test_display")
+                    .build().expect("Unable to build circuit")
+            )
+            .with_requester(
+                &parse_hex(
+                    "0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482").unwrap())
+            .with_requester_node_id("acme-node-000")
+            .build().expect("Unable to build proposals")
+    }
+
+    /// Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection ensures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
     }
 }

--- a/libsplinter/src/admin/service/event/store/diesel/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/mod.rs
@@ -14,6 +14,98 @@
 
 //! Database backend support for the `AdminServiceEventStore`, powered by
 //! [`Diesel`](https://crates.io/crates/diesel).
+//!
+//! This module contains the [`DieselAdminServiceStore`].
+//!
+//! [`DieselAdminServiceEventStore`]: struct.DieselAdminServiceEventStore.html
+//! [`AdminServiceEventStore`]: ../trait.AdminServiceEventStore.html
 
 mod models;
+mod operations;
 mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::admin::service::event::{
+    store::{AdminServiceEventStore, AdminServiceEventStoreError, EventIter},
+    AdminServiceEvent,
+};
+use crate::admin::service::messages;
+
+/// A database-backed AdminServiceEventStore, powered by [`Diesel`](https://crates.io/crates/diesel).
+pub struct DieselAdminServiceEventStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselAdminServiceEventStore<C> {
+    /// Creates a new `DieselAdminServiceEventStore`.
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool for the database
+    pub fn _new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselAdminServiceEventStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl Clone for DieselAdminServiceEventStore<diesel::sqlite::SqliteConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl AdminServiceEventStore for DieselAdminServiceEventStore<diesel::sqlite::SqliteConnection> {
+    fn add_event(
+        &self,
+        _event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+
+    fn list_events_since(&self, _start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+
+    fn list_events_by_management_type_since(
+        &self,
+        _management_type: String,
+        _start: i64,
+    ) -> Result<EventIter, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Clone for DieselAdminServiceEventStore<diesel::pg::PgConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl AdminServiceEventStore for DieselAdminServiceEventStore<diesel::pg::PgConnection> {
+    fn add_event(
+        &self,
+        _event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+
+    fn list_events_since(&self, _start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+
+    fn list_events_by_management_type_since(
+        &self,
+        _management_type: String,
+        _start: i64,
+    ) -> Result<EventIter, AdminServiceEventStoreError> {
+        unimplemented!()
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/add_event.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/add_event.rs
@@ -1,0 +1,232 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "add event" operation for the `DieselAdminServiceEventStore`.
+
+use std::convert::TryFrom;
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use super::AdminServiceEventStoreOperations;
+
+use crate::admin::service::event::{
+    store::{
+        diesel::{
+            models::{
+                AdminEventCircuitProposalModel, AdminEventProposedCircuitModel,
+                AdminEventProposedNodeEndpointModel, AdminEventProposedNodeModel,
+                AdminEventProposedServiceArgumentModel, AdminEventProposedServiceModel,
+                AdminEventVoteRecordModel, AdminServiceEventModel, NewAdminServiceEventModel,
+            },
+            schema::{
+                admin_event_circuit_proposal, admin_event_proposed_circuit,
+                admin_event_proposed_node, admin_event_proposed_node_endpoint,
+                admin_event_proposed_service, admin_event_proposed_service_argument,
+                admin_event_vote_record, admin_service_event,
+            },
+        },
+        AdminServiceEventStoreError,
+    },
+    AdminServiceEvent,
+};
+use crate::admin::service::messages;
+
+use crate::error::{ConstraintViolationError, ConstraintViolationType};
+
+pub(in crate::admin::service::event::store::diesel) trait AdminServiceEventStoreAddEventOperation {
+    fn add_event(
+        &self,
+        event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> AdminServiceEventStoreAddEventOperation
+    for AdminServiceEventStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_event(
+        &self,
+        event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
+        self.conn.transaction::<AdminServiceEvent, _, _>(|| {
+            // Create a `NewAdminServiceEventModel` from the event
+            let new_event: NewAdminServiceEventModel = NewAdminServiceEventModel::from(&event);
+            // This creates the initial event entry, returning the ID from the inserted row
+            // to be used to correlate the other `admin_event_*` entries to this event.
+            let event_id: i64 = insert_into(admin_service_event::table)
+                .values(new_event)
+                .returning(admin_service_event::id)
+                .get_result(self.conn)?;
+            // Saving the event's proposal to build the required models.
+            let proposal = event.proposal().clone();
+
+            // Check if an `CircuitProposal` already exists with the given `event_id`
+            if admin_event_circuit_proposal::table
+                .filter(admin_event_circuit_proposal::event_id.eq(event_id))
+                .first::<AdminEventCircuitProposalModel>(self.conn)
+                .optional()?
+                .is_some()
+            {
+                return Err(AdminServiceEventStoreError::ConstraintViolationError(
+                    ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+                ));
+            }
+            // Insert the database model of the admin event's `CircuitProposal`
+            let proposal_model = AdminEventCircuitProposalModel::from((event_id, &proposal));
+            insert_into(admin_event_circuit_proposal::table)
+                .values(proposal_model)
+                .execute(self.conn)?;
+            // Insert `ProposedCircuitModel`, representing the `create_circuit` of an admin event's
+            // `CircuitProposal`
+            let proposed_circuit_model =
+                AdminEventProposedCircuitModel::from((event_id, &proposal.circuit));
+            insert_into(admin_event_proposed_circuit::table)
+                .values(proposed_circuit_model)
+                .execute(self.conn)?;
+            // Insert `members` of an admin event's `CreateCircuit`, represented by the
+            // `AdminEventProposedCircuitModel`
+            let proposed_members: Vec<AdminEventProposedNodeModel> =
+                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal);
+            insert_into(admin_event_proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)?;
+            // Insert the node `endpoints` and the proposed `members` of an admin event's
+            // `CreateCircuit`, represented by the `AdminEventProposedCircuitModel`
+            let proposed_member_endpoints: Vec<AdminEventProposedNodeEndpointModel> =
+                AdminEventProposedNodeEndpointModel::list_from_proposal_with_id(
+                    event_id, &proposal,
+                );
+            insert_into(admin_event_proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)?;
+            // Insert `roster`, list of `Services` of an admin event's `CreateCircuit`,
+            // represented by the `AdminEventProposedCircuitModel`
+            let proposed_services: Vec<AdminEventProposedServiceModel> =
+                AdminEventProposedServiceModel::list_from_proposal_with_id(event_id, &proposal)?;
+            insert_into(admin_event_proposed_service::table)
+                .values(proposed_services)
+                .execute(self.conn)?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_arguments: Vec<AdminEventProposedServiceArgumentModel> =
+                AdminEventProposedServiceArgumentModel::list_from_proposal_with_id(
+                    event_id, &proposal,
+                );
+            insert_into(admin_event_proposed_service_argument::table)
+                .values(proposed_service_arguments)
+                .execute(self.conn)?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_records: Vec<AdminEventVoteRecordModel> =
+                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal);
+            insert_into(admin_event_vote_record::table)
+                .values(vote_records)
+                .execute(self.conn)?;
+
+            AdminServiceEvent::try_from((event_id, &event))
+                .map_err(AdminServiceEventStoreError::InvalidStateError)
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> AdminServiceEventStoreAddEventOperation
+    for AdminServiceEventStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_event(
+        &self,
+        event: messages::AdminServiceEvent,
+    ) -> Result<AdminServiceEvent, AdminServiceEventStoreError> {
+        self.conn.transaction::<AdminServiceEvent, _, _>(|| {
+            // Create a `NewAdminServiceEventModel` from the event
+            let new_event: NewAdminServiceEventModel = NewAdminServiceEventModel::from(&event);
+            // This creates the initial event entry, returning the ID from the inserted row
+            // to be used to correlate the other `admin_event_*` entries to this event.
+            insert_into(admin_service_event::table)
+                .values(new_event)
+                .execute(self.conn)?;
+            // Retrieving the previously inserted event to get the autoincremented ID, used to
+            // associate the other database entries to this event.
+            let event_id: i64 = admin_service_event::table
+                .order(admin_service_event::id.desc())
+                .first::<AdminServiceEventModel>(self.conn)?
+                .id;
+
+            // Saving the event's proposal to build the required models.
+            let proposal = event.proposal().clone();
+
+            // Check if an `CircuitProposal` already exists with the given `event_id`
+            if admin_event_circuit_proposal::table
+                .filter(admin_event_circuit_proposal::event_id.eq(event_id))
+                .first::<AdminEventCircuitProposalModel>(self.conn)
+                .optional()?
+                .is_some()
+            {
+                return Err(AdminServiceEventStoreError::ConstraintViolationError(
+                    ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+                ));
+            }
+            // Insert the database model of the admin event's `CircuitProposal`
+            let proposal_model = AdminEventCircuitProposalModel::from((event_id, &proposal));
+            insert_into(admin_event_circuit_proposal::table)
+                .values(proposal_model)
+                .execute(self.conn)?;
+            // Insert `ProposedCircuitModel`, representing the `create_circuit` of an admin event's
+            // `CircuitProposal`
+            let proposed_circuit_model =
+                AdminEventProposedCircuitModel::from((event_id, &proposal.circuit));
+            insert_into(admin_event_proposed_circuit::table)
+                .values(proposed_circuit_model)
+                .execute(self.conn)?;
+            // Insert `members` of an admin event's `CreateCircuit`, represented by the
+            // `AdminEventProposedCircuitModel`
+            let proposed_members: Vec<AdminEventProposedNodeModel> =
+                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal);
+            insert_into(admin_event_proposed_node::table)
+                .values(proposed_members)
+                .execute(self.conn)?;
+            // Insert the node `endpoints` and the proposed `members` of an admin event's
+            // `CreateCircuit`, represented by the `AdminEventProposedCircuitModel`
+            let proposed_member_endpoints: Vec<AdminEventProposedNodeEndpointModel> =
+                AdminEventProposedNodeEndpointModel::list_from_proposal_with_id(
+                    event_id, &proposal,
+                );
+            insert_into(admin_event_proposed_node_endpoint::table)
+                .values(proposed_member_endpoints)
+                .execute(self.conn)?;
+            // Insert `roster`, list of `Services` of an admin event's `CreateCircuit`,
+            // represented by the `AdminEventProposedCircuitModel`
+            let proposed_services: Vec<AdminEventProposedServiceModel> =
+                AdminEventProposedServiceModel::list_from_proposal_with_id(event_id, &proposal)?;
+            insert_into(admin_event_proposed_service::table)
+                .values(proposed_services)
+                .execute(self.conn)?;
+            // Insert `service_arguments` from the `Services` inserted above
+            let proposed_service_arguments: Vec<AdminEventProposedServiceArgumentModel> =
+                AdminEventProposedServiceArgumentModel::list_from_proposal_with_id(
+                    event_id, &proposal,
+                );
+            insert_into(admin_event_proposed_service_argument::table)
+                .values(proposed_service_arguments)
+                .execute(self.conn)?;
+            // Insert `votes` from the `CircuitProposal`
+            let vote_records: Vec<AdminEventVoteRecordModel> =
+                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal);
+            insert_into(admin_event_vote_record::table)
+                .values(vote_records)
+                .execute(self.conn)?;
+
+            AdminServiceEvent::try_from((event_id, &event))
+                .map_err(AdminServiceEventStoreError::InvalidStateError)
+        })
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events.rs
@@ -1,0 +1,323 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Used by operations to retrieve all `AdminServiceEvent` instances in the database that match
+//! the specifie event IDs.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use diesel::{prelude::*, types::HasSqlType};
+
+use super::AdminServiceEventStoreOperations;
+
+use crate::admin::service::event::{
+    store::{
+        diesel::{
+            models::{
+                AdminEventCircuitProposalModel, AdminEventProposedCircuitModel,
+                AdminEventProposedNodeModel, AdminEventProposedServiceArgumentModel,
+                AdminEventProposedServiceModel, AdminEventVoteRecordModel, AdminServiceEventModel,
+            },
+            schema::{
+                admin_event_circuit_proposal, admin_event_proposed_circuit,
+                admin_event_proposed_node, admin_event_proposed_node_endpoint,
+                admin_event_proposed_service, admin_event_proposed_service_argument,
+                admin_event_vote_record, admin_service_event,
+            },
+        },
+        AdminServiceEventStoreError, EventIter,
+    },
+    AdminServiceEvent,
+};
+use crate::admin::store::{
+    AuthorizationType, CircuitProposalBuilder, DurabilityType, PersistenceType, ProposalType,
+    ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder, ProposedService,
+    ProposedServiceBuilder, RouteType, VoteRecord,
+};
+
+pub(in crate::admin::service::event::store::diesel) trait AdminServiceEventStoreListEventsOperation
+{
+    fn list_events(&self, events_id: Vec<i64>) -> Result<EventIter, AdminServiceEventStoreError>;
+}
+
+impl<'a, C> AdminServiceEventStoreListEventsOperation for AdminServiceEventStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    C::Backend: HasSqlType<diesel::sql_types::BigInt>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+{
+    fn list_events(&self, event_ids: Vec<i64>) -> Result<EventIter, AdminServiceEventStoreError> {
+        self.conn.transaction::<EventIter, _, _>(|| {
+            // List of the events, and the one-to-one models present in the database
+            let event_models: Vec<(
+                AdminServiceEventModel,
+                AdminEventCircuitProposalModel,
+                AdminEventProposedCircuitModel,
+            )> = admin_service_event::table
+                .filter(admin_service_event::id.eq_any(&event_ids))
+                .inner_join(
+                    admin_event_circuit_proposal::table
+                        .on(admin_service_event::id.eq(admin_event_circuit_proposal::event_id)),
+                )
+                .inner_join(
+                    admin_event_proposed_circuit::table
+                        .on(admin_service_event::id.eq(admin_event_proposed_circuit::event_id)),
+                )
+                .load::<(
+                    AdminServiceEventModel,
+                    AdminEventCircuitProposalModel,
+                    AdminEventProposedCircuitModel,
+                )>(self.conn)?;
+            // Transform previously-retrieved models into builders, keyed to the event ID
+            let events_map: HashMap<
+                i64,
+                (
+                    AdminServiceEventModel,
+                    CircuitProposalBuilder,
+                    ProposedCircuitBuilder,
+                ),
+            > = event_models
+                .into_iter()
+                .map(
+                    |(event_model, circuit_proposal_model, proposed_circuit_model)| {
+                        let proposal_builder = CircuitProposalBuilder::new()
+                            .with_proposal_type(&ProposalType::try_from(
+                                circuit_proposal_model.proposal_type.to_string(),
+                            )?)
+                            .with_circuit_id(&circuit_proposal_model.circuit_id)
+                            .with_circuit_hash(&circuit_proposal_model.circuit_hash)
+                            .with_requester(&circuit_proposal_model.requester)
+                            .with_requester_node_id(&circuit_proposal_model.requester_node_id);
+                        let mut proposed_circuit_builder = ProposedCircuitBuilder::new()
+                            .with_circuit_id(&proposed_circuit_model.circuit_id)
+                            .with_authorization_type(&AuthorizationType::try_from(
+                                proposed_circuit_model.authorization_type,
+                            )?)
+                            .with_persistence(&PersistenceType::try_from(
+                                proposed_circuit_model.persistence,
+                            )?)
+                            .with_durability(&DurabilityType::try_from(
+                                proposed_circuit_model.durability,
+                            )?)
+                            .with_routes(&RouteType::try_from(proposed_circuit_model.routes)?)
+                            .with_circuit_management_type(
+                                &proposed_circuit_model.circuit_management_type,
+                            );
+                        if let Some(application_metadata) =
+                            &proposed_circuit_model.application_metadata
+                        {
+                            proposed_circuit_builder = proposed_circuit_builder
+                                .with_application_metadata(&application_metadata);
+                        }
+
+                        if let Some(comments) = &proposed_circuit_model.comments {
+                            proposed_circuit_builder =
+                                proposed_circuit_builder.with_comments(&comments);
+                        }
+
+                        if let Some(display_name) = &proposed_circuit_model.display_name {
+                            proposed_circuit_builder =
+                                proposed_circuit_builder.with_display_name(&display_name);
+                        }
+
+                        Ok((
+                            event_model.id,
+                            (event_model, proposal_builder, proposed_circuit_builder),
+                        ))
+                    },
+                )
+                .collect::<Result<HashMap<i64, (_, _, _)>, AdminServiceEventStoreError>>()?;
+
+            // Collect `ProposedServices` to apply to the `ProposedCircuit`
+            // Create HashMap of (`event_id`, `service_id`) to a `ProposedServiceBuilder`
+            let mut proposed_services: HashMap<(i64, String), ProposedServiceBuilder> =
+                HashMap::new();
+            // Create HashMap of (`event_id`, `service_id`) to the associated argument values
+            let mut arguments_map: HashMap<(i64, String), Vec<(String, String)>> = HashMap::new();
+            for (proposed_service, opt_arg) in admin_event_proposed_service::table
+                .filter(admin_event_proposed_service::event_id.eq_any(&event_ids))
+                .left_join(
+                    admin_event_proposed_service_argument::table.on(
+                        admin_event_proposed_service::event_id
+                            .eq(admin_event_proposed_service_argument::event_id)
+                            .and(
+                                admin_event_proposed_service::service_id
+                                    .eq(admin_event_proposed_service_argument::service_id),
+                            ),
+                    ),
+                )
+                .select((
+                    admin_event_proposed_service::all_columns,
+                    admin_event_proposed_service_argument::all_columns.nullable(),
+                ))
+                .load::<(
+                    AdminEventProposedServiceModel,
+                    Option<AdminEventProposedServiceArgumentModel>,
+                )>(self.conn)?
+            {
+                if let Some(arg_model) = opt_arg {
+                    if let Some(args) = arguments_map.get_mut(&(
+                        proposed_service.event_id,
+                        proposed_service.service_id.to_string(),
+                    )) {
+                        args.push((arg_model.key.to_string(), arg_model.value.to_string()));
+                    } else {
+                        arguments_map.insert(
+                            (
+                                proposed_service.event_id,
+                                proposed_service.service_id.to_string(),
+                            ),
+                            vec![(arg_model.key.to_string(), arg_model.value.to_string())],
+                        );
+                    }
+                }
+                // Insert new `ProposedServiceBuilder` if it does not already exist
+                proposed_services
+                    .entry((
+                        proposed_service.event_id,
+                        proposed_service.service_id.to_string(),
+                    ))
+                    .or_insert_with(|| {
+                        ProposedServiceBuilder::new()
+                            .with_service_id(&proposed_service.service_id)
+                            .with_service_type(&proposed_service.service_type)
+                            .with_node_id(&proposed_service.node_id)
+                    });
+            }
+            // Need to collect the `ProposedServices` mapped to `event_ids`
+            let mut built_proposed_services: HashMap<i64, Vec<ProposedService>> = HashMap::new();
+            for ((event_id, service_id), mut builder) in proposed_services.into_iter() {
+                if let Some(args) = arguments_map.get(&(event_id, service_id.to_string())) {
+                    builder = builder.with_arguments(&args);
+                }
+                let proposed_service = builder
+                    .build()
+                    .map_err(AdminServiceEventStoreError::InvalidStateError)?;
+
+                if let Some(service_list) = built_proposed_services.get_mut(&event_id) {
+                    service_list.push(proposed_service);
+                } else {
+                    built_proposed_services.insert(event_id, vec![proposed_service]);
+                }
+            }
+            // Collect `ProposedNodes` and proposed node endpoints
+            let mut proposed_nodes: HashMap<(i64, String), ProposedNodeBuilder> = HashMap::new();
+            for (node, endpoint) in admin_event_proposed_node::table
+                .filter(admin_event_proposed_node::event_id.eq_any(&event_ids))
+                .inner_join(
+                    admin_event_proposed_node_endpoint::table.on(
+                        admin_event_proposed_node::node_id
+                            .eq(admin_event_proposed_node_endpoint::node_id)
+                            .and(
+                                admin_event_proposed_node_endpoint::event_id
+                                    .eq(admin_event_proposed_node::event_id),
+                            ),
+                    ),
+                )
+                .select((
+                    admin_event_proposed_node::all_columns,
+                    admin_event_proposed_node_endpoint::endpoint,
+                ))
+                .load::<(AdminEventProposedNodeModel, String)>(self.conn)?
+            {
+                if let Some(proposed_node) =
+                    proposed_nodes.remove(&(node.event_id, node.node_id.to_string()))
+                {
+                    if let Some(mut endpoints) = proposed_node.endpoints() {
+                        endpoints.push(endpoint);
+                        let proposed_node = proposed_node.with_endpoints(&endpoints);
+                        proposed_nodes.insert((node.event_id, node.node_id), proposed_node);
+                    } else {
+                        let proposed_node = proposed_node.with_endpoints(&[endpoint]);
+                        proposed_nodes.insert((node.event_id, node.node_id), proposed_node);
+                    }
+                } else {
+                    let proposed_node = ProposedNodeBuilder::new()
+                        .with_node_id(&node.node_id)
+                        .with_endpoints(&[endpoint]);
+                    proposed_nodes.insert((node.event_id, node.node_id), proposed_node);
+                }
+            }
+            let mut built_proposed_nodes: HashMap<i64, Vec<ProposedNode>> = HashMap::new();
+            for ((event_id, _), builder) in proposed_nodes.into_iter() {
+                if let Some(nodes) = built_proposed_nodes.get_mut(&event_id) {
+                    nodes.push(
+                        builder
+                            .build()
+                            .map_err(AdminServiceEventStoreError::InvalidStateError)?,
+                    )
+                } else {
+                    built_proposed_nodes.insert(
+                        event_id,
+                        vec![builder
+                            .build()
+                            .map_err(AdminServiceEventStoreError::InvalidStateError)?],
+                    );
+                }
+            }
+
+            // Collect votes to apply to the 'CircuitProposal'
+            let mut vote_records: HashMap<i64, Vec<VoteRecord>> = HashMap::new();
+            for vote in admin_event_vote_record::table
+                .filter(admin_event_vote_record::event_id.eq_any(&event_ids))
+                .load::<AdminEventVoteRecordModel>(self.conn)?
+                .into_iter()
+            {
+                if let Some(votes) = vote_records.get_mut(&vote.event_id) {
+                    votes.push(
+                        VoteRecord::try_from(&vote)
+                            .map_err(AdminServiceEventStoreError::InvalidStateError)?,
+                    );
+                } else {
+                    vote_records.insert(
+                        vote.event_id,
+                        vec![VoteRecord::try_from(&vote)
+                            .map_err(AdminServiceEventStoreError::InvalidStateError)?],
+                    );
+                }
+            }
+
+            let mut events: Vec<AdminServiceEvent> = Vec::new();
+            for (event_id, (event_model, mut proposal_builder, mut proposed_circuit_builder)) in
+                events_map
+            {
+                if let Some(services) = built_proposed_services.get(&event_id) {
+                    proposed_circuit_builder = proposed_circuit_builder.with_roster(&services);
+                }
+                if let Some(nodes) = built_proposed_nodes.get(&event_id) {
+                    proposed_circuit_builder = proposed_circuit_builder.with_members(nodes);
+                }
+                if let Some(votes) = vote_records.get(&event_id) {
+                    proposal_builder = proposal_builder.with_votes(&votes);
+                }
+                let proposal = proposal_builder
+                    .with_circuit(
+                        &proposed_circuit_builder
+                            .build()
+                            .map_err(AdminServiceEventStoreError::InvalidStateError)?,
+                    )
+                    .build()
+                    .map_err(AdminServiceEventStoreError::InvalidStateError)?;
+                events.push(AdminServiceEvent::try_from((event_model, proposal))?)
+            }
+            // Ensure the events are returned in a deterministic order, ascending by event ID
+            events.sort_by_key(|a| a.event_id);
+
+            Ok(Box::new(events.into_iter()))
+        })
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
@@ -1,0 +1,59 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list events by management type" operation for the `DieselAdminServiceEventStore`.
+
+use diesel::{prelude::*, types::HasSqlType};
+
+use super::{
+    list_events::AdminServiceEventStoreListEventsOperation, AdminServiceEventStoreOperations,
+};
+
+use crate::admin::service::event::store::{
+    diesel::schema::admin_event_proposed_circuit, AdminServiceEventStoreError, EventIter,
+};
+
+pub(in crate::admin::service::event::store::diesel) trait AdminServiceEventStoreListEventsByManagementTypeSinceOperation
+{
+    fn list_events_by_management_type_since(
+        &self,
+        management_type: String,
+        start: i64,
+    ) -> Result<EventIter, AdminServiceEventStoreError>;
+}
+
+impl<'a, C> AdminServiceEventStoreListEventsByManagementTypeSinceOperation
+    for AdminServiceEventStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    C::Backend: HasSqlType<diesel::sql_types::BigInt>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+{
+    fn list_events_by_management_type_since(
+        &self,
+        management_type: String,
+        start: i64,
+    ) -> Result<EventIter, AdminServiceEventStoreError> {
+        self.conn.transaction::<EventIter, _, _>(|| {
+            let event_ids: Vec<i64> = admin_event_proposed_circuit::table
+                .filter(admin_event_proposed_circuit::event_id.gt(start))
+                .filter(admin_event_proposed_circuit::circuit_management_type.eq(management_type))
+                .select(admin_event_proposed_circuit::event_id)
+                .load(self.conn)?;
+            AdminServiceEventStoreOperations::new(self.conn).list_events(event_ids)
+        })
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
@@ -1,0 +1,50 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list events since" operation for the `DieselAdminServiceEventStore`.
+
+use diesel::{prelude::*, types::HasSqlType};
+
+use super::{
+    list_events::AdminServiceEventStoreListEventsOperation, AdminServiceEventStoreOperations,
+};
+
+use crate::admin::service::event::store::{
+    diesel::schema::admin_service_event, AdminServiceEventStoreError, EventIter,
+};
+
+pub(in crate::admin::service::event::store::diesel) trait AdminServiceEventStoreListEventsSinceOperation
+{
+    fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError>;
+}
+
+impl<'a, C> AdminServiceEventStoreListEventsSinceOperation
+    for AdminServiceEventStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    C::Backend: HasSqlType<diesel::sql_types::BigInt>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+{
+    fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
+        self.conn.transaction::<EventIter, _, _>(|| {
+            let event_ids: Vec<i64> = admin_service_event::table
+                .filter(admin_service_event::id.gt(start))
+                .select(admin_service_event::id)
+                .load(self.conn)?;
+            AdminServiceEventStoreOperations::new(self.conn).list_events(event_ids)
+        })
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/mod.rs
@@ -1,0 +1,25 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides database operations for the `DieselAdminServiceEventStore`.
+
+pub struct AdminServiceEventStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C: diesel::Connection> AdminServiceEventStoreOperations<'a, C> {
+    pub fn new(conn: &'a C) -> Self {
+        AdminServiceEventStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/mod.rs
@@ -14,6 +14,11 @@
 
 //! Provides database operations for the `DieselAdminServiceEventStore`.
 
+pub(super) mod add_event;
+pub(super) mod list_events;
+pub(super) mod list_events_by_management_type_since;
+pub(super) mod list_events_since;
+
 pub struct AdminServiceEventStoreOperations<'a, C> {
     conn: &'a C,
 }


### PR DESCRIPTION
Adds the diesel implementation of the `AdminServiceEventStore` trait. Also includes a few unit tests for the operations in `libsplinter/src/admin/service/event/store/diesel/mod.rs`.