### PR TITLE
Add a circuit version to Circuit definitions 

### DIFF
--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -83,6 +83,7 @@ $ splinter circuit show 01234-ABCDE \
   ---url URL-of-alpha-node-splinterd-REST-API
 Proposal to create: 01234-ABCDE
     Display Name: -
+    Version: 2
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -280,6 +280,7 @@ pub struct CircuitSlice {
     pub roster: Vec<CircuitServiceSlice>,
     pub management_type: String,
     pub display_name: Option<String>,
+    pub circuit_version: i32,
 }
 
 impl fmt::Display for CircuitSlice {
@@ -292,7 +293,10 @@ impl fmt::Display for CircuitSlice {
             display_string += "Display Name: -\n    ";
         }
 
-        display_string += &format!("Management Type: {}\n", self.management_type);
+        display_string += &format!(
+            "Version: {}\n    Management Type: {}\n",
+            self.circuit_version, self.management_type
+        );
 
         for member in self.members.iter() {
             display_string += &format!("\n    {}\n", member);
@@ -363,7 +367,10 @@ impl fmt::Display for ProposalSlice {
             display_string += "Display Name: -\n    ";
         }
 
-        display_string += &format!("Management Type: {}\n", self.circuit.management_type);
+        display_string += &format!(
+            "Version: {}\n    Management Type: {}\n",
+            self.circuit.circuit_version, self.circuit.management_type
+        );
 
         for member in self.circuit.members.iter() {
             display_string += &format!("\n    {} ({:?})\n", member.node_id, member.endpoints);
@@ -421,6 +428,7 @@ pub struct ProposalCircuitSlice {
     pub management_type: String,
     pub comments: Option<String>,
     pub display_name: Option<String>,
+    pub circuit_version: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -35,6 +35,7 @@ pub struct CreateCircuitMessageBuilder {
     application_metadata: Vec<u8>,
     comments: Option<String>,
     display_name: Option<String>,
+    circuit_version: Option<i32>,
 }
 
 impl CreateCircuitMessageBuilder {
@@ -49,6 +50,7 @@ impl CreateCircuitMessageBuilder {
             application_metadata: vec![],
             comments: None,
             display_name: None,
+            circuit_version: None,
         }
     }
 
@@ -238,6 +240,10 @@ impl CreateCircuitMessageBuilder {
         self.display_name = Some(display_name.into());
     }
 
+    pub fn set_circuit_version(&mut self, circuit_version: i32) {
+        self.circuit_version = Some(circuit_version);
+    }
+
     pub fn build(mut self) -> Result<CreateCircuit, CliError> {
         let circuit_builder = self.create_circuit_builder();
 
@@ -303,6 +309,10 @@ impl CreateCircuitMessageBuilder {
 
         if let Some(display_name) = self.display_name {
             create_circuit_builder = create_circuit_builder.with_display_name(&display_name);
+        }
+
+        if let Some(circuit_version) = self.circuit_version {
+            create_circuit_builder = create_circuit_builder.with_circuit_version(circuit_version);
         }
 
         #[cfg(feature = "circuit-auth-type")]

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -26,6 +26,7 @@ use std::fs::File;
 use clap::ArgMatches;
 use serde::Deserialize;
 use splinter::admin::messages::{CreateCircuit, SplinterService};
+use splinter::protocol::CIRCUIT_PROTOCOL_VERSION;
 
 use crate::error::CliError;
 #[cfg(feature = "circuit-template")]
@@ -167,6 +168,10 @@ impl Action for CircuitProposeAction {
                 ));
             }
             builder.set_display_name(display_name);
+        }
+
+        if args.value_of("compat_version") != Some("0.4") {
+            builder.set_circuit_version(CIRCUIT_PROTOCOL_VERSION);
         }
 
         let create_circuit = builder.build()?;
@@ -526,6 +531,7 @@ impl TryFrom<&CreateCircuit> for CircuitSlice {
                 .collect::<Result<Vec<CircuitServiceSlice>, CliError>>()?,
             management_type: circuit.circuit_management_type.clone(),
             display_name: circuit.display_name.clone(),
+            circuit_version: circuit.circuit_version,
         })
     }
 }

