### PR TITLE
Add profile provider and biome/profile REST API endpoints

### DIFF
--- a/libsplinter/src/biome/rest_api/actix/mod.rs
+++ b/libsplinter/src/biome/rest_api/actix/mod.rs
@@ -20,6 +20,12 @@ pub(super) mod key_management;
 pub(super) mod login;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod logout;
+#[cfg(feature = "biome-profile")]
+pub(super) mod profile;
+#[cfg(feature = "biome-profile")]
+pub(super) mod profiles;
+#[cfg(feature = "biome-profile")]
+pub(super) mod profiles_identity;
 #[cfg(feature = "biome-credentials")]
 pub(super) mod register;
 #[cfg(feature = "biome-credentials")]

--- a/libsplinter/src/biome/rest_api/actix/profile.rs
+++ b/libsplinter/src/biome/rest_api/actix/profile.rs
@@ -1,0 +1,72 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use super::authorize::get_authorized_user;
+use crate::actix_web::HttpResponse;
+#[cfg(feature = "biome-profile")]
+use crate::biome::profile::store::UserProfileStore;
+use crate::futures::IntoFuture;
+use crate::protocol;
+#[cfg(feature = "authorization")]
+use crate::rest_api::auth::Permission;
+use crate::rest_api::{
+    actix_web_1::{HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
+    ErrorResponse,
+};
+
+pub fn make_profile_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
+    let resource =
+        Resource::build("/biome/profile").add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_FETCH_PROFILE_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ));
+    #[cfg(feature = "authorization")]
+    {
+        resource.add_method(
+            Method::Get,
+            Permission::AllowAuthenticated,
+            handle_get(profile_store),
+        )
+    }
+    #[cfg(not(feature = "authorization"))]
+    {
+        resource.add_method(Method::Get, handle_get(profile_store))
+    }
+}
+
+/// Defines a REST endpoint for retrieving the profile of the authenticated user
+fn handle_get(profile_store: Arc<dyn UserProfileStore>) -> HandlerFunction {
+    Box::new(move |request, _| {
+        let profile_store = profile_store.clone();
+
+        let user = match get_authorized_user(&request) {
+            Ok(user) => user,
+            Err(response) => return response,
+        };
+
+        match profile_store.get_profile(&user) {
+            Ok(profile) => Box::new(HttpResponse::Ok().json(profile).into_future()),
+            Err(err) => {
+                debug!("Failed to fetch profile {}", err);
+                Box::new(
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                )
+            }
+        }
+    })
+}

--- a/libsplinter/src/biome/rest_api/actix/profiles.rs
+++ b/libsplinter/src/biome/rest_api/actix/profiles.rs
@@ -1,0 +1,67 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::HttpResponse;
+use crate::futures::IntoFuture;
+use crate::protocol;
+use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+
+#[cfg(feature = "biome-profile")]
+use crate::biome::profile::store::UserProfileStore;
+
+#[cfg(feature = "authorization")]
+use crate::biome::rest_api::BIOME_USER_READ_PERMISSION;
+
+/// Defines a REST endpoint to list profiles from the database
+pub fn make_profiles_list_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
+    let resource =
+        Resource::build("/biome/profiles").add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_LIST_PROFILES_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ));
+    #[cfg(feature = "authorization")]
+    {
+        resource.add_method(Method::Get, BIOME_USER_READ_PERMISSION, move |_, _| {
+            let profile_store = profile_store.clone();
+            Box::new(match profile_store.list_profiles() {
+                Ok(profiles) => Box::new(HttpResponse::Ok().json(profiles).into_future()),
+                Err(err) => {
+                    debug!("Failed to get profiles from the database {}", err);
+                    Box::new(
+                        HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future(),
+                    )
+                }
+            })
+        })
+    }
+    #[cfg(not(feature = "authorization"))]
+    {
+        resource.add_method(Method::Get, move |_, _| {
+            let profile_store = profile_store.clone();
+            Box::new(match profile_store.list_profiles() {
+                Ok(profiles) => HttpResponse::Ok().json(profiles).into_future(),
+                Err(err) => {
+                    debug!("Failed to get profiles from the database {}", err);
+                    HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future()
+                }
+            })
+        })
+    }
+}

