### PR TITLE
Modify key-load using methods

### DIFF
--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -147,9 +147,18 @@ fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliError> 
             let path = &current_user_search_path();
             load_key(key_name, path)
                 .map_err(|err| CliError::ActionError(err.to_string()))?
-                .ok_or_else(|| CliError::ActionError( {
-                    format!("No signing key found in {:?}.  Either specify the --key argument or generate the default key via splinter keygen", path)
-                }))?
+                .ok_or_else(|| {
+                    CliError::ActionError({
+                        format!(
+                            "No signing key found in {}. Either specify the --key argument or \
+                            generate the default key via splinter keygen",
+                            path.iter()
+                                .map(|path| path.as_path().display().to_string())
+                                .collect::<Vec<String>>()
+                                .join(":")
+                        )
+                    })
+                })?
         }
     } else {
         let path = match env::var("CYLINDER_PATH") {
@@ -168,9 +177,18 @@ fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliError> 
         };
         load_key(&current_user_key_name(), &path)
             .map_err(|err| CliError::ActionError(err.to_string()))?
-            .ok_or_else(|| CliError::ActionError({
-                format!("No signing key found in {:?}.  Either specify the --key argument or generate the default key via splinter keygen", path)
-            }))?
+            .ok_or_else(|| {
+                CliError::ActionError({
+                    format!(
+                        "No signing key found in {}. Either specify the --key argument or \
+                        generate the default key via splinter keygen",
+                        path.iter()
+                            .map(|path| path.as_path().display().to_string())
+                            .collect::<Vec<String>>()
+                            .join(":")
+                    )
+                })
+            })?
     };
 
     let context = Secp256k1Context::new();

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -161,6 +161,8 @@ fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliError> 
                 })?
         }
     } else {
+        // If the `CYLINDER_PATH` environment variable is not set, add `$HOME/.splinter/keys`
+        // to the vector of paths to search. This is for backwards compatibility.
         let path = match env::var("CYLINDER_PATH") {
             Ok(_) => current_user_search_path(),
             Err(_) => {

--- a/examples/gameroom/daemon/src/main.rs
+++ b/examples/gameroom/daemon/src/main.rs
@@ -103,9 +103,11 @@ fn run() -> Result<(), GameroomDaemonError> {
     let context = Secp256k1Context::new();
     let private_key = load_key(config.key(), &[PathBuf::from("")])
         .map_err(|err| GameroomDaemonError::SigningError(err.to_string()))?
-        .ok_or_else(|| GameroomDaemonError::SigningError( {
-            format!("No signing key found in {:?}.  Either specify the --key argument or generate the default key via splinter keygen", config.key())
-        }))?;
+        .ok_or_else(|| {
+            GameroomDaemonError::SigningError({
+                format!("No signing key found in {}", config.key())
+            })
+        })?;
     let private_key_hex = private_key.as_hex();
     let public_key_hex = context.get_public_key(&private_key)?.as_hex();
 

--- a/services/scabbard/cli/src/key.rs
+++ b/services/scabbard/cli/src/key.rs
@@ -111,9 +111,18 @@ pub fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliErr
             let path = &current_user_search_path();
             load_key(key_name, path)
                 .map_err(|err| CliError::action_error(&err.to_string()))?
-                .ok_or_else(|| CliError::action_error( {
-                    &format!("No signing key found in {:?}.  Either specify the --key argument or generate the default key via splinter keygen", path)
-                }))?
+                .ok_or_else(|| {
+                    CliError::action_error({
+                        &format!(
+                            "No signing key found in {}. Either specify the --key argument or \
+                            generate the default key via splinter keygen",
+                            path.iter()
+                                .map(|path| path.as_path().display().to_string())
+                                .collect::<Vec<String>>()
+                                .join(":")
+                        )
+                    })
+                })?
         }
     } else {
         let path = match env::var("CYLINDER_PATH") {
@@ -132,9 +141,18 @@ pub fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliErr
         };
         load_key(&current_user_key_name(), &path)
             .map_err(|err| CliError::action_error(&err.to_string()))?
-            .ok_or_else(|| CliError::action_error({
-                &format!("No signing key found in {:?}.  Either specify the --key argument or generate the default key via splinter keygen", path)
-            }))?
+            .ok_or_else(|| {
+                CliError::action_error({
+                    &format!(
+                        "No signing key found in {}. Either specify the --key argument or \
+                        generate the default key via splinter keygen",
+                        path.iter()
+                            .map(|path| path.as_path().display().to_string())
+                            .collect::<Vec<String>>()
+                            .join(":")
+                    )
+                })
+            })?
     };
 
     let context = Secp256k1Context::new();

--- a/services/scabbard/cli/src/key.rs
+++ b/services/scabbard/cli/src/key.rs
@@ -125,6 +125,8 @@ pub fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliErr
                 })?
         }
     } else {
+        // If the `CYLINDER_PATH` environment variable is not set, add `$HOME/.splinter/keys`
+        // to the vector of paths to search. This is for backwards compatibility.
         let path = match env::var("CYLINDER_PATH") {
             Ok(_) => current_user_search_path(),
             Err(_) => {


### PR DESCRIPTION
- Modify error messages for methods that use cylinder key-load to print the list of searched paths as a string with ':' separating the paths.
- Add a comment to the create_cylinder_jwt_auth method in scabbard cli and splinter cli about `$HOME/.splinter/keys` being added to the list of paths to be searched for backwards compatibility.