### PR TITLE
Add permission details

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ experimental = [
     "circuit-auth-type",
     "health",
     "https-certs",
+    "permissions",
 ]
 
 authorization-handler-maintenance = []
@@ -81,6 +82,7 @@ circuit-template = ["splinter/circuit-template"]
 health = []
 
 https-certs = []
+permissions = []
 
 database = ["diesel"]
 postgres = [

--- a/cli/man/splinter-permissions.1.md
+++ b/cli/man/splinter-permissions.1.md
@@ -1,0 +1,128 @@
+% SPLINTER-PERMISSIONS(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-permissions** — Lists REST API permissions for a Splinter node
+
+SYNOPSIS
+========
+**splinter permissions** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command lists all permissions for the local Splinter node's REST API.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the permissions. (default `human`). Possible
+  values for formatting are `human`, `csv`, and `json`.
+
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+The following command displays REST API permissions in a human-readable table
+(the output is abbreviated for readability):
+
+```
+$ splinter permissions \
+  --key /path/to/key.priv \
+  --url http://example.com:8080
+ID                              NAME                   DESCRIPTION
+registry.read                   Registry read          Allows the client to read the registry
+registry.write                  Registry write         Allows the client to modify the registry
+circuit.read                    Circuit read           Allows the client to read circuit state
+circuit.write                   Circuit write          Allows the client to modify circuit state
+...
+```
+
+The following command displays REST API permissions as CSV (output abbreviated):
+
+```
+$ splinter permissions \
+  --format csv
+  --key /path/to/key.priv \
+  --url http://example.com:8080
+ID,NAME,DESCRIPTION
+registry.read,Registry read,Allows the client to read the registry
+registry.write,Registry write,Allows the client to modify the registry
+circuit.read,Circuit read,Allows the client to read circuit state
+circuit.write,Circuit write,Allows the client to modify circuit state
+...
+```
+
+The following command displays REST API permissions as JSON (output
+abbreviated):
+
+```
+$ splinter permissions \
+  --format json
+  --key /path/to/key.priv \
+  --url http://example.com:8080
+[
+  [
+    "ID",
+    "NAME",
+    "DESCRIPTION"
+  ],
+  [
+    "registry.read",
+    "Registry read",
+    "Allows the client to read the registry"
+  ],
+  [
+    "registry.write",
+    "Registry write",
+    "Allows the client to modify the registry"
+  ],
+  [
+    "circuit.read",
+    "Circuit read",
+    "Allows the client to read circuit state"
+  ],
+  [
+    "circuit.write",
+    "Circuit write",
+    "Allows the client to modify circuit state"
+  ],
+  ...
+]
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -34,7 +34,7 @@ use crate::template::CircuitTemplate;
 
 use super::api::SplinterRestClientBuilder;
 use super::{
-    msg_from_io_error, read_private_key, Action, DEFAULT_SPLINTER_REST_API_URL,
+    msg_from_io_error, print_table, read_private_key, Action, DEFAULT_SPLINTER_REST_API_URL,
     SPLINTER_REST_API_URL_ENV,
 };
 
@@ -897,37 +897,4 @@ fn list_proposals(
     }
 
     Ok(())
-}
-
-// Takes a vec of vecs of strings. The first vec should include the title of the columns.
-// The max length of each column is calculated and is used as the column with when printing the
-// table.
-fn print_table(table: Vec<Vec<String>>) {
-    let mut max_lengths = Vec::new();
-
-    // find the max lengths of the columns
-    for row in table.iter() {
-        for (i, col) in row.iter().enumerate() {
-            if let Some(length) = max_lengths.get_mut(i) {
-                if col.len() > *length {
-                    *length = col.len()
-                }
-            } else {
-                max_lengths.push(col.len())
-            }
-        }
-    }
-
-    // print each row with correct column size
-    for row in table.iter() {
-        let mut col_string = String::from("");
-        for (i, len) in max_lengths.iter().enumerate() {
-            if let Some(value) = row.get(i) {
-                col_string += &format!("{}{} ", value, " ".repeat(*len - value.len()),);
-            } else {
-                col_string += &" ".repeat(*len);
-            }
-        }
-        println!("{}", col_string);
-    }
 }

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -24,6 +24,8 @@ pub mod health;
 pub mod keygen;
 #[cfg(feature = "authorization-handler-maintenance")]
 pub mod maintenance;
+#[cfg(feature = "permissions")]
+pub mod permissions;
 pub mod registry;
 
 use std::collections::HashMap;

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -201,3 +201,36 @@ fn create_cylinder_jwt_auth(key_name: Option<&str>) -> Result<String, CliError> 
 
     Ok(format!("Bearer Cylinder:{}", encoded_token))
 }
+
+// Takes a vec of vecs of strings. The first vec should include the title of the columns.
+// The max length of each column is calculated and is used as the column with when printing the
+// table.
+fn print_table(table: Vec<Vec<String>>) {
+    let mut max_lengths = Vec::new();
+
+    // find the max lengths of the columns
+    for row in table.iter() {
+        for (i, col) in row.iter().enumerate() {
+            if let Some(length) = max_lengths.get_mut(i) {
+                if col.len() > *length {
+                    *length = col.len()
+                }
+            } else {
+                max_lengths.push(col.len())
+            }
+        }
+    }
+
+    // print each row with correct column size
+    for row in table.iter() {
+        let mut col_string = String::from("");
+        for (i, len) in max_lengths.iter().enumerate() {
+            if let Some(value) = row.get(i) {
+                col_string += &format!("{}{} ", value, " ".repeat(*len - value.len()),);
+            } else {
+                col_string += &" ".repeat(*len);
+            }
+        }
+        println!("{}", col_string);
+    }
+}

--- a/cli/src/action/permissions.rs
+++ b/cli/src/action/permissions.rs
@@ -1,0 +1,75 @@
+// Copyright 2018-2020 Cargill Incorporated
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgMatches;
+
+use crate::error::CliError;
+
+use super::{
+    api::SplinterRestClientBuilder, create_cylinder_jwt_auth, print_table, Action,
+    DEFAULT_SPLINTER_REST_API_URL, SPLINTER_REST_API_URL_ENV,
+};
+
+pub struct ListAction;
+
+impl Action for ListAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let format = arg_matches
+            .and_then(|args| args.value_of("format"))
+            .unwrap_or("human");
+        let url = arg_matches
+            .and_then(|args| args.value_of("url"))
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
+        let key = arg_matches.and_then(|args| args.value_of("private_key_file"));
+
+        let permissions = SplinterRestClientBuilder::new()
+            .with_url(url)
+            .with_auth(create_cylinder_jwt_auth(key)?)
+            .build()?
+            .list_permissions()?;
+
+        let data = std::iter::once(vec![
+            "ID".to_string(),
+            "NAME".to_string(),
+            "DESCRIPTION".to_string(),
+        ])
+        .chain(permissions.into_iter().map(|perm| {
+            vec![
+                perm.permission_id,
+                perm.permission_display_name,
+                perm.permission_description,
+            ]
+        }));
+
+        match format {
+            "csv" => {
+                for row in data {
+                    println!("{}", row.join(","))
+                }
+            }
+            "json" => println!(
+                "\n {}",
+                serde_json::to_string_pretty(&data.collect::<Vec<_>>()).map_err(|err| {
+                    CliError::ActionError(format!("Cannot format permissions into json: {}", err))
+                })?
+            ),
+            _ => print_table(data.collect()),
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -822,6 +822,38 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         )
     }
 
+    #[cfg(feature = "permissions")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("permissions")
+                .about("Lists REST API permissions for a Splinter node")
+                .arg(
+                    Arg::with_name("format")
+                        .short("F")
+                        .long("format")
+                        .help("Output format")
+                        .possible_values(&["human", "csv", "json"])
+                        .default_value("human")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("url")
+                        .short("U")
+                        .long("url")
+                        .help("URL of the Splinter daemon REST API")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("private_key_file")
+                        .value_name("private-key-file")
+                        .short("k")
+                        .long("key")
+                        .takes_value(true)
+                        .help("Name or path of private key"),
+                ),
+        )
+    }
+
     let matches = app.get_matches_from_safe(args)?;
 
     // set default to info
@@ -917,6 +949,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 .with_command("enable", maintenance::EnableAction)
                 .with_command("disable", maintenance::DisableAction),
         )
+    }
+
+    #[cfg(feature = "permissions")]
+    {
+        use action::permissions;
+        subcommands = subcommands.with_command("permissions", permissions::ListAction)
     }
 
     subcommands.run(Some(&matches))

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -27,9 +27,17 @@ use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
 use crate::rest_api::auth::authorization::Permission;
 
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const CIRCUIT_READ_PERMISSION: Permission = Permission::Check("circuit.read");
+const CIRCUIT_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "circuit.read",
+    permission_display_name: "Circuit read",
+    permission_description: "Allows the client to read circuit state",
+};
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const CIRCUIT_WRITE_PERMISSION: Permission = Permission::Check("circuit.write");
+const CIRCUIT_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "circuit.write",
+    permission_display_name: "Circuit write",
+    permission_description: "Allows the client to modify circuit state",
+};
 
 /// The admin service provides the following endpoints as REST API resources:
 ///

--- a/libsplinter/src/biome/rest_api/mod.rs
+++ b/libsplinter/src/biome/rest_api/mod.rs
@@ -80,9 +80,17 @@ use super::credentials::store::CredentialsStore;
 use crate::rest_api::sessions::AccessTokenIssuer;
 
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const BIOME_USER_READ_PERMISSION: Permission = Permission::Check("biome.user.read");
+const BIOME_USER_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "biome.user.read",
+    permission_display_name: "Biome user read",
+    permission_description: "Allows the client to view all Biome users",
+};
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const BIOME_USER_WRITE_PERMISSION: Permission = Permission::Check("biome.user.write");
+const BIOME_USER_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "biome.user.write",
+    permission_display_name: "Biome user write",
+    permission_description: "Allows the client to modify all Biome users",
+};
 
 /// Provides the REST API endpoints for biome
 ///

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -53,6 +53,8 @@ pub const AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
     feature = "rest-api-actix"
 ))]
 pub(crate) const AUTHORIZATION_MAINTENANCE_MIN: u32 = 1;
+#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+pub(crate) const AUTHORIZATION_PERMISSIONS_MIN: u32 = 1;
 
 // Authorization (namely RBAC management)  protocol versions
 #[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix"))]

--- a/libsplinter/src/registry/rest_api/mod.rs
+++ b/libsplinter/src/registry/rest_api/mod.rs
@@ -25,9 +25,17 @@ use crate::rest_api::auth::authorization::Permission;
 use super::RwRegistry;
 
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const REGISTRY_READ_PERMISSION: Permission = Permission::Check("registry.read");
+const REGISTRY_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "registry.read",
+    permission_display_name: "Registry read",
+    permission_description: "Allows the client to read the registry",
+};
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const REGISTRY_WRITE_PERMISSION: Permission = Permission::Check("registry.write");
+const REGISTRY_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "registry.write",
+    permission_display_name: "Registry write",
+    permission_description: "Allows the client to modify the registry",
+};
 
 /// The `RwRegistry` trait service provides the following endpoints as REST API resources:
 ///

--- a/libsplinter/src/rest_api/actix_web_1/resource.rs
+++ b/libsplinter/src/rest_api/actix_web_1/resource.rs
@@ -377,10 +377,15 @@ mod test {
     #[cfg(feature = "authorization")]
     #[test]
     fn test_resource_permission() {
+        let permission = Permission::Check {
+            permission_id: "test",
+            permission_display_name: "",
+            permission_description: "",
+        };
         let (_, permission_map) = Resource::build("/test")
             .add_method(
                 Method::Get,
-                Permission::Check("test"),
+                permission,
                 |_: HttpRequest, _: web::Payload| Box::new(Response::Ok().finish().into_future()),
             )
             .into_route();
@@ -389,7 +394,7 @@ mod test {
             permission_map
                 .get_permission(&Method::Get, "/test")
                 .expect("Missing permission"),
-            &Permission::Check("test"),
+            &permission,
         );
     }
 }

--- a/libsplinter/src/rest_api/auth/authorization/maintenance/routes/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/maintenance/routes/mod.rs
@@ -26,11 +26,17 @@ use crate::rest_api::auth::authorization::Permission;
 use super::MaintenanceModeAuthorizationHandler;
 
 #[cfg(feature = "rest-api-actix")]
-const AUTHORIZATION_MAINTENANCE_READ_PERMISSION: Permission =
-    Permission::Check("authorization.maintenance.read");
+const AUTHORIZATION_MAINTENANCE_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "authorization.maintenance.read",
+    permission_display_name: "Maintenance mode read",
+    permission_description: "Allows the client to check maintenance mode status",
+};
 #[cfg(feature = "rest-api-actix")]
-const AUTHORIZATION_MAINTENANCE_WRITE_PERMISSION: Permission =
-    Permission::Check("authorization.maintenance.write");
+const AUTHORIZATION_MAINTENANCE_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "authorization.maintenance.write",
+    permission_display_name: "Maintenance mode write",
+    permission_description: "Allows the client to enable/disable maintenance mode",
+};
 
 /// The `MaintenanceModeAuthorizationHandler` provides the following endpoints as REST API
 /// resources:

--- a/libsplinter/src/rest_api/auth/authorization/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/mod.rs
@@ -29,10 +29,17 @@ use super::identity::Identity;
 pub(in crate::rest_api) use permission_map::PermissionMap;
 
 /// A permission assigned to an endpoint
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Permission {
     /// Check that the authenticated client has the specified permission.
-    Check(&'static str),
+    Check {
+        /// The permission ID that's passed to [`AuthorizationHandler::has_permission`]
+        permission_id: &'static str,
+        /// The human-readable name for the permission
+        permission_display_name: &'static str,
+        /// A description for the permission
+        permission_description: &'static str,
+    },
     /// Allow any request that has been authenticated (the client's identity has been determined).
     /// This may be used by endpoints that need to know the client's identity but do not require a
     /// special permission to be checked (the Biome key management and OAuth logout routes are an

--- a/libsplinter/src/rest_api/auth/authorization/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/mod.rs
@@ -21,6 +21,7 @@ pub mod maintenance;
 mod permission_map;
 #[cfg(feature = "authorization-handler-rbac")]
 pub mod rbac;
+pub(in crate::rest_api) mod routes;
 
 use crate::error::InternalError;
 

--- a/libsplinter/src/rest_api/auth/authorization/permission_map.rs
+++ b/libsplinter/src/rest_api/auth/authorization/permission_map.rs
@@ -161,13 +161,21 @@ mod tests {
     /// Verifies that the `PermissionMap` works correctly
     #[test]
     fn permission_map() {
-        let perm1 = Permission::Check("perm1");
-        let perm2 = Permission::Check("perm2");
+        let perm1 = Permission::Check {
+            permission_id: "perm1",
+            permission_display_name: "",
+            permission_description: "",
+        };
+        let perm2 = Permission::Check {
+            permission_id: "perm2",
+            permission_display_name: "",
+            permission_description: "",
+        };
 
         let mut map = PermissionMap::new();
         assert!(map.internal.is_empty());
 
-        map.add_permission(Method::Get, "/test/endpoint", perm1.clone());
+        map.add_permission(Method::Get, "/test/endpoint", perm1);
         assert_eq!(map.internal.len(), 1);
         assert_eq!(
             map.get_permission(&Method::Get, "/test/endpoint"),
@@ -177,7 +185,7 @@ mod tests {
         assert_eq!(map.get_permission(&Method::Get, "/test/other"), None);
 
         let mut other_map = PermissionMap::new();
-        other_map.add_permission(Method::Put, "/test/endpoint/{variable}", perm2.clone());
+        other_map.add_permission(Method::Put, "/test/endpoint/{variable}", perm2);
         map.append(&mut other_map);
         assert_eq!(map.internal.len(), 2);
         assert_eq!(

--- a/libsplinter/src/rest_api/auth/authorization/permission_map.rs
+++ b/libsplinter/src/rest_api/auth/authorization/permission_map.rs
@@ -28,6 +28,11 @@ impl PermissionMap {
         Self::default()
     }
 
+    /// Gets a list of all permissions.
+    pub fn permissions(&self) -> impl Iterator<Item = Permission> + '_ {
+        self.internal.iter().map(|(_, perm)| *perm)
+    }
+
     /// Sets the permission for the given (method, endpoint) pair. The endpoint may contain path
     /// variables surrounded by `{}`.
     pub fn add_permission(&mut self, method: Method, endpoint: &str, permission: Permission) {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/mod.rs
@@ -24,7 +24,15 @@ use crate::rest_api::auth::Permission;
 pub use actix_web_1::RoleBasedAuthorizationResourceProvider;
 
 #[cfg(feature = "rest-api-actix")]
-const RBAC_READ_PERMISSION: Permission = Permission::Check("authorization.rbac.read");
+const RBAC_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "authorization.rbac.read",
+    permission_display_name: "RBAC read",
+    permission_description: "Allows the client to read roles, identities, and role assignments",
+};
 
 #[cfg(feature = "rest-api-actix")]
-const RBAC_WRITE_PERMISSION: Permission = Permission::Check("authorization.rbac.write");
+const RBAC_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "authorization.rbac.write",
+    permission_display_name: "RBAC write",
+    permission_description: "Allows the client to modify roles, identities, and role assignments",
+};

--- a/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
@@ -1,0 +1,216 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides the following endpoints:
+//!
+//! * `GET /authroization/permissions` for displaying all REST API permissions
+
+use actix_web::HttpResponse;
+use futures::future::IntoFuture;
+
+use crate::protocol;
+use crate::rest_api::{
+    actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
+    auth::authorization::Permission,
+};
+
+use super::{resources::PermissionResponse, AUTHORIZATION_PERMISSIONS_READ_PERMISSION};
+
+pub fn make_permissions_resource(permissions: Vec<Permission>) -> Resource {
+    let permissions = permissions
+        .into_iter()
+        // Add this endpoint's own permission
+        .chain(std::iter::once(AUTHORIZATION_PERMISSIONS_READ_PERMISSION))
+        // Deduplicate and convert to serializable response structs
+        .fold(vec![], |mut perms: Vec<PermissionResponse>, perm| {
+            // Only interested in assignable permissions
+            if let Permission::Check {
+                permission_id,
+                permission_display_name,
+                permission_description,
+            } = perm
+            {
+                if !perms
+                    .iter()
+                    .any(|existing_perm| permission_id == existing_perm.permission_id)
+                {
+                    perms.push(PermissionResponse {
+                        permission_id,
+                        permission_display_name,
+                        permission_description,
+                    });
+                }
+            }
+            perms
+        });
+
+    Resource::build("/authorization/permissions")
+        .add_request_guard(ProtocolVersionRangeGuard::new(
+            protocol::AUTHORIZATION_PERMISSIONS_MIN,
+            protocol::AUTHORIZATION_PROTOCOL_VERSION,
+        ))
+        .add_method(
+            Method::Get,
+            AUTHORIZATION_PERMISSIONS_READ_PERMISSION,
+            move |_, _| {
+                Box::new(
+                    HttpResponse::Ok()
+                        .json(json!({
+                            "data": &permissions,
+                        }))
+                        .into_future(),
+                )
+            },
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use reqwest::{blocking::Client, StatusCode, Url};
+
+    use crate::rest_api::actix_web_1::{RestApiBuilder, RestApiShutdownHandle};
+
+    const PERM1: Permission = Permission::Check {
+        permission_id: "id1",
+        permission_display_name: "display name 1",
+        permission_description: "description 1",
+    };
+    const PERM2: Permission = Permission::Check {
+        permission_id: "id2",
+        permission_display_name: "display name 2",
+        permission_description: "description 2",
+    };
+
+    /// Verifies that the `GET /authorization/permissions` endpoint returns the correct values
+    ///
+    /// 1. Start the REST API with a duplicated permission, a non-duplicated permission, an
+    ///    "allow authenticated" permission, and an "allow unauthenticated" permission
+    /// 2. Make a request to the endpoint and verify the resulting permissions list contains only
+    ///    the non-duplciated permision, a single instance of the duplicated permission, and the
+    ///    endpoint's own permission
+    /// 3. Shutdown the REST API
+    #[test]
+    fn get_permissions() {
+        let (shutdown_handle, join_handle, bind_url) =
+            run_rest_api_on_open_port(vec![make_permissions_resource(vec![
+                PERM1,
+                PERM1,
+                PERM2,
+                Permission::AllowAuthenticated,
+                Permission::AllowUnauthenticated,
+            ])]);
+
+        let url = Url::parse(&format!("http://{}/authorization/permissions", bind_url))
+            .expect("Failed to parse URL");
+        let resp = Client::new()
+            .get(url)
+            .header(
+                "SplinterProtocolVersion",
+                protocol::AUTHORIZATION_PROTOCOL_VERSION,
+            )
+            .send()
+            .expect("Failed to perform request");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let permissions = resp
+            .json::<Response>()
+            .expect("Failed to parse response body")
+            .data;
+        assert_eq!(permissions.len(), 3);
+        match PERM1 {
+            Permission::Check {
+                permission_id,
+                permission_display_name,
+                permission_description,
+            } => {
+                assert!(permissions
+                    .iter()
+                    .any(|perm| perm.permission_id == permission_id
+                        && perm.permission_display_name == permission_display_name
+                        && perm.permission_description == permission_description));
+            }
+            _ => unreachable!(),
+        }
+        match PERM2 {
+            Permission::Check {
+                permission_id,
+                permission_display_name,
+                permission_description,
+            } => {
+                assert!(permissions
+                    .iter()
+                    .any(|perm| perm.permission_id == permission_id
+                        && perm.permission_display_name == permission_display_name
+                        && perm.permission_description == permission_description));
+            }
+            _ => unreachable!(),
+        }
+        match AUTHORIZATION_PERMISSIONS_READ_PERMISSION {
+            Permission::Check {
+                permission_id,
+                permission_display_name,
+                permission_description,
+            } => {
+                assert!(permissions
+                    .iter()
+                    .any(|perm| perm.permission_id == permission_id
+                        && perm.permission_display_name == permission_display_name
+                        && perm.permission_description == permission_description));
+            }
+            _ => unreachable!(),
+        }
+
+        shutdown_handle
+            .shutdown()
+            .expect("Unable to shutdown rest api");
+        join_handle.join().expect("Unable to join rest api thread");
+    }
+
+    #[derive(Deserialize)]
+    struct Response {
+        data: Vec<PermissionData>,
+    }
+
+    #[derive(Deserialize)]
+    struct PermissionData {
+        permission_id: String,
+        permission_display_name: String,
+        permission_description: String,
+    }
+
+    fn run_rest_api_on_open_port(
+        resources: Vec<Resource>,
+    ) -> (RestApiShutdownHandle, std::thread::JoinHandle<()>, String) {
+        #[cfg(not(feature = "https-bind"))]
+        let bind = "127.0.0.1:0";
+        #[cfg(feature = "https-bind")]
+        let bind = crate::rest_api::RestApiBind::Insecure("127.0.0.1:0".into());
+
+        let result = RestApiBuilder::new()
+            .with_bind(bind)
+            .add_resources(resources.clone())
+            .build_insecure()
+            .expect("Failed to build REST API")
+            .run_insecure();
+        match result {
+            Ok((shutdown_handle, join_handle)) => {
+                let port = shutdown_handle.port_numbers()[0];
+                (shutdown_handle, join_handle, format!("127.0.0.1:{}", port))
+            }
+            Err(err) => panic!("Failed to run REST API: {}", err),
+        }
+    }
+}

--- a/libsplinter/src/rest_api/auth/authorization/routes/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/mod.rs
@@ -1,0 +1,77 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! REST API endpoints for authorization tools
+
+#[cfg(feature = "rest-api-actix")]
+mod actix;
+#[cfg(feature = "rest-api-actix")]
+mod resources;
+
+use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
+#[cfg(feature = "rest-api-actix")]
+use crate::rest_api::auth::authorization::Permission;
+
+#[cfg(feature = "rest-api-actix")]
+const AUTHORIZATION_PERMISSIONS_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "authorization.permissions.read",
+    permission_display_name: "Permissions read",
+    permission_description: "Allows the client to read REST API permissions",
+};
+
+/// Provides the REST API [Resource] definitions for authorization endpoints. The following
+/// endpoints are provided:
+///
+/// * `GET /authorization/permissions` - Get the list of all REST API permissions
+///
+/// These endpoints are only available if the following REST API backend feature is enabled:
+///
+/// * `rest-api-actix`
+pub struct AuthorizationResourceProvider {
+    #[cfg(feature = "rest-api-actix")]
+    permissions: Vec<Permission>,
+}
+
+impl AuthorizationResourceProvider {
+    /// Creates a new `AuthorizationResourceProvider`
+    pub fn new(#[cfg(feature = "rest-api-actix")] permissions: Vec<Permission>) -> Self {
+        Self {
+            #[cfg(feature = "rest-api-actix")]
+            permissions,
+        }
+    }
+}
+
+/// `AuthorizationResourceProvider` provides the following endpoints as REST API resources:
+///
+/// * `GET /authorization/permissions` - Get the list of all REST API permissions
+///
+/// These endpoints are only available if the following REST API backend feature is enabled:
+///
+/// * `rest-api-actix`
+impl RestResourceProvider for AuthorizationResourceProvider {
+    fn resources(&self) -> Vec<Resource> {
+        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
+        // enabled
+        #[allow(unused_mut)]
+        let mut resources = Vec::new();
+
+        #[cfg(feature = "rest-api-actix")]
+        {
+            resources.push(actix::make_permissions_resource(self.permissions.clone()));
+        }
+
+        resources
+    }
+}

--- a/libsplinter/src/rest_api/auth/authorization/routes/resources.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/resources.rs
@@ -1,0 +1,22 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Resources for the authorization tools' REST API endpoints
+
+#[derive(Serialize)]
+pub struct PermissionResponse {
+    pub permission_id: &'static str,
+    pub permission_display_name: &'static str,
+    pub permission_description: &'static str,
+}

--- a/libsplinter/src/rest_api/auth/mod.rs
+++ b/libsplinter/src/rest_api/auth/mod.rs
@@ -75,25 +75,27 @@ fn authorize(
                 Some(identity) => AuthorizationResult::Authorized(identity),
                 None => AuthorizationResult::Unauthorized,
             },
-            Permission::Check(perm) => match get_identity(auth_header, identity_providers) {
-                Some(identity) => {
-                    for handler in authorization_handlers {
-                        match handler.has_permission(&identity, perm) {
-                            Ok(AuthorizationHandlerResult::Allow) => {
-                                return AuthorizationResult::Authorized(identity)
+            Permission::Check { permission_id, .. } => {
+                match get_identity(auth_header, identity_providers) {
+                    Some(identity) => {
+                        for handler in authorization_handlers {
+                            match handler.has_permission(&identity, permission_id) {
+                                Ok(AuthorizationHandlerResult::Allow) => {
+                                    return AuthorizationResult::Authorized(identity)
+                                }
+                                Ok(AuthorizationHandlerResult::Deny) => {
+                                    return AuthorizationResult::Unauthorized
+                                }
+                                Ok(AuthorizationHandlerResult::Continue) => {}
+                                Err(err) => error!("{}", err),
                             }
-                            Ok(AuthorizationHandlerResult::Deny) => {
-                                return AuthorizationResult::Unauthorized
-                            }
-                            Ok(AuthorizationHandlerResult::Continue) => {}
-                            Err(err) => error!("{}", err),
                         }
+                        // No handler allowed the request, so deny by default
+                        AuthorizationResult::Unauthorized
                     }
-                    // No handler allowed the request, so deny by default
-                    AuthorizationResult::Unauthorized
+                    None => AuthorizationResult::Unauthorized,
                 }
-                None => AuthorizationResult::Unauthorized,
-            },
+            }
         }
     }
     #[cfg(not(feature = "authorization"))]
@@ -651,7 +653,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };
@@ -680,7 +686,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };
@@ -708,7 +718,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };
@@ -746,7 +760,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };
@@ -784,7 +802,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };
@@ -822,7 +844,11 @@ mod tests {
             map.add_permission(
                 Method::Get,
                 "/test/endpoint",
-                Permission::Check("permission"),
+                Permission::Check {
+                    permission_id: "permission",
+                    permission_display_name: "",
+                    permission_description: "",
+                },
             );
             map
         };

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -29,7 +29,11 @@ use splinter::{
 use std::any::Any;
 
 #[cfg(feature = "authorization")]
-pub const HEALTH_READ_PERMISSION: Permission = Permission::Check("health.read");
+const HEALTH_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "health.read",
+    permission_display_name: "Health read",
+    permission_description: "Allows the client to check node health",
+};
 
 pub struct HealthService {
     service_id: String,

--- a/services/scabbard/libscabbard/src/client/mod.rs
+++ b/services/scabbard/libscabbard/src/client/mod.rs
@@ -536,9 +536,18 @@ mod tests {
     // These have to be redefined here because the `scabbard::service::rest_api` module where these
     // are originally defined is private
     #[cfg(feature = "authorization")]
-    const SCABBARD_READ_PERMISSION: Permission = Permission::Check("scabbard.read");
+    const SCABBARD_READ_PERMISSION: Permission = Permission::Check {
+        permission_id: "scabbard.read",
+        permission_display_name: "Scabbard read",
+        permission_description:
+            "Allows the client to read scabbard services' state and batch statuses",
+    };
     #[cfg(feature = "authorization")]
-    const SCABBARD_WRITE_PERMISSION: Permission = Permission::Check("scabbard.write");
+    const SCABBARD_WRITE_PERMISSION: Permission = Permission::Check {
+        permission_id: "scabbard.write",
+        permission_display_name: "Scabbard write",
+        permission_description: "Allows the client to submit batches to scabbard services",
+    };
 
     /// Verify that a `ServiceId` can be correctly parsed from a fully-qualified service ID string.
     #[test]

--- a/services/scabbard/libscabbard/src/service/rest_api/mod.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/mod.rs
@@ -20,6 +20,14 @@ pub mod resources;
 use splinter::rest_api::auth::authorization::Permission;
 
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const SCABBARD_READ_PERMISSION: Permission = Permission::Check("scabbard.read");
+const SCABBARD_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "scabbard.read",
+    permission_display_name: "Scabbard read",
+    permission_description: "Allows the client to read scabbard services' state and batch statuses",
+};
 #[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
-const SCABBARD_WRITE_PERMISSION: Permission = Permission::Check("scabbard.write");
+const SCABBARD_WRITE_PERMISSION: Permission = Permission::Check {
+    permission_id: "scabbard.write",
+    permission_display_name: "Scabbard write",
+    permission_description: "Allows the client to submit batches to scabbard services",
+};

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -342,6 +342,63 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /authorization/maintenance:
+    get:
+      tags:
+        - Authorization
+      description: Checks whether or not maintenance mode is enabled
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+      responses:
+        200:
+          description: Successfully checked maintenance mode
+          content:
+            text/plain:
+              schema:
+                type: string
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - true
+                      - false
+        401:
+          description: The client is unauthorized
+    post:
+      tags:
+        - Authorization
+      description: Sets whether or not maintenance mode is enabled
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+        - name: enabled
+          in: query
+          description: |
+            If "true", maintenance mode will be enabled; if "false", maintenance
+            mode will be disabled.
+          required: true
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: Successfully checked maintenance mode
+          content:
+            text/plain:
+              schema:
+                type: string
+                properties:
+                  message:
+                    type: boolean
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: The client is unauthorized
+
   /authorization/roles:
     get:
       summary: Fetches a list of roles
@@ -1862,63 +1919,6 @@ paths:
             application/json:
                 schema:
                   $ref: '#/components/schemas/Error'
-
-  /authorization/maintenance:
-    get:
-      tags:
-        - Authorization
-      description: Checks whether or not maintenance mode is enabled
-      parameters:
-        - $ref: "#/components/parameters/auth"
-        - $ref: "#/components/parameters/protocol_version"
-      responses:
-        200:
-          description: Successfully checked maintenance mode
-          content:
-            text/plain:
-              schema:
-                type: string
-                properties:
-                  message:
-                    type: string
-                    enum:
-                      - true
-                      - false
-        401:
-          description: The client is unauthorized
-    post:
-      tags:
-        - Authorization
-      description: Sets whether or not maintenance mode is enabled
-      parameters:
-        - $ref: "#/components/parameters/auth"
-        - $ref: "#/components/parameters/protocol_version"
-        - name: enabled
-          in: query
-          description: |
-            If "true", maintenance mode will be enabled; if "false", maintenance
-            mode will be disabled.
-          required: true
-          schema:
-            type: boolean
-      responses:
-        200:
-          description: Successfully checked maintenance mode
-          content:
-            text/plain:
-              schema:
-                type: string
-                properties:
-                  message:
-                    type: boolean
-        400:
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        401:
-          description: The client is unauthorized
 
 components:
   parameters:

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -399,6 +399,36 @@ paths:
         401:
           description: The client is unauthorized
 
+  /authorization/permissions:
+    get:
+      tags:
+        - Authorization
+        - Permissions
+      description: Fetches the list of all REST API permissions
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+      responses:
+        200:
+          description: Successfully retrieved the list of REST API permissions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: '#/components/schemas/Permission'
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: The client is unauthorized
+
   /authorization/roles:
     get:
       summary: Fetches a list of roles
@@ -2335,6 +2365,22 @@ components:
           type: string
           description: "Username of a user"
           example: "bob@biome.com"
+
+    Permission:
+      type: object
+      properties:
+        permission_id:
+          type: string
+          description: "Unique identifier for the permission"
+          example: "circuit.read"
+        permission_display_name:
+          type: string
+          description: "A human readable name of the permission"
+          example: "Circuit read"
+        permission_description:
+          type: string
+          description: "A helpful description of the permission"
+          example: "Allows the client to modify circuit state"
 
     Role:
       type: object

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -1516,7 +1516,7 @@ fn create_allow_keys_authorization_handler(
         .to_string();
 
     debug!(
-        "Creating allow keys authorization handler file: {:?}",
+        "Reading allow keys authorization handler file: {:?}",
         allow_keys_path
     );
 

--- a/splinterd/src/routes/status.rs
+++ b/splinterd/src/routes/status.rs
@@ -18,7 +18,11 @@ use splinter::futures::{Future, IntoFuture};
 use splinter::rest_api::auth::authorization::Permission;
 
 #[cfg(feature = "authorization")]
-pub const STATUS_READ_PERMISSION: Permission = Permission::Check("status.read");
+pub const STATUS_READ_PERMISSION: Permission = Permission::Check {
+    permission_id: "status.read",
+    permission_display_name: "Status read",
+    permission_description: "Allows the client to get node status info",
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Status {


### PR DESCRIPTION
Adds a display name and description to all checked REST API permissions along with the `/authorization/permissions` endpoint and `splinter permissions` CLI command for viewing all permission details.

# Testing

1. Start splinterd:

```bash
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features=experimental -- database migrate
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features=experimental -- cert generate
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- --rest-api-endpoint http://localhost:8080 --tls-insecure -vv
```

2. Generate a key pair for yourself you don't already have one:

```bash
cargo run --manifest-path cli/Cargo.toml --features=experimental -- keygen
```

3. Copy your public key to the allow keys file:

```bash
cat ~/.cylinder/keys/<your-username>.pub > /tmp/splinter/data/allow_keys
```

4. List permissions using the CLI:

```bash
cargo run --manifest-path cli/Cargo.toml --features=experimental -- permissions -U http://localhost:8080
ID                              NAME                   DESCRIPTION
registry.read                   Registry read          Allows the client to read the registry
registry.write                  Registry write         Allows the client to modify the registry
circuit.read                    Circuit read           Allows the client to read circuit state
circuit.write                   Circuit write          Allows the client to modify circuit state
scabbard.write                  Scabbard write         Allows the client to submit batches to scabbard services
scabbard.read                   Scabbard read          Allows the client to read scabbard services' state and batch statuses
authorization.maintenance.read  Maintenance mode read  Allows the client to check maintenance mode status
authorization.maintenance.write Maintenance mode write Allows the client to enable/disable maintenance mode
status.read                     Status read            Allows the client to get node status info
authorization.rbac.read         RBAC read              Allows the client to read roles, identities, and role assignments
authorization.rbac.write        RBAC write             Allows the client to modify roles, identities, and role assignments
health.read                     Health read            Allows the client to check node health
authorization.permissions.read  Permissions read       Allows the client to read REST API permissions
```