### PR TITLE
Add userprofilestore

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -52,7 +52,7 @@ percent-encoding = { version = "2.0", optional = true }
 protobuf = "2.19"
 rand = "0.7"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
@@ -102,6 +102,7 @@ experimental = [
     "biome-notifications",
     "biome-oauth",
     "biome-oauth-user-store-postgres",
+    "biome-profile",
     "cylinder-jwt",
     "https-bind",
     "oauth",
@@ -129,6 +130,7 @@ biome-key-management = []
 biome-notifications = []
 biome-oauth = []
 biome-oauth-user-store-postgres = ["biome-oauth", "postgres"]
+biome-profile = []
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]

--- a/libsplinter/src/biome/mod.rs
+++ b/libsplinter/src/biome/mod.rs
@@ -37,6 +37,9 @@ pub mod notifications;
 #[cfg(feature = "biome-oauth")]
 pub mod oauth;
 
+#[cfg(feature = "biome-profile")]
+pub mod profile;
+
 #[cfg(feature = "biome-credentials")]
 pub mod refresh_tokens;
 
@@ -63,6 +66,13 @@ pub use oauth::store::diesel::DieselOAuthUserSessionStore;
 pub use oauth::store::memory::MemoryOAuthUserSessionStore;
 #[cfg(feature = "biome-oauth")]
 pub use oauth::store::OAuthUserSessionStore;
+
+#[cfg(all(feature = "biome-profile", feature = "diesel"))]
+pub use profile::store::diesel::DieselUserProfileStore;
+#[cfg(feature = "biome-profile")]
+pub use profile::store::memory::MemoryUserProfileStore;
+#[cfg(feature = "biome-profile")]
+pub use profile::store::UserProfileStore;
 
 #[cfg(all(feature = "biome-credentials", feature = "diesel"))]
 pub use refresh_tokens::store::diesel::DieselRefreshTokenStore;

--- a/libsplinter/src/biome/profile/mod.rs
+++ b/libsplinter/src/biome/profile/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Biome functionality to support user profiles.
+
+pub mod store;

