### PR TITLE
Update methods using the cylinder key-load feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
-cylinder = "0.2"
+cylinder = "0.2.2"
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 dirs = "2.0"
 flexi_logger = "0.14"

--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -49,7 +49,7 @@ impl Action for KeyGenAction {
         } else {
             dirs::home_dir()
                 .map(|mut p| {
-                    p.push(".splinter/keys");
+                    p.push(".cylinder/keys");
                     p
                 })
                 .ok_or_else(|| CliError::EnvironmentError("Home directory not found".into()))?

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -37,7 +37,7 @@ actix-rt = "1.0"
 bcrypt = "0.5"
 clap = "2"
 ctrlc = "3.0"
-cylinder = { version = "0.2", features = ["jwt", "key-load"] }
+cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
 flexi_logger = "0.14"

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
-cylinder = "0.2"
+cylinder = "0.2.2"
 dirs = "2.0"
 flexi_logger = "0.14"
 log = "0.4"


### PR DESCRIPTION
Update the `create_cylinder_jwt_auth` method to use the updated cylinder key load API to retrieve the private key used in jwt signing.

Update the default location that `keygen` saves keys to be ~/.cylinder/keys

Modify gameroom daemon to use the new `load_key` method from the cylinder key::load module.

Modify the scabbard `create_cylinder_jwt_auth` method to use the new methods in the cylinder key::load module.