### PR TITLE
Add position to tables in the AdminServiceStore for listed items

### DIFF
--- a/libsplinter/src/admin/service/event/store/diesel/operations/add_event.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/add_event.rs
@@ -97,7 +97,7 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             // Insert `members` of an admin event's `CreateCircuit`, represented by the
             // `AdminEventProposedCircuitModel`
             let proposed_members: Vec<AdminEventProposedNodeModel> =
-                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal);
+                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal)?;
             insert_into(admin_event_proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
@@ -106,7 +106,7 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             let proposed_member_endpoints: Vec<AdminEventProposedNodeEndpointModel> =
                 AdminEventProposedNodeEndpointModel::list_from_proposal_with_id(
                     event_id, &proposal,
-                );
+                )?;
             insert_into(admin_event_proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
@@ -121,13 +121,13 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             let proposed_service_arguments: Vec<AdminEventProposedServiceArgumentModel> =
                 AdminEventProposedServiceArgumentModel::list_from_proposal_with_id(
                     event_id, &proposal,
-                );
+                )?;
             insert_into(admin_event_proposed_service_argument::table)
                 .values(proposed_service_arguments)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
             let vote_records: Vec<AdminEventVoteRecordModel> =
-                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal);
+                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal)?;
             insert_into(admin_event_vote_record::table)
                 .values(vote_records)
                 .execute(self.conn)?;
@@ -190,7 +190,7 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             // Insert `members` of an admin event's `CreateCircuit`, represented by the
             // `AdminEventProposedCircuitModel`
             let proposed_members: Vec<AdminEventProposedNodeModel> =
-                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal);
+                AdminEventProposedNodeModel::list_from_proposal_with_id(event_id, &proposal)?;
             insert_into(admin_event_proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
@@ -199,7 +199,7 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             let proposed_member_endpoints: Vec<AdminEventProposedNodeEndpointModel> =
                 AdminEventProposedNodeEndpointModel::list_from_proposal_with_id(
                     event_id, &proposal,
-                );
+                )?;
             insert_into(admin_event_proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
@@ -214,13 +214,13 @@ impl<'a> AdminServiceEventStoreAddEventOperation
             let proposed_service_arguments: Vec<AdminEventProposedServiceArgumentModel> =
                 AdminEventProposedServiceArgumentModel::list_from_proposal_with_id(
                     event_id, &proposal,
-                );
+                )?;
             insert_into(admin_event_proposed_service_argument::table)
                 .values(proposed_service_arguments)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
             let vote_records: Vec<AdminEventVoteRecordModel> =