--- a/libsplinter/src/biome/profile/store/diesel/mod.rs
+++ b/libsplinter/src/biome/profile/store/diesel/mod.rs
@@ -1,0 +1,351 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Database-backed implementation of the [UserProfileStore], powered by [diesel].
+
+pub(in crate::biome) mod models;
+mod operations;
+pub(in crate::biome) mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::{Profile, UserProfileStore, UserProfileStoreError};
+
+use models::ProfileModel;
+
+use operations::{
+    add_profile::UserProfileStoreAddProfile as _, get_profile::UserProfileStoreGetProfile as _,
+    list_profiles::UserProfileStorelistProfiles as _,
+    remove_profile::UserProfileStoreRemoveProfile as _,
+    update_profile::UserProfileStoreUpdateProfile as _, UserProfileStoreOperations,
+};
+
+/// Manages creating, updating, and fetching profiles from the database
+pub struct DieselUserProfileStore<C: diesel::Connection + 'static> {
+    connection_pool: Pool<ConnectionManager<C>>,
+}
+
+impl<C: diesel::Connection> DieselUserProfileStore<C> {
+    /// Creates a new DieselUserProfileStore
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool to the database
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselUserProfileStore { connection_pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl UserProfileStore for DieselUserProfileStore<diesel::pg::PgConnection> {
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).add_profile(profile)
+    }
+
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).update_profile(profile)
+    }
+
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).remove_profile(user_id)
+    }
+
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).get_profile(user_id)
+    }
+
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).list_profiles()
+    }
+
+    fn clone_box(&self) -> Box<dyn UserProfileStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl UserProfileStore for DieselUserProfileStore<diesel::sqlite::SqliteConnection> {
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).add_profile(profile)
+    }
+
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).update_profile(profile)
+    }
+
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).remove_profile(user_id)
+    }
+
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).get_profile(user_id)
+    }
+
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError> {
+        let connection = self.connection_pool.get()?;
+        UserProfileStoreOperations::new(&*connection).list_profiles()
+    }
+
+    fn clone_box(&self) -> Box<dyn UserProfileStore> {
+        Box::new(Self {
+            connection_pool: self.connection_pool.clone(),
+        })
+    }
+}
+
+impl From<ProfileModel> for Profile {
+    fn from(user_profile: ProfileModel) -> Self {
+        Self {
+            user_id: user_profile.user_id,
+            name: user_profile.name,
+            given_name: user_profile.given_name,
+            family_name: user_profile.family_name,
+            email: user_profile.email,
+            picture: user_profile.picture,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+pub mod tests {
+    use super::*;
+
+    use crate::biome::profile::store::ProfileBuilder;
+    use crate::migrations::run_sqlite_migrations;
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    /// Verify that a SQLite-backed `DieselUserProfileStore` correctly supports adding and getting profiles.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create the `DieselUserProfileStore`.
+    /// 3. Add a profile.
+    /// 4. Verify that the `get_profile` method returns correct values for all profile fields.
+    /// 5. Verify that the `get_profile` method returns an error when given an nonexistent user_id.
+    #[test]
+    fn sqlite_add_and_get_profile() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_profile_store = DieselUserProfileStore::new(pool);
+
+        let user_id = "user_id".to_string();
+        let name = Some("name".to_string());
+
+        let profile = ProfileBuilder::new()
+            .with_user_id(user_id.clone())
+            .with_name(name)
+            .with_given_name(None)
+            .with_family_name(None)
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build profile");
+        user_profile_store
+            .add_profile(profile)
+            .expect("Unable to add profile");
+
+        let profile = user_profile_store
+            .get_profile(&user_id.clone())
+            .expect("Unable to get profile");
+
+        assert_eq!(profile.user_id(), &user_id);
+        assert_eq!(profile.name(), Some("name"));
+        assert_eq!(profile.given_name(), None);
+        assert_eq!(profile.family_name(), None);
+        assert_eq!(profile.email(), None);
+        assert_eq!(profile.picture(), None);
+
+        assert!(user_profile_store.get_profile("InvalidID").is_err());
+    }
+
+    /// Verify that a SQLite-backed `DieselUserProfileStore` correctly supports listing profiles.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create the `DieselUserProfileStore`.
+    /// 3. Add a profile.
+    /// 4. Verify that the `list_profiles` method returns a vector containing the added profile.
+    /// 5. Verify that all values of the returned profile are correct.
+    #[test]
+    fn sqlite_list_profiles() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_profile_store = DieselUserProfileStore::new(pool);
+
+        let user_id = "user_id".to_string();
+        let name = Some("name".to_string());
+
+        let profile = ProfileBuilder::new()
+            .with_user_id(user_id.clone())
+            .with_name(name)
+            .with_given_name(None)
+            .with_family_name(None)
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build profile");
+        user_profile_store
+            .add_profile(profile)
+            .expect("Unable to add profile");
+
+        let profiles = user_profile_store
+            .list_profiles()
+            .expect("Unable to get profiles");
+        let profile = &profiles.unwrap()[0];
+
+        assert_eq!(profile.user_id(), "user_id");
+        assert_eq!(profile.name(), Some("name"));
+        assert!(profile.given_name().is_none());
+        assert!(profile.family_name().is_none());
+        assert!(profile.email().is_none());
+        assert!(profile.picture().is_none());
+    }
+
+    /// Verify that a SQLite-backed `DieselUserProfileStore` correctly supports updating profiles.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create the `DieselUserProfileStore`.
+    /// 3. Add a profile.
+    /// 4. Create an updated profile with the same `user_id` as the first.
+    /// 5. Call `update_profile` on the store with the updated profile as the argument.
+    /// 6. Verify that the `get_profile` method returns the profile with the updated fields.
+    /// 7. Create a profile with a different `user_id`.
+    /// 8. Call `update_profile` on the store with the new profile.
+    /// 9. Verify an error is returned because there is no profile in the store with the given `user_id`.
+    #[test]
+    fn sqlite_update_profile() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_profile_store = DieselUserProfileStore::new(pool);
+
+        let user_id = "user_id".to_string();
+        let name = Some("name".to_string());
+
+        let profile = ProfileBuilder::new()
+            .with_user_id(user_id.clone())
+            .with_name(name)
+            .with_given_name(None)
+            .with_family_name(None)
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build profile");
+        user_profile_store
+            .add_profile(profile)
+            .expect("Unable to add profile");
+
+        let updated_profile = ProfileBuilder::new()
+            .with_user_id(user_id.clone())
+            .with_name(Some("New Name".to_string()))
+            .with_given_name(Some("New".to_string()))
+            .with_family_name(Some("Name".to_string()))
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build updated profile");
+
+        user_profile_store
+            .update_profile(updated_profile)
+            .expect("Unable to update profile");
+
+        let updated_profile = user_profile_store
+            .get_profile(&user_id.clone())
+            .expect("Unable to get updated profile");
+
+        assert_eq!(updated_profile.user_id(), "user_id");
+        assert_eq!(updated_profile.name(), Some("New Name"));
+        assert_eq!(updated_profile.given_name(), Some("New"));
+        assert_eq!(updated_profile.family_name(), Some("Name"));
+        assert!(updated_profile.email().is_none());
+        assert!(updated_profile.picture().is_none());
+
+        let bad_profile = ProfileBuilder::new()
+            .with_user_id("bad_id".to_string())
+            .with_name(None)
+            .with_given_name(None)
+            .with_family_name(None)
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build profile");
+
+        assert!(user_profile_store.update_profile(bad_profile).is_err());
+    }
+
+    /// Verify that a SQLite-backed `DieselUserProfileStore` correctly supports removing profiles.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create the `DieselUserProfileStore`.
+    /// 3. Add a profile.
+    /// 4. Call `remove_profile` on the store.
+    /// 5. Verify that calling `get_profile` on the store with the `user_id` of the previously
+    ///    added profile returns an error.
+    #[test]
+    fn sqlite_remove_profile() {
+        let pool = create_connection_pool_and_migrate();
+
+        let user_profile_store = DieselUserProfileStore::new(pool);
+
+        let user_id = "user_id".to_string();
+        let name = Some("name".to_string());
+
+        let profile = ProfileBuilder::new()
+            .with_user_id(user_id.clone())
+            .with_name(name)
+            .with_given_name(None)
+            .with_family_name(None)
+            .with_email(None)
+            .with_picture(None)
+            .build()
+            .expect("Unable to build profile");
+        user_profile_store
+            .add_profile(profile)
+            .expect("Unable to add profile");
+
+        user_profile_store
+            .remove_profile(&user_id.clone())
+            .expect("Unable to remove profile");
+
+        assert!(user_profile_store.get_profile("user_id").is_err());
+    }
+
+    /// Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection insures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/models.rs
+++ b/libsplinter/src/biome/profile/store/diesel/models.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::schema::user_profile;
+
+#[derive(Queryable, Identifiable, Associations, PartialEq, Debug)]
+#[table_name = "user_profile"]
+pub struct ProfileModel {
+    pub id: i64,
+    pub user_id: String,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub email: Option<String>,
+    pub picture: Option<String>,
+}
+
+#[derive(Insertable, PartialEq, Debug)]
+#[table_name = "user_profile"]
+pub struct NewProfileModel {
+    pub user_id: String,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub email: Option<String>,
+    pub picture: Option<String>,
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/add_profile.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/add_profile.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UserProfileStoreOperations;
+
+use diesel::{dsl::insert_into, prelude::*, result::Error::NotFound};
+
+use crate::biome::profile::store::{
+    diesel::{
+        models::{NewProfileModel, ProfileModel},
+        schema::user_profile,
+    },
+    Profile, UserProfileStoreError,
+};
+
+use crate::error::{ConstraintViolationError, ConstraintViolationType, InternalError};
+
+pub trait UserProfileStoreAddProfile {
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> UserProfileStoreAddProfile
+    for UserProfileStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let duplicate_profile = user_profile::table
+            .filter(user_profile::user_id.eq(&profile.user_id))
+            .first::<ProfileModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?;
+
+        if duplicate_profile.is_some() {
+            return Err(UserProfileStoreError::ConstraintViolation(
+                ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+            ));
+        }
+
+        let new_profile: NewProfileModel = profile.into();
+
+        insert_into(user_profile::table)
+            .values(new_profile)
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|_| {
+                UserProfileStoreError::Internal(InternalError::with_message(
+                    "Failed to add credentials".to_string(),
+                ))
+            })?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> UserProfileStoreAddProfile for UserProfileStoreOperations<'a, diesel::pg::PgConnection> {
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let duplicate_profile = user_profile::table
+            .filter(user_profile::user_id.eq(&profile.user_id))
+            .first::<ProfileModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?;
+
+        if duplicate_profile.is_some() {
+            return Err(UserProfileStoreError::ConstraintViolation(
+                ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+            ));
+        }
+
+        let new_profile: NewProfileModel = profile.into();
+
+        insert_into(user_profile::table)
+            .values(new_profile)
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|_| {
+                UserProfileStoreError::Internal(InternalError::with_message(
+                    "Failed to add credentials".to_string(),
+                ))
+            })?;
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/get_profile.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/get_profile.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UserProfileStoreOperations;
+
+use diesel::{prelude::*, result::Error::NotFound};
+
+use crate::biome::profile::store::{
+    diesel::{models::ProfileModel, schema::user_profile},
+    Profile, UserProfileStoreError,
+};
+use crate::error::{InternalError, InvalidArgumentError};
+
+pub trait UserProfileStoreGetProfile {
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError>;
+}
+
+impl<'a, C> UserProfileStoreGetProfile for UserProfileStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError> {
+        let profile = user_profile::table
+            .filter(user_profile::user_id.eq(user_id))
+            .first::<ProfileModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?
+            .ok_or_else(|| {
+                UserProfileStoreError::InvalidArgument(InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ))
+            })?;
+        Ok(Profile::from(profile))
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/list_profiles.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/list_profiles.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UserProfileStoreOperations;
+
+use diesel::prelude::*;
+
+use crate::biome::profile::store::{
+    diesel::{models::ProfileModel, schema::user_profile},
+    Profile, UserProfileStoreError,
+};
+use crate::error::{InternalError, InvalidArgumentError};
+
+pub trait UserProfileStorelistProfiles {
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError>;
+}
+
+impl<'a, C> UserProfileStorelistProfiles for UserProfileStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError> {
+        let profiles = user_profile::table
+            .select(user_profile::all_columns)
+            .load::<ProfileModel>(self.conn)
+            .map(Some)
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed to get profiles {}",
+                    err
+                )))
+            })?
+            .ok_or_else(|| {
+                UserProfileStoreError::InvalidArgument(InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ))
+            })?
+            .into_iter()
+            .map(Profile::from)
+            .collect();
+        Ok(Some(profiles))
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/mod.rs
@@ -1,0 +1,34 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides [UserProfileStore] operations implemented for a diesel backend
+
+pub(super) mod add_profile;
+pub(super) mod get_profile;
+pub(super) mod list_profiles;
+pub(super) mod remove_profile;
+pub(super) mod update_profile;
+
+pub(super) struct UserProfileStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C> UserProfileStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    pub fn new(conn: &'a C) -> Self {
+        UserProfileStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/remove_profile.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/remove_profile.rs
@@ -1,0 +1,68 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UserProfileStoreOperations;
+
+use diesel::{dsl::delete, prelude::*, result::Error::NotFound};
+
+use crate::biome::profile::store::{
+    diesel::{models::ProfileModel, schema::user_profile},
+    UserProfileStoreError,
+};
+
+use crate::error::{InternalError, InvalidArgumentError};
+
+pub trait UserProfileStoreRemoveProfile {
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError>;
+}
+
+impl<'a, C> UserProfileStoreRemoveProfile for UserProfileStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError> {
+        let profile = user_profile::table
+            .filter(user_profile::user_id.eq(user_id))
+            .first::<ProfileModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?;
+        if profile.is_none() {
+            return Err(UserProfileStoreError::InvalidArgument(
+                InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ),
+            ));
+        }
+
+        delete(user_profile::table.filter(user_profile::user_id.eq(user_id)))
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?;
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/operations/update_profile.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/update_profile.rs
@@ -1,0 +1,75 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::UserProfileStoreOperations;
+
+use diesel::{dsl::update, prelude::*, result::Error::NotFound};
+
+use crate::biome::profile::store::{
+    diesel::{models::ProfileModel, schema::user_profile},
+    Profile, UserProfileStoreError,
+};
+
+use crate::error::{InternalError, InvalidArgumentError};
+
+pub trait UserProfileStoreUpdateProfile {
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError>;
+}
+
+impl<'a, C> UserProfileStoreUpdateProfile for UserProfileStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let profile_exists = user_profile::table
+            .filter(user_profile::user_id.eq(&profile.user_id))
+            .first::<ProfileModel>(self.conn)
+            .map(Some)
+            .or_else(|err| if err == NotFound { Ok(None) } else { Err(err) })
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed check for existing user_id {}",
+                    err
+                )))
+            })?;
+        if profile_exists.is_none() {
+            return Err(UserProfileStoreError::InvalidArgument(
+                InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ),
+            ));
+        }
+        update(user_profile::table.filter(user_profile::user_id.eq(&profile.user_id)))
+            .set((
+                user_profile::user_id.eq(&profile.user_id),
+                user_profile::name.eq(&profile.name),
+                user_profile::given_name.eq(&profile.given_name),
+                user_profile::family_name.eq(&profile.family_name),
+                user_profile::email.eq(&profile.email),
+                user_profile::picture.eq(&profile.picture),
+            ))
+            .execute(self.conn)
+            .map(|_| ())
+            .map_err(|err| {
+                UserProfileStoreError::Internal(InternalError::with_message(format!(
+                    "Failed to update profile {}",
+                    err
+                )))
+            })?;
+        Ok(())
+    }
+}

