### PR TITLE
Add actix 1 paging extraction method

### DIFF
--- a/libsplinter/src/rest_api/actix_web_1/mod.rs
+++ b/libsplinter/src/rest_api/actix_web_1/mod.rs
@@ -17,6 +17,7 @@ mod auth;
 mod builder;
 mod error;
 mod guard;
+mod paging;
 mod resource;
 mod websocket;
 
@@ -27,6 +28,7 @@ pub use auth::{get_authorization_token, require_header};
 pub use builder::RestApiBuilder;
 pub use error::ResponseError;
 pub use guard::{Continuation, ProtocolVersionRangeGuard, RequestGuard};
+pub use paging::{get_paging_query, BadPagingRequest};
 pub use resource::{
     into_bytes, into_protobuf, HandlerFunction, Method, Resource, RestResourceProvider,
 };

--- a/libsplinter/src/rest_api/actix_web_1/paging.rs
+++ b/libsplinter/src/rest_api/actix_web_1/paging.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Target Brands, Inc.
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use crate::actix_web::{web, Error, HttpResponse};
+use crate::futures::{future::IntoFuture, Future};
+use crate::rest_api::{
+    paging::{PagingQuery, DEFAULT_LIMIT, DEFAULT_OFFSET},
+    ErrorResponse,
+};
+
+/// Return the PagingQuery from a Query object of key-value pairs.
+pub fn get_paging_query(
+    query: &web::Query<HashMap<String, String>>,
+) -> Result<PagingQuery, BadPagingRequest> {
+    let offset = match query.get("offset") {
+        Some(value) => value.parse::<usize>().map_err(|err| {
+            BadPagingRequest::new(format!(
+                "Invalid offset value passed: {}. Error: {}",
+                value, err
+            ))
+        })?,
+        None => DEFAULT_OFFSET,
+    };
+
+    let limit = match query.get("limit") {
+        Some(value) => value.parse::<usize>().map_err(|err| {
+            BadPagingRequest::new(format!(
+                "Invalid limit value passed: {}. Error: {}",
+                value, err
+            ))
+        })?,
+        None => DEFAULT_LIMIT,
+    };
+
+    Ok(PagingQuery { offset, limit })
+}
+
+#[derive(Debug)]
+pub struct BadPagingRequest {
+    message: String,
+}
+
+impl std::fmt::Display for BadPagingRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for BadPagingRequest {}
+
+impl BadPagingRequest {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl IntoFuture for BadPagingRequest {
+    type Future = Box<(dyn Future<Item = HttpResponse, Error = Error> + 'static)>;
+    type Item = HttpResponse;
+    type Error = Error;
+
+    fn into_future(self) -> Self::Future {
+        Box::new(
+            HttpResponse::BadRequest()
+                .json(ErrorResponse::bad_request(&self.message))
+                .into_future(),
+        )
+    }
+}

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -84,10 +84,10 @@ pub use response_models::ErrorResponse;
 #[cfg(feature = "auth")]
 pub use actix_web_1::AuthConfig;
 pub use actix_web_1::{
-    get_authorization_token, into_bytes, into_protobuf, new_websocket_event_sender, require_header,
-    Continuation, EventSender, HandlerFunction, Method, ProtocolVersionRangeGuard, Request,
-    RequestGuard, Resource, Response, ResponseError, RestApi, RestApiBuilder,
-    RestApiShutdownHandle, RestResourceProvider,
+    get_authorization_token, get_paging_query, into_bytes, into_protobuf,
+    new_websocket_event_sender, require_header, BadPagingRequest, Continuation, EventSender,
+    HandlerFunction, Method, ProtocolVersionRangeGuard, Request, RequestGuard, Resource, Response,
+    ResponseError, RestApi, RestApiBuilder, RestApiShutdownHandle, RestResourceProvider,
 };
 
 const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS

--- a/libsplinter/src/rest_api/paging.rs
+++ b/libsplinter/src/rest_api/paging.rs
@@ -16,6 +16,20 @@
 pub const DEFAULT_LIMIT: usize = 100;
 pub const DEFAULT_OFFSET: usize = 0;
 
+pub struct PagingQuery {
+    pub offset: usize,
+    pub limit: usize,
+}
+
+impl Default for PagingQuery {
+    fn default() -> Self {
+        Self {
+            offset: DEFAULT_OFFSET,
+            limit: DEFAULT_LIMIT,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Paging {
     pub current: String,
@@ -29,13 +43,11 @@ pub struct Paging {
 }
 
 pub fn get_response_paging_info(
-    limit: Option<usize>,
-    offset: Option<usize>,
+    paging_query: PagingQuery,
     link: &str,
     query_count: usize,
 ) -> Paging {
-    let limit = limit.unwrap_or(DEFAULT_LIMIT);
-    let offset = offset.unwrap_or(DEFAULT_OFFSET);
+    let PagingQuery { offset, limit } = paging_query;
 
     let base_link = {
         // if the link does not already contain ? add it to the end
@@ -90,7 +102,8 @@ mod tests {
     #[test]
     fn test_default_paging_response() {
         // Create paging response from default limit, default offset, a total of 1000
-        let test_paging_response = get_response_paging_info(None, None, TEST_LINK, 1000);
+        let test_paging_response =
+            get_response_paging_info(PagingQuery::default(), TEST_LINK, 1000);
         let generated_paging_response =
             create_test_paging_response(DEFAULT_OFFSET, DEFAULT_LIMIT, 100, 0, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -99,7 +112,14 @@ mod tests {
     #[test]
     fn test_50offset_paging_response() {
         // Create paging response from default limit, offset of 50, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(50), TEST_LINK, 1000);
+        let test_paging_response = get_response_paging_info(
+            PagingQuery {
+                limit: DEFAULT_LIMIT,
+                offset: 50,
+            },
+            TEST_LINK,
+            1000,
+        );
         let generated_paging_response = create_test_paging_response(50, DEFAULT_LIMIT, 150, 0, 900);
         assert_eq!(test_paging_response, generated_paging_response);
     }
@@ -107,7 +127,14 @@ mod tests {
     #[test]
     fn test_550offset_paging_response() {
         // Create paging response from default limit, offset value of 150, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(550), TEST_LINK, 1000);
+        let test_paging_response = get_response_paging_info(
+            PagingQuery {
+                limit: DEFAULT_LIMIT,
+                offset: 550,
+            },
+            TEST_LINK,
+            1000,
+        );
         let generated_paging_response =
             create_test_paging_response(550, DEFAULT_LIMIT, 650, 450, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -116,7 +143,14 @@ mod tests {
     #[test]
     fn test_950offset_paging_response() {
         // Create paging response from default limit, offset value of 950, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(950), TEST_LINK, 1000);
+        let test_paging_response = get_response_paging_info(
+            PagingQuery {
+                limit: DEFAULT_LIMIT,
+                offset: 950,
+            },
+            TEST_LINK,
+            1000,
+        );
         let generated_paging_response =
             create_test_paging_response(950, DEFAULT_LIMIT, 900, 850, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -125,7 +159,14 @@ mod tests {
     #[test]
     fn test_50limit_paging_response() {
         // Create paging response from default limit, offset of 50, and a total of 1000
-        let test_paging_response = get_response_paging_info(Some(50), None, TEST_LINK, 1000);
+        let test_paging_response = get_response_paging_info(
+            PagingQuery {
+                offset: DEFAULT_OFFSET,
+                limit: 50,
+            },
+            TEST_LINK,
+            1000,
+        );
         let generated_paging_response = create_test_paging_response(DEFAULT_OFFSET, 50, 50, 0, 950);
         assert_eq!(test_paging_response, generated_paging_response);
     }
@@ -133,7 +174,14 @@ mod tests {
     #[test]
     fn test_50limit_150offset_paging_response() {
         // Create paging response from limit of 50, offset of 150, and total of 1000
-        let test_paging_response = get_response_paging_info(Some(50), Some(150), TEST_LINK, 1000);
+        let test_paging_response = get_response_paging_info(
+            PagingQuery {
+                offset: 150,
+                limit: 50,
+            },
+            TEST_LINK,
+            1000,
+        );
         let generated_paging_response = create_test_paging_response(150, 50, 200, 100, 950);
         assert_eq!(test_paging_response, generated_paging_response);
     }


### PR DESCRIPTION
This change introduces a function that will extract paging information from a query and convert it into a PagingQuery struct that contains the limit and offset. Any errors are returned in a single BadPagingRequest error that can be converted into an HttpResponse future containing a BadRequest.

This change also includes updating existing routes that make use of these functions.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>