### PR TITLE
Add `circuit_status` to circuits

### DIFF
--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -737,8 +737,8 @@ mod test {
     };
 
     use splinter::admin::messages::{
-        AuthorizationType, CreateCircuit, DurabilityType, PersistenceType, ProposalType, RouteType,
-        Vote, VoteRecord,
+        AuthorizationType, CircuitStatus, CreateCircuit, DurabilityType, PersistenceType,
+        ProposalType, RouteType, Vote, VoteRecord,
     };
 
     static DATABASE_URL: &str = "postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test";
@@ -1294,6 +1294,7 @@ mod test {
             comments: Some("test circuit".to_string()),
             display_name: None,
             circuit_version: 1,
+            circuit_status: CircuitStatus::Active,
         }
     }
 

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -64,6 +64,19 @@ message Circuit {
         ANY_ROUTE = 1;
     }
 
+    enum CircuitStatus {
+        UNSET_CIRCUIT_STATUS = 0;
+
+        ACTIVE = 1;
+
+        // The circuit has been disbanded and no longer has networking
+        // capabilities
+        DISBANDED = 2;
+
+        // The circuit has been abandoned and may be removed from storage
+        ABANDONED = 3;
+    }
+
     // The unique circuit name
     string circuit_id = 1;
 
@@ -101,6 +114,9 @@ message Circuit {
 
     // The version of the circuit
     int32 circuit_version = 12;
+
+    // The status of the circuit
+    CircuitStatus circuit_status = 13;
 }
 
 // Contains the vote counts for a given proposal.

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -127,7 +127,7 @@ message CircuitProposal {
         UPDATE_ROSTER = 2;
         ADD_NODE = 3;
         REMOVE_NODE = 4;
-        DESTROY = 5;
+        DISBAND = 5;
     }
 
     // An individual vote record
@@ -184,7 +184,7 @@ message CircuitManagementPayload {
          CIRCUIT_UPDATE_REMOVE_NODE = 5;
          CIRCUIT_UPDATE_APPLICATION_METADATA_REQUEST = 6;
          CIRCUIT_JOIN_REQUEST = 7;
-         CIRCUIT_DESTROY_REQUEST = 8;
+         CIRCUIT_DISBAND_REQUEST = 8;
          CIRCUIT_ABANDON = 9;
     }
 
@@ -215,7 +215,7 @@ message CircuitManagementPayload {
     CircuitUpdateApplicationMetadataRequest
         circuit_update_application_metadata_request = 8;
     CircuitJoinRequest circuit_join_request = 9;
-    CircuitDestroyRequest circuit_destroy_request = 10;
+    CircuitDisbandRequest circuit_disband_request = 10;
     CircuitAbandon circuit_abandon = 11;
 }
 
@@ -287,7 +287,7 @@ message CircuitJoinRequest {
     Circuit circuit = 1;
 }
 