--- a/libsplinter/src/biome/profile/store/diesel/schema.rs
+++ b/libsplinter/src/biome/profile/store/diesel/schema.rs
@@ -1,0 +1,25 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+table! {
+    user_profile {
+        id -> Int8,
+        user_id -> Text,
+        name -> Nullable<Text>,
+        given_name -> Nullable<Text>,
+        family_name -> Nullable<Text>,
+        email -> Nullable<Text>,
+        picture -> Nullable<Text>,
+    }
+}

--- a/libsplinter/src/biome/profile/store/error.rs
+++ b/libsplinter/src/biome/profile/store/error.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+use crate::error::ConstraintViolationType;
+use crate::error::{
+    ConstraintViolationError, InternalError, InvalidArgumentError, InvalidStateError,
+};
+
+/// Errors that may occur during [UserProfileStoreError] operations.
+#[derive(Debug)]
+pub enum UserProfileStoreError {
+    ConstraintViolation(ConstraintViolationError),
+    Internal(InternalError),
+    InvalidArgument(InvalidArgumentError),
+    InvalidState(InvalidStateError),
+}
+
+impl Error for UserProfileStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            UserProfileStoreError::ConstraintViolation(err) => err.source(),
+            UserProfileStoreError::Internal(err) => err.source(),
+            UserProfileStoreError::InvalidArgument(err) => err.source(),
+            UserProfileStoreError::InvalidState(err) => err.source(),
+        }
+    }
+}
+
+impl fmt::Display for UserProfileStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UserProfileStoreError::ConstraintViolation(err) => f.write_str(&err.to_string()),
+            UserProfileStoreError::Internal(err) => f.write_str(&err.to_string()),
+            UserProfileStoreError::InvalidArgument(err) => f.write_str(&err.to_string()),
+            UserProfileStoreError::InvalidState(err) => f.write_str(&err.to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for UserProfileStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> UserProfileStoreError {
+        UserProfileStoreError::Internal(InternalError::from_source(Box::new(err)))
+    }
+}
+
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+impl From<diesel::result::Error> for UserProfileStoreError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::DatabaseError(ref kind, _) => match kind {
+                diesel::result::DatabaseErrorKind::UniqueViolation => {
+                    UserProfileStoreError::ConstraintViolation(
+                        ConstraintViolationError::from_source_with_violation_type(
+                            ConstraintViolationType::Unique,
+                            Box::new(err),
+                        ),
+                    )
+                }
+                diesel::result::DatabaseErrorKind::ForeignKeyViolation => {
+                    UserProfileStoreError::ConstraintViolation(
+                        ConstraintViolationError::from_source_with_violation_type(
+                            ConstraintViolationType::ForeignKey,
+                            Box::new(err),
+                        ),
+                    )
+                }
+                _ => UserProfileStoreError::Internal(InternalError::from_source(Box::new(err))),
+            },
+            _ => UserProfileStoreError::Internal(InternalError::from_source(Box::new(err))),
+        }
+    }
+}

