### PR TITLE
Backport: Clippy fixes for 1.49.0 Rust

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ flexi_logger = "0.14"
 libc = "0.2"
 log = "0.4"
 openssl = "0.10"
-protobuf = "2"
+protobuf = "~2.18"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ description = """\
 [dependencies]
 log = "0.3.8"
 openssl = "0.10"
-protobuf = "2"
+protobuf = "~2.18"
 splinter = { path = "../libsplinter" }
 url = "1.7.1"
 

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -47,7 +47,7 @@ hyper = "0.12"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2.0"
-protobuf = "2"
+protobuf = "~2.18"
 sabre-sdk = "0.7"
 scabbard = { path = "../../../services/scabbard/libscabbard", features = ["events"] }
 serde = "1.0"

--- a/examples/gameroom/daemon/src/rest_api/routes/submit.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/submit.rs
@@ -319,11 +319,8 @@ async fn check_batch_status(
                 // send request again to re-check the batch status
                 if batches_info
                     .iter()
-                    .any(|batch_info| match batch_info.status {
-                        BatchStatus::Pending => true,
-                        BatchStatus::Valid(_) => true,
-                        _ => false,
-                    })
+                    .any(|batch_info|
+                         matches!(batch_info.status, BatchStatus::Pending | BatchStatus::Valid(_)))
                     && Instant::now().duration_since(start_time) < Duration::from_secs(wait)
                 {
                     // wait one second before sending request again

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -47,7 +47,7 @@ mio = "0.6"
 mio-extras = "2"
 openssl = "0.10"
 percent-encoding = { version = "2.0", optional = true }
-protobuf = "2"
+protobuf = "~2.18"
 rand = "0.7"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 serde = "1.0"

--- a/libsplinter/src/admin/service/consensus.rs
+++ b/libsplinter/src/admin/service/consensus.rs
@@ -171,12 +171,14 @@ impl ProposalManager for AdminProposalManager {
             // consensus. The ID is the hash of the circuit management playload. This example will
             // not work with forking consensus, because it does not track previously accepted
             // proposals.
-            let mut proposal = Proposal::default();
-            proposal.id = sha256(&circuit_payload)
-                .map_err(|err| ProposalManagerError::Internal(Box::new(err)))?
-                .as_bytes()
-                .into();
-            proposal.summary = expected_hash.as_bytes().into();
+            let mut proposal = Proposal {
+                id: sha256(&circuit_payload)
+                    .map_err(|err| ProposalManagerError::Internal(Box::new(err)))?
+                    .as_bytes()
+                    .into(),
+                summary: expected_hash.as_bytes().into(),
+                ..Default::default()
+            };
 
             let mut required_verifiers = RequiredVerifiers::new();
             let mut verifiers = vec![];

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -14,7 +14,6 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::iter::FromIterator;
 use std::path::Path;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
@@ -1287,13 +1286,12 @@ impl AdminServiceShared {
         let ready = {
             if let Some(uninitialized_circuit) = self.uninitialized_circuits.get(circuit_id) {
                 if let Some(ref circuit_proposal) = uninitialized_circuit.circuit {
-                    let all_members = HashSet::from_iter(
-                        circuit_proposal
-                            .get_circuit_proposal()
-                            .members
-                            .iter()
-                            .map(|node| node.node_id.clone()),
-                    );
+                    let all_members = circuit_proposal
+                        .get_circuit_proposal()
+                        .members
+                        .iter()
+                        .map(|node| node.node_id.clone())
+                        .collect::<HashSet<String>>();
                     all_members.is_subset(&uninitialized_circuit.ready_members)
                 } else {
                     false

--- a/libsplinter/src/consensus/two_phase/mod.rs
+++ b/libsplinter/src/consensus/two_phase/mod.rs
@@ -42,7 +42,6 @@
 mod timing;
 
 use std::collections::{HashSet, VecDeque};
-use std::iter::FromIterator;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
 use std::time::Duration;
 
@@ -474,7 +473,11 @@ impl TwoPhaseEngine {
         let verifiers = if !proposal.consensus_data.is_empty() {
             let required_verifiers: RequiredVerifiers =
                 protobuf::parse_from_bytes(&proposal.consensus_data)?;
-            HashSet::from_iter(required_verifiers.verifiers.into_iter().map(PeerId::from))
+            required_verifiers
+                .verifiers
+                .into_iter()
+                .map(PeerId::from)
+                .collect::<HashSet<PeerId>>()
         } else {
             let mut verifiers = self.peers.clone();
             verifiers.insert(self.id.clone());

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -434,11 +434,8 @@ impl ManagedAuthorizations {
     }
 
     fn is_complete(&self, connection_id: &str) -> Option<bool> {
-        self.states.get(connection_id).map(|state| match state {
-            AuthorizationState::Authorized(_) => true,
-            AuthorizationState::Unauthorized => true,
-            _ => false,
-        })
+        self.states.get(connection_id).map(|state|
+            matches!(state, AuthorizationState::Authorized(_) | AuthorizationState::Unauthorized))
     }
 }
 

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -40,18 +40,20 @@ pub trait TokenIssuer<T: Serialize> {
 
 #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
 pub(crate) fn default_validation(issuer: &str) -> Validation {
-    let mut validation = Validation::default();
-    validation.leeway = DEFAULT_LEEWAY;
-    validation.iss = Some(issuer.to_string());
-    validation
+    Validation {
+        leeway: DEFAULT_LEEWAY,
+        iss: Some(issuer.to_string()),
+        ..Default::default()
+    }
 }
 
 /// Validates authorization token but ignores the expiration date
 #[cfg(feature = "biome-credentials")]
 pub(crate) fn ignore_exp_validation(issuer: &str) -> Validation {
-    let mut validation = Validation::default();
-    validation.leeway = DEFAULT_LEEWAY;
-    validation.iss = Some(issuer.to_string());
-    validation.validate_exp = false;
-    validation
+    Validation {
+        leeway: DEFAULT_LEEWAY,
+        iss: Some(issuer.to_string()),
+        validate_exp: false,
+        ..Default::default()
+    }
 }

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -30,7 +30,7 @@ cylinder = "0.2"
 futures = { version = "0.1", optional = true }
 log = "0.3.0"
 openssl = "0.10"
-protobuf = "2"
+protobuf = "~2.18"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth = { version = "0.6", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.7"

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -177,9 +177,11 @@ impl ProposalManager for ScabbardProposalManager {
             // Intentionally leaving out the previous_id and proposal_height fields, since this
             // service and two phase consensus don't use them. This means the proposal ID can just
             // be the summary.
-            let mut proposal = Proposal::default();
-            proposal.id = expected_hash.as_bytes().into();
-            proposal.summary = expected_hash.as_bytes().into();
+            let proposal = Proposal {
+                id: expected_hash.as_bytes().into(),
+                summary: expected_hash.as_bytes().into(),
+                ..Default::default()
+            };
 
             shared.add_proposed_batch(proposal.id.clone(), batch.clone());
 

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
 use std::path::Path;
 use std::time::Duration;
 
@@ -126,16 +125,15 @@ impl ServiceFactory for ScabbardFactory {
         let peer_services_str = args.get("peer_services").ok_or_else(|| {
             FactoryCreateError::InvalidArguments("peer_services argument not provided".into())
         })?;
-        let peer_services = HashSet::from_iter(
-            serde_json::from_str::<Vec<_>>(peer_services_str)
-                .map_err(|err| {
-                    FactoryCreateError::InvalidArguments(format!(
-                        "failed to parse peer_services list: {}",
-                        err,
-                    ))
-                })?
-                .into_iter(),
-        );
+        let peer_services = serde_json::from_str::<Vec<_>>(peer_services_str)
+            .map_err(|err| {
+                FactoryCreateError::InvalidArguments(format!(
+                    "failed to parse peer_services list: {}",
+                    err,
+                ))
+            })?
+            .into_iter()
+            .collect::<HashSet<String>>();
         let state_db_dir = Path::new(&self.state_db_dir);
         let receipt_db_dir = Path::new(&self.receipt_db_dir);
         let admin_keys_str = args.get("admin_keys").ok_or_else(|| {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -38,7 +38,7 @@ flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
 openssl = { version = "0.10", optional = true }
-protobuf = "2"
+protobuf = "~2.18"
 rand = "0.7"
 serde = "1.0.80"
 serde_derive = "1.0.80"


### PR DESCRIPTION
also pins protobuf to 2.18 due to deprecations introduced in 2.19