-message CircuitDestroyRequest {
+message CircuitDisbandRequest {
     // The unique circuit name
     string circuit_id = 1;
 }

--- a/libsplinter/src/admin/messages.rs
+++ b/libsplinter/src/admin/messages.rs
@@ -14,8 +14,8 @@
 
 pub use super::service::messages::{
     is_valid_circuit_id, is_valid_service_id, AdminServiceEvent, AuthorizationType,
-    CircuitProposal, CircuitProposalVote, CreateCircuit, DurabilityType, PersistenceType,
-    ProposalType, RouteType, SplinterNode, SplinterService, Vote, VoteRecord,
+    CircuitProposal, CircuitProposalVote, CircuitStatus, CreateCircuit, DurabilityType,
+    PersistenceType, ProposalType, RouteType, SplinterNode, SplinterService, Vote, VoteRecord,
 };
 
 pub use super::service::messages::builders::{

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -233,8 +233,8 @@ mod tests {
 
     use crate::admin::{
         messages::{
-            AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType, PersistenceType,
-            ProposalType, RouteType, SplinterNode,
+            AuthorizationType, CircuitProposal, CircuitStatus, CreateCircuit, DurabilityType,
+            PersistenceType, ProposalType, RouteType, SplinterNode,
         },
         service::proposal_store::{ProposalIter, ProposalStoreError},
         store::{
@@ -768,6 +768,7 @@ mod tests {
                 comments: Some("mock circuit 1".into()),
                 display_name: Some("circuit_1".into()),
                 circuit_version: 1,
+                circuit_status: CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],
@@ -793,6 +794,7 @@ mod tests {
                 comments: Some("mock circuit 2".into()),
                 display_name: Some("circuit_2".into()),
                 circuit_version: 2,
+                circuit_status: CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],
@@ -821,6 +823,7 @@ mod tests {
                 comments: Some("mock circuit 3".into()),
                 display_name: None,
                 circuit_version: 1,
+                circuit_status: CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -135,8 +135,8 @@ mod tests {
 
     use crate::admin::{
         messages::{
-            AuthorizationType, CircuitProposal, CreateCircuit, DurabilityType, PersistenceType,
-            ProposalType, RouteType,
+            AuthorizationType, CircuitProposal, CircuitStatus, CreateCircuit, DurabilityType,
+            PersistenceType, ProposalType, RouteType,
         },
         service::proposal_store::{ProposalIter, ProposalStoreError},
         store::CircuitPredicate,
@@ -279,6 +279,7 @@ mod tests {
                 comments: Some("mock circuit".into()),
                 display_name: Some("test_circuit".into()),
                 circuit_version: 1,
+                circuit_status: CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/rest_api/resources/v1/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v1/proposals.rs
@@ -43,7 +43,7 @@ impl<'a> From<&'a CircuitProposal> for ProposalResponse<'a> {
             ProposalType::UpdateRoster => "UpdateRoster",
             ProposalType::AddNode => "AddNode",
             ProposalType::RemoveNode => "RemoveNode",
-            ProposalType::Destroy => "Destroy",
+            ProposalType::Disband => "Disband",
         };
 
         Self {

--- a/libsplinter/src/admin/rest_api/resources/v1/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v1/proposals_circuit_id.rs
@@ -36,7 +36,7 @@ impl<'a> From<&'a CircuitProposal> for ProposalResponse<'a> {
             ProposalType::UpdateRoster => "UpdateRoster",
             ProposalType::AddNode => "AddNode",
             ProposalType::RemoveNode => "RemoveNode",
-            ProposalType::Destroy => "Destroy",
+            ProposalType::Disband => "Disband",
         };
 
         Self {

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::admin::store::{Circuit, Service};
+use crate::admin::store::{Circuit, CircuitStatus, Service};
 use crate::rest_api::paging::Paging;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -31,6 +31,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub management_type: &'a str,
     pub display_name: &'a Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: &'a CircuitStatus,
 }
 
 impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
@@ -42,6 +43,7 @@ impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
             management_type: circuit.circuit_management_type(),
             display_name: circuit.display_name(),
             circuit_version: circuit.circuit_version(),
+            circuit_status: circuit.circuit_status(),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::admin::store::{Circuit, Service};
+use crate::admin::store::{Circuit, CircuitStatus, Service};
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct CircuitResponse<'a> {
@@ -24,6 +24,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub management_type: &'a str,
     pub display_name: &'a Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: &'a CircuitStatus,
 }
 
 impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
@@ -35,6 +36,7 @@ impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
             management_type: circuit.circuit_management_type(),
             display_name: circuit.display_name(),
             circuit_version: circuit.circuit_version(),
+            circuit_status: circuit.circuit_status(),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
@@ -46,7 +46,7 @@ impl<'a> TryFrom<&'a CircuitProposal> for ProposalResponse<'a> {
             ProposalType::UpdateRoster => "UpdateRoster",
             ProposalType::AddNode => "AddNode",
             ProposalType::RemoveNode => "RemoveNode",
-            ProposalType::Destroy => "Destroy",
+            ProposalType::Disband => "Disband",
         };
 
         Ok(Self {

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
@@ -14,7 +14,8 @@
 use std::convert::TryFrom;
 
 use crate::admin::messages::{
-    CircuitProposal, CreateCircuit, ProposalType, SplinterNode, SplinterService, Vote, VoteRecord,
+    CircuitProposal, CircuitStatus, CreateCircuit, ProposalType, SplinterNode, SplinterService,
+    Vote, VoteRecord,
 };
 use crate::hex::as_hex;
 use crate::rest_api::paging::Paging;
@@ -94,6 +95,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub comments: &'a Option<String>,
     pub display_name: &'a Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: &'a CircuitStatus,
 }
 
 impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
@@ -113,6 +115,7 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
             comments: &circuit.comments,
             display_name: &circuit.display_name,
             circuit_version: circuit.circuit_version,
+            circuit_status: &circuit.circuit_status,
         })
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
@@ -41,7 +41,7 @@ impl<'a> TryFrom<&'a CircuitProposal> for ProposalResponse<'a> {
             ProposalType::UpdateRoster => "UpdateRoster",
             ProposalType::AddNode => "AddNode",
             ProposalType::RemoveNode => "RemoveNode",
-            ProposalType::Destroy => "Destroy",
+            ProposalType::Disband => "Disband",
         };
 
         Ok(Self {

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
@@ -15,7 +15,8 @@
 use std::convert::TryFrom;
 
 use crate::admin::messages::{
-    CircuitProposal, CreateCircuit, ProposalType, SplinterNode, SplinterService, Vote, VoteRecord,
+    CircuitProposal, CircuitStatus, CreateCircuit, ProposalType, SplinterNode, SplinterService,
+    Vote, VoteRecord,
 };
 use crate::hex::as_hex;
 
@@ -89,6 +90,7 @@ pub(crate) struct CircuitResponse<'a> {
     pub comments: &'a Option<String>,
     pub display_name: &'a Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: &'a CircuitStatus,
 }
 
 impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
@@ -108,6 +110,7 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
             comments: &circuit.comments,
             display_name: &circuit.display_name,
             circuit_version: circuit.circuit_version,
+            circuit_status: &circuit.circuit_status,
         })
     }
 }

--- a/libsplinter/src/admin/service/event/store/diesel/mod.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/mod.rs
@@ -125,8 +125,8 @@ pub mod tests {
 
     use crate::admin::service::event::EventType;
     use crate::admin::store::{
-        CircuitProposal, CircuitProposalBuilder, ProposalType, ProposedCircuitBuilder,
-        ProposedNodeBuilder, ProposedServiceBuilder,
+        CircuitProposal, CircuitProposalBuilder, CircuitStatus, ProposalType,
+        ProposedCircuitBuilder, ProposedNodeBuilder, ProposedServiceBuilder,
     };
     use crate::hex::parse_hex;
     use crate::migrations::run_sqlite_migrations;
@@ -446,6 +446,7 @@ pub mod tests {
                     .with_comments("This is a test")
                     .with_circuit_management_type(management_type)
                     .with_display_name("test_display")
+                    .with_circuit_status(&CircuitStatus::Active)
                     .build().expect("Unable to build circuit")
             )
             .with_requester(

--- a/libsplinter/src/admin/service/event/store/diesel/models.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/models.rs
@@ -443,7 +443,7 @@ impl From<&messages::ProposalType> for String {
             messages::ProposalType::UpdateRoster => String::from("UpdateRoster"),
             messages::ProposalType::AddNode => String::from("AddNode"),
             messages::ProposalType::RemoveNode => String::from("RemoveNode"),
-            messages::ProposalType::Destroy => String::from("Destroy"),
+            messages::ProposalType::Disband => String::from("Disband"),
         }
     }
 }

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events.rs
@@ -61,6 +61,7 @@ where
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
 {
     fn list_events(&self, event_ids: Vec<i64>) -> Result<EventIter, AdminServiceEventStoreError> {
         self.conn.transaction::<EventIter, _, _>(|| {

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_by_management_type_since.rs
@@ -42,6 +42,7 @@ where
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
 {
     fn list_events_by_management_type_since(
         &self,

--- a/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/operations/list_events_since.rs
@@ -38,6 +38,7 @@ where
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
     Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Binary, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
 {
     fn list_events_since(&self, start: i64) -> Result<EventIter, AdminServiceEventStoreError> {
         self.conn.transaction::<EventIter, _, _>(|| {

--- a/libsplinter/src/admin/service/event/store/diesel/schema.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/schema.rs
@@ -44,6 +44,7 @@ table! {
         comments -> Nullable<Text>,
         display_name -> Nullable<Text>,
         circuit_version -> Integer,
+        circuit_status -> SmallInt,
     }
 }
 

--- a/libsplinter/src/admin/service/event/store/memory.rs
+++ b/libsplinter/src/admin/service/event/store/memory.rs
@@ -420,6 +420,7 @@ mod tests {
                 comments: Some("mock circuit".into()),
                 display_name: None,
                 circuit_version: 1,
+                circuit_status: messages::CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/service/mailbox.rs
+++ b/libsplinter/src/admin/service/mailbox.rs
@@ -334,6 +334,7 @@ mod tests {
                 comments: Some("mock circuit".into()),
                 display_name: Some("test_circuit".into()),
                 circuit_version: 1,
+                circuit_status: messages::CircuitStatus::Active,
             },
             votes: vec![],
             requester: vec![],

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -17,8 +17,9 @@ use std::error::Error as StdError;
 use crate::base62::generate_random_base62_string;
 
 use super::{
-    is_valid_circuit_id, is_valid_service_id, AuthorizationType, CreateCircuit, DurabilityType,
-    PersistenceType, RouteType, SplinterNode, SplinterService, UNSET_CIRCUIT_VERSION,
+    is_valid_circuit_id, is_valid_service_id, AuthorizationType, CircuitStatus, CreateCircuit,
+    DurabilityType, PersistenceType, RouteType, SplinterNode, SplinterService,
+    UNSET_CIRCUIT_VERSION,
 };
 
 #[derive(Default, Clone)]
@@ -35,6 +36,7 @@ pub struct CreateCircuitBuilder {
     comments: Option<String>,
     display_name: Option<String>,
     circuit_version: Option<i32>,
+    circuit_status: Option<CircuitStatus>,
 }
 
 impl CreateCircuitBuilder {
@@ -88,6 +90,10 @@ impl CreateCircuitBuilder {
 
     pub fn circuit_version(&self) -> Option<i32> {
         self.circuit_version
+    }
+
+    pub fn circuit_status(&self) -> Option<CircuitStatus> {
+        self.circuit_status.clone()
     }
 
     pub fn with_circuit_id(mut self, circuit_id: &str) -> CreateCircuitBuilder {
@@ -159,6 +165,11 @@ impl CreateCircuitBuilder {
         self
     }
 
+    pub fn with_circuit_status(mut self, status: &CircuitStatus) -> CreateCircuitBuilder {
+        self.circuit_status = Some(status.clone());
+        self
+    }
+
     pub fn build(self) -> Result<CreateCircuit, BuilderError> {
         let circuit_id = match self.circuit_id {
             Some(circuit_id) if is_valid_circuit_id(&circuit_id) => circuit_id,
@@ -224,6 +235,8 @@ impl CreateCircuitBuilder {
 
         let circuit_version = self.circuit_version.unwrap_or(UNSET_CIRCUIT_VERSION);
 
+        let circuit_status = self.circuit_status.unwrap_or_else(CircuitStatus::default);
+
         let create_circuit_message = CreateCircuit {
             circuit_id,
             roster,
@@ -237,6 +250,7 @@ impl CreateCircuitBuilder {
             comments,
             display_name,
             circuit_version,
+            circuit_status,
         };
 
         Ok(create_circuit_message)

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -379,7 +379,7 @@ impl CircuitProposal {
             admin::CircuitProposal_ProposalType::UPDATE_ROSTER => ProposalType::UpdateRoster,
             admin::CircuitProposal_ProposalType::ADD_NODE => ProposalType::AddNode,
             admin::CircuitProposal_ProposalType::REMOVE_NODE => ProposalType::RemoveNode,
-            admin::CircuitProposal_ProposalType::DESTROY => ProposalType::Destroy,
+            admin::CircuitProposal_ProposalType::DISBAND => ProposalType::Disband,
             admin::CircuitProposal_ProposalType::UNSET_PROPOSAL_TYPE => {
                 return Err(MarshallingError::UnsetField(
                     "Unset proposal type".to_string(),
@@ -410,7 +410,7 @@ impl CircuitProposal {
             ProposalType::UpdateRoster => admin::CircuitProposal_ProposalType::UPDATE_ROSTER,
             ProposalType::AddNode => admin::CircuitProposal_ProposalType::ADD_NODE,
             ProposalType::RemoveNode => admin::CircuitProposal_ProposalType::REMOVE_NODE,
-            ProposalType::Destroy => admin::CircuitProposal_ProposalType::DESTROY,
+            ProposalType::Disband => admin::CircuitProposal_ProposalType::DISBAND,
         };
 
         let votes = self
@@ -441,7 +441,7 @@ impl From<store::CircuitProposal> for CircuitProposal {
             store::ProposalType::UpdateRoster => ProposalType::UpdateRoster,
             store::ProposalType::AddNode => ProposalType::AddNode,
             store::ProposalType::RemoveNode => ProposalType::RemoveNode,
-            store::ProposalType::Destroy => ProposalType::Destroy,
+            store::ProposalType::Disband => ProposalType::Disband,
         };
 
         let store_circuit = store_proposal.circuit();
@@ -518,7 +518,7 @@ pub enum ProposalType {
     UpdateRoster,
     AddNode,
     RemoveNode,
-    Destroy,
+    Disband,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -47,6 +47,7 @@ pub struct CreateCircuit {
     pub display_name: Option<String>,
     #[serde(default)]
     pub circuit_version: i32,
+    pub circuit_status: CircuitStatus,
 }
 
 impl CreateCircuit {
@@ -82,6 +83,16 @@ impl CreateCircuit {
             admin::Circuit_RouteType::ANY_ROUTE => RouteType::Any,
             admin::Circuit_RouteType::UNSET_ROUTE_TYPE => {
                 return Err(MarshallingError::UnsetField("Unset route type".to_string()));
+            }
+        };
+
+        let circuit_status = match proto.get_circuit_status() {
+            admin::Circuit_CircuitStatus::ACTIVE => CircuitStatus::Active,
+            admin::Circuit_CircuitStatus::DISBANDED => CircuitStatus::Disbanded,
+            admin::Circuit_CircuitStatus::ABANDONED => CircuitStatus::Abandoned,
+            admin::Circuit_CircuitStatus::UNSET_CIRCUIT_STATUS => {
+                debug!("Defaulting `UNSET_CIRCUIT_STATUS` of proposed circuit to `Active`");
+                CircuitStatus::Active
             }
         };
 
@@ -124,6 +135,7 @@ impl CreateCircuit {
             comments,
             display_name,
             circuit_version,
+            circuit_status,
         })
     }
 
@@ -181,6 +193,18 @@ impl CreateCircuit {
             RouteType::Any => circuit.set_routes(admin::Circuit_RouteType::ANY_ROUTE),
         };
 
+        match self.circuit_status {
+            CircuitStatus::Active => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+            }
+            CircuitStatus::Disbanded => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
+            }
+            CircuitStatus::Abandoned => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
+            }
+        };
+
         let mut create_request = CircuitCreateRequest::new();
         create_request.set_circuit(circuit);
 
@@ -230,6 +254,29 @@ pub enum RouteType {
 impl Default for RouteType {
     fn default() -> Self {
         RouteType::Any
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum CircuitStatus {
+    Active,
+    Disbanded,
+    Abandoned,
+}
+
+impl Default for CircuitStatus {
+    fn default() -> Self {
+        CircuitStatus::Active
+    }
+}
+
+impl From<&store::CircuitStatus> for CircuitStatus {
+    fn from(store_enum: &store::CircuitStatus) -> Self {
+        match *store_enum {
+            store::CircuitStatus::Active => CircuitStatus::Active,
+            store::CircuitStatus::Disbanded => CircuitStatus::Disbanded,
+            store::CircuitStatus::Abandoned => CircuitStatus::Abandoned,
+        }
     }
 }
 
@@ -435,6 +482,7 @@ impl From<store::CircuitProposal> for CircuitProposal {
             comments: store_circuit.comments().clone(),
             display_name: store_circuit.display_name().clone(),
             circuit_version: store_circuit.circuit_version(),
+            circuit_status: CircuitStatus::from(&store_circuit.circuit_status().clone()),
         };
 
         Self {

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -32,6 +32,7 @@ pub struct Circuit {
     circuit_management_type: String,
     display_name: Option<String>,
     circuit_version: i32,
+    circuit_status: CircuitStatus,
 }
 
 impl Circuit {
@@ -83,6 +84,11 @@ impl Circuit {
     /// Returns the circuit version for the circuit
     pub fn circuit_version(&self) -> i32 {
         self.circuit_version
+    }
+
+    /// Returns the status of the circuit
+    pub fn circuit_status(&self) -> &CircuitStatus {
+        &self.circuit_status
     }
 }
 
@@ -154,6 +160,30 @@ impl From<&messages::RouteType> for RouteType {
     }
 }
 
+/// Status of the circuit
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CircuitStatus {
+    Active,
+    Disbanded,
+    Abandoned,
+}
+
+impl Default for CircuitStatus {
+    fn default() -> Self {
+        CircuitStatus::Active
+    }
+}
+
+impl From<&messages::CircuitStatus> for CircuitStatus {
+    fn from(message_enum: &messages::CircuitStatus) -> Self {
+        match *message_enum {
+            messages::CircuitStatus::Active => CircuitStatus::Active,
+            messages::CircuitStatus::Disbanded => CircuitStatus::Disbanded,
+            messages::CircuitStatus::Abandoned => CircuitStatus::Abandoned,
+        }
+    }
+}
+
 /// Builder to be used to build a `Circuit`
 #[derive(Default, Clone)]
 pub struct CircuitBuilder {
@@ -167,6 +197,7 @@ pub struct CircuitBuilder {
     circuit_management_type: Option<String>,
     display_name: Option<String>,
     circuit_version: Option<i32>,
+    circuit_status: Option<CircuitStatus>,
 }
 
 impl CircuitBuilder {
@@ -223,6 +254,11 @@ impl CircuitBuilder {
     /// Returns the circuit version in the builder
     pub fn circuit_version(&self) -> Option<i32> {
         self.circuit_version
+    }
+
+    /// Returns the circuit status in the builder
+    pub fn circuit_status(&self) -> Option<CircuitStatus> {
+        self.circuit_status.clone()
     }
 
     /// Sets the circuit ID
@@ -330,6 +366,16 @@ impl CircuitBuilder {
         self
     }
 
+    /// Sets the status for the circuit
+    ///
+    /// # Arguments
+    ///
+    ///  * `circuit_status` - The status for the circuit
+    pub fn with_circuit_status(mut self, circuit_status: &CircuitStatus) -> CircuitBuilder {
+        self.circuit_status = Some(circuit_status.clone());
+        self
+    }
+
     /// Builds a `Circuit`
     ///
     /// Returns an error if the circuit ID, roster, members or circuit management
@@ -377,6 +423,8 @@ impl CircuitBuilder {
 
         let circuit_version = self.circuit_version.unwrap_or(UNSET_CIRCUIT_VERSION);
 
+        let circuit_status = self.circuit_status.unwrap_or_default();
+
         let circuit = Circuit {
             id: circuit_id,
             roster,
@@ -388,6 +436,7 @@ impl CircuitBuilder {
             circuit_management_type,
             display_name,
             circuit_version,
+            circuit_status,
         };
 
         Ok(circuit)
@@ -411,6 +460,7 @@ impl From<ProposedCircuit> for Circuit {
             circuit_management_type: circuit.circuit_management_type().into(),
             display_name: circuit.display_name().clone(),
             circuit_version: circuit.circuit_version(),
+            circuit_status: circuit.circuit_status().clone(),
         }
     }
 }

--- a/libsplinter/src/admin/store/circuit_proposal.rs
+++ b/libsplinter/src/admin/store/circuit_proposal.rs
@@ -87,7 +87,7 @@ impl CircuitProposal {
             admin::CircuitProposal_ProposalType::UPDATE_ROSTER => ProposalType::UpdateRoster,
             admin::CircuitProposal_ProposalType::ADD_NODE => ProposalType::AddNode,
             admin::CircuitProposal_ProposalType::REMOVE_NODE => ProposalType::RemoveNode,
-            admin::CircuitProposal_ProposalType::DESTROY => ProposalType::Destroy,
+            admin::CircuitProposal_ProposalType::DISBAND => ProposalType::Disband,
             admin::CircuitProposal_ProposalType::UNSET_PROPOSAL_TYPE => {
                 return Err(InvalidStateError::with_message(
                     "unable to build, missing field: `proposal type`".to_string(),
@@ -118,7 +118,7 @@ impl CircuitProposal {
             ProposalType::UpdateRoster => admin::CircuitProposal_ProposalType::UPDATE_ROSTER,
             ProposalType::AddNode => admin::CircuitProposal_ProposalType::ADD_NODE,
             ProposalType::RemoveNode => admin::CircuitProposal_ProposalType::REMOVE_NODE,
-            ProposalType::Destroy => admin::CircuitProposal_ProposalType::DESTROY,
+            ProposalType::Disband => admin::CircuitProposal_ProposalType::DISBAND,
         };
 
         let votes = self
@@ -497,7 +497,7 @@ pub enum ProposalType {
     UpdateRoster,
     AddNode,
     RemoveNode,
-    Destroy,
+    Disband,
 }
 
 impl From<&messages::ProposalType> for ProposalType {
@@ -507,7 +507,7 @@ impl From<&messages::ProposalType> for ProposalType {
             messages::ProposalType::UpdateRoster => ProposalType::UpdateRoster,
             messages::ProposalType::AddNode => ProposalType::AddNode,
             messages::ProposalType::RemoveNode => ProposalType::RemoveNode,
-            messages::ProposalType::Destroy => ProposalType::Destroy,
+            messages::ProposalType::Disband => ProposalType::Disband,
         }
     }
 }

--- a/libsplinter/src/admin/store/diesel/mod.rs
+++ b/libsplinter/src/admin/store/diesel/mod.rs
@@ -265,9 +265,9 @@ pub mod tests {
     use super::*;
 
     use crate::admin::store::{
-        CircuitBuilder, CircuitNodeBuilder, CircuitProposal, CircuitProposalBuilder, ProposalType,
-        ProposedCircuitBuilder, ProposedNodeBuilder, ProposedServiceBuilder, ServiceBuilder, Vote,
-        VoteRecordBuilder,
+        CircuitBuilder, CircuitNodeBuilder, CircuitProposal, CircuitProposalBuilder, CircuitStatus,
+        ProposalType, ProposedCircuitBuilder, ProposedNodeBuilder, ProposedServiceBuilder,
+        ServiceBuilder, Vote, VoteRecordBuilder,
     };
     use crate::hex::parse_hex;
     use crate::migrations::run_sqlite_migrations;
@@ -890,7 +890,8 @@ pub mod tests {
                     .with_comments("This is a test")
                     .with_circuit_management_type("gameroom")
                     .with_display_name("test_display")
-                    .build().expect("Unable to build circuit")
+                    .build()
+                    .expect("Unable to build circuit")
             )
             .with_requester(
                 &parse_hex(
@@ -967,6 +968,7 @@ pub mod tests {
                         ]
                     )
                     .with_circuit_management_type("gameroom")
+                    .with_circuit_status(&CircuitStatus::Active)
                     .build().expect("Unable to build circuit")
             )
             .with_requester(
@@ -1007,6 +1009,7 @@ pub mod tests {
             .with_circuit_management_type("gameroom")
             .with_display_name("test_display")
             .with_circuit_version(3)
+            .with_circuit_status(&CircuitStatus::Active)
             .build()
             .expect("Unable to build circuit")
     }

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -499,7 +499,7 @@ impl TryFrom<String> for ProposalType {
             "UpdateRoster" => Ok(ProposalType::UpdateRoster),
             "AddNode" => Ok(ProposalType::AddNode),
             "RemoveNode" => Ok(ProposalType::RemoveNode),
-            "Destroy" => Ok(ProposalType::Destroy),
+            "Disband" => Ok(ProposalType::Disband),
             _ => Err(AdminServiceStoreError::InvalidStateError(
                 InvalidStateError::with_message("Unable to convert string to ProposalType".into()),
             )),
@@ -514,7 +514,7 @@ impl From<&ProposalType> for String {
             ProposalType::UpdateRoster => String::from("UpdateRoster"),
             ProposalType::AddNode => String::from("AddNode"),
             ProposalType::RemoveNode => String::from("RemoveNode"),
-            ProposalType::Destroy => String::from("Destroy"),
+            ProposalType::Disband => String::from("Disband"),
         }
     }
 }

--- a/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
@@ -16,7 +16,7 @@
 
 use diesel::{
     prelude::*,
-    sql_types::{Binary, Integer, Nullable, Text},
+    sql_types::{Binary, Integer, Nullable, SmallInt, Text},
 };
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -34,9 +34,9 @@ use crate::admin::store::{
         },
     },
     error::AdminServiceStoreError,
-    AuthorizationType, CircuitProposal, CircuitProposalBuilder, DurabilityType, PersistenceType,
-    ProposalType, ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder, ProposedService,
-    ProposedServiceBuilder, RouteType, VoteRecord,
+    AuthorizationType, CircuitProposal, CircuitProposalBuilder, CircuitStatus, DurabilityType,
+    PersistenceType, ProposalType, ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder,
+    ProposedService, ProposedServiceBuilder, RouteType, VoteRecord,
 };
 
 pub(in crate::admin::store::diesel) trait AdminServiceStoreFetchProposalOperation {
@@ -65,6 +65,7 @@ where
             Nullable<Text>,
             Nullable<Text>,
             Integer,
+            SmallInt,
         ),
         C::Backend,
     >,
@@ -237,7 +238,8 @@ where
                 .with_durability(&DurabilityType::try_from(proposed_circuit.durability)?)
                 .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
                 .with_circuit_management_type(&proposed_circuit.circuit_management_type)
-                .with_circuit_version(proposed_circuit.circuit_version);
+                .with_circuit_version(proposed_circuit.circuit_version)
+                .with_circuit_status(&CircuitStatus::from(&proposed_circuit.circuit_status));
 
             if let Some(application_metadata) = &proposed_circuit.application_metadata {
                 builder = builder.with_application_metadata(&application_metadata);

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -25,8 +25,8 @@ use crate::admin::store::{
         schema::{circuit, circuit_member, service, service_argument},
     },
     error::AdminServiceStoreError,
-    AuthorizationType, Circuit, CircuitBuilder, CircuitPredicate, DurabilityType, PersistenceType,
-    RouteType, Service, ServiceBuilder,
+    AuthorizationType, Circuit, CircuitBuilder, CircuitPredicate, CircuitStatus, DurabilityType,
+    PersistenceType, RouteType, Service, ServiceBuilder,
 };
 
 use super::AdminServiceStoreOperations;
@@ -44,6 +44,7 @@ where
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
 {
     fn list_circuits(
         &self,
@@ -215,7 +216,8 @@ where
                         .with_durability(&DurabilityType::try_from(model.durability)?)
                         .with_routes(&RouteType::try_from(model.routes)?)
                         .with_circuit_management_type(&model.circuit_management_type)
-                        .with_circuit_version(model.circuit_version);
+                        .with_circuit_version(model.circuit_version)
+                        .with_circuit_status(&CircuitStatus::from(&model.circuit_status));
 
                     if let Some(display_name) = &model.display_name {
                         circuit_builder = circuit_builder.with_display_name(&display_name);

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -20,7 +20,7 @@ use std::convert::TryFrom;
 use diesel::{
     dsl::exists,
     prelude::*,
-    sql_types::{Binary, Integer, Nullable, Text},
+    sql_types::{Binary, Integer, Nullable, SmallInt, Text},
 };
 
 use crate::admin::store::{
@@ -35,9 +35,9 @@ use crate::admin::store::{
         },
     },
     error::AdminServiceStoreError,
-    AuthorizationType, CircuitPredicate, CircuitProposal, CircuitProposalBuilder, DurabilityType,
-    PersistenceType, ProposalType, ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder,
-    ProposedService, ProposedServiceBuilder, RouteType, VoteRecord,
+    AuthorizationType, CircuitPredicate, CircuitProposal, CircuitProposalBuilder, CircuitStatus,
+    DurabilityType, PersistenceType, ProposalType, ProposedCircuitBuilder, ProposedNode,
+    ProposedNodeBuilder, ProposedService, ProposedServiceBuilder, RouteType, VoteRecord,
 };
 use crate::error::InvalidStateError;
 
@@ -69,6 +69,7 @@ where
             Nullable<Text>,
             Nullable<Text>,
             Integer,
+            SmallInt,
         ),
         C::Backend,
     >,
@@ -179,7 +180,10 @@ where
                             )?)
                             .with_routes(&RouteType::try_from(proposed_circuit.routes)?)
                             .with_circuit_management_type(&proposed_circuit.circuit_management_type)
-                            .with_circuit_version(proposed_circuit.circuit_version);
+                            .with_circuit_version(proposed_circuit.circuit_version)
+                            .with_circuit_status(&CircuitStatus::from(
+                                &proposed_circuit.circuit_status,
+                            ));
 
                         if let Some(application_metadata) = &proposed_circuit.application_metadata {
                             proposed_circuit_builder = proposed_circuit_builder

--- a/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_circuit.rs
@@ -33,6 +33,7 @@ where
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
     i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
 {
     fn remove_circuit(&self, circuit_id: &str) -> Result<(), AdminServiceStoreError> {
         self.conn.transaction::<(), _, _>(|| {

--- a/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/remove_proposal.rs
@@ -17,7 +17,7 @@
 use diesel::{
     dsl::delete,
     prelude::*,
-    sql_types::{Binary, Integer, Nullable, Text},
+    sql_types::{Binary, Integer, Nullable, SmallInt, Text},
 };
 
 use crate::admin::store::{
@@ -53,6 +53,7 @@ where
             Nullable<Text>,
             Nullable<Text>,
             Integer,
+            SmallInt,
         ),
         C::Backend,
     >,

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -66,7 +66,8 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                 .with_persistence(proposed_circuit.persistence())
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
-                .with_circuit_management_type(proposed_circuit.circuit_management_type());
+                .with_circuit_management_type(proposed_circuit.circuit_management_type())
+                .with_circuit_status(proposed_circuit.circuit_status());
 
             if let Some(display_name) = proposed_circuit.display_name() {
                 builder = builder.with_display_name(display_name);
@@ -127,7 +128,8 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
                 .with_circuit_management_type(proposed_circuit.circuit_management_type())
-                .with_circuit_version(proposed_circuit.circuit_version());
+                .with_circuit_version(proposed_circuit.circuit_version())
+                .with_circuit_status(proposed_circuit.circuit_status());
 
             if let Some(display_name) = proposed_circuit.display_name() {
                 builder = builder.with_display_name(display_name);

--- a/libsplinter/src/admin/store/diesel/schema.rs
+++ b/libsplinter/src/admin/store/diesel/schema.rs
@@ -34,6 +34,7 @@ table! {
         comments -> Nullable<Text>,
         display_name -> Nullable<Text>,
         circuit_version -> Integer,
+        circuit_status -> SmallInt,
     }
 }
 
@@ -114,6 +115,7 @@ table! {
         circuit_management_type -> Text,
         display_name -> Nullable<Text>,
         circuit_version -> Integer,
+        circuit_status -> SmallInt,
     }
 }
 

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -43,7 +43,8 @@ use std::cmp::Ordering;
 use std::fmt;
 
 pub use self::circuit::{
-    AuthorizationType, Circuit, CircuitBuilder, DurabilityType, PersistenceType, RouteType,
+    AuthorizationType, Circuit, CircuitBuilder, CircuitStatus, DurabilityType, PersistenceType,
+    RouteType,
 };
 pub use self::circuit_node::{CircuitNode, CircuitNodeBuilder};
 pub use self::circuit_proposal::{

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1273,7 +1273,7 @@ pub enum YamlProposalType {
     UpdateRoster,
     AddNode,
     RemoveNode,
-    Destroy,
+    Disband,
 }
 
 impl From<YamlProposalType> for ProposalType {
@@ -1283,7 +1283,7 @@ impl From<YamlProposalType> for ProposalType {
             YamlProposalType::UpdateRoster => ProposalType::UpdateRoster,
             YamlProposalType::AddNode => ProposalType::AddNode,
             YamlProposalType::RemoveNode => ProposalType::RemoveNode,
-            YamlProposalType::Destroy => ProposalType::Destroy,
+            YamlProposalType::Disband => ProposalType::Disband,
         }
     }
 }
@@ -1295,7 +1295,7 @@ impl From<ProposalType> for YamlProposalType {
             ProposalType::UpdateRoster => YamlProposalType::UpdateRoster,
             ProposalType::AddNode => YamlProposalType::AddNode,
             ProposalType::RemoveNode => YamlProposalType::RemoveNode,
-            ProposalType::Destroy => YamlProposalType::Destroy,
+            ProposalType::Disband => YamlProposalType::Disband,
         }
     }
 }

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -29,9 +29,10 @@ use std::sync::{Arc, Mutex};
 use super::{
     AdminServiceStore, AdminServiceStoreError, AuthorizationType, Circuit, CircuitBuilder,
     CircuitNode, CircuitNodeBuilder, CircuitPredicate, CircuitProposal, CircuitProposalBuilder,
-    DurabilityType, PersistenceType, ProposalType, ProposedCircuit, ProposedCircuitBuilder,
-    ProposedNode, ProposedNodeBuilder, ProposedService, ProposedServiceBuilder, RouteType, Service,
-    ServiceBuilder, ServiceId, Vote, VoteRecord, VoteRecordBuilder,
+    CircuitStatus, DurabilityType, PersistenceType, ProposalType, ProposedCircuit,
+    ProposedCircuitBuilder, ProposedNode, ProposedNodeBuilder, ProposedService,
+    ProposedServiceBuilder, RouteType, Service, ServiceBuilder, ServiceId, Vote, VoteRecord,
+    VoteRecordBuilder,
 };
 
 use crate::error::{
@@ -1024,6 +1025,7 @@ struct YamlCircuit {
     display_name: Option<String>,
     #[serde(default = "default_circuit_value")]
     circuit_version: i32,
+    circuit_status: YamlCircuitStatus,
 }
 
 impl TryFrom<YamlCircuit> for Circuit {
@@ -1045,7 +1047,8 @@ impl TryFrom<YamlCircuit> for Circuit {
             .with_durability(&DurabilityType::from(circuit.durability))
             .with_routes(&RouteType::from(circuit.routes))
             .with_circuit_management_type(&circuit.circuit_management_type)
-            .with_circuit_version(circuit.circuit_version);
+            .with_circuit_version(circuit.circuit_version)
+            .with_circuit_status(&CircuitStatus::from(circuit.circuit_status));
 
         if let Some(display_name) = &circuit.display_name {
             builder = builder.with_display_name(display_name);
@@ -1072,6 +1075,7 @@ impl From<Circuit> for YamlCircuit {
             circuit_management_type: circuit.circuit_management_type().into(),
             display_name: circuit.display_name().clone(),
             circuit_version: circuit.circuit_version(),
+            circuit_status: circuit.circuit_status().clone().into(),
         }
     }
 }
@@ -1348,6 +1352,7 @@ struct YamlProposedCircuit {
     display_name: Option<String>,
     #[serde(default = "default_circuit_value")]
     circuit_version: i32,
+    circuit_status: YamlCircuitStatus,
 }
 
 impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
@@ -1375,7 +1380,8 @@ impl TryFrom<YamlProposedCircuit> for ProposedCircuit {
             .with_durability(&DurabilityType::from(circuit.durability))
             .with_routes(&RouteType::from(circuit.routes))
             .with_circuit_management_type(&circuit.circuit_management_type)
-            .with_circuit_version(circuit.circuit_version);
+            .with_circuit_version(circuit.circuit_version)
+            .with_circuit_status(&CircuitStatus::from(circuit.circuit_status));
 
         if let Some(application_metadata) = circuit.application_metadata {
             builder = builder.with_application_metadata(&parse_hex(&application_metadata).map_err(
@@ -1432,6 +1438,7 @@ impl From<ProposedCircuit> for YamlProposedCircuit {
             comments: circuit.comments().clone(),
             display_name: circuit.display_name().clone(),
             circuit_version: circuit.circuit_version(),
+            circuit_status: circuit.circuit_status().clone().into(),
         }
     }
 }
@@ -1672,6 +1679,34 @@ fn default_circuit_value() -> i32 {
     1
 }
 
+/// YAML file specific CircuitStatus definition for serialization.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum YamlCircuitStatus {
+    Active,
+    Disbanded,
+    Abandoned,
+}
+
+impl From<CircuitStatus> for YamlCircuitStatus {
+    fn from(circuit_status: CircuitStatus) -> Self {
+        match circuit_status {
+            CircuitStatus::Active => YamlCircuitStatus::Active,
+            CircuitStatus::Disbanded => YamlCircuitStatus::Disbanded,
+            CircuitStatus::Abandoned => YamlCircuitStatus::Abandoned,
+        }
+    }
+}
+
+impl From<YamlCircuitStatus> for CircuitStatus {
+    fn from(yaml_circuit_status: YamlCircuitStatus) -> Self {
+        match yaml_circuit_status {
+            YamlCircuitStatus::Active => CircuitStatus::Active,
+            YamlCircuitStatus::Disbanded => CircuitStatus::Disbanded,
+            YamlCircuitStatus::Abandoned => CircuitStatus::Abandoned,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Read;
@@ -1721,7 +1756,8 @@ circuits:
         persistence: Any
         durability: NoDurability
         routes: Any
-        circuit_management_type: gameroom";
+        circuit_management_type: gameroom
+        circuit_status: Active";
 
     const PROPOSAL_STATE: &[u8] = b"---
 proposals:
@@ -1763,6 +1799,7 @@ proposals:
             routes: Any
             circuit_management_type: gameroom
             display_name: \"test_display\"
+            circuit_status: Active
         votes: []
         requester: 0283a14e0a17cb7f665311e9b5560f4cde2b502f17e2d03223e15d90d9318d7482
         requester_node_id: acme-node-000";
@@ -2046,6 +2083,7 @@ proposals:
                 ])
                 .with_members(&vec!["bubba-node-000".into(), "acme-node-000".into()])
                 .with_circuit_management_type("test")
+                .with_circuit_status(&CircuitStatus::default())
                 .build()
                 .expect("Unable to build circuit");
 
@@ -2376,6 +2414,7 @@ proposals:
                     )
                     .with_circuit_management_type("gameroom")
                     .with_display_name("test_display")
+                    .with_circuit_status(&CircuitStatus::default())
                     .build().expect("Unable to build circuit")
             )
             .with_requester(
@@ -2418,6 +2457,7 @@ proposals:
             .with_members(&vec!["bubba-node-000".into(), "acme-node-000".into()])
             .with_circuit_management_type("gameroom")
             .with_circuit_version(1)
+            .with_circuit_status(&CircuitStatus::default())
             .build()
             .expect("Unable to build circuit")
     }
@@ -2467,6 +2507,7 @@ proposals:
                         ]
                     )
                     .with_circuit_management_type("test")
+                    .with_circuit_status(&CircuitStatus::default())
                     .build().expect("Unable to build circuit")
             )
             .with_requester(
@@ -2509,6 +2550,7 @@ proposals:
                 ]
             )
             .with_circuit_management_type("test")
+            .with_circuit_status(&CircuitStatus::default())
             .build().expect("Unable to build circuit"),
         CircuitNodeBuilder::default()
             .with_node_id("new-node-000".into())

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/down.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+DROP COLUMN circuit_status;
+
+ALTER TABLE proposed_circuit
+DROP COLUMN circuit_status;
+
+ALTER TABLE admin_event_proposed_circuit
+DROP COLUMN circuit_status;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+ADD COLUMN circuit_status INTEGER;
+
+ALTER TABLE proposed_circuit
+ADD COLUMN circuit_status INTEGER;
+
+ALTER TABLE admin_event_proposed_circuit
+ADD COLUMN circuit_status INTEGER;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/down.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+DROP COLUMN circuit_status;
+
+ALTER TABLE proposed_circuit
+DROP COLUMN circuit_status;
+
+ALTER TABLE admin_event_proposed_circuit
+DROP COLUMN circuit_status;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
@@ -1,0 +1,23 @@
+---- Copyright 2018-2020 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- --
+
+ALTER TABLE circuit
+ADD COLUMN circuit_status INTEGER;
+
+ALTER TABLE proposed_circuit
+ADD COLUMN circuit_status INTEGER;
+
+ALTER TABLE admin_event_proposed_circuit
+ADD COLUMN circuit_status INTEGER;

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1869,7 +1869,7 @@ components:
             - UpdateRoster
             - AddNode
             - RemoveNode
-            - Destroy
+            - Disband
         circuit_id:
           type: string
           example: 01234-ABCDE

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1906,6 +1906,13 @@ components:
               circuit_version:
                   description: The protocol version the circuit adheres to
                   type: integer
+              circuit_status:
+                  description: The status of the circuit
+                  type: string
+                  enum:
+                    - Active
+                    - Disbanded
+                    - Abandoned
         votes:
           type: array
           items:


### PR DESCRIPTION
Adds a `circuit_status` flag to circuits, from the proto message up.

Also renames the `destroy` request in the protos to `disband`, including the affected structs, mainly the `ProposalType` in a `CircuitProposal` which represented the `destroy` option, now renamed to `disband`.