### PR TITLE
Remove doc tests for clone_box methods

### DIFF
--- a/libsplinter/src/oauth/subject/mod.rs
+++ b/libsplinter/src/oauth/subject/mod.rs
@@ -34,14 +34,6 @@ pub trait SubjectProvider: Send + Sync {
 
     /// Clone implementation for `SubjectProvider`. The implementation of the `Clone` trait for
     /// `Box<dyn SubjectProvider>` calls this method.
-    ///
-    /// # Example
-    ///
-    ///```ignore
-    ///  fn clone_box(&self) -> Box<dyn SubjectProvider> {
-    ///     Box::new(self.clone())
-    ///  }
-    ///```
     fn clone_box(&self) -> Box<dyn SubjectProvider>;
 }
 

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -276,13 +276,6 @@ pub trait RegistryWriter: Send + Sync {
 pub trait RwRegistry: RegistryWriter + RegistryReader {
     /// Clone implementation for `RwRegistry`. The implementation of the `Clone` trait for
     /// `Box<RwRegistry>` calls this method.
-    ///
-    /// # Example
-    ///```ignore
-    ///  fn clone_box(&self) -> Box<dyn RwRegistry> {
-    ///     Box::new(self.clone())
-    ///  }
-    ///```
     fn clone_box(&self) -> Box<dyn RwRegistry>;
 
     /// Clone the `RwRegistry` as a `Box<dyn RegistryReader>`.

--- a/libsplinter/src/rest_api/auth/identity/mod.rs
+++ b/libsplinter/src/rest_api/auth/identity/mod.rs
@@ -48,14 +48,6 @@ pub trait IdentityProvider: Send + Sync {
 
     /// Clone implementation for `IdentityProvider`. The implementation of the `Clone` trait for
     /// `Box<dyn IdentityProvider>` calls this method.
-    ///
-    /// # Example
-    ///
-    ///```ignore
-    ///  fn clone_box(&self) -> Box<dyn IdentityProvider> {
-    ///     Box::new(self.clone())
-    ///  }
-    ///```
     fn clone_box(&self) -> Box<dyn IdentityProvider>;
 }
 

--- a/libsplinter/src/rest_api/auth/mod.rs
+++ b/libsplinter/src/rest_api/auth/mod.rs
@@ -77,14 +77,6 @@ pub trait AuthorizationHandler: Send + Sync {
 
     /// Clone implementation for `AuthorizationHandler`. The implementation of the `Clone` trait for
     /// `Box<dyn AuthorizationHandler>` calls this method.
-    ///
-    /// # Example
-    ///
-    ///```ignore
-    ///  fn clone_box(&self) -> Box<dyn AuthorizationHandler> {
-    ///     Box::new(self.clone())
-    ///  }
-    ///```
     fn clone_box(&self) -> Box<dyn AuthorizationHandler>;
 }
 


### PR DESCRIPTION
Removes the ignored doc tests for various `clone_box` trait methods.
These doc tests are not particularly useful.

Signed-off-by: Logan Seeley <seeley@bitwise.io>