### PR TITLE
Remove feature guards from Identity

### DIFF
--- a/libsplinter/src/rest_api/auth/identity/cylinder.rs
+++ b/libsplinter/src/rest_api/auth/identity/cylinder.rs
@@ -16,7 +16,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use cylinder::{jwt::JsonWebTokenParser, PublicKey, Verifier};
+use cylinder::{jwt::JsonWebTokenParser, Verifier};
 
 use crate::error::InternalError;
 use crate::rest_api::auth::{AuthorizationHeader, BearerToken};
@@ -57,9 +57,8 @@ impl IdentityProvider for CylinderKeyIdentityProvider {
                 )
             })?)
             .parse(token)
-            .ok()
-            .and_then(|parsed_token| PublicKey::new_from_hex(&parsed_token.issuer().as_hex()).ok())
-            .map(Identity::Key),
+            .map(|parsed_token| Identity::Key(parsed_token.issuer().as_hex()))
+            .ok(),
         )
     }
 

--- a/libsplinter/src/rest_api/auth/identity/mod.rs
+++ b/libsplinter/src/rest_api/auth/identity/mod.rs
@@ -21,9 +21,6 @@ pub mod cylinder;
 #[cfg(feature = "oauth")]
 pub mod oauth;
 
-#[cfg(feature = "cylinder-jwt")]
-use ::cylinder::PublicKey;
-
 use crate::error::InternalError;
 
 use super::AuthorizationHeader;
@@ -33,10 +30,8 @@ use super::AuthorizationHeader;
 pub enum Identity {
     /// A custom identity
     Custom(String),
-    #[cfg(feature = "cylinder-jwt")]
-    /// A Cylinder public key
-    Key(PublicKey),
-    #[cfg(any(feature = "biome-credentials", feature = "oauth"))]
+    /// A public key
+    Key(String),
     /// A Biome user ID
     User(String),
 }


### PR DESCRIPTION
Removes the feature guards for the various `Identity` variants so
they're always available.

Signed-off-by: Logan Seeley <seeley@bitwise.io>