### PR TITLE
OAuth OpenID scope + param config

### DIFF
--- a/libsplinter/src/oauth/builder/openid.rs
+++ b/libsplinter/src/oauth/builder/openid.rs
@@ -85,6 +85,22 @@ impl OpenIdOAuthClientBuilder {
         }
     }
 
+    /// Sets extra parameters that will be added to an authorization request.
+    pub fn with_extra_auth_params(self, extra_auth_params: Vec<(String, String)>) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self.inner.with_extra_auth_params(extra_auth_params),
+        }
+    }
+
+    /// Sets the scopes to request from the OAuth2 provider.
+    pub fn with_scopes(self, scopes: Vec<String>) -> Self {
+        Self {
+            openid_discovery_url: self.openid_discovery_url,
+            inner: self.inner.with_scopes(scopes),
+        }
+    }
+
     /// Sets the in-flight request store in order to store values between requests to and from the
     /// OAuth2 provider.
     pub fn with_inflight_request_store(

--- a/libsplinter/src/rest_api/actix_web_1/builder.rs
+++ b/libsplinter/src/rest_api/actix_web_1/builder.rs
@@ -206,14 +206,24 @@ impl RestApiBuilder {
                                 client_secret,
                                 redirect_url,
                                 oauth_openid_url,
+                                auth_params,
+                                scopes,
                                 inflight_request_store,
-                            } => OpenIdOAuthClientBuilder::new()
-                                .with_discovery_url(oauth_openid_url)
-                                .with_client_id(client_id)
-                                .with_client_secret(client_secret)
-                                .with_redirect_url(redirect_url)
-                                .with_inflight_request_store(inflight_request_store)
-                                .build()?,
+                            } => {
+                                let mut builder = OpenIdOAuthClientBuilder::new()
+                                    .with_discovery_url(oauth_openid_url)
+                                    .with_client_id(client_id)
+                                    .with_client_secret(client_secret)
+                                    .with_redirect_url(redirect_url)
+                                    .with_inflight_request_store(inflight_request_store);
+                                if let Some(auth_params) = auth_params {
+                                    builder = builder.with_extra_auth_params(auth_params);
+                                }
+                                if let Some(scopes) = scopes {
+                                    builder = builder.with_scopes(scopes);
+                                }
+                                builder.build()?
+                            }
                         };
 
                         identity_providers.push(Box::new(OAuthUserIdentityProvider::new(

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -175,6 +175,10 @@ pub enum OAuthConfig {
         redirect_url: String,
         /// The URL of the OpenID discovery document for the OpenId OAuth app
         oauth_openid_url: String,
+        /// Additional parameters to add to auth requests made to the OpenID OAuth provider
+        auth_params: Option<Vec<(String, String)>>,
+        /// Additional scopes to request from the OpenID OAuth provider
+        scopes: Option<Vec<String>>,
         /// The store for in-flight requests
         inflight_request_store: Box<dyn InflightOAuthRequestStore>,
     },

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -162,6 +162,16 @@ OPTIONS
 `--oauth-client-secret OAUTH-CLIENT-SECRET`
 : Specifies the client secret for the OAuth provider used by the REST API.
 
+`--oauth-openid-auth-params` `[,...]`
+: Specifies one or more additional parameters to add to OAuth OpenID auth
+  requests. Each parameter must be formatted as a `<key>=<value>` pair. This
+  option only has an effect when `--oauth-provider openid` is used.
+
+`--oauth-openid-scopes` `[,...]`
+: Specifies one or more additional scopes to request from the OAuth OpenID
+  provider. This option only has an effect when `--oauth-provider openid` is
+  used.
+
 `--oauth-openid-url OAUTH-OPENID-URL`
 : OpenID discovery document URL for the OAuth provider used by the REST API.
   This option is required when `--oauth-provider azure` or
@@ -353,6 +363,17 @@ The Splinter daemon provides 5 options for configuring OAuth for the REST API:
   be used to find the OAuth and OpenID endpoints for authentication. This option
   is required if the `oauth-provider` option is set to `azure` or `openid`; if a
   different provider is configured, this option will have no effect.
+
+* `oauth-openid-auth-params` for specifying additional parameters to add to
+  OAuth OpenID auth requests. Each parameter must be formatted as a
+  `<key>=<value>` pair. This option only has an effect when
+  `--oauth-provider openid` is used; if a different provider is configured,
+  this option will have no effect.
+
+* `oauth-openid-scopes` for specifying one or more additional scopes to request
+  from the OAuth OpenID provider. This option only has an effect when
+  `--oauth-provider openid` is used; if a different provider is configured,
+  this option will have no effect.
 
 The first 4 of the above arguments (provider, client ID, client secret, and
 redirect URL) must be provided when using OAuth authorization. If some but not

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -390,6 +390,20 @@ impl ConfigBuilder {
                     None => None,
                 }
             }),
+            #[cfg(feature = "oauth")]
+            oauth_openid_auth_params: self.partial_configs.iter().find_map(|p| {
+                match p.oauth_openid_auth_params() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }
+            }),
+            #[cfg(feature = "oauth")]
+            oauth_openid_scopes: self.partial_configs.iter().find_map(|p| {
+                match p.oauth_openid_scopes() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }
+            }),
             strict_ref_counts: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -27,7 +27,7 @@ fn parse_value(matches: &ArgMatches, arg: &str) -> Result<Option<u64>, ConfigErr
     match value_t!(matches.value_of(arg), u64) {
         Ok(v) => Ok(Some(v)),
         Err(e) => match e.kind {
-            ErrorKind::ValueValidation => Err(ConfigError::InvalidArgument(e)),
+            ErrorKind::ValueValidation => Err(ConfigError::InvalidArgument(e.to_string())),
             _ => Ok(None),
         },
     }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -148,6 +148,35 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                         .map(String::from),
                 )
                 .with_oauth_openid_url(self.matches.value_of("oauth_openid_url").map(String::from))
