### PR TITLE
Implement `CircuitDisbandRequest` in admin service

### DIFF
--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -556,6 +556,9 @@ fn process_admin_event(
 
             igniter.start_ws(&xo_ws).map_err(AppAuthHandlerError::from)
         }
+        AdminServiceEvent::CircuitDisbanded(_) => Err(AppAuthHandlerError::InvalidMessageError(
+            "Unsupported event type".to_string(),
+        )),
     }
 }
 

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -106,6 +106,7 @@ experimental = [
     "biome-oauth",
     "biome-oauth-user-store-postgres",
     "biome-profile",
+    "circuit-disband",
     "https-bind",
     "oauth",
     "oauth-github",
@@ -135,6 +136,7 @@ biome-notifications = []
 biome-oauth = []
 biome-oauth-user-store-postgres = ["biome-oauth", "postgres"]
 biome-profile = []
+circuit-disband = []
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -335,7 +335,7 @@ message MemberReady {
     string member_node_id = 2;
 }
 
-// This message is sent to a connection AdminService to agree upon prtocol
+// This message is sent to a connection AdminService to agree upon protocol
 // version.
 //
 // The sending service will provide the min and max protocol versions they

--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -17,7 +17,9 @@ use std::fmt;
 
 use crate::admin::store::error::AdminServiceStoreError;
 use crate::consensus::error::ProposalManagerError;
-use crate::orchestrator::{InitializeServiceError, ShutdownServiceError};
+use crate::orchestrator::InitializeServiceError;
+#[cfg(feature = "circuit-disband")]
+use crate::orchestrator::ShutdownServiceError;
 use crate::service::error::{ServiceError, ServiceSendError};
 
 use protobuf::error;
@@ -161,6 +163,7 @@ pub enum AdminSharedError {
         context: String,
         source: Option<InitializeServiceError>,
     },
+    #[cfg(feature = "circuit-disband")]
     ServiceShutdownFailed {
         context: String,
         source: Option<ShutdownServiceError>,
@@ -190,6 +193,7 @@ impl Error for AdminSharedError {
                     None
                 }
             }
+            #[cfg(feature = "circuit-disband")]
             AdminSharedError::ServiceShutdownFailed { source, .. } => {
                 if let Some(ref err) = source {
                     Some(err)
@@ -224,6 +228,7 @@ impl fmt::Display for AdminSharedError {
                     f.write_str(&context)
                 }
             }
+            #[cfg(feature = "circuit-disband")]
             AdminSharedError::ServiceShutdownFailed { context, source } => {
                 if let Some(ref err) = source {
                     write!(f, "{}: {}", context, err)

--- a/libsplinter/src/admin/service/event/mod.rs
+++ b/libsplinter/src/admin/service/event/mod.rs
@@ -42,6 +42,7 @@ pub enum EventType {
     ProposalAccepted { requester: Vec<u8> },
     ProposalRejected { requester: Vec<u8> },
     CircuitReady,
+    CircuitDisbanded,
 }
 
 impl TryFrom<(i64, &messages::AdminServiceEvent)> for AdminServiceEvent {
@@ -81,6 +82,11 @@ impl TryFrom<(i64, &messages::AdminServiceEvent)> for AdminServiceEvent {
             messages::AdminServiceEvent::CircuitReady(_) => Ok(AdminServiceEvent {
                 event_id,
                 event_type: EventType::CircuitReady,
+                proposal,
+            }),
+            messages::AdminServiceEvent::CircuitDisbanded(_) => Ok(AdminServiceEvent {
+                event_id,
+                event_type: EventType::CircuitDisbanded,
                 proposal,
             }),
         }

--- a/libsplinter/src/admin/service/event/store/diesel/models.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/models.rs
@@ -533,6 +533,10 @@ impl<'a> From<&'a messages::AdminServiceEvent> for NewAdminServiceEventModel<'a>
                 event_type: "CircuitReady",
                 data: None,
             },
+            messages::AdminServiceEvent::CircuitDisbanded(_) => NewAdminServiceEventModel {
+                event_type: "CircuitDisbanded",
+                data: None,
+            },
         }
     }
 }
@@ -567,6 +571,11 @@ impl TryFrom<(AdminServiceEventModel, CircuitProposal)> for AdminServiceEvent {
             ("CircuitReady", None) => Ok(AdminServiceEvent {
                 event_id: event_model.id,
                 event_type: EventType::CircuitReady,
+                proposal,
+            }),
+            ("CircuitDisbanded", None) => Ok(AdminServiceEvent {
+                event_id: event_model.id,
+                event_type: EventType::CircuitDisbanded,
                 proposal,
             }),
             _ => Err(AdminServiceEventStoreError::InvalidStateError(

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -612,6 +612,7 @@ pub enum AdminServiceEvent {
     ProposalAccepted((CircuitProposal, Vec<u8>)),
     ProposalRejected((CircuitProposal, Vec<u8>)),
     CircuitReady(CircuitProposal),
+    CircuitDisbanded(CircuitProposal),
 }
 
 impl AdminServiceEvent {
@@ -622,6 +623,7 @@ impl AdminServiceEvent {
             AdminServiceEvent::ProposalAccepted((proposal, _)) => proposal,
             AdminServiceEvent::ProposalRejected((proposal, _)) => proposal,
             AdminServiceEvent::CircuitReady(proposal) => proposal,
+            AdminServiceEvent::CircuitDisbanded(proposal) => proposal,
         }
     }
 }
@@ -642,6 +644,7 @@ impl From<&event::AdminServiceEvent> for AdminServiceEvent {
                 AdminServiceEvent::ProposalRejected((admin_proposal, requester.to_vec()))
             }
             EventType::CircuitReady => AdminServiceEvent::CircuitReady(admin_proposal),
+            EventType::CircuitDisbanded => AdminServiceEvent::CircuitDisbanded(admin_proposal),
         }
     }
 }

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -210,6 +210,75 @@ impl CreateCircuit {
 
         Ok(create_request)
     }