--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -1293,6 +1293,7 @@ mod test {
             application_metadata,
             comments: Some("test circuit".to_string()),
             display_name: None,
+            circuit_version: 1,
         }
     }
 

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -98,6 +98,9 @@ message Circuit {
 
     // Human-readable display name for the circuit
     string display_name = 11;
+
+    // The version of the circuit
+    int32 circuit_version = 12;
 }
 
 // Contains the vote counts for a given proposal.

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -698,6 +698,7 @@ mod tests {
                         .with_circuit_management_type("mgmt_type_2")
                         .with_comments("mock circuit 2")
                         .with_display_name("circuit_2")
+                        .with_circuit_version(2)
                         .build()
                         .expect("Unable to create proposed circuit"),
                 )
@@ -754,6 +755,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit 1".into()),
                 display_name: Some("circuit_1".into()),
+                circuit_version: 1,
             },
             votes: vec![],
             requester: vec![],
@@ -778,6 +780,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit 2".into()),
                 display_name: Some("circuit_2".into()),
+                circuit_version: 2,
             },
             votes: vec![],
             requester: vec![],
@@ -805,6 +808,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit 3".into()),
                 display_name: None,
+                circuit_version: 1,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -265,6 +265,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit".into()),
                 display_name: Some("test_circuit".into()),
+                circuit_version: 1,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -30,6 +30,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub roster: Vec<ServiceResponse<'a>>,
     pub management_type: &'a str,
     pub display_name: &'a Option<String>,
+    pub circuit_version: i32,
 }
 
 impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
@@ -40,6 +41,7 @@ impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
             roster: circuit.roster().iter().map(ServiceResponse::from).collect(),
             management_type: circuit.circuit_management_type(),
             display_name: circuit.display_name(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
@@ -23,6 +23,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub roster: Vec<ServiceResponse<'a>>,
     pub management_type: &'a str,
     pub display_name: &'a Option<String>,
+    pub circuit_version: i32,
 }
 
 impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
@@ -33,6 +34,7 @@ impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
             roster: circuit.roster().iter().map(ServiceResponse::from).collect(),
             management_type: circuit.circuit_management_type(),
             display_name: circuit.display_name(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
@@ -93,6 +93,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub application_metadata: &'a [u8],
     pub comments: &'a Option<String>,
     pub display_name: &'a Option<String>,
+    pub circuit_version: i32,
 }
 
 impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
@@ -111,6 +112,7 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
             application_metadata: &circuit.application_metadata,
             comments: &circuit.comments,
             display_name: &circuit.display_name,
+            circuit_version: circuit.circuit_version,
         })
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
@@ -88,6 +88,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub application_metadata: &'a [u8],
     pub comments: &'a Option<String>,
     pub display_name: &'a Option<String>,
+    pub circuit_version: i32,
 }
 
 impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
@@ -106,6 +107,7 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
             application_metadata: &circuit.application_metadata,
             comments: &circuit.comments,
             display_name: &circuit.display_name,
+            circuit_version: circuit.circuit_version,
         })
     }
 }

--- a/libsplinter/src/admin/service/event/store/diesel/models.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/models.rs
@@ -91,6 +91,7 @@ pub struct AdminEventProposedCircuitModel {
     pub application_metadata: Option<Vec<u8>>,
     pub comments: Option<String>,
     pub display_name: Option<String>,
+    pub circuit_version: i32,
 }
 
 impl From<(i64, &CreateCircuit)> for AdminEventProposedCircuitModel {
@@ -112,6 +113,7 @@ impl From<(i64, &CreateCircuit)> for AdminEventProposedCircuitModel {
             application_metadata,
             comments: create_circuit.comments.clone(),
             display_name: create_circuit.display_name.clone(),
+            circuit_version: create_circuit.circuit_version,
         }
     }
 }

--- a/libsplinter/src/admin/service/event/store/diesel/schema.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/schema.rs
@@ -43,6 +43,7 @@ table! {
         application_metadata -> Nullable<Binary>,
         comments -> Nullable<Text>,
         display_name -> Nullable<Text>,
+        circuit_version -> Integer,
     }
 }
 

