### PR TITLE
Role-based Authorization Handler

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -99,6 +99,7 @@ experimental = [
     "admin-service-event-store",
     "admin-service-event-store-diesel",
     "authorization",
+    "authorization-handler-rbac",
     "biome-notifications",
     "biome-oauth",
     "biome-oauth-user-store-postgres",
@@ -124,6 +125,7 @@ admin-service = []
 admin-service-event-store = ["admin-service"]
 admin-service-event-store-diesel = ["diesel", "admin-service-event-store"]
 authorization = ["rest-api"]
+authorization-handler-rbac = ["authorization"]
 biome-credentials = ["bcrypt"]
 biome-key-management = []
 biome-notifications = []

--- a/libsplinter/src/rest_api/auth/rbac/handler.rs
+++ b/libsplinter/src/rest_api/auth/rbac/handler.rs
@@ -1,0 +1,275 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::InternalError;
+
+use crate::rest_api::auth::{identity::Identity, AuthorizationHandler, AuthorizationHandlerResult};
+
+use super::store::{Identity as StoreIdentity, RoleBasedAuthorizationStore};
+
+/// A Role-based authorization handler.
+///
+/// This handler determines if an identity has a requested permission by examining the roles that
+/// it has been assigned.  If one of the identity's assigned roles contains the permission, then
+/// the identity is allowed access. If not, the handler defers to the next handler in the chain.
+///
+/// It currently does not deny any permissions.
+pub struct RoleBasedAuthorizationHandler {
+    role_based_auth_store: Box<dyn RoleBasedAuthorizationStore>,
+}
+
+impl RoleBasedAuthorizationHandler {
+    /// Construct a new role-based authorization handler with the given store.
+    pub fn new(role_based_auth_store: Box<dyn RoleBasedAuthorizationStore>) -> Self {
+        Self {
+            role_based_auth_store,
+        }
+    }
+}
+
+impl AuthorizationHandler for RoleBasedAuthorizationHandler {
+    fn has_permission(
+        &self,
+        identity: &Identity,
+        permission_id: &str,
+    ) -> Result<AuthorizationHandlerResult, InternalError> {
+        let store_identity = match identity {
+            Identity::Custom(_) =>
+            // RoleBasedAuthorization does not currently support custom identities, so return
+            // continue in case a downstream handler will support it.
+            {
+                return Ok(AuthorizationHandlerResult::Continue)
+            }
+            Identity::Key(key) => StoreIdentity::Key(key.to_string()),
+            Identity::User(user_id) => StoreIdentity::User(user_id.to_string()),
+        };
+
+        Ok(self
+            .role_based_auth_store
+            .get_assigned_roles(&store_identity)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?
+            .find(|role| role.permissions().iter().any(|perm| perm == permission_id))
+            .map(|_| AuthorizationHandlerResult::Allow)
+            .unwrap_or(AuthorizationHandlerResult::Continue))
+    }
+
+    fn clone_box(&self) -> Box<dyn AuthorizationHandler> {
+        Box::new(RoleBasedAuthorizationHandler {
+            role_based_auth_store: self.role_based_auth_store.clone_box(),
+        })
+    }
+}
+
+#[cfg(all(test, feature = "sqlite",))]
+mod tests {
+    use super::*;
+
+    use crate::rest_api::auth::rbac::store::{
+        AssignmentBuilder, DieselRoleBasedAuthorizationStore, RoleBuilder,
+    };
+
+    use crate::migrations::run_sqlite_migrations;
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    #[test]
+    fn allow_key_identity_with_assignment() {
+        test_allow_identity_with_assignment(
+            Identity::Key("abc123".into()),
+            StoreIdentity::Key("abc123".into()),
+        );
+    }
+
+    #[test]
+    fn allow_user_identity_with_assignment() {
+        test_allow_identity_with_assignment(
+            Identity::User("some-user-id".into()),
+            StoreIdentity::User("some-user-id".into()),
+        );
+    }
+
+    #[test]
+    fn continue_key_identity_with_assignment_mismatch() {
+        test_continue_identity_with_mismatched_assignment(
+            Identity::Key("abc123".into()),
+            StoreIdentity::Key("abc123".into()),
+        );
+    }
+
+    #[test]
+    fn continue_user_identity_with_assignment_mismatch() {
+        test_continue_identity_with_mismatched_assignment(
+            Identity::User("some-user-id".into()),
+            StoreIdentity::User("some-user-id".into()),
+        );
+    }
+
+    #[test]
+    fn continue_key_identity_with_no_assignment() {
+        test_continue_identity_with_no_assignment(Identity::Key("abc123".into()));
+    }
+
+    #[test]
+    fn continue_user_identity_with_no_assignment() {
+        test_continue_identity_with_no_assignment(Identity::User("some-user-id".into()));
+    }
+
+    #[test]
+    fn continue_custom_identity() {
+        let role_based_auth_store = create_role_based_authorization_store();
+        let handler = RoleBasedAuthorizationHandler::new(role_based_auth_store);
+        let result = handler
+            .has_permission(&Identity::Custom("Anything".into()), "a")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Continue));
+    }
+
+    /// This test checks that an identity with an assigned role will return Allow when queried.
+    fn test_allow_identity_with_assignment(identity: Identity, store_identity: StoreIdentity) {
+        let role_based_auth_store = create_role_based_authorization_store();
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-1".into())
+            .with_display_name("Test Role 1".into())
+            .with_permissions(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-2".into())
+            .with_display_name("Test Role 2".into())
+            .with_permissions(vec!["x".to_string(), "y".to_string(), "z".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        let assignment = AssignmentBuilder::new()
+            .with_identity(store_identity)
+            .with_roles(vec!["test-role-1".to_string(), "test-role-2".to_string()])
+            .build()
+            .expect("Unable to build assignment");
+
+        role_based_auth_store
+            .add_assignment(assignment)
+            .expect("Unable to add assignment");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let handler = RoleBasedAuthorizationHandler::new(role_based_auth_store);
+
+        // Check a permission in the first role
+        let result = handler
+            .has_permission(&identity, "a")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Allow));
+
+        // Check a permission in the second role
+        let result = handler
+            .has_permission(&identity, "z")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Allow));
+    }
+
+    /// This test checks that an identity with an assignment that does not include the permission
+    /// being checked returns Continue.
+    fn test_continue_identity_with_mismatched_assignment(
+        identity: Identity,
+        store_identity: StoreIdentity,
+    ) {
+        let role_based_auth_store = create_role_based_authorization_store();
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-1".into())
+            .with_display_name("Test Role 1".into())
+            .with_permissions(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-2".into())
+            .with_display_name("Test Role 2".into())
+            .with_permissions(vec!["x".to_string(), "y".to_string(), "z".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        let assignment = AssignmentBuilder::new()
+            .with_identity(store_identity)
+            .with_roles(vec!["test-role-1".to_string(), "test-role-2".to_string()])
+            .build()
+            .expect("Unable to build assignment");
+
+        role_based_auth_store
+            .add_assignment(assignment)
+            .expect("Unable to add assignment");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let handler = RoleBasedAuthorizationHandler::new(role_based_auth_store);
+        let result = handler
+            .has_permission(&identity, "non-assigned-permission")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Continue));
+    }
+
+    fn test_continue_identity_with_no_assignment(identity: Identity) {
+        let role_based_auth_store = create_role_based_authorization_store();
+
+        let handler = RoleBasedAuthorizationHandler::new(role_based_auth_store);
+        let result = handler
+            .has_permission(&identity, "non-assigned-permission")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Continue));
+    }
+
+    /// Creates a RoleBasedAuthorizationStore
+    fn create_role_based_authorization_store() -> Box<dyn RoleBasedAuthorizationStore> {
+        let pool = create_connection_pool_and_migrate();
+        Box::new(DieselRoleBasedAuthorizationStore::new(pool))
+    }
+
+    /// Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection insures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+}