+
+    pub fn into_circuit_proto(self) -> Result<admin::Circuit, MarshallingError> {
+        let mut circuit = admin::Circuit::new();
+
+        circuit.set_circuit_id(self.circuit_id);
+        circuit.set_roster(RepeatedField::from_vec(
+            self.roster
+                .into_iter()
+                .map(SplinterService::into_proto)
+                .collect(),
+        ));
+        circuit.set_members(RepeatedField::from_vec(
+            self.members
+                .into_iter()
+                .map(SplinterNode::into_proto)
+                .collect(),
+        ));
+
+        circuit.set_circuit_management_type(self.circuit_management_type);
+        circuit.set_application_metadata(self.application_metadata);
+
+        if let Some(comments) = self.comments {
+            circuit.set_comments(comments);
+        }
+
+        if let Some(display_name) = self.display_name {
+            circuit.set_display_name(display_name);
+        }
+
+        if self.circuit_version != UNSET_CIRCUIT_VERSION {
+            circuit.set_circuit_version(self.circuit_version);
+        }
+
+        match self.authorization_type {
+            AuthorizationType::Trust => {
+                circuit
+                    .set_authorization_type(admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION);
+            }
+        };
+
+        match self.persistence {
+            PersistenceType::Any => {
+                circuit.set_persistence(admin::Circuit_PersistenceType::ANY_PERSISTENCE);
+            }
+        };
+        match self.durability {
+            DurabilityType::NoDurability => {
+                circuit.set_durability(admin::Circuit_DurabilityType::NO_DURABILITY);
+            }
+        };
+
+        match self.routes {
+            RouteType::Any => circuit.set_routes(admin::Circuit_RouteType::ANY_ROUTE),
+        };
+
+        match self.circuit_status {
+            CircuitStatus::Active => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+            }
+            CircuitStatus::Disbanded => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
+            }
+            CircuitStatus::Abandoned => {
+                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
+            }
+        };
+
+        Ok(circuit)
+    }
 }
 
 /// Determines if a circuit ID is valid. A valid circuit ID is an 11 character string composed of
@@ -230,6 +299,14 @@ pub enum AuthorizationType {
     Trust,
 }
 
+impl From<&store::AuthorizationType> for AuthorizationType {
+    fn from(store_enum: &store::AuthorizationType) -> Self {
+        match *store_enum {
+            store::AuthorizationType::Trust => AuthorizationType::Trust,
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum PersistenceType {
     Any,
@@ -241,9 +318,25 @@ impl Default for PersistenceType {
     }
 }
 
+impl From<&store::PersistenceType> for PersistenceType {
+    fn from(store_enum: &store::PersistenceType) -> Self {
+        match *store_enum {
+            store::PersistenceType::Any => PersistenceType::Any,
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum DurabilityType {
     NoDurability,
+}
+
+impl From<&store::DurabilityType> for DurabilityType {
+    fn from(store_enum: &store::DurabilityType) -> Self {
+        match *store_enum {
+            store::DurabilityType::NoDurability => DurabilityType::NoDurability,
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -254,6 +347,14 @@ pub enum RouteType {
 impl Default for RouteType {
     fn default() -> Self {
         RouteType::Any
+    }
+}
+
+impl From<&store::RouteType> for RouteType {
+    fn from(store_enum: &store::RouteType) -> Self {
+        match *store_enum {
+            store::RouteType::Any => RouteType::Any,
+        }
     }
 }
 

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -37,7 +37,7 @@ use protobuf::{self, Message};
 
 #[cfg(feature = "admin-service-event-store")]
 use crate::admin::service::event::store::AdminServiceEventStore;
-use crate::admin::store::AdminServiceStore;
+use crate::admin::store::{self, AdminServiceStore};
 use crate::circuit::routing::{self, RoutingTableWriter};
 use crate::consensus::Proposal;
 use crate::hex::to_hex;
@@ -298,9 +298,9 @@ impl AdminService {
                 ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
             })?
             .get_circuits()
-            .map_err(|err| {
-                ServiceStartError::Internal(format!("Unable to get circuits: {}", err))
-            })?;
+            .map_err(|err| ServiceStartError::Internal(format!("Unable to get circuits: {}", err)))?
+            .filter(|circuit| circuit.circuit_status() == &store::CircuitStatus::Active)
+            .collect::<Vec<store::Circuit>>();
 
         let nodes = self
             .admin_service_shared


### PR DESCRIPTION
Adds a few commits necessary to implement the `CircuitDisbandRequest` in the admin service. 

This feature will be fully testable once the CLI commands are implemented (wip), but otherwise run `cargo test --features experimental disband` to specify the tests added for this implementation. 