--- a/libsplinter/src/biome/profile/store/memory.rs
+++ b/libsplinter/src/biome/profile/store/memory.rs
@@ -1,0 +1,127 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A memory-backed implementation of the [UserProfileStore]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::error::{InternalError, InvalidArgumentError, InvalidStateError};
+
+use super::{error::UserProfileStoreError, Profile, ProfileBuilder, UserProfileStore};
+
+#[derive(Default, Clone)]
+pub struct MemoryUserProfileStore {
+    inner: Arc<Mutex<HashMap<String, Profile>>>,
+}
+
+impl MemoryUserProfileStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl UserProfileStore for MemoryUserProfileStore {
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            UserProfileStoreError::Internal(InternalError::with_message(
+                "Cannot access user profile store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+
+        inner.insert(profile.user_id.clone(), profile);
+        Ok(())
+    }
+
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            UserProfileStoreError::Internal(InternalError::with_message(
+                "Cannot access user profile store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        if inner.contains_key(&profile.user_id) {
+            let new_profile = ProfileBuilder::default()
+                .with_user_id(profile.user_id.clone())
+                .with_name(profile.name)
+                .with_given_name(profile.given_name)
+                .with_family_name(profile.family_name)
+                .with_email(profile.email)
+                .build()
+                .map_err(|_| {
+                    UserProfileStoreError::Internal(InternalError::with_message(
+                        "Failed to build profile with updated details".to_string(),
+                    ))
+                })?;
+            inner.insert(profile.user_id, new_profile);
+            Ok(())
+        } else {
+            Err(UserProfileStoreError::InvalidArgument(
+                InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ),
+            ))
+        }
+    }
+
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            UserProfileStoreError::Internal(InternalError::with_message(
+                "Cannot access user profile store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        if inner.remove(user_id).is_some() {
+            Ok(())
+        } else {
+            Err(UserProfileStoreError::InvalidState(
+                InvalidStateError::with_message(
+                    "A profile with the given user id does not exist".to_string(),
+                ),
+            ))
+        }
+    }
+
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError> {
+        let inner = self.inner.lock().map_err(|_| {
+            UserProfileStoreError::Internal(InternalError::with_message(
+                "Cannot access user profile store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        if let Some(profile) = inner.get(user_id) {
+            Ok(profile.clone())
+        } else {
+            Err(UserProfileStoreError::InvalidArgument(
+                InvalidArgumentError::new(
+                    "user_id".to_string(),
+                    "A profile for the given user_id does not exist".to_string(),
+                ),
+            ))
+        }
+    }
+
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError> {
+        let inner = self.inner.lock().map_err(|_| {
+            UserProfileStoreError::Internal(InternalError::with_message(
+                "Cannot access user profile store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+        Ok(Some(
+            inner.iter().map(|(_, profile)| profile.clone()).collect(),
+        ))
+    }
+
+    fn clone_box(&self) -> Box<dyn UserProfileStore> {
+        Box::new(self.clone())
+    }
+}

--- a/libsplinter/src/biome/profile/store/mod.rs
+++ b/libsplinter/src/biome/profile/store/mod.rs
@@ -1,0 +1,253 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(in crate::biome) mod diesel;
+pub mod error;
+pub(in crate::biome) mod memory;
+
+use crate::error::InvalidStateError;
+
+use serde::{Deserialize, Serialize};
+
+pub use error::UserProfileStoreError;
+
+#[cfg(feature = "diesel")]
+use self::diesel::models::NewProfileModel;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Profile {
+    user_id: String,
+    name: Option<String>,
+    given_name: Option<String>,
+    family_name: Option<String>,
+    email: Option<String>,
+    picture: Option<String>,
+}
+
+impl Profile {
+    /// Returns the user_id for the profile
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
+    /// Returns the name for the profile
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Returns the given name for the profile
+    pub fn given_name(&self) -> Option<&str> {
+        self.given_name.as_deref()
+    }
+
+    /// Returns the family name for the profile
+    pub fn family_name(&self) -> Option<&str> {
+        self.family_name.as_deref()
+    }
+
+    /// Returns the email for the profile
+    pub fn email(&self) -> Option<&str> {
+        self.email.as_deref()
+    }
+
+    /// Returns the picture for the profile
+    pub fn picture(&self) -> Option<&str> {
+        self.picture.as_deref()
+    }
+}
+
+/// Builder for profile.
+#[derive(Default)]
+pub struct ProfileBuilder {
+    user_id: Option<String>,
+    name: Option<String>,
+    given_name: Option<String>,
+    family_name: Option<String>,
+    email: Option<String>,
+    picture: Option<String>,
+}
+
+impl ProfileBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the user id for the profile
+    pub fn with_user_id(mut self, user_id: String) -> ProfileBuilder {
+        self.user_id = Some(user_id);
+        self
+    }
+
+    /// Sets the name for the profile
+    pub fn with_name(mut self, name: Option<String>) -> ProfileBuilder {
+        self.name = name;
+        self
+    }
+
+    /// Sets the given name for the profile
+    pub fn with_given_name(mut self, given_name: Option<String>) -> ProfileBuilder {
+        self.given_name = given_name;
+        self
+    }
+
+    /// Sets the family name for the profile
+    pub fn with_family_name(mut self, family_name: Option<String>) -> ProfileBuilder {
+        self.family_name = family_name;
+        self
+    }
+
+    /// Sets the email for the profile
+    pub fn with_email(mut self, email: Option<String>) -> ProfileBuilder {
+        self.email = email;
+        self
+    }
+
+    /// Sets the picture for the profile
+    pub fn with_picture(mut self, picture: Option<String>) -> ProfileBuilder {
+        self.picture = picture;
+        self
+    }
+
+    /// Builds the profile
+    pub fn build(self) -> Result<Profile, InvalidStateError> {
+        Ok(Profile {
+            user_id: self.user_id.ok_or_else(|| {
+                InvalidStateError::with_message("A user id is required to build a Profile".into())
+            })?,
+            name: self.name,
+            given_name: self.given_name,
+            family_name: self.family_name,
+            email: self.email,
+            picture: self.picture,
+        })
+    }
+}
+
+/// Defines methods for CRUD operations and fetching a user’s
+/// profile without defining a storage strategy
+pub trait UserProfileStore: Sync + Send {
+    /// Adds a profile to the underlying storage
+    ///
+    /// # Arguments
+    ///
+    ///  * `profile` - The profile to be added
+    ///
+    /// # Errors
+    ///
+    /// Returns a UserProfileStoreError if the implementation cannot add a new
+    /// profile.
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError>;
+
+    /// Replaces a profile for a user in the underlying storage with a new profile.
+    ///
+    /// #Arguments
+    ///
+    ///  * `user_id` - The unique identifier of the user the profile belongs to
+    ///  * `name` - The updated name for the user profile
+    ///  * `given_name` - The updated given name for the user profile
+    ///  * `family_name` - The updated family name for the user profile
+    ///  * `email` - The updated email for the user profile
+    ///  * `picture` - The updated picture for the user profile
+    ///
+    /// # Errors
+    ///
+    /// Returns a UserProfileStoreError if the implementation cannot update profile
+    /// or if the specified profile does not exist.
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError>;
+
+    /// Removes a profile from the underlying storage.
+    ///
+    /// # Arguments
+    ///
+    ///  * `user_id`: The unique identifier of the user the profile belongs to
+    ///
+    /// # Errors
+    ///
+    /// Returns a UserProfileStoreError if the implementation cannot remove the
+    /// profile or if a profile with the specified `user_id` does not exist.
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError>;
+
+    /// Fetches a profile from the underlying storage.
+    ///
+    /// # Arguments
+    ///
+    ///  * `user_id` - The unique identifier of the user the profile belongs to
+    ///
+    /// # Errors
+    ///
+    /// Returns a UserProfileStoreError if the implementation cannot retrieve the
+    /// profile or if a profile with the specified `user_id` does not exist.
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError>;
+
+    /// List all profiles from the underlying storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a UserProfileStoreError if implementation cannot fetch the stored
+    /// profiles.
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError>;
+
+    /// Clone into a boxed, dynamically dispatched store
+    fn clone_box(&self) -> Box<dyn UserProfileStore>;
+}
+
+impl Clone for Box<dyn UserProfileStore> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+impl<PS> UserProfileStore for Box<PS>
+where
+    PS: UserProfileStore + ?Sized,
+{
+    fn add_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        (**self).add_profile(profile)
+    }
+
+    fn update_profile(&self, profile: Profile) -> Result<(), UserProfileStoreError> {
+        (**self).update_profile(profile)
+    }
+
+    fn remove_profile(&self, user_id: &str) -> Result<(), UserProfileStoreError> {
+        (**self).remove_profile(user_id)
+    }
+
+    fn get_profile(&self, user_id: &str) -> Result<Profile, UserProfileStoreError> {
+        (**self).get_profile(user_id)
+    }
+
+    fn list_profiles(&self) -> Result<Option<Vec<Profile>>, UserProfileStoreError> {
+        (**self).list_profiles()
+    }
+
+    fn clone_box(&self) -> Box<dyn UserProfileStore> {
+        (**self).clone_box()
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl Into<NewProfileModel> for Profile {
+    fn into(self) -> NewProfileModel {
+        NewProfileModel {
+            user_id: self.user_id,
+            name: self.name,
+            given_name: self.given_name,
+            family_name: self.family_name,
+            email: self.email,
+            picture: self.picture,
+        }
+    }
+}

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -66,7 +66,8 @@ mod base62;
     feature = "biome-credentials",
     feature = "biome-key-management",
     feature = "biome-notifications",
-    feature = "biome-oauth"
+    feature = "biome-oauth",
+    feature = "biome-profile"
 ))]
 pub mod biome;
 pub mod channel;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE user_profile;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/up.sql
@@ -1,0 +1,24 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_profile (
+  id           BIGSERIAL    PRIMARY KEY,
+  user_id      TEXT,
+  name         TEXT,
+  given_name   TEXT,
+  family_name  TEXT,
+  email        TEXT,
+  picture      TEXT
+);

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE user_profile;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/up.sql
@@ -1,0 +1,24 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_profile (
+  id           INTEGER    PRIMARY KEY AUTOINCREMENT,
+  user_id      TEXT       NOT NULL,
+  name         TEXT,
+  given_name   TEXT,
+  family_name  TEXT,
+  email        TEXT,
+  picture      TEXT
+);

--- a/libsplinter/src/store/memory.rs
+++ b/libsplinter/src/store/memory.rs
@@ -28,6 +28,8 @@ use crate::biome::{
 };
 #[cfg(feature = "biome-key-management")]
 use crate::biome::{KeyStore, MemoryKeyStore};
+#[cfg(feature = "biome-profile")]
+use crate::biome::{MemoryUserProfileStore, UserProfileStore};
 #[cfg(feature = "oauth")]
 use crate::oauth::store::MemoryInflightOAuthRequestStore;
 
@@ -46,6 +48,8 @@ pub struct MemoryStoreFactory {
     biome_oauth_user_session_store: MemoryOAuthUserSessionStore,
     #[cfg(feature = "oauth")]
     inflight_request_store: MemoryInflightOAuthRequestStore,
+    #[cfg(feature = "biome-profile")]
+    biome_profile_store: MemoryUserProfileStore,
 }
 
 impl MemoryStoreFactory {
@@ -64,6 +68,9 @@ impl MemoryStoreFactory {
         #[cfg(feature = "oauth")]
         let inflight_request_store = MemoryInflightOAuthRequestStore::new();
 
+        #[cfg(feature = "biome-profile")]
+        let biome_profile_store = MemoryUserProfileStore::new();
+
         Self {
             #[cfg(feature = "biome-credentials")]
             biome_credentials_store,
@@ -75,6 +82,8 @@ impl MemoryStoreFactory {
             biome_oauth_user_session_store,
             #[cfg(feature = "oauth")]
             inflight_request_store,
+            #[cfg(feature = "biome-profile")]
+            biome_profile_store,
         }
     }
 }
@@ -174,5 +183,10 @@ impl StoreFactory for MemoryStoreFactory {
         &self,
     ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
         unimplemented!()
+    }
+
+    #[cfg(feature = "biome-profile")]
+    fn get_biome_user_profile_store(&self) -> Box<dyn UserProfileStore> {
+        Box::new(self.biome_profile_store.clone())
     }
 }

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -63,6 +63,9 @@ pub trait StoreFactory {
     fn get_role_based_authorization_store(
         &self,
     ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore>;
+
+    #[cfg(feature = "biome-profile")]
+    fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -115,4 +115,9 @@ impl StoreFactory for PgStoreFactory {
     ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
         unimplemented!()
     }
+
+    #[cfg(feature = "biome-profile")]
+    fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore> {
+        Box::new(crate::biome::DieselUserProfileStore::new(self.pool.clone()))
+    }
 }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -90,6 +90,11 @@ impl StoreFactory for SqliteStoreFactory {
             ),
         )
     }
+
+    #[cfg(feature = "biome-profile")]
+    fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore> {
+        Box::new(crate::biome::DieselUserProfileStore::new(self.pool.clone()))
+    }
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
Create a 'UserProfileStore' trait with methods for adding, removing, fetching, updating, and listing profiles. Implement 'UserProfileStore' for memory, postgres, and sqlite backends.

Add UserProfileStore database migration folders for SQLite and PostgreSQL backends.