### PR TITLE
Update UserProfileStore

### DIFF
--- a/libsplinter/src/biome/profile/store/diesel/mod.rs
+++ b/libsplinter/src/biome/profile/store/diesel/mod.rs
@@ -118,7 +118,7 @@ impl UserProfileStore for DieselUserProfileStore<diesel::sqlite::SqliteConnectio
 impl From<ProfileModel> for Profile {
     fn from(user_profile: ProfileModel) -> Self {
         Self {
-            user_id: user_profile.user_id,
+            subject: user_profile.subject,
             name: user_profile.name,
             given_name: user_profile.given_name,
             family_name: user_profile.family_name,

--- a/libsplinter/src/biome/profile/store/diesel/mod.rs
+++ b/libsplinter/src/biome/profile/store/diesel/mod.rs
@@ -118,6 +118,7 @@ impl UserProfileStore for DieselUserProfileStore<diesel::sqlite::SqliteConnectio
 impl From<ProfileModel> for Profile {
     fn from(user_profile: ProfileModel) -> Self {
         Self {
+            user_id: user_profile.user_id,
             subject: user_profile.subject,
             name: user_profile.name,
             given_name: user_profile.given_name,
@@ -154,10 +155,12 @@ pub mod tests {
         let user_profile_store = DieselUserProfileStore::new(pool);
 
         let user_id = "user_id".to_string();
+        let subject = "subject".to_string();
         let name = Some("name".to_string());
 
         let profile = ProfileBuilder::new()
             .with_user_id(user_id.clone())
+            .with_subject(subject.clone())
             .with_name(name)
             .with_given_name(None)
             .with_family_name(None)
@@ -174,6 +177,7 @@ pub mod tests {
             .expect("Unable to get profile");
 
         assert_eq!(profile.user_id(), &user_id);
+        assert_eq!(profile.subject(), &subject);
         assert_eq!(profile.name(), Some("name"));
         assert_eq!(profile.given_name(), None);
         assert_eq!(profile.family_name(), None);
@@ -197,10 +201,12 @@ pub mod tests {
         let user_profile_store = DieselUserProfileStore::new(pool);
 
         let user_id = "user_id".to_string();
+        let subject = "subject".to_string();
         let name = Some("name".to_string());
 
         let profile = ProfileBuilder::new()
             .with_user_id(user_id.clone())
+            .with_subject(subject.clone())
             .with_name(name)
             .with_given_name(None)
             .with_family_name(None)
@@ -218,6 +224,7 @@ pub mod tests {
         let profile = &profiles.unwrap()[0];
 
         assert_eq!(profile.user_id(), "user_id");
+        assert_eq!(profile.subject(), "subject");
         assert_eq!(profile.name(), Some("name"));
         assert!(profile.given_name().is_none());
         assert!(profile.family_name().is_none());
@@ -243,10 +250,12 @@ pub mod tests {
         let user_profile_store = DieselUserProfileStore::new(pool);
 
         let user_id = "user_id".to_string();
+        let subject = "subject".to_string();
         let name = Some("name".to_string());
 
         let profile = ProfileBuilder::new()
             .with_user_id(user_id.clone())
+            .with_subject(subject.clone())
             .with_name(name)
             .with_given_name(None)
             .with_family_name(None)
@@ -260,6 +269,7 @@ pub mod tests {
 
         let updated_profile = ProfileBuilder::new()
             .with_user_id(user_id.clone())
+            .with_subject(subject.clone())
             .with_name(Some("New Name".to_string()))
             .with_given_name(Some("New".to_string()))
             .with_family_name(Some("Name".to_string()))
@@ -277,6 +287,7 @@ pub mod tests {
             .expect("Unable to get updated profile");
 
         assert_eq!(updated_profile.user_id(), "user_id");
+        assert_eq!(updated_profile.subject(), "subject");
         assert_eq!(updated_profile.name(), Some("New Name"));
         assert_eq!(updated_profile.given_name(), Some("New"));
         assert_eq!(updated_profile.family_name(), Some("Name"));
@@ -285,6 +296,7 @@ pub mod tests {
 
         let bad_profile = ProfileBuilder::new()
             .with_user_id("bad_id".to_string())
+            .with_subject(subject.clone())
             .with_name(None)
             .with_given_name(None)
             .with_family_name(None)
@@ -311,10 +323,12 @@ pub mod tests {
         let user_profile_store = DieselUserProfileStore::new(pool);
 
         let user_id = "user_id".to_string();
+        let subject = "subject".to_string();
         let name = Some("name".to_string());
 
         let profile = ProfileBuilder::new()
             .with_user_id(user_id.clone())
+            .with_subject(subject.clone())
             .with_name(name)
             .with_given_name(None)
             .with_family_name(None)
@@ -322,6 +336,7 @@ pub mod tests {
             .with_picture(None)
             .build()
             .expect("Unable to build profile");
+
         user_profile_store
             .add_profile(profile)
             .expect("Unable to add profile");

--- a/libsplinter/src/biome/profile/store/diesel/models.rs
+++ b/libsplinter/src/biome/profile/store/diesel/models.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::biome::profile::store::Profile;
+
 use super::schema::user_profile;
 
-#[derive(Queryable, Identifiable, Associations, PartialEq, Debug)]
+#[derive(Insertable, Queryable, Identifiable, Associations, PartialEq, Debug)]
 #[table_name = "user_profile"]
+#[primary_key(user_id)]
 pub struct ProfileModel {
-    pub id: i64,
+    pub user_id: String,
     pub subject: String,
     pub name: Option<String>,
     pub given_name: Option<String>,
@@ -26,13 +29,16 @@ pub struct ProfileModel {
     pub picture: Option<String>,
 }
 
-#[derive(Insertable, PartialEq, Debug)]
-#[table_name = "user_profile"]
-pub struct NewProfileModel {
-    pub subject: String,
-    pub name: Option<String>,
-    pub given_name: Option<String>,
-    pub family_name: Option<String>,
-    pub email: Option<String>,
-    pub picture: Option<String>,
+impl From<Profile> for ProfileModel {
+    fn from(profile: Profile) -> Self {
+        ProfileModel {
+            user_id: profile.user_id,
+            subject: profile.subject,
+            name: profile.name,
+            given_name: profile.given_name,
+            family_name: profile.family_name,
+            email: profile.email,
+            picture: profile.picture,
+        }
+    }
 }

--- a/libsplinter/src/biome/profile/store/diesel/models.rs
+++ b/libsplinter/src/biome/profile/store/diesel/models.rs
@@ -18,7 +18,7 @@ use super::schema::user_profile;
 #[table_name = "user_profile"]
 pub struct ProfileModel {
     pub id: i64,
-    pub user_id: String,
+    pub subject: String,
     pub name: Option<String>,
     pub given_name: Option<String>,
     pub family_name: Option<String>,
@@ -29,7 +29,7 @@ pub struct ProfileModel {
 #[derive(Insertable, PartialEq, Debug)]
 #[table_name = "user_profile"]
 pub struct NewProfileModel {
-    pub user_id: String,
+    pub subject: String,
     pub name: Option<String>,
     pub given_name: Option<String>,
     pub family_name: Option<String>,

--- a/libsplinter/src/biome/profile/store/diesel/operations/add_profile.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/add_profile.rs
@@ -17,10 +17,7 @@ use super::UserProfileStoreOperations;
 use diesel::{dsl::insert_into, prelude::*, result::Error::NotFound};
 
 use crate::biome::profile::store::{
-    diesel::{
-        models::{NewProfileModel, ProfileModel},
-        schema::user_profile,
-    },
+    diesel::{models::ProfileModel, schema::user_profile},
     Profile, UserProfileStoreError,
 };
 
@@ -53,10 +50,8 @@ impl<'a> UserProfileStoreAddProfile
             ));
         }
 
-        let new_profile: NewProfileModel = profile.into();
-
         insert_into(user_profile::table)
-            .values(new_profile)
+            .values(ProfileModel::from(profile))
             .execute(self.conn)
             .map(|_| ())
             .map_err(|_| {
@@ -89,10 +84,8 @@ impl<'a> UserProfileStoreAddProfile for UserProfileStoreOperations<'a, diesel::p
             ));
         }
 
-        let new_profile: NewProfileModel = profile.into();
-
         insert_into(user_profile::table)
-            .values(new_profile)
+            .values(ProfileModel::from(profile))
             .execute(self.conn)
             .map(|_| ())
             .map_err(|_| {

--- a/libsplinter/src/biome/profile/store/diesel/schema.rs
+++ b/libsplinter/src/biome/profile/store/diesel/schema.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 table! {
-    user_profile {
-        id -> Int8,
+    user_profile (user_id) {
+        user_id -> Text,
         subject -> Text,
         name -> Nullable<Text>,
         given_name -> Nullable<Text>,

--- a/libsplinter/src/biome/profile/store/diesel/schema.rs
+++ b/libsplinter/src/biome/profile/store/diesel/schema.rs
@@ -15,7 +15,7 @@
 table! {
     user_profile {
         id -> Int8,
-        user_id -> Text,
+        subject -> Text,
         name -> Nullable<Text>,
         given_name -> Nullable<Text>,
         family_name -> Nullable<Text>,

--- a/libsplinter/src/biome/profile/store/mod.rs
+++ b/libsplinter/src/biome/profile/store/mod.rs
@@ -18,7 +18,6 @@ pub mod error;
 pub(in crate::biome) mod memory;
 
 use crate::error::InvalidStateError;
-
 use serde::{Deserialize, Serialize};
 
 pub use error::UserProfileStoreError;
@@ -28,7 +27,7 @@ use self::diesel::models::NewProfileModel;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Profile {
-    user_id: String,
+    subject: String,
     name: Option<String>,
     given_name: Option<String>,
     family_name: Option<String>,
@@ -37,9 +36,9 @@ pub struct Profile {
 }
 
 impl Profile {
-    /// Returns the user_id for the profile
-    pub fn user_id(&self) -> &str {
-        &self.user_id
+    /// Returns the subject for the profile
+    pub fn subject(&self) -> &str {
+        &self.subject
     }
 
     /// Returns the name for the profile
@@ -71,7 +70,7 @@ impl Profile {
 /// Builder for profile.
 #[derive(Default)]
 pub struct ProfileBuilder {
-    user_id: Option<String>,
+    subject: Option<String>,
     name: Option<String>,
     given_name: Option<String>,
     family_name: Option<String>,
@@ -84,9 +83,9 @@ impl ProfileBuilder {
         Self::default()
     }
 
-    /// Sets the user id for the profile
-    pub fn with_user_id(mut self, user_id: String) -> ProfileBuilder {
-        self.user_id = Some(user_id);
+    /// Sets the subject for the profile
+    pub fn with_subject(mut self, subject: String) -> ProfileBuilder {
+        self.subject = Some(subject);
         self
     }
 
@@ -123,7 +122,7 @@ impl ProfileBuilder {
     /// Builds the profile
     pub fn build(self) -> Result<Profile, InvalidStateError> {
         Ok(Profile {
-            user_id: self.user_id.ok_or_else(|| {
+            subject: self.subject.ok_or_else(|| {
                 InvalidStateError::with_message("A user id is required to build a Profile".into())
             })?,
             name: self.name,

--- a/libsplinter/src/biome/profile/store/mod.rs
+++ b/libsplinter/src/biome/profile/store/mod.rs
@@ -166,12 +166,7 @@ pub trait UserProfileStore: Sync + Send {
     ///
     /// #Arguments
     ///
-    ///  * `user_id` - The unique identifier of the user the profile belongs to
-    ///  * `name` - The updated name for the user profile
-    ///  * `given_name` - The updated given name for the user profile
-    ///  * `family_name` - The updated family name for the user profile
-    ///  * `email` - The updated email for the user profile
-    ///  * `picture` - The updated picture for the user profile
+    ///  * `profile` - The profile to be added
     ///
     /// # Errors
     ///

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-07-083000_biome_create_profiles/up.sql
@@ -14,8 +14,8 @@
 -- -----------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS user_profile (
-  id           BIGSERIAL    PRIMARY KEY,
-  user_id      TEXT,
+  user_id      TEXT        PRIMARY KEY,
+  subject      TEXT        NOT NULL UNIQUE,
   name         TEXT,
   given_name   TEXT,
   family_name  TEXT,

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-07-083000_biome_create_profiles/up.sql
@@ -14,8 +14,8 @@
 -- -----------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS user_profile (
-  id           INTEGER    PRIMARY KEY AUTOINCREMENT,
-  user_id      TEXT       NOT NULL,
+  user_id      TEXT        PRIMARY KEY,
+  subject      TEXT        NOT NULL UNIQUE,
   name         TEXT,
   given_name   TEXT,
   family_name  TEXT,


### PR DESCRIPTION
Rename `user_id` as `subject` in the `Profile` struct that represents oauth user profile data. 

Add an `InsertableProfile` struct which has a `user_id` field, this is the Biome ID associated with the profile. This struct represents user profile data that is able to be stored in the `UserProfileStore` Modify the `ProfileModel` struct to have a `user_id` field as well and remove the `NewProfileModel` struct Modify the user profile store table to use `user_id` as the primary key.

Fix doc comment typo for the `update_profile` method.

Modify the postgres and sqlite migrations for the `user_profile` table to have subject and use user_id as the primary key.