### PR TITLE
Change default REST API endpoint value

### DIFF
--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -195,7 +195,7 @@ OPTIONS
   read. (Default: 10 seconds.) Use 0 to turn off forced refreshes.
 
 `--rest-api-endpoint REST-API-ENDPOINT`
-: Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
+: Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8443.)
 
 `--state-dir STATE-DIR`
 : Specifies the storage directory.

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -30,7 +30,10 @@ const TLS_REST_API_CERT: &str = "rest_api.crt";
 const TLS_REST_API_KEY: &str = "private/rest_api.key";
 const TLS_CA_FILE: &str = "ca.pem";
 
+#[cfg(not(feature = "https-bind"))]
 const REST_API_ENDPOINT: &str = "127.0.0.1:8080";
+#[cfg(feature = "https-bind")]
+const REST_API_ENDPOINT: &str = "127.0.0.1:8443";
 #[cfg(feature = "service-endpoint")]
 const SERVICE_ENDPOINT: &str = "tcp://127.0.0.1:8043";
 const NETWORK_ENDPOINT: &str = "tcps://127.0.0.1:8044";


### PR DESCRIPTION
This PR changes the default REST API endpoint value from port 8080 to port 8443, to better map to the default https port (443).