-                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal);
+                AdminEventVoteRecordModel::list_from_proposal_with_id(event_id, &proposal)?;
             insert_into(admin_event_vote_record::table)
                 .values(vote_records)
                 .execute(self.conn)?;

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
@@ -40,6 +40,7 @@ where
     C::Backend: HasSqlType<diesel::sql_types::BigInt>,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
 {
     fn list_events_by_management_type_since(

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
@@ -36,6 +36,7 @@ where
     C::Backend: HasSqlType<diesel::sql_types::BigInt>,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
 {
     fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError> {

--- a/libsplinter/src/admin/service/event/store/diesel/schema.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/schema.rs
@@ -52,6 +52,7 @@ table! {
         public_key -> Binary,
         vote -> Text,
         voter_node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -59,6 +60,7 @@ table! {
     admin_event_proposed_node (event_id, node_id) {
         event_id -> Int8,
         node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -67,6 +69,7 @@ table! {
         event_id -> Int8,
         node_id -> Text,
         endpoint -> Text,
+        position -> Integer,
     }
 }
 
@@ -76,6 +79,7 @@ table! {
         service_id -> Text,
         service_type -> Text,
         node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -85,6 +89,7 @@ table! {
         service_id -> Text,
         key -> Text,
         value -> Text,
+        position -> Integer,
     }
 }
 

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -327,17 +327,13 @@ impl CircuitBuilder {
             }
         };
 
-        let mut roster = self.roster.ok_or_else(|| {
+        let roster = self.roster.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `roster`".to_string())
         })?;
 
-        roster.sort_by_key(|service| service.service_id().to_string());
-
-        let mut members = self.members.ok_or_else(|| {
+        let members = self.members.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `members`".to_string())
         })?;
-
-        members.sort();
 
         let authorization_type = self.authorization_type.unwrap_or(AuthorizationType::Trust);
 

--- a/libsplinter/src/admin/store/circuit_proposal.rs
+++ b/libsplinter/src/admin/store/circuit_proposal.rs
@@ -304,9 +304,7 @@ impl CircuitProposalBuilder {
             InvalidStateError::with_message("unable to build, missing field: `circuit`".to_string())
         })?;
 
-        let mut votes = self.votes.unwrap_or_default();
-
-        votes.sort_by_key(|vote| vote.voter_node_id().to_string());
+        let votes = self.votes.unwrap_or_default();
 
         let requester = self.requester.ok_or_else(|| {
             InvalidStateError::with_message(

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -875,7 +875,9 @@ pub mod tests {
                         &vec![
                         ProposedNodeBuilder::default()
                             .with_node_id("bubba-node-000".into())
-                            .with_endpoints(&vec!["tcps://splinterd-node-bubba:8044".into()])
+                            .with_endpoints(
+                                &vec!["tcps://splinterd-node-bubba:8044".into(),
+                                      "tcps://splinterd-node-bubba-2:8044".into()])
                             .build().expect("Unable to build node"),
                         ProposedNodeBuilder::default()
                             .with_node_id("acme-node-000".into())
@@ -893,6 +895,29 @@ pub mod tests {
                 &parse_hex(
                     "0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482").unwrap())
             .with_requester_node_id("acme-node-000")
+            .with_votes(&vec![VoteRecordBuilder::new()
+                .with_public_key(
+                    &parse_hex(
+                        "035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550",
+                    )
+                    .unwrap(),
+                )
+                .with_vote(&Vote::Accept)
+                .with_voter_node_id("bubba-node-000")
+                .build()
+                .expect("Unable to build vote record"),
+                VoteRecordBuilder::new()
+                    .with_public_key(
+                        &parse_hex(
+                            "035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550",
+                        )
+                        .unwrap(),
+                    )
+                    .with_vote(&Vote::Accept)
+                    .with_voter_node_id("bubba-node-002")
+                    .build()
+                    .expect("Unable to build vote record")]
+            )
             .build().expect("Unable to build proposals")
     }
 
@@ -959,10 +984,9 @@ pub mod tests {
                     .with_service_type("scabbard")
                     .with_node_id("acme-node-000")
                     .with_arguments(&vec![
+                        ("peer_services".into(), "[\"a001\"]".into()),
                         ("admin_keys".into(),
-                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
-                            .into()),
-                       ("peer_services".into(), "[\"a001\"]".into()),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
                     ])
                     .build()
                     .expect("Unable to build service"),
@@ -970,13 +994,11 @@ pub mod tests {
                     .with_service_id("a001")
                     .with_service_type("scabbard")
                     .with_node_id("bubba-node-000")
-                    .with_arguments(&vec![(
-                        "admin_keys".into(),
-                        "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]"
-                            .into()
-                    ),(
-                        "peer_services".into(), "[\"a000\"]".into()
-                    )])
+                    .with_arguments(&vec![
+                        ("peer_services".into(), "[\"a000\"]".into()),
+                        ("admin_keys".into(),
+                       "[\"035724d11cae47c8907f8bfdf510488f49df8494ff81b63825bad923733c4ac550\"]".into())
+                    ])
                     .build()
                     .expect("Unable to build service"),
             ])

--- a/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_proposal.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! Provides the "add proposal" operation for the `DieselAdminServiceStore`.
+use std::convert::TryFrom;
 
 use diesel::{dsl::insert_into, prelude::*};
 
@@ -69,29 +70,29 @@ impl<'a> AdminServiceStoreAddProposalOperation
                 .values(proposed_circuit_model)
                 .execute(self.conn)?;
             // Insert `members` of a `ProposedCircuit`
-            let proposed_members: Vec<ProposedNodeModel> = Vec::from(proposal.circuit());
+            let proposed_members: Vec<ProposedNodeModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
             // Insert the node `endpoints` and the proposed `members` of a `ProposedCircuit`
             let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
             // Insert `roster`, list of `Services` of a `ProposedCircuit`
-            let proposed_services: Vec<ProposedServiceModel> = Vec::from(proposal.circuit());
+            let proposed_services: Vec<ProposedServiceModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service::table)
                 .values(proposed_services)
                 .execute(self.conn)?;
             // Insert `service_arguments` from the `Services` inserted above
             let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service_argument::table)
                 .values(proposed_service_argument)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
-            let vote_records: Vec<VoteRecordModel> = Vec::from(&proposal);
+            let vote_records: Vec<VoteRecordModel> = Vec::try_from(&proposal)?;
             insert_into(vote_record::table)
                 .values(vote_records)
                 .execute(self.conn)?;
@@ -132,29 +133,29 @@ impl<'a> AdminServiceStoreAddProposalOperation
                 .values(proposed_circuit_model)
                 .execute(self.conn)?;
             // Insert `members` of a `ProposedCircuit`
-            let proposed_members: Vec<ProposedNodeModel> = Vec::from(proposal.circuit());
+            let proposed_members: Vec<ProposedNodeModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
             // Insert the node `endpoints` and the proposed `members` of a `ProposedCircuit`
             let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
             // Insert `roster`, list of `Services` of a `ProposedCircuit`
-            let proposed_services: Vec<ProposedServiceModel> = Vec::from(proposal.circuit());
+            let proposed_services: Vec<ProposedServiceModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service::table)
                 .values(proposed_services)
                 .execute(self.conn)?;
             // Insert `service_arguments` from the `Services` inserted above
             let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service_argument::table)
                 .values(proposed_service_argument)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
-            let vote_records: Vec<VoteRecordModel> = Vec::from(&proposal);
+            let vote_records: Vec<VoteRecordModel> = Vec::try_from(&proposal)?;
             insert_into(vote_record::table)
                 .values(vote_records)
                 .execute(self.conn)?;

--- a/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
@@ -37,6 +37,7 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
 {
     fn get_circuit(&self, circuit_id: &str) -> Result<Option<Circuit>, AdminServiceStoreError> {
         self.conn.transaction::<Option<Circuit>, _, _>(|| {
@@ -55,6 +56,7 @@ where
             // Collecting the members of the `Circuit`
             let members: Vec<CircuitMemberModel> = circuit_member::table
                 .filter(circuit_member::circuit_id.eq(circuit_id.to_string()))
+                .order(circuit_member::position)
                 .load(self.conn)?;
 
             // Collecting services associated with the `Circuit` using the `list_services` method,

--- a/libsplinter/src/admin/store/diesel/operations/get_node.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_node.rs
@@ -35,6 +35,7 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
 {
     fn get_node(&self, node_id: &str) -> Result<Option<CircuitNode>, AdminServiceStoreError> {
         self.conn.transaction::<Option<CircuitNode>, _, _>(|| {

--- a/libsplinter/src/admin/store/diesel/operations/get_service.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_service.rs
@@ -38,6 +38,7 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
 {
     fn get_service(
         &self,
@@ -61,6 +62,7 @@ where
             let arguments: Vec<(String, String)> = service_argument::table
                 .filter(service_argument::circuit_id.eq(&service_id.circuit_id))
                 .filter(service_argument::service_id.eq(&service_id.service_id))
+                .order(service_argument::position)
                 .load::<ServiceArgumentModel>(self.conn)?
                 .iter()
                 .map(|arg| (arg.key.to_string(), arg.value.to_string()))

--- a/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
@@ -32,6 +32,7 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
 {
     fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
         self.conn.transaction::<(), _, _>(|| {

--- a/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
@@ -17,7 +17,7 @@
 use diesel::{
     dsl::delete,
     prelude::*,
-    sql_types::{Binary, Nullable, Text},
+    sql_types::{Binary, Integer, Nullable, Text},
 };
 
 use crate::admin::store::{
@@ -39,6 +39,7 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     CircuitProposalModel: diesel::Queryable<(Text, Text, Text, Binary, Text), C::Backend>,
     ProposedCircuitModel: diesel::Queryable<
         (
@@ -54,7 +55,7 @@ where
         ),
         C::Backend,
     >,
-    VoteRecordModel: diesel::Queryable<(Text, Binary, Text, Text), C::Backend>,
+    VoteRecordModel: diesel::Queryable<(Text, Binary, Text, Text, Integer), C::Backend>,
 {
     fn remove_proposal(&self, proposal_id: &str) -> Result<(), AdminServiceStoreError> {
         self.conn.transaction::<(), _, _>(|| {

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! Provides the "update circuit" operation for the `DieselAdminServiceStore`.
+use std::convert::TryFrom;
 
 use diesel::{
     dsl::{delete, insert_into, update},
@@ -71,15 +72,15 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             )
             .execute(self.conn)?;
             // Insert new data associate with the `Circuit`
-            let services: Vec<ServiceModel> = Vec::from(&circuit);
+            let services: Vec<ServiceModel> = Vec::try_from(&circuit)?;
             insert_into(service::table)
                 .values(&services)
                 .execute(self.conn)?;
-            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            let service_argument: Vec<ServiceArgumentModel> = Vec::try_from(&circuit)?;
             insert_into(service_argument::table)
                 .values(&service_argument)
                 .execute(self.conn)?;
-            let circuit_member: Vec<CircuitMemberModel> = Vec::from(&circuit);
+            let circuit_member: Vec<CircuitMemberModel> = Vec::try_from(&circuit)?;
             insert_into(circuit_member::table)
                 .values(circuit_member)
                 .execute(self.conn)?;
@@ -125,15 +126,15 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             )
             .execute(self.conn)?;
             // Insert new data associate with the `Circuit`
-            let services: Vec<ServiceModel> = Vec::from(&circuit);
+            let services: Vec<ServiceModel> = Vec::try_from(&circuit)?;
             insert_into(service::table)
                 .values(&services)
                 .execute(self.conn)?;
-            let service_argument: Vec<ServiceArgumentModel> = Vec::from(&circuit);
+            let service_argument: Vec<ServiceArgumentModel> = Vec::try_from(&circuit)?;
             insert_into(service_argument::table)
                 .values(&service_argument)
                 .execute(self.conn)?;
-            let circuit_member: Vec<CircuitMemberModel> = Vec::from(&circuit);
+            let circuit_member: Vec<CircuitMemberModel> = Vec::try_from(&circuit)?;
             insert_into(circuit_member::table)
                 .values(circuit_member)
                 .execute(self.conn)?;

--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -14,6 +14,8 @@
 
 //! Provides the "update proposal" operation for the `DieselAdminServiceStore`.
 
+use std::convert::TryFrom;
+
 use diesel::{
     dsl::{delete, insert_into, update},
     prelude::*,
@@ -114,29 +116,29 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
             // Insert the updated info for all of the `CircuitProposal` and `ProposedCircuit`
             // associated data
             // Insert `members` of a `ProposedCircuit`
-            let proposed_members: Vec<ProposedNodeModel> = Vec::from(proposal.circuit());
+            let proposed_members: Vec<ProposedNodeModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
             // Insert the node `endpoints` the proposed `members` of a `ProposedCircuit`
             let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
             // Insert `roster`, list of `Services` of a `ProposedCircuit`
-            let proposed_service: Vec<ProposedServiceModel> = Vec::from(proposal.circuit());
+            let proposed_service: Vec<ProposedServiceModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service::table)
                 .values(proposed_service)
                 .execute(self.conn)?;
             // Insert `service_arguments` from the `Services` inserted above
             let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service_argument::table)
                 .values(proposed_service_argument)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
-            let vote_record: Vec<VoteRecordModel> = Vec::from(&proposal);
+            let vote_record: Vec<VoteRecordModel> = Vec::try_from(&proposal)?;
             insert_into(vote_record::table)
                 .values(vote_record)
                 .execute(self.conn)?;
@@ -221,29 +223,29 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
             // Insert the updated info for all of the `CircuitProposal` and `ProposedCircuit`
             // associated data
             // Insert `members` of a `ProposedCircuit`
-            let proposed_members: Vec<ProposedNodeModel> = Vec::from(proposal.circuit());
+            let proposed_members: Vec<ProposedNodeModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node::table)
                 .values(proposed_members)
                 .execute(self.conn)?;
             // Insert the node `endpoints` the proposed `members` of a `ProposedCircuit`
             let proposed_member_endpoints: Vec<ProposedNodeEndpointModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_node_endpoint::table)
                 .values(proposed_member_endpoints)
                 .execute(self.conn)?;
             // Insert `roster`, list of `Services` of a `ProposedCircuit`
-            let proposed_service: Vec<ProposedServiceModel> = Vec::from(proposal.circuit());
+            let proposed_service: Vec<ProposedServiceModel> = Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service::table)
                 .values(proposed_service)
                 .execute(self.conn)?;
             // Insert `service_arguments` from the `Services` inserted above
             let proposed_service_argument: Vec<ProposedServiceArgumentModel> =
-                Vec::from(proposal.circuit());
+                Vec::try_from(proposal.circuit())?;
             insert_into(proposed_service_argument::table)
                 .values(proposed_service_argument)
                 .execute(self.conn)?;
             // Insert `votes` from the `CircuitProposal`
-            let vote_record: Vec<VoteRecordModel> = Vec::from(&proposal);
+            let vote_record: Vec<VoteRecordModel> = Vec::try_from(&proposal)?;
             insert_into(vote_record::table)
                 .values(vote_record)
                 .execute(self.conn)?;

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -42,6 +42,7 @@ table! {
         public_key -> Binary,
         vote -> Text,
         voter_node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -49,6 +50,7 @@ table! {
     proposed_node (circuit_id, node_id) {
         circuit_id -> Text,
         node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -57,6 +59,7 @@ table! {
         circuit_id -> Text,
         node_id -> Text,
         endpoint -> Text,
+        position -> Integer,
     }
 }
 
@@ -66,6 +69,7 @@ table! {
         service_id -> Text,
         service_type -> Text,
         node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -75,6 +79,7 @@ table! {
         service_id -> Text,
         key -> Text,
         value -> Text,
+        position -> Integer,
     }
 }
 
@@ -84,6 +89,7 @@ table! {
         service_id -> Text,
         service_type -> Text,
         node_id -> Text,
+        position -> Integer,
     }
 }
 
@@ -93,6 +99,7 @@ table! {
         service_id -> Text,
         key -> Text,
         value -> Text,
+        position -> Integer,
     }
 }
 
@@ -112,6 +119,7 @@ table! {
     circuit_member (circuit_id, node_id) {
         circuit_id -> Text,
         node_id -> Text,
+        position -> Integer,
     }
 }
 

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -444,17 +444,13 @@ impl ProposedCircuitBuilder {
             }
         };
 
-        let mut roster = self.roster.ok_or_else(|| {
+        let roster = self.roster.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `roster`".to_string())
         })?;
 
-        roster.sort_by_key(|service| service.service_id().to_string());
-
-        let mut members = self.members.ok_or_else(|| {
+        let members = self.members.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `members`".to_string())
         })?;
-
-        members.sort_by_key(|node| node.node_id().to_string());
 
         let authorization_type = self.authorization_type.unwrap_or(AuthorizationType::Trust);
 

--- a/libsplinter/src/admin/store/proposed_node.rs
+++ b/libsplinter/src/admin/store/proposed_node.rs
@@ -104,13 +104,11 @@ impl ProposedNodeBuilder {
             InvalidStateError::with_message("unable to build, missing field: `node_id`".to_string())
         })?;
 
-        let mut endpoints = self.endpoints.ok_or_else(|| {
+        let endpoints = self.endpoints.ok_or_else(|| {
             InvalidStateError::with_message(
                 "unable to build, missing field: `endpoints`".to_string(),
             )
         })?;
-
-        endpoints.sort();
 
         let node = ProposedNode { node_id, endpoints };
 

--- a/libsplinter/src/admin/store/proposed_service.rs
+++ b/libsplinter/src/admin/store/proposed_service.rs
@@ -196,9 +196,7 @@ impl ProposedServiceBuilder {
             InvalidStateError::with_message("unable to build, missing field: `node_id`".to_string())
         })?;
 
-        let mut arguments = self.arguments.unwrap_or_default();
-
-        arguments.sort();
+        let arguments = self.arguments.unwrap_or_default();
 
         let service = ProposedService {
             service_id,

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-23-204959_admin_service_add_position/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-23-204959_admin_service_add_position/down.sql
@@ -1,0 +1,30 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE proposed_node DROP COLUMN position;
+
+ALTER TABLE proposed_node_endpoint DROP COLUMN position;
+
+ALTER TABLE proposed_service DROP COLUMN position;
+
+ALTER TABLE proposed_service_argument DROP COLUMN position;
+
+ALTER TABLE vote_record DROP COLUMN position;
+
+ALTER TABLE service DROP COLUMN position;
+
+ALTER TABLE service_argument DROP COLUMN position;
+
+ALTER TABLE circuit_member DROP COLUMN position;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-23-204959_admin_service_add_position/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2020-12-23-204959_admin_service_add_position/up.sql
@@ -1,0 +1,32 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE proposed_node ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE proposed_node_endpoint
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE proposed_service ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE proposed_service_argument
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE vote_record ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE service ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE service_argument ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE circuit_member ADD COLUMN position INTEGER NOT NULL DEFAULT 0;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-211600_admin_service_event_add_position/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-211600_admin_service_event_add_position/down.sql
@@ -1,0 +1,24 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_proposed_node DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_node_endpoint DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_service DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_service_argument DROP COLUMN position;
+
+ALTER TABLE admin_event_vote_record DROP COLUMN position;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-211600_admin_service_event_add_position/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-211600_admin_service_event_add_position/up.sql
@@ -1,0 +1,29 @@
+-- Your SQL goes here---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_proposed_node
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_node_endpoint
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_service
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_service_argument
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_vote_record
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-23-204959_admin_service_add_position/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-23-204959_admin_service_add_position/down.sql
@@ -1,0 +1,30 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE proposed_node DROP COLUMN position;
+
+ALTER TABLE proposed_node_endpoint DROP COLUMN position;
+
+ALTER TABLE proposed_service DROP COLUMN position;
+
+ALTER TABLE proposed_service_argument DROP COLUMN position;
+
+ALTER TABLE vote_record DROP COLUMN position;
+
+ALTER TABLE service DROP COLUMN position;
+
+ALTER TABLE service_argument DROP COLUMN position;
+
+ALTER TABLE circuit_member DROP COLUMN position;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-23-204959_admin_service_add_position/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2020-12-23-204959_admin_service_add_position/up.sql
@@ -1,0 +1,32 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE proposed_node ADD COLUMN position INTEGER DEFAULT 0 NOT NULL;
+
+ALTER TABLE proposed_node_endpoint
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE proposed_service ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE proposed_service_argument
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE vote_record ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE service ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE service_argument ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE circuit_member ADD COLUMN position INTEGER NOT NULL DEFAULT 0;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-211600_admin_service_event_add_position/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-211600_admin_service_event_add_position/down.sql
@@ -1,0 +1,24 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_proposed_node DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_node_endpoint DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_service DROP COLUMN position;
+
+ALTER TABLE admin_event_proposed_service_argument DROP COLUMN position;
+
+ALTER TABLE admin_event_vote_record DROP COLUMN position;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-211600_admin_service_event_add_position/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-211600_admin_service_event_add_position/up.sql
@@ -1,0 +1,29 @@
+-- Your SQL goes here---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_proposed_node
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_node_endpoint
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_service
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_proposed_service_argument
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE admin_event_vote_record
+ADD COLUMN position INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
The order of members, services, arguments, etc must be consistent
across splinter nodes, do to the hashing that is a part of circuit
management. When the storage was a yaml file, this was kept
consistent.

However, with the change to use diesel backends the order was switched
to be alphabetical. This caused an issue with working with 0.4 splinter
nodes.

This commit updates the tables of items that are listed (requiring a
separate table) to include a position column, so proposals and
circuits can be rebuild correctly.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>