+                .with_oauth_openid_auth_params(
+                    self.matches
+                        .values_of("oauth_openid_auth_params")
+                        .map(|values| {
+                            values
+                                .map(|value| {
+                                    let mut parts = value.splitn(2, '=');
+                                    match (parts.next(), parts.next()) {
+                                        (Some(key), Some(val)) => {
+                                            Ok((key.to_owned(), val.to_owned()))
+                                        }
+                                        (Some(_), None) => Err(ConfigError::InvalidArgument(
+                                            "OAuth OpenID auth parameters must be in the format \
+                                             <key>=<value>"
+                                                .to_string(),
+                                        )),
+                                        // splitn always returns at least one item
+                                        _ => unreachable!(),
+                                    }
+                                })
+                                .collect::<Result<_, _>>()
+                        })
+                        .transpose()?,
+                )
+                .with_oauth_openid_scopes(
+                    self.matches
+                        .values_of("oauth_openid_scopes")
+                        .map(|values| values.map(String::from).collect()),
+                )
         }
 
         Ok(partial_config)

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -23,7 +23,7 @@ use toml::de::Error as TomlError;
 pub enum ConfigError {
     ReadError { file: String, err: io::Error },
     TomlParseError(TomlError),
-    InvalidArgument(clap::Error),
+    InvalidArgument(String),
     MissingValue(String),
     InvalidVersion(String),
     StdError(io::Error),
@@ -37,7 +37,7 @@ impl From<TomlError> for ConfigError {
 
 impl From<clap::Error> for ConfigError {
     fn from(e: clap::Error) -> Self {
-        ConfigError::InvalidArgument(e)
+        ConfigError::InvalidArgument(e.to_string())
     }
 }
 
@@ -46,7 +46,7 @@ impl Error for ConfigError {
         match self {
             ConfigError::ReadError { err, .. } => Some(err),
             ConfigError::TomlParseError(source) => Some(source),
-            ConfigError::InvalidArgument(source) => Some(source),
+            ConfigError::InvalidArgument(_) => None,
             ConfigError::MissingValue(_) => None,
             ConfigError::InvalidVersion(_) => None,
             ConfigError::StdError(source) => Some(source),
@@ -59,8 +59,8 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::ReadError { file, err } => write!(f, "{}: {}", err, file),
             ConfigError::TomlParseError(source) => write!(f, "Invalid File Format: {}", source),
-            ConfigError::InvalidArgument(source) => {
-                write!(f, "Unable to parse command line argument: {}", source)
+            ConfigError::InvalidArgument(msg) => {
+                write!(f, "Unable to parse command line argument: {}", msg)
             }
             ConfigError::MissingValue(msg) => write!(f, "Configuration value must be set: {}", msg),
             ConfigError::InvalidVersion(msg) => write!(f, "{}", msg),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -84,6 +84,10 @@ pub struct Config {
     oauth_redirect_url: Option<(String, ConfigSource)>,
     #[cfg(feature = "oauth")]
     oauth_openid_url: Option<(String, ConfigSource)>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_auth_params: Option<(Vec<(String, String)>, ConfigSource)>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_scopes: Option<(Vec<String>, ConfigSource)>,
     strict_ref_counts: (bool, ConfigSource),
 }
 
@@ -267,6 +271,24 @@ impl Config {
         }
     }
 
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_auth_params(&self) -> Option<&[(String, String)]> {
+        if let Some((auth_params, _)) = &self.oauth_openid_auth_params {
+            Some(auth_params)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_scopes(&self) -> Option<&[String]> {
+        if let Some((scopes, _)) = &self.oauth_openid_scopes {
+            Some(scopes)
+        } else {
+            None
+        }
+    }
+
     pub fn strict_ref_counts(&self) -> bool {
         self.strict_ref_counts.0
     }
@@ -444,6 +466,24 @@ impl Config {
     #[cfg(feature = "oauth")]
     pub fn oauth_openid_url_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.oauth_openid_url {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_auth_params_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.oauth_openid_auth_params {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_scopes_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.oauth_openid_scopes {
             Some(source)
         } else {
             None
@@ -636,6 +676,21 @@ impl Config {
                     "Config: oauth_openid_url: {} (source: {:?})",
                     openid_url, source,
                 );
+            }
+            if let (Some(auth_params), Some(source)) = (
+                self.oauth_openid_auth_params(),
+                self.oauth_openid_auth_params_source(),
+            ) {
+                debug!(
+                    "Config: oauth_openid_auth_params: {:?} (source: {:?})",
+                    auth_params, source,
+                );
+            }
+            if let (Some(scopes), Some(source)) = (
+                self.oauth_openid_scopes(),
+                self.oauth_openid_scopes_source(),
+            ) {
+                debug!("Config: oauth_scopes: {:?} (source: {:?})", scopes, source,);
             }
         }
         debug!(

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -77,6 +77,10 @@ pub struct PartialConfig {
     oauth_redirect_url: Option<String>,
     #[cfg(feature = "oauth")]
     oauth_openid_url: Option<String>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_auth_params: Option<Vec<(String, String)>>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_scopes: Option<Vec<String>>,
     strict_ref_counts: Option<bool>,
 }
 
@@ -129,6 +133,10 @@ impl PartialConfig {
             oauth_redirect_url: None,
             #[cfg(feature = "oauth")]
             oauth_openid_url: None,
+            #[cfg(feature = "oauth")]
+            oauth_openid_auth_params: None,
+            #[cfg(feature = "oauth")]
+            oauth_openid_scopes: None,
             strict_ref_counts: None,
         }
     }
@@ -278,6 +286,16 @@ impl PartialConfig {
     #[cfg(feature = "oauth")]
     pub fn oauth_openid_url(&self) -> Option<String> {
         self.oauth_openid_url.clone()
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_auth_params(&self) -> Option<Vec<(String, String)>> {
+        self.oauth_openid_auth_params.clone()
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn oauth_openid_scopes(&self) -> Option<Vec<String>> {
+        self.oauth_openid_scopes.clone()
     }
 
     pub fn strict_ref_counts(&self) -> Option<bool> {
@@ -665,6 +683,34 @@ impl PartialConfig {
     ///
     pub fn with_oauth_openid_url(mut self, oauth_openid_url: Option<String>) -> Self {
         self.oauth_openid_url = oauth_openid_url;
+        self
+    }
+
+    #[cfg(feature = "oauth")]
+    /// Adds an `with_oauth_openid_auth_params` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `oauth_openid_auth_params` - Add extra auth request parameters to the REST API OAuth
+    ///   OpenID configuration
+    ///
+    pub fn with_oauth_openid_auth_params(
+        mut self,
+        oauth_openid_auth_params: Option<Vec<(String, String)>>,
+    ) -> Self {
+        self.oauth_openid_auth_params = oauth_openid_auth_params;
+        self
+    }
+
+    #[cfg(feature = "oauth")]
+    /// Adds an `with_oauth_openid_scopes` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `oauth_openid_scopes` - Add extra scopes to the REST API OAuth OpenID configuration
+    ///
+    pub fn with_oauth_openid_scopes(mut self, oauth_openid_scopes: Option<Vec<String>>) -> Self {
+        self.oauth_openid_scopes = oauth_openid_scopes;
         self
     }
 

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -134,6 +134,10 @@ pub struct SplinterDaemon {
     oauth_redirect_url: Option<String>,
     #[cfg(feature = "oauth")]
     oauth_openid_url: Option<String>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_auth_params: Option<Vec<(String, String)>>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_scopes: Option<Vec<String>>,
     heartbeat: u64,
     strict_ref_counts: bool,
 }
@@ -689,6 +693,8 @@ impl SplinterDaemon {
                                 "missing OAuth OpenID discovery document URL configuration".into(),
                             )
                         })?,
+                        auth_params: self.oauth_openid_auth_params.clone(),
+                        scopes: self.oauth_openid_scopes.clone(),
                         inflight_request_store: store_factory.get_oauth_inflight_request_store(),
                     },
                     other_provider => {
@@ -1050,6 +1056,10 @@ pub struct SplinterDaemonBuilder {
     oauth_redirect_url: Option<String>,
     #[cfg(feature = "oauth")]
     oauth_openid_url: Option<String>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_auth_params: Option<Vec<(String, String)>>,
+    #[cfg(feature = "oauth")]
+    oauth_openid_scopes: Option<Vec<String>>,
     strict_ref_counts: Option<bool>,
 }
 
@@ -1189,6 +1199,18 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    #[cfg(feature = "oauth")]
+    pub fn with_oauth_openid_auth_params(mut self, value: Option<Vec<(String, String)>>) -> Self {
+        self.oauth_openid_auth_params = value;
+        self
+    }
+
+    #[cfg(feature = "oauth")]
+    pub fn with_oauth_openid_scopes(mut self, value: Option<Vec<String>>) -> Self {
+        self.oauth_openid_scopes = value;
+        self
+    }
+
     pub fn with_strict_ref_counts(mut self, strict_ref_counts: bool) -> Self {
         self.strict_ref_counts = Some(strict_ref_counts);
         self
@@ -1305,6 +1327,10 @@ impl SplinterDaemonBuilder {
             oauth_redirect_url: self.oauth_redirect_url,
             #[cfg(feature = "oauth")]
             oauth_openid_url: self.oauth_openid_url,
+            #[cfg(feature = "oauth")]
+            oauth_openid_auth_params: self.oauth_openid_auth_params,
+            #[cfg(feature = "oauth")]
+            oauth_openid_scopes: self.oauth_openid_scopes,
             heartbeat,
             strict_ref_counts,
         })

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -384,6 +384,28 @@ fn main() {
                 .long("oauth-openid-url")
                 .long_help("URL for an OpenID discovery document used by the REST API")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("oauth_openid_auth_params")
+                .long("oauth-openid-auth-params")
+                .alias("oauth-openid-auth-param")
+                .long_help(
+                    "Addtional parameters to add to OAuth OpenID auth requests, formatted as \
+                     `key=value` pairs (requires `--oauth-provider openid`)",
+                )
+                .takes_value(true)
+                .multiple(true),
+        )
+        .arg(
+            Arg::with_name("oauth_openid_scopes")
+                .long("oauth-openid-scopes")
+                .alias("oauth-openid-scope")
+                .long_help(
+                    "Addtional scopes to request from the OAuth OpenID provider (requires \
+                     `--oauth-provider openid`)",
+                )
+                .takes_value(true)
+                .multiple(true),
         );
 
     let matches = app.get_matches();
@@ -518,7 +540,9 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
             .with_oauth_client_id(config.oauth_client_id().map(ToOwned::to_owned))
             .with_oauth_client_secret(config.oauth_client_secret().map(ToOwned::to_owned))
             .with_oauth_redirect_url(config.oauth_redirect_url().map(ToOwned::to_owned))
-            .with_oauth_openid_url(config.oauth_openid_url().map(ToOwned::to_owned));
+            .with_oauth_openid_url(config.oauth_openid_url().map(ToOwned::to_owned))
+            .with_oauth_openid_auth_params(config.oauth_openid_auth_params().map(ToOwned::to_owned))
+            .with_oauth_openid_scopes(config.oauth_openid_scopes().map(ToOwned::to_owned));
     }
 
     let mut node = daemon_builder.build().map_err(|err| {


### PR DESCRIPTION
# Testing

## Setup

1. Make sure your environment is setup to run splinterd locally:

```bash
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- database migrate
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- cert generate
```

## Testing auth params

2. Run splinterd with Google as auth provider but configure it as a generic OpenID provider with additional params:

```bash
$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- \
  --rest-api-endpoint http://localhost:8080 \
  --tls-insecure \
  --oauth-provider openid \
  --oauth-client-id <client-id> \
  --oauth-client-secret <client-secret> \
  --oauth-redirect-url http://localhost:8080/oauth/callback \
  --oauth-openid-url https://accounts.google.com/.well-known/openid-configuration \
  --oauth-openid-auth-param access_type=offline \
  --oauth-openid-auth-param prompt=consent \
  -vv
```

3. Go to http://localhost:8080/oauth/login?redirect_url=redirect in your browser and login (you will eventually be redirected and get a 404)

4. Verify that the new session has a refresh token (2nd to last value), which indicates that the auth params were added:

```bash
$ sqlite3 /tmp/splinter/data/splinter_state.db
sqlite> SELECT * FROM oauth_user_sessions;
o6AQzhOHlV7yMqrjpTiTgiDPcicwXjIQ|116381315131550692628|ya29.a0AfH6SMD7X8kpebidwV1Ql_Hn4YKim8MxNRhJIGrMBDNpMn4MJT7x77Y326sOkrTq_6_lfnqEzV7ld8V7qiB-O34nfLESMuZWAIf8M2m_zYkCNpXOSczfZz7TZGqDLxT8EDGsUE66j5k5HbZ9cjxTx4U8AAqfe2aZUS0ReqhAoqY|1//04iI1Qw-AR0obCgYIARAAGAQSNwF-L9IrkZOnArAW03diII5zDVguqdEh4HaELG6gJr9zLgomnEMGB0Ry95wAIDtRFsnvSFAPVvQ|1611597844
```

### Testing scopes

5. Run splinterd with Azure as auth provider but configure it as a generic OpenID provider with additional scopes:

```bash
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- \
  --rest-api-endpoint http://localhost:8080 \
  --tls-insecure \
  --oauth-provider openid \
  --oauth-client-id <client-id> \
  --oauth-client-secret <client-secret> \
  --oauth-redirect-url http://localhost:8080/oauth/callback \
  --oauth-openid-url https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration \
  --oauth-openid-scope offline_access \
  -vv
```

6. Repeat steps 3-4 above to verify the scope was added