### PR TITLE
Add authorization handlers to REST API auth

### DIFF
--- a/libsplinter/src/rest_api/actix_web_1/builder.rs
+++ b/libsplinter/src/rest_api/actix_web_1/builder.rs
@@ -29,6 +29,8 @@ use crate::rest_api::auth::identity::cylinder::CylinderKeyIdentityProvider;
 use crate::rest_api::auth::identity::oauth::OAuthUserIdentityProvider;
 #[cfg(feature = "auth")]
 use crate::rest_api::auth::identity::IdentityProvider;
+#[cfg(feature = "authorization")]
+use crate::rest_api::auth::AuthorizationHandler;
 #[cfg(feature = "oauth")]
 use crate::rest_api::{OAuthConfig, OAuthResourceProvider};
 use crate::rest_api::{RestApiBind, RestApiServerError};
@@ -47,6 +49,8 @@ pub struct RestApiBuilder {
     whitelist: Option<Vec<String>>,
     #[cfg(feature = "auth")]
     auth_configs: Vec<AuthConfig>,
+    #[cfg(feature = "authorization")]
+    authorization_handlers: Vec<Box<dyn AuthorizationHandler>>,
 }
 
 impl Default for RestApiBuilder {
@@ -58,6 +62,8 @@ impl Default for RestApiBuilder {
             whitelist: None,
             #[cfg(feature = "auth")]
             auth_configs: Vec::new(),
+            #[cfg(feature = "authorization")]
+            authorization_handlers: Vec::new(),
         }
     }
 }
@@ -98,6 +104,15 @@ impl RestApiBuilder {
     #[cfg(feature = "auth")]
     pub fn with_auth_configs(mut self, auth_configs: Vec<AuthConfig>) -> Self {
         self.auth_configs = auth_configs;
+        self
+    }
+
+    #[cfg(feature = "authorization")]
+    pub fn with_authorization_handlers(
+        mut self,
+        authorization_handlers: Vec<Box<dyn AuthorizationHandler>>,
+    ) -> Self {
+        self.authorization_handlers = authorization_handlers;
         self
     }
 
@@ -238,6 +253,8 @@ impl RestApiBuilder {
             whitelist: self.whitelist,
             #[cfg(feature = "auth")]
             identity_providers,
+            #[cfg(feature = "authorization")]
+            authorization_handlers: self.authorization_handlers,
         })
     }
 
@@ -261,6 +278,8 @@ impl RestApiBuilder {
             whitelist: self.whitelist,
             #[cfg(feature = "auth")]
             identity_providers: vec![],
+            #[cfg(feature = "authorization")]
+            authorization_handlers: vec![],
         })
     }
 }

