### PR TITLE
Fix auth header for `splinter health status` cmd

### DIFF
--- a/cli/src/action/health.rs
+++ b/cli/src/action/health.rs
@@ -45,10 +45,7 @@ impl Action for StatusAction {
         {
             let key = arg_matches.and_then(|args| args.value_of("private_key_file"));
 
-            request = request.header(
-                "Authorization",
-                format!("Bearer Cylinder:{}", create_cylinder_jwt_auth(key)?),
-            );
+            request = request.header("Authorization", create_cylinder_jwt_auth(key)?);
         }
 
         request


### PR DESCRIPTION
Fixes the authorization header sent to the Splinter REST API by the
`splinter health status` CLI command (the value returned by
`create_cylinder_jwt_auth` is already in the format `Bearer
Cylinder:<JWT>`.

Signed-off-by: Logan Seeley <seeley@bitwise.io>