--- a/libsplinter/src/biome/rest_api/actix/profiles_identity.rs
+++ b/libsplinter/src/biome/rest_api/actix/profiles_identity.rs
@@ -1,0 +1,82 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::actix_web::HttpResponse;
+use crate::futures::IntoFuture;
+use crate::protocol;
+use crate::rest_api::{
+    ErrorResponse, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource,
+};
+
+#[cfg(feature = "biome-profile")]
+use crate::biome::profile::store::{UserProfileStore, UserProfileStoreError};
+
+#[cfg(feature = "authorization")]
+use crate::biome::rest_api::BIOME_USER_READ_PERMISSION;
+
+pub fn make_profiles_routes(profile_store: Arc<dyn UserProfileStore>) -> Resource {
+    let resource =
+        Resource::build("/biome/profiles/{id}").add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::BIOME_FETCH_PROFILES_PROTOCOL_MIN,
+            protocol::BIOME_PROTOCOL_VERSION,
+        ));
+    #[cfg(feature = "authorization")]
+    {
+        resource.add_method(
+            Method::Get,
+            BIOME_USER_READ_PERMISSION,
+            add_fetch_profile_method(profile_store.clone()),
+        )
+    }
+    #[cfg(not(feature = "authorization"))]
+    {
+        resource.add_method(Method::Get, add_fetch_profile_method(profile_store.clone()))
+    }
+}
+
+fn add_fetch_profile_method(profile_store: Arc<dyn UserProfileStore>) -> HandlerFunction {
+    Box::new(move |request, _| {
+        let profile_store = profile_store.clone();
+        let user_id = if let Some(t) = request.match_info().get("id") {
+            t.to_string()
+        } else {
+            return Box::new(
+                HttpResponse::BadRequest()
+                    .json(ErrorResponse::bad_request(
+                        &"Failed to process request: no user id".to_string(),
+                    ))
+                    .into_future(),
+            );
+        };
+        Box::new(match profile_store.get_profile(&user_id) {
+            Ok(profile) => HttpResponse::Ok().json(profile).into_future(),
+            Err(err) => {
+                debug!("Failed to get profile from the database {}", err);
+                match err {
+                    UserProfileStoreError::InvalidArgument(_) => HttpResponse::NotFound()
+                        .json(ErrorResponse::not_found(&format!(
+                            "User ID not found: {}",
+                            &user_id
+                        )))
+                        .into_future(),
+                    _ => HttpResponse::InternalServerError()
+                        .json(ErrorResponse::internal_error())
+                        .into_future(),
+                }
+            }
+        })
+    })
+}

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -43,6 +43,9 @@ use self::actix::key_management::{
 #[cfg(feature = "biome-key-management")]
 use super::key_management::store::KeyStore;
 
+#[cfg(feature = "biome-profile")]
+use super::profile::store::UserProfileStore;
+
 #[cfg(any(feature = "biome-key-management", feature = "biome-credentials",))]
 use crate::rest_api::secrets::AutoSecretManager;
 use crate::rest_api::secrets::SecretManager;
@@ -52,6 +55,12 @@ pub use error::BiomeRestResourceManagerBuilderError;
 
 #[cfg(all(feature = "rest-api-actix", feature = "biome-credentials"))]
 use self::actix::logout::make_logout_route;
+#[cfg(all(feature = "rest-api-actix", feature = "biome-profile"))]
+use self::actix::profile::make_profile_route;
+#[cfg(all(feature = "rest-api-actix", feature = "biome-profile"))]
+use self::actix::profiles::make_profiles_list_route;
+#[cfg(all(feature = "rest-api-actix", feature = "biome-profile"))]
+use self::actix::profiles_identity::make_profiles_routes;
 #[cfg(all(feature = "biome-credentials", feature = "rest-api-actix"))]
 use self::actix::register::make_register_route;
 #[cfg(all(feature = "biome-credentials", feature = "rest-api-actix"))]
@@ -89,6 +98,9 @@ const BIOME_USER_WRITE_PERMISSION: Permission = Permission::Check("biome.user.wr
 ///    `public key`
 /// * `POST /biome/login` - Login enpoint for getting access tokens and refresh tokens
 /// * `PATCH /biome/logout` - Login endpoint for removing refresh tokens
+/// * `GET /biome/profile` - Get the profile information of the authenticated user
+/// * `GET /biome/profiles` - Get a list of all user profiles
+/// * `GET /biome/profiles/{id}` - Retrieve profile with specified id
 /// * `POST /biome/register - Creates credentials for a user
 /// * `POST /biome/token` - Creates a new access token for the authorized user
 /// * `POST /biome/verify` - Verify a users password
@@ -110,6 +122,8 @@ pub struct BiomeRestResourceManager {
     refresh_token_store: Arc<dyn RefreshTokenStore>,
     #[cfg(feature = "biome-credentials")]
     credentials_store: Arc<dyn CredentialsStore>,
+    #[cfg(feature = "biome-profile")]
+    profile_store: Arc<dyn UserProfileStore>,
 }
 
 impl BiomeRestResourceManager {
@@ -181,6 +195,13 @@ impl RestResourceProvider for BiomeRestResourceManager {
             ));
         }
 
+        #[cfg(all(feature = "biome-profile", feature = "rest-api-actix",))]
+        {
+            resources.push(make_profiles_list_route(self.profile_store.clone()));
+            resources.push(make_profiles_routes(self.profile_store.clone()));
+            resources.push(make_profile_route(self.profile_store.clone()));
+        }
+
         #[cfg(all(feature = "biome-key-management", feature = "rest-api-actix",))]
         {
             resources.push(make_key_management_route(self.key_store.clone()));
@@ -205,6 +226,8 @@ pub struct BiomeRestResourceManagerBuilder {
     refresh_token_store: Option<Arc<dyn RefreshTokenStore>>,
     #[cfg(feature = "biome-credentials")]
     credentials_store: Option<Arc<dyn CredentialsStore>>,
+    #[cfg(feature = "biome-profile")]
+    profile_store: Option<Arc<dyn UserProfileStore>>,
 }
 
 impl BiomeRestResourceManagerBuilder {
@@ -243,6 +266,20 @@ impl BiomeRestResourceManagerBuilder {
         store: impl CredentialsStore + 'static,
     ) -> BiomeRestResourceManagerBuilder {
         self.credentials_store = Some(Arc::new(store));
+        self
+    }
+
+    #[cfg(feature = "biome-profile")]
+    /// Sets a UserProfileStore for the BiomeRestResourceManager
+    ///
+    /// # Arguments
+    ///
+    /// * `pool`: ConnectionPool to database that will serve as backend for UserProfileStore
+    pub fn with_profile_store(
+        mut self,
+        store: impl UserProfileStore + 'static,
+    ) -> BiomeRestResourceManagerBuilder {
+        self.profile_store = Some(Arc::new(store));
         self
     }
 
@@ -335,6 +372,13 @@ impl BiomeRestResourceManagerBuilder {
             )
         })?;
 
+        #[cfg(feature = "biome-profile")]
+        let profile_store = self.profile_store.ok_or_else(|| {
+            BiomeRestResourceManagerBuilderError::MissingRequiredField(
+                "Missing profile store".to_string(),
+            )
+        })?;
+
         Ok(BiomeRestResourceManager {
             #[cfg(feature = "biome-key-management")]
             key_store,
@@ -348,6 +392,8 @@ impl BiomeRestResourceManagerBuilder {
             refresh_token_store,
             #[cfg(feature = "biome-credentials")]
             credentials_store,
+            #[cfg(feature = "biome-profile")]
+            profile_store,
         })
     }
 }
