### PR TITLE
Make splinter::oauth::rest_api `pub(crate)`

### DIFF
--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -17,7 +17,7 @@
 mod builder;
 mod error;
 #[cfg(feature = "rest-api")]
-pub mod rest_api;
+pub(crate) mod rest_api;
 pub mod store;
 mod subject;
 

--- a/libsplinter/src/oauth/rest_api/mod.rs
+++ b/libsplinter/src/oauth/rest_api/mod.rs
@@ -34,7 +34,7 @@ use super::OAuthClient;
 ///
 /// * `rest-api-actix`
 #[derive(Clone)]
-pub(crate) struct OAuthResourceProvider {
+pub struct OAuthResourceProvider {
     client: OAuthClient,
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
 }


### PR DESCRIPTION
Updates the `splinter::oauth::rest_api` module to only be visible within
the crate, since it's added internally based on the REST API config, not
externally.

Signed-off-by: Logan Seeley <seeley@bitwise.io>