### PR TITLE
Update `circuit_status` handling

### DIFF
--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -15,8 +15,8 @@
 #[cfg(feature = "circuit-auth-type")]
 use splinter::admin::messages::AuthorizationType;
 use splinter::admin::messages::{
-    BuilderError, CreateCircuit, CreateCircuitBuilder, SplinterNode, SplinterNodeBuilder,
-    SplinterServiceBuilder,
+    BuilderError, CircuitStatus, CreateCircuit, CreateCircuitBuilder, SplinterNode,
+    SplinterNodeBuilder, SplinterServiceBuilder,
 };
 
 use crate::error::CliError;
@@ -36,6 +36,7 @@ pub struct CreateCircuitMessageBuilder {
     comments: Option<String>,
     display_name: Option<String>,
     circuit_version: Option<i32>,
+    circuit_status: Option<CircuitStatus>,
 }
 
 impl CreateCircuitMessageBuilder {
@@ -51,6 +52,7 @@ impl CreateCircuitMessageBuilder {
             comments: None,
             display_name: None,
             circuit_version: None,
+            circuit_status: None,
         }
     }
 
@@ -244,6 +246,10 @@ impl CreateCircuitMessageBuilder {
         self.circuit_version = Some(circuit_version);
     }
 
+    pub fn set_circuit_status(&mut self, circuit_status: CircuitStatus) {
+        self.circuit_status = Some(circuit_status);
+    }
+
     pub fn build(mut self) -> Result<CreateCircuit, CliError> {
         let circuit_builder = self.create_circuit_builder();
 
@@ -313,6 +319,10 @@ impl CreateCircuitMessageBuilder {
 
         if let Some(circuit_version) = self.circuit_version {
             create_circuit_builder = create_circuit_builder.with_circuit_version(circuit_version);
+        }
+
+        if let Some(circuit_status) = self.circuit_status {
+            create_circuit_builder = create_circuit_builder.with_circuit_status(&circuit_status);
         }
 
         #[cfg(feature = "circuit-auth-type")]

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -25,7 +25,7 @@ use std::fs::File;
 
 use clap::ArgMatches;
 use serde::Deserialize;
-use splinter::admin::messages::{CreateCircuit, SplinterService};
+use splinter::admin::messages::{CircuitStatus, CreateCircuit, SplinterService};
 use splinter::protocol::CIRCUIT_PROTOCOL_VERSION;
 
 use crate::error::CliError;
@@ -171,6 +171,7 @@ impl Action for CircuitProposeAction {
 
         if args.value_of("compat_version") != Some("0.4") {
             builder.set_circuit_version(CIRCUIT_PROTOCOL_VERSION);
+            builder.set_circuit_status(CircuitStatus::Active);
         }
 
         let create_circuit = builder.build()?;

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -193,17 +193,19 @@ impl CreateCircuit {
             RouteType::Any => circuit.set_routes(admin::Circuit_RouteType::ANY_ROUTE),
         };
 
-        match self.circuit_status {
-            CircuitStatus::Active => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
-            }
-            CircuitStatus::Disbanded => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
-            }
-            CircuitStatus::Abandoned => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
-            }
-        };
+        if self.circuit_version > UNSET_CIRCUIT_VERSION {
+            match self.circuit_status {
+                CircuitStatus::Active => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+                }
+                CircuitStatus::Disbanded => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
+                }
+                CircuitStatus::Abandoned => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
+                }
+            };
+        }
 
         let mut create_request = CircuitCreateRequest::new();
         create_request.set_circuit(circuit);

--- a/libsplinter/src/admin/store/diesel/operations/upgrade.rs
+++ b/libsplinter/src/admin/store/diesel/operations/upgrade.rs
@@ -67,6 +67,7 @@ impl<'a> AdminServiceStoreUpgradeProposalToCircuitOperation
                 .with_durability(proposed_circuit.durability())
                 .with_routes(proposed_circuit.routes())
                 .with_circuit_management_type(proposed_circuit.circuit_management_type())
+                .with_circuit_version(proposed_circuit.circuit_version())
                 .with_circuit_status(proposed_circuit.circuit_status());
 
             if let Some(display_name) = proposed_circuit.display_name() {

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -261,17 +261,21 @@ impl ProposedCircuit {
             RouteType::Any => circuit.set_routes(admin::Circuit_RouteType::ANY_ROUTE),
         };
 
-        match self.circuit_status {
-            CircuitStatus::Active => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+        // If the circuit version is equal to the `CIRCUIT_PROTOCOL_VERSION`, the `circuit_status`
+        // value should be set.
+        if self.circuit_version > UNSET_CIRCUIT_VERSION {
+            match self.circuit_status {
+                CircuitStatus::Active => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+                }
+                CircuitStatus::Disbanded => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
+                }
+                CircuitStatus::Abandoned => {
+                    circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
+                }
             }
-            CircuitStatus::Disbanded => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::DISBANDED);
-            }
-            CircuitStatus::Abandoned => {
-                circuit.set_circuit_status(admin::Circuit_CircuitStatus::ABANDONED);
-            }
-        };
+        }
 
         circuit
     }

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
@@ -14,10 +14,10 @@
 -- --
 
 ALTER TABLE circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status SMALLINT NOT NULL DEFAULT 1;
 
 ALTER TABLE proposed_circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status SMALLINT NOT NULL DEFAULT 1;
 
 ALTER TABLE admin_event_proposed_circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status SMALLINT NOT NULL DEFAULT 1;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-01-14-155512_admin_service_add_circuit_status/up.sql
@@ -14,10 +14,10 @@
 -- --
 
 ALTER TABLE circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status INTEGER NOT NULL DEFAULT 1;
 
 ALTER TABLE proposed_circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status INTEGER NOT NULL DEFAULT 1;
 
 ALTER TABLE admin_event_proposed_circuit
-ADD COLUMN circuit_status INTEGER;
+ADD COLUMN circuit_status INTEGER NOT NULL DEFAULT 1;


### PR DESCRIPTION
Makes a few small updates to the handling of the `circuit_status` to ensure it is represented correctly in the database and in proto messages. Updates this added column to default to 1, as well as changing the postgres-specific migration file to have the type `SMALLINT` rather than `INTEGER`. Also updates the `into_proto` methods to exclude the `circuit_status` field from being set when converting into the proto message. 

This also includes a 1 line bug fix where the `circuit_version` field was not being set in the postgres implementation of the admin store's `upgrade` operation.

This can be tested by running a splinter node (could be on stable, experimental is not required to test) and submitting a circuit proposal, then attempting to view that proposal via the CLI (`splinter circuit proposals`) or REST API (`/admin/proposals`). Before, you would see an error that `circuit_status` was unset from the database (set to 0). This PR both changes the default of this column to be 1 (Active) and also updates the type the `circuit_status` is converted into/from in the database so you should successfully be able to view the circuit proposals. (Before via the CLI, an error would occur that the ProposalStore returned some type of 500 error.)