--- a/libsplinter/src/rest_api/auth/rbac/mod.rs
+++ b/libsplinter/src/rest_api/auth/rbac/mod.rs
@@ -12,4 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "authorization-handler-rbac")]
+mod handler;
 pub mod store;
+
+#[cfg(feature = "authorization-handler-rbac")]
+pub use handler::RoleBasedAuthorizationHandler;

--- a/libsplinter/src/rest_api/auth/rbac/store/diesel/operations/get_assigned_roles.rs
+++ b/libsplinter/src/rest_api/auth/rbac/store/diesel/operations/get_assigned_roles.rs
@@ -1,0 +1,82 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+
+use diesel::prelude::*;
+
+use crate::rest_api::auth::rbac::store::{
+    diesel::{
+        models::{AssignmentModel, IdentityModel, RoleModel, RolePermissionModel},
+        schema::{identities, roles},
+    },
+    Identity, Role, RoleBasedAuthorizationStoreError,
+};
+
+use super::RoleBasedAuthorizationStoreOperations;
+
+pub trait RoleBasedAuthorizationStoreGetAssignedRoles {
+    fn get_assigned_roles(
+        &self,
+        identity: &Identity,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError>;
+}
+
+impl<'a, C> RoleBasedAuthorizationStoreGetAssignedRoles
+    for RoleBasedAuthorizationStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+{
+    fn get_assigned_roles(
+        &self,
+        identity: &Identity,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError> {
+        let search_identity = match identity {
+            Identity::Key(ref key) => key,
+            Identity::User(ref user_id) => user_id,
+        };
+        self.conn
+            .transaction::<Box<dyn ExactSizeIterator<Item = Role>>, _, _>(|| {
+                let identities = identities::table
+                    .filter(identities::identity.eq(search_identity))
+                    .load::<IdentityModel>(self.conn)?;
+
+                let role_ids = AssignmentModel::belonging_to(&identities)
+                    .load::<AssignmentModel>(self.conn)?
+                    .into_iter()
+                    .map(|assignment| assignment.role_id)
+                    .collect::<Vec<_>>();
+
+                let roles = roles::table
+                    .filter(roles::id.eq_any(role_ids))
+                    .load::<RoleModel>(self.conn)?;
+
+                let perms = RolePermissionModel::belonging_to(&roles)
+                    .load::<RolePermissionModel>(self.conn)?
+                    .grouped_by(&roles);
+
+                Ok(Box::new(
+                    roles
+                        .into_iter()
+                        .zip(perms)
+                        .map(|models| models.try_into())
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(RoleBasedAuthorizationStoreError::from)?
+                        .into_iter(),
+                ))
+            })
+    }
+}

--- a/libsplinter/src/rest_api/auth/rbac/store/diesel/operations/mod.rs
+++ b/libsplinter/src/rest_api/auth/rbac/store/diesel/operations/mod.rs
@@ -14,6 +14,7 @@
 
 pub(super) mod add_assignment;
 pub(super) mod add_role;
+pub(super) mod get_assigned_roles;
 pub(super) mod get_assignment;
 pub(super) mod get_role;
 pub(super) mod list_assignments;

--- a/libsplinter/src/rest_api/auth/rbac/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/rbac/store/mod.rs
@@ -350,6 +350,12 @@ pub trait RoleBasedAuthorizationStore: Send + Sync {
         identity: &Identity,
     ) -> Result<Option<Assignment>, RoleBasedAuthorizationStoreError>;
 
+    /// Returns the assigned roles for the given Identity.
+    fn get_assigned_roles(
+        &self,
+        identity: &Identity,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError>;
+
     /// Lists all assignments.
     fn list_assignments(
         &self,

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -81,6 +81,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "authorization",
+    "authorization-handler-rbac",
     "admin-service-event-store",
     "biome-oauth",
     "health",
@@ -102,6 +103,11 @@ authorization = [
     "health/authorization",
     "scabbard/authorization",
     "splinter/authorization",
+]
+authorization-handler-rbac = [
+    "splinter/authorization",
+    "splinter/authorization-handler-rbac",
+    "splinter/role-based-authorization-store-postgres",
 ]
 biome-credentials = ["database", "splinter/biome-credentials"]
 biome-key-management = ["database", "splinter/biome-key-management"]

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -60,6 +60,8 @@ use splinter::registry::{
 };
 #[cfg(feature = "maintenance-mode")]
 use splinter::rest_api::auth::maintenance::MaintenanceModeAuthorizationHandler;
+#[cfg(feature = "authorization-handler-rbac")]
+use splinter::rest_api::auth::rbac::RoleBasedAuthorizationHandler;
 #[cfg(feature = "authorization")]
 use splinter::rest_api::auth::{
     allow_keys::AllowKeysAuthorizationHandler, AuthorizationHandler, Permission,
@@ -538,6 +540,14 @@ impl SplinterDaemon {
         {
             let mut authorization_handlers = vec![];
             authorization_handlers.push(create_allow_keys_authorization_handler(&self.state_dir)?);
+
+            #[cfg(feature = "authorization-handler-rbac")]
+            {
+                authorization_handlers.push(Box::new(RoleBasedAuthorizationHandler::new(
+                    store_factory.get_role_based_authorization_store(),
+                )));
+            }
+
             #[cfg(feature = "maintenance-mode")]
             {
                 let maintenance_mode_auth_handler = MaintenanceModeAuthorizationHandler::new();


### PR DESCRIPTION
This PR implements the Role-based Authorization handler.  It includes an update to the `RoleBaseAuthorizationStore` to provide a function to return the roles assigned to a given identity.