@@ -361,6 +407,8 @@ mod tests {
 
     use reqwest::blocking::Client;
 
+    #[cfg(feature = "biome-profile")]
+    use crate::biome::MemoryUserProfileStore;
     use crate::biome::{MemoryCredentialsStore, MemoryKeyStore, MemoryRefreshTokenStore};
     #[cfg(feature = "authorization")]
     use crate::error::InternalError;
@@ -468,6 +516,8 @@ mod tests {
         let refresh_token_store = MemoryRefreshTokenStore::new();
         let cred_store = MemoryCredentialsStore::new();
         let key_store = MemoryKeyStore::new(cred_store.clone());
+        #[cfg(feature = "biome-profile")]
+        let profile_store = MemoryUserProfileStore::new();
         let config = BiomeRestConfigBuilder::default()
             .with_password_encryption_cost("low")
             .build()
@@ -477,9 +527,12 @@ mod tests {
             .with_refresh_token_store(refresh_token_store)
             .with_credentials_store(cred_store)
             .with_key_store(key_store)
-            .with_rest_config(config)
-            .build()
-            .unwrap();
+            .with_rest_config(config);
+
+        #[cfg(feature = "biome-profile")]
+        let resource_manager = resource_manager.with_profile_store(profile_store);
+
+        let resource_manager = resource_manager.build().unwrap();
 
         let mut rest_api_builder = RestApiBuilder::new();
 

--- a/libsplinter/src/oauth/builder/github.rs
+++ b/libsplinter/src/oauth/builder/github.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "biome-profile")]
+use crate::oauth::GithubProfileProvider;
 use crate::oauth::{
     builder::OAuthClientBuilder, error::OAuthClientBuildError, store::InflightOAuthRequestStore,
     GithubSubjectProvider, OAuthClient,
@@ -25,12 +27,20 @@ pub struct GithubOAuthClientBuilder {
 impl GithubOAuthClientBuilder {
     /// Constructs a Github OAuthClient builder.
     pub fn new() -> Self {
-        Self {
-            inner: OAuthClientBuilder::new()
-                .with_auth_url("https://github.com/login/oauth/authorize".into())
-                .with_token_url("https://github.com/login/oauth/access_token".into())
-                .with_subject_provider(Box::new(GithubSubjectProvider)),
+        // Allowing unused_mut because inner must be mutable if experimental feature
+        // biome-profile is enabled, if feature is removed unused_mut notation can be removed
+        #[allow(unused_mut)]
+        let mut inner = OAuthClientBuilder::new()
+            .with_auth_url("https://github.com/login/oauth/authorize".into())
+            .with_token_url("https://github.com/login/oauth/access_token".into())
+            .with_subject_provider(Box::new(GithubSubjectProvider));
+
+        #[cfg(feature = "biome-profile")]
+        {
+            inner = inner.with_profile_provider(Box::new(GithubProfileProvider));
         }
+
+        Self { inner }
     }
 
     /// Sets the client ID for the OAuth2 provider.

--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -16,6 +16,8 @@
 
 mod builder;
 mod error;
+#[cfg(feature = "biome-profile")]
+mod profile;
 #[cfg(feature = "rest-api")]
 pub(crate) mod rest_api;
 pub mod store;
@@ -39,6 +41,12 @@ pub use builder::OAuthClientBuilder;
 #[cfg(feature = "oauth-openid")]
 pub use builder::OpenIdOAuthClientBuilder;
 pub use error::OAuthClientBuildError;
+#[cfg(all(feature = "biome-profile", feature = "oauth-github"))]
+pub use profile::GithubProfileProvider;
+#[cfg(all(feature = "biome-profile", feature = "oauth-openid"))]
+pub use profile::OpenIdProfileProvider;
+#[cfg(feature = "biome-profile")]
+pub use profile::ProfileProvider;
 #[cfg(feature = "oauth-github")]
 pub use subject::GithubSubjectProvider;
 #[cfg(feature = "oauth-openid")]
@@ -63,6 +71,10 @@ pub struct OAuthClient {
     /// Store for pending authorization requests, including the CSRF token, PKCE verifier, and
     /// client's redirect URL
     inflight_request_store: Box<dyn InflightOAuthRequestStore>,
+
+    /// OAuth2 profile provider used to retrieve user's profile details
+    #[cfg(feature = "biome-profile")]
+    profile_provider: Box<dyn ProfileProvider>,
 }
 
 impl OAuthClient {
@@ -83,6 +95,7 @@ impl OAuthClient {
         scopes: Vec<String>,
         subject_provider: Box<dyn SubjectProvider>,
         inflight_request_store: Box<dyn InflightOAuthRequestStore>,
+        #[cfg(feature = "biome-profile")] profile_provider: Box<dyn ProfileProvider>,
     ) -> Self {
         Self {
             client,
@@ -90,6 +103,8 @@ impl OAuthClient {
             scopes,
             subject_provider,
             inflight_request_store,
+            #[cfg(feature = "biome-profile")]
+            profile_provider,
         }
     }
 
@@ -380,6 +395,8 @@ mod tests {
             vec![SCOPE1.into(), SCOPE2.into()],
             Box::new(TestSubjectProvider),
             request_store.clone(),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let generated_auth_url = Url::parse(
@@ -458,6 +475,28 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "biome-profile")]
+    #[derive(Clone)]
+    pub struct TestProfileProvider;
+
+    #[cfg(feature = "biome-profile")]
+    impl ProfileProvider for TestProfileProvider {
+        fn get_profile(&self, _: &str) -> Result<Option<Profile>, InternalError> {
+            Ok(Some(Profile {
+                subject: "".to_string(),
+                name: None,
+                given_name: None,
+                family_name: None,
+                email: None,
+                picture: None,
+            }))
+        }
+
+        fn clone_box(&self) -> Box<dyn ProfileProvider> {
+            Box::new(self.clone())
+        }
+    }
+
     #[derive(Clone)]
     pub struct TestInflightOAuthRequestStore;
 
@@ -498,6 +537,8 @@ mod actix_tests {
 
     use crate::oauth::store::MemoryInflightOAuthRequestStore;
 
+    #[cfg(feature = "biome-profile")]
+    use super::tests::TestProfileProvider;
     use super::tests::TestSubjectProvider;
 
     const CLIENT_ID: &str = "client_id";
@@ -555,6 +596,8 @@ mod actix_tests {
             vec![],
             Box::new(TestSubjectProvider),
             request_store.clone(),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let (user_info, client_redirect_url) = client
@@ -611,6 +654,8 @@ mod actix_tests {
             vec![],
             Box::new(TestSubjectProvider),
             Box::new(MemoryInflightOAuthRequestStore::new()),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let access_token = client

--- a/libsplinter/src/oauth/profile/github.rs
+++ b/libsplinter/src/oauth/profile/github.rs
@@ -1,0 +1,83 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A profile provider that looks up GitHub profile information
+
+use reqwest::{blocking::Client, StatusCode};
+use serde::Deserialize;
+
+use crate::error::InternalError;
+use crate::oauth::Profile;
+
+use super::ProfileProvider;
+
+/// Retrieves a GitHub profile information from the GitHub servers
+#[derive(Clone)]
+pub struct GithubProfileProvider;
+
+impl ProfileProvider for GithubProfileProvider {
+    fn get_profile(&self, access_token: &str) -> Result<Option<Profile>, InternalError> {
+        let response = Client::builder()
+            .build()
+            .map_err(|err| InternalError::from_source(err.into()))?
+            .get("https://api.github.com/user")
+            .header("Authorization", format!("Bearer {}", access_token))
+            .header("User-Agent", "splinter")
+            .send()
+            .map_err(|err| InternalError::from_source(err.into()))?;
+
+        if !response.status().is_success() {
+            match response.status() {
+                StatusCode::UNAUTHORIZED => return Ok(None),
+                status_code => {
+                    return Err(InternalError::with_message(format!(
+                        "Received unexpected response code: {}",
+                        status_code
+                    )))
+                }
+            }
+        }
+
+        let user_profile = response
+            .json::<GithubProfileResponse>()
+            .map_err(|_| InternalError::with_message("Received unexpected response body".into()))?;
+
+        Ok(Some(Profile::from(user_profile)))
+    }
+
+    fn clone_box(&self) -> Box<dyn ProfileProvider> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GithubProfileResponse {
+    pub login: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+impl From<GithubProfileResponse> for Profile {
+    fn from(github_profile: GithubProfileResponse) -> Self {
+        Profile {
+            subject: github_profile.login,
+            name: github_profile.name,
+            given_name: None,
+            family_name: None,
+            email: github_profile.email,
+            picture: github_profile.avatar_url,
+        }
+    }
+}

--- a/libsplinter/src/oauth/profile/mod.rs
+++ b/libsplinter/src/oauth/profile/mod.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! APIs and implementations for fetching profile details from OAuth servers
+
+#[cfg(feature = "oauth-github")]
+mod github;
+#[cfg(feature = "oauth-openid")]
+mod openid;
+
+use crate::error::InternalError;
+use crate::oauth::Profile;
+
+#[cfg(feature = "oauth-github")]
+pub use github::GithubProfileProvider;
+#[cfg(feature = "oauth-openid")]
+pub use openid::OpenIdProfileProvider;
+
+/// A service that fetches profile details from a backing OAuth server
+pub trait ProfileProvider: Send + Sync {
+    /// Attempts to get the profile details for the account that the given access token is for.
+    fn get_profile(&self, access_token: &str) -> Result<Option<Profile>, InternalError>;
+
+    /// Clone implementation for `ProfileProvider`. The implementation of the `Clone` trait for
+    /// `Box<dyn ProfileProvider>` calls this method.
+    ///
+    /// # Example
+    ///
+    ///```ignore
+    ///  fn clone_box(&self) -> Box<dyn ProfileProvider> {
+    ///     Box::new(self.clone())
+    ///  }
+    ///```
+    fn clone_box(&self) -> Box<dyn ProfileProvider>;
+}
+
+impl Clone for Box<dyn ProfileProvider> {
+    fn clone(&self) -> Box<dyn ProfileProvider> {
+        self.clone_box()
+    }
+}

--- a/libsplinter/src/oauth/profile/openid.rs
+++ b/libsplinter/src/oauth/profile/openid.rs
@@ -1,0 +1,91 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A profile provider that looks up OpenID profile information
+
+use reqwest::{blocking::Client, StatusCode};
+use serde::Deserialize;
+
+use crate::error::InternalError;
+use crate::oauth::Profile;
+
+use super::ProfileProvider;
+
+#[derive(Clone)]
+pub struct OpenIdProfileProvider {
+    userinfo_endpoint: String,
+}
+
+impl OpenIdProfileProvider {
+    pub fn new(userinfo_endpoint: String) -> OpenIdProfileProvider {
+        OpenIdProfileProvider { userinfo_endpoint }
+    }
+}
+
+impl ProfileProvider for OpenIdProfileProvider {
+    fn get_profile(&self, access_token: &str) -> Result<Option<Profile>, InternalError> {
+        let response = Client::builder()
+            .build()
+            .map_err(|err| InternalError::from_source(err.into()))?
+            .get(&self.userinfo_endpoint)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .send()
+            .map_err(|err| InternalError::from_source(err.into()))?;
+
+        if !response.status().is_success() {
+            match response.status() {
+                StatusCode::UNAUTHORIZED => return Ok(None),
+                status_code => {
+                    return Err(InternalError::with_message(format!(
+                        "Received unexpected response code: {}",
+                        status_code
+                    )))
+                }
+            }
+        }
+
+        let user_profile = response
+            .json::<OpenIdProfileResponse>()
+            .map_err(|_| InternalError::with_message("Received unexpected response body".into()))?;
+
+        Ok(Some(Profile::from(user_profile)))
+    }
+
+    fn clone_box(&self) -> Box<dyn ProfileProvider> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenIdProfileResponse {
+    pub sub: String,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub email: Option<String>,
+    pub picture: Option<String>,
+}
+
+impl From<OpenIdProfileResponse> for Profile {
+    fn from(openid_profile: OpenIdProfileResponse) -> Self {
+        Profile {
+            subject: openid_profile.sub,
+            name: openid_profile.name,
+            given_name: openid_profile.given_name,
+            family_name: openid_profile.family_name,
+            email: openid_profile.email,
+            picture: openid_profile.picture,
+        }
+    }
+}

--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -21,6 +21,13 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
 use crate::biome::oauth::store::{InsertableOAuthUserSessionBuilder, OAuthUserSessionStore};
+
+#[cfg(feature = "biome-profile")]
+use crate::biome::{
+    profile::store::ProfileBuilder, profile::store::UserProfileStoreError, UserProfileStore,
+};
+use crate::error::InternalError;
+use crate::oauth::Profile as OauthProfile;
 use crate::oauth::{
     rest_api::resources::callback::{generate_redirect_query, CallbackQuery},
     OAuthClient,
@@ -36,6 +43,7 @@ use crate::rest_api::{
 pub fn make_callback_route(
     client: OAuthClient,
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+    #[cfg(feature = "biome-profile")] user_profile_store: Box<dyn UserProfileStore>,
 ) -> Resource {
     let resource =
         Resource::build("/oauth/callback").add_request_guard(ProtocolVersionRangeGuard::new(
@@ -83,22 +91,48 @@ pub fn make_callback_route(
                                     {
                                         Ok(session) => {
                                             match oauth_user_session_store.add_session(session) {
-                                                Ok(_) => HttpResponse::Found()
-                                                    .header(LOCATION, redirect_url)
-                                                    .finish(),
+                                                Ok(_) => {}
                                                 Err(err) => {
                                                     error!("Unable to store user session: {}", err);
-                                                    HttpResponse::InternalServerError()
-                                                        .json(ErrorResponse::internal_error())
+                                                    return Box::new(
+                                                        HttpResponse::InternalServerError()
+                                                            .json(ErrorResponse::internal_error())
+                                                            .into_future(),
+                                                    );
                                                 }
                                             }
                                         }
                                         Err(err) => {
                                             error!("Unable to build user session: {}", err);
-                                            HttpResponse::InternalServerError()
-                                                .json(ErrorResponse::internal_error())
+                                            return Box::new(
+                                                HttpResponse::InternalServerError()
+                                                    .json(ErrorResponse::internal_error())
+                                                    .into_future(),
+                                            );
+                                        }
+                                    };
+                                    #[cfg(feature = "biome-profile")]
+                                    {
+                                        match save_user_profile(
+                                            user_profile_store.clone_box(),
+                                            oauth_user_session_store.clone_box(),
+                                            &user_info.profile().clone(),
+                                            user_info.subject.clone(),
+                                        ) {
+                                            Ok(_) => debug!("User profile saved"),
+                                            Err(err) => {
+                                                error!("Failed to save profile: {}", err);
+                                                return Box::new(
+                                                    HttpResponse::InternalServerError()
+                                                        .json(ErrorResponse::internal_error())
+                                                        .into_future(),
+                                                );
+                                            }
                                         }
                                     }
+                                    HttpResponse::Found()
+                                        .header(LOCATION, redirect_url)
+                                        .finish()
                                 }
                                 Ok(None) => {
                                     error!(
@@ -163,22 +197,48 @@ pub fn make_callback_route(
                                 {
                                     Ok(session) => {
                                         match oauth_user_session_store.add_session(session) {
-                                            Ok(_) => HttpResponse::Found()
-                                                .header(LOCATION, redirect_url)
-                                                .finish(),
+                                            Ok(_) => {}
                                             Err(err) => {
                                                 error!("Unable to store user session: {}", err);
-                                                HttpResponse::InternalServerError()
-                                                    .json(ErrorResponse::internal_error())
+                                                return Box::new(
+                                                    HttpResponse::InternalServerError()
+                                                        .json(ErrorResponse::internal_error())
+                                                        .into_future(),
+                                                );
                                             }
                                         }
                                     }
                                     Err(err) => {
                                         error!("Unable to build user session: {}", err);
-                                        HttpResponse::InternalServerError()
-                                            .json(ErrorResponse::internal_error())
+                                        return Box::new(
+                                            HttpResponse::InternalServerError()
+                                                .json(ErrorResponse::internal_error())
+                                                .into_future(),
+                                        );
+                                    }
+                                };
+                                #[cfg(feature = "biome-profile")]
+                                {
+                                    match save_user_profile(
+                                        user_profile_store.clone_box(),
+                                        oauth_user_session_store.clone_box(),
+                                        &user_info.profile().clone(),
+                                        user_info.subject.clone(),
+                                    ) {
+                                        Ok(_) => debug!("User profile saved"),
+                                        Err(err) => {
+                                            error!("Failed to save profile: {}", err);
+                                            return Box::new(
+                                                HttpResponse::InternalServerError()
+                                                    .json(ErrorResponse::internal_error())
+                                                    .into_future(),
+                                            );
+                                        }
                                     }
                                 }
+                                HttpResponse::Found()
+                                    .header(LOCATION, redirect_url)
+                                    .finish()
                             }
                             Ok(None) => {
                                 error!(
@@ -212,6 +272,46 @@ pub fn make_callback_route(
 /// Generates a new Splinter access token, which is a string of 32 random alphanumeric characters
 fn new_splinter_access_token() -> String {
     thread_rng().sample_iter(&Alphanumeric).take(32).collect()
+}
+
+/// Gets the user's Biome ID from the session store and saves the user profile information to
+/// the user profile store
+#[cfg(feature = "biome-profile")]
+fn save_user_profile(
+    user_profile_store: Box<dyn UserProfileStore>,
+    oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+    profile: &OauthProfile,
+    subject: String,
+) -> Result<(), InternalError> {
+    if let Some(user) = oauth_user_session_store
+        .get_user(&subject)
+        .map_err(|err| InternalError::from_source(Box::new(err)))?
+    {
+        let profile = ProfileBuilder::new()
+            .with_user_id(user.user_id().into())
+            .with_subject(profile.subject.clone())
+            .with_name(profile.name.clone())
+            .with_given_name(profile.given_name.clone())
+            .with_family_name(profile.family_name.clone())
+            .with_email(profile.email.clone())
+            .with_picture(profile.picture.clone())
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        match user_profile_store.get_profile(&user.user_id()) {
+            Ok(_) => user_profile_store
+                .update_profile(profile)
+                .map_err(|err| InternalError::from_source(Box::new(err))),
+            Err(UserProfileStoreError::InvalidArgument(_)) => user_profile_store
+                .add_profile(profile)
+                .map_err(|err| InternalError::from_source(Box::new(err))),
+            Err(err) => Err(InternalError::from_source(Box::new(err))),
+        }
+    } else {
+        Err(InternalError::with_message(
+            "Unable to retrieve user".to_string(),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -302,8 +402,16 @@ mod tests {
 
         let session_store = MemoryOAuthUserSessionStore::new();
 
+        #[cfg(feature = "biome-profile")]
+        let profile_store = MemoryUserProfileStore::new();
+
         let (splinter_shutdown_handle, join_handle, bind_url) =
-            run_rest_api_on_open_port(vec![make_callback_route(client, session_store.clone_box())]);
+            run_rest_api_on_open_port(vec![make_callback_route(
+                client,
+                session_store.clone_box(),
+                #[cfg(feature = "biome-profile")]
+                profile_store.clone_box(),
+            )]);
 
         let url = ReqwestUrl::parse_with_params(
             &format!("http://{}/oauth/callback", bind_url),
@@ -403,8 +511,16 @@ mod tests {
 
         let session_store = MemoryOAuthUserSessionStore::new();
 
+        #[cfg(feature = "biome-profile")]
+        let profile_store = MemoryUserProfileStore::new();
+
         let (splinter_shutdown_handle, join_handle, bind_url) =
-            run_rest_api_on_open_port(vec![make_callback_route(client, session_store.clone_box())]);
+            run_rest_api_on_open_port(vec![make_callback_route(
+                client,
+                session_store.clone_box(),
+                #[cfg(feature = "biome-profile")]
+                profile_store.clone_box(),
+            )]);
 
         let url = ReqwestUrl::parse_with_params(
             &format!("http://{}/oauth/callback", bind_url),
@@ -476,8 +592,16 @@ mod tests {
 
         let session_store = MemoryOAuthUserSessionStore::new();
 
+        #[cfg(feature = "biome-profile")]
+        let profile_store = MemoryUserProfileStore::new();
+
         let (splinter_shutdown_handle, join_handle, bind_url) =
-            run_rest_api_on_open_port(vec![make_callback_route(client, session_store.clone_box())]);
+            run_rest_api_on_open_port(vec![make_callback_route(
+                client,
+                session_store.clone_box(),
+                #[cfg(feature = "biome-profile")]
+                profile_store.clone_box(),
+            )]);
 
         let url = ReqwestUrl::parse_with_params(
             &format!("http://{}/oauth/callback", bind_url),
@@ -551,8 +675,16 @@ mod tests {
 
         let session_store = MemoryOAuthUserSessionStore::new();
 
+        #[cfg(feature = "biome-profile")]
+        let profile_store = MemoryUserProfileStore::new();
+
         let (splinter_shutdown_handle, join_handle, bind_url) =
-            run_rest_api_on_open_port(vec![make_callback_route(client, session_store.clone_box())]);
+            run_rest_api_on_open_port(vec![make_callback_route(
+                client,
+                session_store.clone_box(),
+                #[cfg(feature = "biome-profile")]
+                profile_store.clone_box(),
+            )]);
 
         let url = ReqwestUrl::parse_with_params(
             &format!("http://{}/oauth/callback", bind_url),

--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -229,6 +229,8 @@ mod tests {
     use url::Url;
 
     use crate::biome::MemoryOAuthUserSessionStore;
+    #[cfg(feature = "biome-profile")]
+    use crate::biome::MemoryUserProfileStore;
     use crate::rest_api::actix_web_1::{RestApiBuilder, RestApiShutdownHandle};
 
     use crate::oauth::{
@@ -237,6 +239,9 @@ mod tests {
         tests::TestSubjectProvider,
         PendingAuthorization,
     };
+
+    #[cfg(feature = "biome-profile")]
+    use crate::oauth::tests::TestProfileProvider;
 
     const TOKEN_ENDPOINT: &str = "/token";
     const AUTH_CODE: &str = "auth_code";
@@ -291,6 +296,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             request_store.clone(),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let session_store = MemoryOAuthUserSessionStore::new();
@@ -390,6 +397,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             Box::new(MemoryInflightOAuthRequestStore::new()),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let session_store = MemoryOAuthUserSessionStore::new();
@@ -461,6 +470,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             request_store.clone(),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let session_store = MemoryOAuthUserSessionStore::new();
@@ -534,6 +545,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             request_store.clone(),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let session_store = MemoryOAuthUserSessionStore::new();

--- a/libsplinter/src/oauth/rest_api/actix/login.rs
+++ b/libsplinter/src/oauth/rest_api/actix/login.rs
@@ -148,6 +148,8 @@ mod tests {
 
     use reqwest::{blocking::Client, redirect, StatusCode, Url};
 
+    #[cfg(feature = "biome-profile")]
+    use crate::oauth::tests::TestProfileProvider;
     use crate::oauth::{
         new_basic_client,
         store::{
@@ -194,6 +196,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             Box::new(TestInflightOAuthRequestStore),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let (shutdown_handle, join_handle, bind_url) =
@@ -257,6 +261,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             Box::new(TestInflightOAuthRequestStore),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let (shutdown_handle, join_handle, bind_url) =
@@ -314,6 +320,8 @@ mod tests {
             vec![],
             Box::new(TestSubjectProvider),
             Box::new(MemoryInflightOAuthRequestStore::new()),
+            #[cfg(feature = "biome-profile")]
+            Box::new(TestProfileProvider),
         );
 
         let (shutdown_handle, join_handle, bind_url) =

--- a/libsplinter/src/oauth/rest_api/mod.rs
+++ b/libsplinter/src/oauth/rest_api/mod.rs
@@ -21,6 +21,9 @@ mod resources;
 use crate::biome::OAuthUserSessionStore;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
 
+#[cfg(feature = "biome-profile")]
+use crate::biome::UserProfileStore;
+
 use super::OAuthClient;
 
 /// Provides the REST API [Resource](../../../rest_api/struct.Resource.html) definitions for OAuth
@@ -37,6 +40,8 @@ use super::OAuthClient;
 pub struct OAuthResourceProvider {
     client: OAuthClient,
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+    #[cfg(feature = "biome-profile")]
+    user_profile_store: Box<dyn UserProfileStore>,
 }
 
 impl OAuthResourceProvider {
@@ -44,10 +49,13 @@ impl OAuthResourceProvider {
     pub fn new(
         client: OAuthClient,
         oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+        #[cfg(feature = "biome-profile")] user_profile_store: Box<dyn UserProfileStore>,
     ) -> Self {
         Self {
             client,
             oauth_user_session_store,
+            #[cfg(feature = "biome-profile")]
+            user_profile_store,
         }
     }
 }
@@ -75,6 +83,8 @@ impl RestResourceProvider for OAuthResourceProvider {
                 actix::callback::make_callback_route(
                     self.client.clone(),
                     self.oauth_user_session_store.clone(),
+                    #[cfg(feature = "biome-profile")]
+                    self.user_profile_store.clone(),
                 ),
                 actix::logout::make_logout_route(self.oauth_user_session_store.clone()),
             ]);

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -97,3 +97,10 @@ pub(crate) const BIOME_VERIFY_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(all(feature = "biome-key-management", feature = "rest-api",))]
 pub(crate) const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;
+
+#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
+pub(crate) const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;
+#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
+pub(crate) const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
+#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
+pub(crate) const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;

--- a/libsplinter/src/rest_api/actix_web_1/auth.rs
+++ b/libsplinter/src/rest_api/actix_web_1/auth.rs
@@ -20,6 +20,8 @@ use cylinder::Verifier;
 use crate::biome::rest_api::BiomeRestResourceManager;
 #[cfg(feature = "oauth")]
 use crate::biome::OAuthUserSessionStore;
+#[cfg(all(feature = "oauth", feature = "biome-profile"))]
+use crate::biome::UserProfileStore;
 #[cfg(feature = "oauth")]
 use crate::rest_api::OAuthConfig;
 use crate::rest_api::{auth::identity::IdentityProvider, RequestError};
@@ -47,6 +49,9 @@ pub enum AuthConfig {
         oauth_config: OAuthConfig,
         /// The Biome OAuth user session store
         oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
+        /// The Biome user profile store
+        #[cfg(feature = "biome-profile")]
+        user_profile_store: Box<dyn UserProfileStore>,
     },
     /// A custom authentication method
     Custom {

--- a/libsplinter/src/rest_api/actix_web_1/builder.rs
+++ b/libsplinter/src/rest_api/actix_web_1/builder.rs
@@ -150,6 +150,8 @@ impl RestApiBuilder {
                     AuthConfig::OAuth {
                         oauth_config,
                         oauth_user_session_store,
+                        #[cfg(feature = "biome-profile")]
+                        user_profile_store,
                     } => {
                         if oauth_configured {
                             return Err(RestApiServerError::InvalidStateError(
@@ -220,8 +222,13 @@ impl RestApiBuilder {
                             None,
                         )));
                         self.resources.append(
-                            &mut OAuthResourceProvider::new(oauth_client, oauth_user_session_store)
-                                .resources(),
+                            &mut OAuthResourceProvider::new(
+                                oauth_client,
+                                oauth_user_session_store,
+                                #[cfg(feature = "biome-profile")]
+                                user_profile_store,
+                            )
+                            .resources(),
                         );
                         oauth_configured = true;
                     }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -86,6 +86,7 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-oauth",
+    "biome-profile",
     "health",
     "https-bind",
     "oauth",
@@ -121,6 +122,7 @@ biome-oauth = [
     "splinter/biome-oauth",
     "splinter/biome-oauth-user-store-postgres"
 ]
+biome-profile = ["splinter/biome-profile"]
 database = ["splinter/postgres", "splinter/sqlite"]
 https-bind = ["splinter/https-bind"]
 oauth = [

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1387,6 +1387,97 @@ paths:
                 schema:
                   $ref: '#/components/schemas/ErrorBiome'
 
+  /biome/profiles:
+    get:
+      tags:
+        - Biome
+        description: List all user profiles
+        parameters:
+          - $ref: "#/components/parameters/auth"
+          - $ref: "#/components/parameters/protocol_version"
+        responses:
+          200:
+            description: List of profiles for all users
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/BiomeProfile'
+          401:
+            description: The client is unauthorized
+          500:
+            description: Internal server error occurred
+            content:
+              application/json:
+                  schema:
+                    $ref: '#/components/schemas/ErrorBiome' 
+
+  /biome/profiles/{user_id}:
+    get:
+      tags:
+      - Biome
+      description: Fetch a profile by ID
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+        - name: user_id
+          in: path
+          description: ID of the user
+          required: true
+          schema:
+            type: string
+            example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+      responses:
+        200:
+          description: User profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                $ref: '#/components/schemas/BiomeProfile'
+        401:
+          description: The client is unauthorized
+        404:
+          description: Resource not found
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+
+  /biome/profile:
+    get:
+      tags:
+        - Biome
+        description: Get the profile of the authenticated user
+        parameters:
+          - $ref: "#/components/parameters/auth"
+          - $ref: "#/components/parameters/protocol_version"
+        responses:
+          200:
+            description: User's profile
+            content:
+              application/json:
+                schema:
+                  type: object
+                    properties:
+                    $ref: '#/components/schemas/BiomeProfile'
+          401:
+            description: The client is unauthorized
+          500:
+            description: Internal server error occurred
+            content:
+              application/json:
+                  schema:
+                    $ref: '#/components/schemas/ErrorBiome'
+
   /biome/keys:
     get:
       tags:
@@ -2221,6 +2312,38 @@ components:
           description: "An array of permissions included with this role."
           items:
             type: string
+
+    BiomeProfile:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: "Internal unique identifier for the user"
+          example: "f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4"
+        subject:
+          type: string
+          description: "Oauth provider's unique identifier for the user"
+          example: "129367690558975733497"
+        name:
+          type: string
+          description: "User's name"
+          example: "Alice Foo"
+        given_name:
+          type: string
+          description: "The given name of the user"
+          example: "Alice"
+        family_name:
+          type: string
+          description: "The family name of the user"
+          example: "Foo"
+        email:
+          type: string
+          description: "The email address of the user"
+          example: "alice@gmail.com"
+        picture:
+          type: string
+          description: "The profile picture for the user's account"
+          example: "https://lh6.googleusercontent.com/AMZpcempiaceeiA/s96-c/photo.jpg"
 
 tags:
   - name: Biome

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -1001,6 +1001,11 @@ fn build_biome_routes(
         biome_rest_provider_builder =
             biome_rest_provider_builder.with_key_store(store_factory.get_biome_key_store())
     }
+    #[cfg(feature = "biome-profile")]
+    {
+        biome_rest_provider_builder = biome_rest_provider_builder
+            .with_profile_store(store_factory.get_biome_user_profile_store());
+    }
     let biome_rest_provider = biome_rest_provider_builder.build().map_err(|err| {
         StartError::RestApiError(format!("Unable to build Biome REST routes: {}", err))
     })?;

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -702,6 +702,8 @@ impl SplinterDaemon {
                 auth_configs.push(AuthConfig::OAuth {
                     oauth_config,
                     oauth_user_session_store: store_factory.get_biome_oauth_user_session_store(),
+                    #[cfg(feature = "biome-profile")]
+                    user_profile_store: store_factory.get_biome_user_profile_store(),
                 });
             }
         }


### PR DESCRIPTION
Create a ProfileProvider trait and implement it for github and openid. The trait has a method 'get_profile' which takes an access token as an argument and queries the user info endpoint to retrieve the profile information given by the oauth provider.

Add ProfileProvider to the OAuthClient struct. Add a 'with_profile_provider' method to the OAuthClientBuilder as well as the github and openid OAuthClientBuilders.

Add a 'profile' field to the UserInfo struct. Modify the 'exchange_authorization_code' method to retrieve the profile information
using the profile provider and set the profile field of the UserInfo struct when the biome-profile feature is enabled.

Modify the 'make_callback_route' method to take a UserProfileStore as an argument and save the profile information stored in the profile field of the UserInfo struct if the biome-profile feature is enabled. If the given profile already exists in the profile store it will be updated otherwise it will be added as a new profile.

Add a user_profile_store field to AuthConfig::OAuth and OAuthResourceProvider these fields are only available when the 'biome-profile' feature is enabled.

Impl From oauth::Profile for biome::profile::store::Profile to allow for conversion between the two structs.

Add the biome/profile/{id} and biome/profiles endpoints for retrieving and listing biome user profiles.


## **Testing:**
1. Start splinterd with an oauth provider
```
$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
$ cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- \
  --database postgres://postgres:mypassword@localhost:5432/splinter \
  --oauth-provider <provider> \
  --oauth-client-id <client-id> \
  --oauth-client-secret <client-secret> \
  --oauth-redirect-url http://localhost:8080/oauth/callback \
  --rest-api-endpoint http://localhost:8080
  --tls-insecure
  -vv
```

2. In a browser go to `localhost:8080/oauth/login?redirect_url=redirect`

3. Go back to the terminal window where splinterd is running and check that it shows `INFO [splinter::oauth::rest_api::actix::callback] User profile saved`
4. Copy the access token from splinterd, it should be in a log message: `GET /oauth/redirect?access_token=<access-token>` and Make the following curl calls

`curl -i -H'Authorization:Bearer <access-token>' http://localhost:8080/biome/profile`
should return the profile information for the profile you used to log in

copy the user_id from the _Authenticated user_ debug message from splinterd 
`curl -i -H'Authorization:Bearer <access-token>' http://localhost:8080/biome/profiles/<user_id>`
should get a `HTTP/1.1 401 Unauthorized` indicating the endpoint exists

`curl -i -H'Authorization:Bearer <access-token>' http://localhost:8080/biome/profiles`
should get a `HTTP/1.1 401 Unauthorized` indicating the endpoint exists