--- a/libsplinter/src/admin/service/event/store/memory.rs
+++ b/libsplinter/src/admin/service/event/store/memory.rs
@@ -419,6 +419,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit".into()),
                 display_name: None,
+                circuit_version: 1,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/service/mailbox.rs
+++ b/libsplinter/src/admin/service/mailbox.rs
@@ -333,6 +333,7 @@ mod tests {
                 application_metadata: vec![],
                 comments: Some("mock circuit".into()),
                 display_name: Some("test_circuit".into()),
+                circuit_version: 1,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -18,7 +18,7 @@ use crate::base62::generate_random_base62_string;
 
 use super::{
     is_valid_circuit_id, is_valid_service_id, AuthorizationType, CreateCircuit, DurabilityType,
-    PersistenceType, RouteType, SplinterNode, SplinterService,
+    PersistenceType, RouteType, SplinterNode, SplinterService, UNSET_CIRCUIT_VERSION,
 };
 
 #[derive(Default, Clone)]
@@ -34,6 +34,7 @@ pub struct CreateCircuitBuilder {
     application_metadata: Option<Vec<u8>>,
     comments: Option<String>,
     display_name: Option<String>,
+    circuit_version: Option<i32>,
 }
 
 impl CreateCircuitBuilder {
@@ -83,6 +84,10 @@ impl CreateCircuitBuilder {
 
     pub fn display_name(&self) -> Option<String> {
         self.display_name.clone()
+    }
+
+    pub fn circuit_version(&self) -> Option<i32> {
+        self.circuit_version
     }
 
     pub fn with_circuit_id(mut self, circuit_id: &str) -> CreateCircuitBuilder {
@@ -149,6 +154,11 @@ impl CreateCircuitBuilder {
         self
     }
 
+    pub fn with_circuit_version(mut self, circuit_version: i32) -> CreateCircuitBuilder {
+        self.circuit_version = Some(circuit_version);
+        self
+    }
+
     pub fn build(self) -> Result<CreateCircuit, BuilderError> {
         let circuit_id = match self.circuit_id {
             Some(circuit_id) if is_valid_circuit_id(&circuit_id) => circuit_id,
@@ -212,6 +222,8 @@ impl CreateCircuitBuilder {
 
         let display_name = self.display_name;
 
+        let circuit_version = self.circuit_version.unwrap_or(UNSET_CIRCUIT_VERSION);
+
         let create_circuit_message = CreateCircuit {
             circuit_id,
             roster,
@@ -224,6 +236,7 @@ impl CreateCircuitBuilder {
             application_metadata,
             comments,
             display_name,
+            circuit_version,
         };
 
         Ok(create_circuit_message)

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -17,7 +17,7 @@
 use crate::admin::messages::{self, is_valid_circuit_id};
 use crate::error::InvalidStateError;
 
-use super::{ProposedCircuit, Service};
+use super::{ProposedCircuit, Service, UNSET_CIRCUIT_VERSION};
 
 /// Native representation of a circuit in state
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -31,6 +31,7 @@ pub struct Circuit {
     routes: RouteType,
     circuit_management_type: String,
     display_name: Option<String>,
+    circuit_version: i32,
 }
 
 impl Circuit {
@@ -77,6 +78,11 @@ impl Circuit {
     /// Returns the display name for the circuit
     pub fn display_name(&self) -> &Option<String> {
         &self.display_name
+    }
+
+    /// Returns the circuit version for the circuit
+    pub fn circuit_version(&self) -> i32 {
+        self.circuit_version
     }
 }
 
@@ -160,6 +166,7 @@ pub struct CircuitBuilder {
     routes: Option<RouteType>,
     circuit_management_type: Option<String>,
     display_name: Option<String>,
+    circuit_version: Option<i32>,
 }
 
 impl CircuitBuilder {
@@ -211,6 +218,11 @@ impl CircuitBuilder {
     /// Returns the display_name in the builder
     pub fn display_name(&self) -> Option<String> {
         self.display_name.clone()
+    }
+
+    /// Returns the circuit version in the builder
+    pub fn circuit_version(&self) -> Option<i32> {
+        self.circuit_version
     }
 
     /// Sets the circuit ID
@@ -306,6 +318,18 @@ impl CircuitBuilder {
         self
     }
 
+    /// Sets the circuit version for the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_version` - The protocol version the circuit must implement
+    ///
+    /// If this is not set, the circuit version is assumed to be 1.
+    pub fn with_circuit_version(mut self, circuit_version: i32) -> CircuitBuilder {
+        self.circuit_version = Some(circuit_version);
+        self
+    }
+
     /// Builds a `Circuit`
     ///
     /// Returns an error if the circuit ID, roster, members or circuit management
@@ -351,6 +375,8 @@ impl CircuitBuilder {
 
         let display_name = self.display_name;
 
+        let circuit_version = self.circuit_version.unwrap_or(UNSET_CIRCUIT_VERSION);
+
         let circuit = Circuit {
             id: circuit_id,
             roster,
@@ -361,6 +387,7 @@ impl CircuitBuilder {
             routes,
             circuit_management_type,
             display_name,
+            circuit_version,
         };
 
         Ok(circuit)
@@ -383,6 +410,7 @@ impl From<ProposedCircuit> for Circuit {
             routes: circuit.routes().clone(),
             circuit_management_type: circuit.circuit_management_type().into(),
             display_name: circuit.display_name().clone(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -885,6 +885,7 @@ pub mod tests {
                             .build().expect("Unable to build node"),
                         ]
                     )
+                    .with_circuit_version(3)
                     .with_application_metadata(b"test")
                     .with_comments("This is a test")
                     .with_circuit_management_type("gameroom")
@@ -1005,6 +1006,7 @@ pub mod tests {
             .with_members(&vec!["bubba-node-000".into(), "acme-node-000".into()])
             .with_circuit_management_type("gameroom")
             .with_display_name("test_display")
+            .with_circuit_version(3)
             .build()
             .expect("Unable to build circuit")
     }

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -70,6 +70,7 @@ pub struct ProposedCircuitModel {
     pub application_metadata: Option<Vec<u8>>,
     pub comments: Option<String>,
     pub display_name: Option<String>,
+    pub circuit_version: i32,
 }
 
 impl From<&ProposedCircuit> for ProposedCircuitModel {
@@ -84,6 +85,7 @@ impl From<&ProposedCircuit> for ProposedCircuitModel {
             application_metadata: proposed_circuit.application_metadata().clone(),
             comments: proposed_circuit.comments().clone(),
             display_name: proposed_circuit.display_name().clone(),
+            circuit_version: proposed_circuit.circuit_version(),
         }
     }
 }
@@ -390,6 +392,7 @@ pub struct CircuitModel {
     pub routes: String,
     pub circuit_management_type: String,
     pub display_name: Option<String>,
+    pub circuit_version: i32,
 }
 
 impl From<&Circuit> for CircuitModel {
@@ -402,6 +405,7 @@ impl From<&Circuit> for CircuitModel {
             routes: String::from(circuit.routes()),
             circuit_management_type: circuit.circuit_management_type().into(),
             display_name: circuit.display_name().clone(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }

--- a/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
@@ -75,7 +75,8 @@ where
                 .with_persistence(&PersistenceType::try_from(circuit.persistence)?)
                 .with_durability(&DurabilityType::try_from(circuit.durability)?)
                 .with_routes(&RouteType::try_from(circuit.routes)?)
-                .with_circuit_management_type(&circuit.circuit_management_type);
+                .with_circuit_management_type(&circuit.circuit_management_type)
+                .with_circuit_version(circuit.circuit_version);
 
             // if display name is set, add to builder
             if let Some(display_name) = circuit.display_name {

--- a/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
@@ -64,6 +64,7 @@ where
             Nullable<Binary>,
             Nullable<Text>,
             Nullable<Text>,
+            Integer,
         ),
         C::Backend,
     >,
@@ -235,7 +236,8 @@ where
                 .with_persistence(&PersistenceType::try_from(proposed_circuit.persistence)?)
                 .with_durability(&DurabilityType::try_from(proposed_circuit.durability)?)
                 .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
-                .with_circuit_management_type(&proposed_circuit.circuit_management_type);
+                .with_circuit_management_type(&proposed_circuit.circuit_management_type)
+                .with_circuit_version(proposed_circuit.circuit_version);
 
             if let Some(application_metadata) = &proposed_circuit.application_metadata {
                 builder = builder.with_application_metadata(&application_metadata);

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -214,7 +214,8 @@ where
                         .with_persistence(&PersistenceType::try_from(model.persistence)?)
                         .with_durability(&DurabilityType::try_from(model.durability)?)
                         .with_routes(&RouteType::try_from(model.routes)?)
-                        .with_circuit_management_type(&model.circuit_management_type);
+                        .with_circuit_management_type(&model.circuit_management_type)
+                        .with_circuit_version(model.circuit_version);
 
                     if let Some(display_name) = &model.display_name {
                         circuit_builder = circuit_builder.with_display_name(&display_name);

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -68,6 +68,7 @@ where
             Nullable<Binary>,
             Nullable<Text>,
             Nullable<Text>,
+            Integer,
         ),
         C::Backend,
     >,
@@ -177,9 +178,8 @@ where
                                 proposed_circuit.durability,
                             )?)
                             .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
-                            .with_circuit_management_type(
-                                &proposed_circuit.circuit_management_type,
-                            );
+                            .with_circuit_management_type(&proposed_circuit.circuit_management_type)
+                            .with_circuit_version(proposed_circuit.circuit_version);
 
                         if let Some(application_metadata) = &proposed_circuit.application_metadata {
                             proposed_circuit_builder = proposed_circuit_builder

--- a/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
@@ -52,6 +52,7 @@ where
             Nullable<Binary>,
             Nullable<Text>,
             Nullable<Text>,
+            Integer,
         ),
         C::Backend,
     >,

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -126,7 +126,8 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
-                .with_circuit_management_type(proposed_circuit.circuit_management_type());
+                .with_circuit_management_type(proposed_circuit.circuit_management_type())
+                .with_circuit_version(proposed_circuit.circuit_version());
 
             if let Some(display_name) = proposed_circuit.display_name() {
                 builder = builder.with_display_name(display_name);

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -33,6 +33,7 @@ table! {
         application_metadata -> Nullable<Binary>,
         comments -> Nullable<Text>,
         display_name -> Nullable<Text>,
+        circuit_version -> Integer,
     }
 }
 
@@ -112,6 +113,7 @@ table! {
         routes -> Text,
         circuit_management_type -> Text,
         display_name -> Nullable<Text>,
+        circuit_version -> Integer,
     }
 }
 

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -55,6 +55,8 @@ pub use self::proposed_node::{ProposedNode, ProposedNodeBuilder};
 pub use self::proposed_service::{ProposedService, ProposedServiceBuilder};
 pub use self::service::{Service, ServiceBuilder};
 
+pub const UNSET_CIRCUIT_VERSION: i32 = 1;
+
 /// The unique ID of service made up of a circuit ID and the individual service ID.
 /// A service ID is only required to be unique from within a circuit.
 #[derive(Clone, Debug, PartialEq)]

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1022,6 +1022,8 @@ struct YamlCircuit {
     routes: YamlRouteType,
     circuit_management_type: String,
     display_name: Option<String>,
+    #[serde(default = "default_circuit_value")]
+    circuit_version: i32,
 }
 
 impl TryFrom<YamlCircuit> for Circuit {
@@ -1042,7 +1044,8 @@ impl TryFrom<YamlCircuit> for Circuit {
             .with_persistence(&PersistenceType::from(circuit.persistence))
             .with_durability(&DurabilityType::from(circuit.durability))
             .with_routes(&RouteType::from(circuit.routes))
-            .with_circuit_management_type(&circuit.circuit_management_type);
+            .with_circuit_management_type(&circuit.circuit_management_type)
+            .with_circuit_version(circuit.circuit_version);
 
         if let Some(display_name) = &circuit.display_name {
             builder = builder.with_display_name(display_name);
@@ -1068,6 +1071,7 @@ impl From<Circuit> for YamlCircuit {
             routes: circuit.routes().clone().into(),
             circuit_management_type: circuit.circuit_management_type().into(),
             display_name: circuit.display_name().clone(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }
@@ -1342,6 +1346,8 @@ struct YamlProposedCircuit {
     application_metadata: Option<String>,
     comments: Option<String>,
     display_name: Option<String>,
+    #[serde(default = "default_circuit_value")]
+    circuit_version: i32,
 }
 
 impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
@@ -1368,7 +1374,8 @@ impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
             .with_persistence(&PersistenceType::from(circuit.persistence))
             .with_durability(&DurabilityType::from(circuit.durability))
             .with_routes(&RouteType::from(circuit.routes))
-            .with_circuit_management_type(&circuit.circuit_management_type);
+            .with_circuit_management_type(&circuit.circuit_management_type)
+            .with_circuit_version(circuit.circuit_version);
 
         if let Some(application_metadata) = circuit.application_metadata {
             builder = builder.with_application_metadata(&parse_hex(&application_metadata).map_err(
@@ -1424,6 +1431,7 @@ impl From<ProposedCircuit> for YamlProposedCircuit {
             application_metadata,
             comments: circuit.comments().clone(),
             display_name: circuit.display_name().clone(),
+            circuit_version: circuit.circuit_version(),
         }
     }
 }
@@ -1658,6 +1666,10 @@ struct YamlState {
     circuit_state: CircuitState,
     proposal_state: ProposalState,
     service_directory: BTreeMap<ServiceId, Service>,
+}
+
+fn default_circuit_value() -> i32 {
+    1
 }
 
 #[cfg(test)]
@@ -2405,6 +2417,7 @@ proposals:
             ])
             .with_members(&vec!["bubba-node-000".into(), "acme-node-000".into()])
             .with_circuit_management_type("gameroom")
+            .with_circuit_version(1)
             .build()
             .expect("Unable to build circuit")
     }

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-162225_admin_service_add_circuit_version/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-162225_admin_service_add_circuit_version/down.sql
@@ -1,0 +1,23 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE circuit
+DROP COLUMN circuit_version;
+
+ALTER TABLE proposed_circuit
+DROP COLUMN circuit_version;
+
+ALTER TABLE admin_event_proposed_circuit
+DROP COLUMN circuit_version;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-162225_admin_service_add_circuit_version/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-08-162225_admin_service_add_circuit_version/up.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;
+
+ALTER TABLE proposed_circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;
+
+ALTER TABLE admin_event_proposed_circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-162225_admin_service_add_circuit_version/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-162225_admin_service_add_circuit_version/down.sql
@@ -1,0 +1,23 @@
+-- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE circuit
+DROP COLUMN circuit_version;
+
+ALTER TABLE proposed_circuit
+DROP COLUMN circuit_version;
+
+ALTER TABLE admin_event_proposed_circuit
+DROP COLUMN circuit_version;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-162225_admin_service_add_circuit_version/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-08-162225_admin_service_add_circuit_version/up.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;
+
+ALTER TABLE proposed_circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;
+
+ALTER TABLE admin_event_proposed_circuit
+ADD COLUMN circuit_version INTEGER DEFAULT 1;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -42,6 +42,9 @@ pub const ADMIN_SERVICE_PROTOCOL_VERSION: u32 = 2;
 #[cfg(feature = "admin-service")]
 pub(crate) const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
 
+// The currently supported circuit version
+pub const CIRCUIT_PROTOCOL_VERSION: i32 = 2;
+
 #[cfg(feature = "oauth")]
 pub const OAUTH_PROTOCOL_VERSION: u32 = 1;
 

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1903,6 +1903,9 @@ components:
                 description: Human readable name for the circuit
                 type: string
                 nullable: true
+              circuit_version:
+                  description: The protocol version the circuit adheres to
+                  type: integer
         votes:
           type: array
           items:


### PR DESCRIPTION
Going forward, circuits will include an explicit version
that will make it easier to tell what is included in a
circuit. If a circuit does not have a version included it,
is assumed to be 1.

Also update the REST API (v2) and CLI to include circuit version.


```
splinter circuit show 3xU9w-3sd1s

Circuit: 3xU9w-3sd1s
    Display Name: -
    Version: 2
    Management Type: test

    acme-node-000
        Service (scabbard): a000
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a001

    bubba-node-000
        Service (scabbard): a001
          admin_keys:
              PRIVATE-KEY-FILE
          peer_services:
              a000
```
