### PR TITLE
Fix Postgres Biome OAuth session store trigger

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-12-155512_biome_oauth_trigger_fix/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-12-155512_biome_oauth_trigger_fix/down.sql
@@ -1,0 +1,33 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Drop the updated trigger and function
+DROP TRIGGER IF EXISTS oauth_user_sessions_timestamp_update
+  ON oauth_user_sessions;
+
+DROP FUNCTION IF EXISTS update_oauth_user_session_timestamp();
+
+-- Recreate the old function and trigger
+CREATE FUNCTION update_oauth_user_session_timestamp() RETURNS trigger AS $$
+    BEGIN
+      UPDATE oauth_user_sessions
+      SET last_authenticated = extract(epoch from now())
+      WHERE splinter_access_token = OLD.splinter_access_token;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER oauth_user_sessions_timestamp_update
+  AFTER UPDATE ON oauth_user_sessions
+  FOR EACH ROW EXECUTE PROCEDURE update_oauth_user_session_timestamp();

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-12-155512_biome_oauth_trigger_fix/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-12-155512_biome_oauth_trigger_fix/up.sql
@@ -1,0 +1,34 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Drop the old trigger and function
+DROP TRIGGER IF EXISTS oauth_user_sessions_timestamp_update
+  ON oauth_user_sessions;
+
+DROP FUNCTION IF EXISTS update_oauth_user_session_timestamp();
+
+-- Create the updated function and trigger
+CREATE FUNCTION update_oauth_user_session_timestamp() RETURNS TRIGGER AS $$
+    BEGIN
+      UPDATE oauth_user_sessions
+      SET last_authenticated = extract(epoch from now())
+      WHERE splinter_access_token = OLD.splinter_access_token;
+      RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER oauth_user_sessions_timestamp_update
+  AFTER UPDATE OF oauth_access_token ON oauth_user_sessions
+  FOR EACH ROW EXECUTE PROCEDURE update_oauth_user_session_timestamp();


### PR DESCRIPTION
Adds a new PostgreSQL migration for the Biome OAuth user session store
that fixes two bugs in the trigger that updates the "last authenticated"
timestamp:

* The function executed by the trigger needs to `RETURN NULL;` to
  execute correctly
* The trigger should only be executed when the `oauth_access_token`
  column is updated to prevent recursive calls that would occur when the
  trigger itself updates the timestamp column

Signed-off-by: Logan Seeley <seeley@bitwise.io>

### Testing

1. Start a postgres instance, run migrations, and run splinterd with your OAuth provider details (this example uses Google, but Azure can be used as well):

```bash
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
$ cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- \
  --database postgres://postgres:mypassword@localhost:5432/splinter \
  --oauth-provider google \
  --oauth-client-id <CLIENT-ID> \
  --oauth-client-secret <CLIENT-SECRET> \
  --oauth-redirect-url http://localhost:8080/oauth/callback \
  --rest-api-endpoint http://localhost:8080 --tls-insecure -vv
```

2. In a browser window, navigate to `http://localhost:8080/oauth/login?redirect_url=redirect` and login (you will be redirected back to localhost and get a 404 but that doesn't matter)

3. In a new terminal session, login to the postgres container and check the `oauth_user_sessions` table entry:

```bash
$ docker run -it --rm --link postgres:postgres postgres psql -h postgres -U postgres
Password for user postgres: # password is 'mypassword'
psql (13.0 (Debian 13.0-1.pgdg100+1))
Type "help" for help.

postgres=# \c splinter
You are now connected to database "splinter" as user "postgres".
splinter=# SELECT * FROM oauth_user_sessions;
      splinter_access_token       |        subject        |
                    oauth_access_token                                                                                 |
                                           oauth_refresh_token                                           | last_authenti
cated
----------------------------------+-----------------------+-------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------------------+
---------------------------------------------------------------------------------------------------------+--------------
------
 0tnsm4Vd6Dtq1XraS7arq86dPt8xTyvY | 116381315131550692628 | ya29.a0AfH6SMBMXr6UgFS7woffu583Oqe_G_ZpgN7uj0XD4R5LfdwBTD6l6
QUy0HmSE-oELwof1bJtQQyqkM3_TElnyjg5HYDQ1fsg5y683_5WFv6BJrU_ImraYC78VjydHp1Pke5ITvkaisoAtgXCCBpViA6BErajzwrqzgM4fQTotaA |
 1//04OEdtUZKWh1kCgYIARAAGAQSNwF-L9IrrcOOE4crBglcqgIA38TFfO_muwCbKkwtqiMYKNsHj5cZoNJQFREY32TWEqmKBRjlGlw |         16104
68678
```

4. Set the timestamp for the session to 0 to simulate an expired token (over an hour old):

```bash
splinter=# UPDATE oauth_user_sessions SET last_authenticated = 0 WHERE splinter_access_token = '<SPLINTER-ACCESS-TOKEN>';
UPDATE 1
```

5. In a new terminal window, use the session's access token to make a request to the REST API and trigger the refresh token exchange:

```bash
$ curl -H "Authorization: Bearer OAuth2:<SPLINTER-ACCESS-TOKEN>" http://localhost:8080/status
{"node_id":"n22099","display_name":"Node n22099","service_endpoint":"tcp://127.0.0.1:8043","network_endpoints":["tcps://127.0.0.1:8044"],"advertised_endpoints":["tcps://127.0.0.1:8044"],"version":"0.5.1"}
```

6. In the postgres container, verify that the session's timestamp has been updated:

```bash
splinter=# SELECT * FROM oauth_user_sessions;
      splinter_access_token       |        subject        |
                    oauth_access_token                                                                                 |
                                           oauth_refresh_token                                           | last_authenti
cated
----------------------------------+-----------------------+-------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------------------+
---------------------------------------------------------------------------------------------------------+--------------
------
 0tnsm4Vd6Dtq1XraS7arq86dPt8xTyvY | 116381315131550692628 | ya29.a0AfH6SMBMXr6UgFS7woffu583Oqe_G_ZpgN7uj0XD4R5LfdwBTD6l6
QUy0HmSE-oELwof1bJtQQyqkM3_TElnyjg5HYDQ1fsg5y683_5WFv6BJrU_ImraYC78VjydHp1Pke5ITvkaisoAtgXCCBpViA6BErajzwrqzgM4fQTotaA |
 1//04OEdtUZKWh1kCgYIARAAGAQSNwF-L9IrrcOOE4crBglcqgIA38TFfO_muwCbKkwtqiMYKNsHj5cZoNJQFREY32TWEqmKBRjlGlw |         16104
68752
```