--- a/services/scabbard/libscabbard/src/client/mod.rs
+++ b/services/scabbard/libscabbard/src/client/mod.rs
@@ -548,7 +548,7 @@ mod tests {
     use splinter::rest_api::{
         auth::{
             identity::{Identity, IdentityProvider},
-            AuthorizationHeader, Permission,
+            AuthorizationHandler, AuthorizationHandlerResult, AuthorizationHeader, Permission,
         },
         AuthConfig,
     };
@@ -1221,11 +1221,12 @@ mod tests {
                     .with_bind(&bind_url)
                     .add_resources(resources.clone());
                 #[cfg(feature = "authorization")]
-                let rest_api_builder =
-                    rest_api_builder.with_auth_configs(vec![AuthConfig::Custom {
+                let rest_api_builder = rest_api_builder
+                    .with_auth_configs(vec![AuthConfig::Custom {
                         resources: vec![],
                         identity_provider: Box::new(AlwaysAcceptIdentityProvider),
-                    }]);
+                    }])
+                    .with_authorization_handlers(vec![Box::new(AlwaysAllowAuthorizationHandler)]);
                 let result = rest_api_builder
                     .build()
                     .expect("Failed to build REST API")
@@ -1256,6 +1257,26 @@ mod tests {
         }
 
         fn clone_box(&self) -> Box<dyn IdentityProvider> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// An authorization handler that always returns `Ok(AuthorizationHandlerResult::Allow)`
+    #[cfg(feature = "authorization")]
+    #[derive(Clone)]
+    struct AlwaysAllowAuthorizationHandler;
+
+    #[cfg(feature = "authorization")]
+    impl AuthorizationHandler for AlwaysAllowAuthorizationHandler {
+        fn has_permission(
+            &self,
+            _identity: &Identity,
+            _permission_id: &str,
+        ) -> Result<AuthorizationHandlerResult, InternalError> {
+            Ok(AuthorizationHandlerResult::Allow)
+        }
+
+        fn clone_box(&self) -> Box<dyn AuthorizationHandler> {
             Box::new(self.clone())
         }
     }

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -120,7 +120,7 @@ mod tests {
     use splinter::rest_api::{
         auth::{
             identity::{Identity, IdentityProvider},
-            AuthorizationHeader,
+            AuthorizationHandler, AuthorizationHandlerResult, AuthorizationHeader,
         },
         AuthConfig,
     };
@@ -397,11 +397,12 @@ mod tests {
                     .with_bind(&bind_url)
                     .add_resources(resources.clone());
                 #[cfg(feature = "authorization")]
-                let rest_api_builder =
-                    rest_api_builder.with_auth_configs(vec![AuthConfig::Custom {
+                let rest_api_builder = rest_api_builder
+                    .with_auth_configs(vec![AuthConfig::Custom {
                         resources: vec![],
                         identity_provider: Box::new(AlwaysAcceptIdentityProvider),
-                    }]);
+                    }])
+                    .with_authorization_handlers(vec![Box::new(AlwaysAllowAuthorizationHandler)]);
                 let result = rest_api_builder
                     .build()
                     .expect("Failed to build REST API")
@@ -432,6 +433,26 @@ mod tests {
         }
 
         fn clone_box(&self) -> Box<dyn IdentityProvider> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// An authorization handler that always returns `Ok(AuthorizationHandlerResult::Allow)`
+    #[cfg(feature = "authorization")]
+    #[derive(Clone)]
+    struct AlwaysAllowAuthorizationHandler;
+
+    #[cfg(feature = "authorization")]
+    impl AuthorizationHandler for AlwaysAllowAuthorizationHandler {
+        fn has_permission(
+            &self,
+            _identity: &Identity,
+            _permission_id: &str,
+        ) -> Result<AuthorizationHandlerResult, InternalError> {
+            Ok(AuthorizationHandlerResult::Allow)
+        }
+
+        fn clone_box(&self) -> Box<dyn AuthorizationHandler> {
             Box::new(self.clone())
         }
     }

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -95,7 +95,7 @@ mod tests {
     use splinter::rest_api::{
         auth::{
             identity::{Identity, IdentityProvider},
-            AuthorizationHeader,
+            AuthorizationHandler, AuthorizationHandlerResult, AuthorizationHeader,
         },
         AuthConfig,
     };
@@ -288,11 +288,12 @@ mod tests {
                     .with_bind(&bind_url)
                     .add_resources(resources.clone());
                 #[cfg(feature = "authorization")]
-                let rest_api_builder =
-                    rest_api_builder.with_auth_configs(vec![AuthConfig::Custom {
+                let rest_api_builder = rest_api_builder
+                    .with_auth_configs(vec![AuthConfig::Custom {
                         resources: vec![],
                         identity_provider: Box::new(AlwaysAcceptIdentityProvider),
-                    }]);
+                    }])
+                    .with_authorization_handlers(vec![Box::new(AlwaysAllowAuthorizationHandler)]);
                 let result = rest_api_builder
                     .build()
                     .expect("Failed to build REST API")
@@ -323,6 +324,26 @@ mod tests {
         }
 
         fn clone_box(&self) -> Box<dyn IdentityProvider> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// An authorization handler that always returns `Ok(AuthorizationHandlerResult::Allow)`
+    #[cfg(feature = "authorization")]
+    #[derive(Clone)]
+    struct AlwaysAllowAuthorizationHandler;
+
+    #[cfg(feature = "authorization")]
+    impl AuthorizationHandler for AlwaysAllowAuthorizationHandler {
+        fn has_permission(
+            &self,
+            _identity: &Identity,
+            _permission_id: &str,
+        ) -> Result<AuthorizationHandlerResult, InternalError> {
+            Ok(AuthorizationHandlerResult::Allow)
+        }
+
+        fn clone_box(&self) -> Box<dyn AuthorizationHandler> {
             Box::new(self.clone())
         }
     }


### PR DESCRIPTION
Adds the `AuthorizationHandler` trait for determining which clients have
which permissions. Also updates the REST API's authorization layer to
use a configured list of authorization handlers to check permissions.

Signed-off-by: Logan Seeley <seeley@bitwise.io>