### PR TITLE
Alphabetize `splinter permissions` command output

### DIFF
--- a/cli/man/splinter-permissions.1.md
+++ b/cli/man/splinter-permissions.1.md
@@ -58,10 +58,10 @@ $ splinter permissions \
   --key /path/to/key.priv \
   --url http://example.com:8080
 ID                              NAME                   DESCRIPTION
-registry.read                   Registry read          Allows the client to read the registry
-registry.write                  Registry write         Allows the client to modify the registry
-circuit.read                    Circuit read           Allows the client to read circuit state
-circuit.write                   Circuit write          Allows the client to modify circuit state
+authorization.maintenance.read  Maintenance mode read  Allows the client to check maintenance mode status
+authorization.maintenance.write Maintenance mode write Allows the client to enable/disable maintenance mode
+authorization.permissions.read  Permissions read       Allows the client to read REST API permissions
+authorization.rbac.read         RBAC read              Allows the client to read roles, identities, and role assignments
 ...
 ```
 
@@ -73,10 +73,10 @@ $ splinter permissions \
   --key /path/to/key.priv \
   --url http://example.com:8080
 ID,NAME,DESCRIPTION
-registry.read,Registry read,Allows the client to read the registry
-registry.write,Registry write,Allows the client to modify the registry
-circuit.read,Circuit read,Allows the client to read circuit state
-circuit.write,Circuit write,Allows the client to modify circuit state
+authorization.maintenance.read,Maintenance mode read,Allows the client to check maintenance mode status
+authorization.maintenance.write,Maintenance mode write,Allows the client to enable/disable maintenance mode
+authorization.permissions.read,Permissions read,Allows the client to read REST API permissions
+authorization.rbac.read,RBAC read,Allows the client to read roles, identities, and role assignments
 ...
 ```
 
@@ -89,31 +89,31 @@ $ splinter permissions \
   --key /path/to/key.priv \
   --url http://example.com:8080
 [
-  [
-    "ID",
-    "NAME",
-    "DESCRIPTION"
-  ],
-  [
-    "registry.read",
-    "Registry read",
-    "Allows the client to read the registry"
-  ],
-  [
-    "registry.write",
-    "Registry write",
-    "Allows the client to modify the registry"
-  ],
-  [
-    "circuit.read",
-    "Circuit read",
-    "Allows the client to read circuit state"
-  ],
-  [
-    "circuit.write",
-    "Circuit write",
-    "Allows the client to modify circuit state"
-  ],
+ [
+   "ID",
+   "NAME",
+   "DESCRIPTION"
+ ],
+ [
+   "authorization.maintenance.read",
+   "Maintenance mode read",
+   "Allows the client to check maintenance mode status"
+ ],
+ [
+   "authorization.maintenance.write",
+   "Maintenance mode write",
+   "Allows the client to enable/disable maintenance mode"
+ ],
+ [
+   "authorization.permissions.read",
+   "Permissions read",
+   "Allows the client to read REST API permissions"
+ ],
+ [
+   "authorization.rbac.read",
+   "RBAC read",
+   "Allows the client to read roles, identities, and role assignments"
+ ],
   ...
 ]
 ```

--- a/cli/src/action/api.rs
+++ b/cli/src/action/api.rs
@@ -189,7 +189,13 @@ impl SplinterRestClient {
                 let status = res.status();
                 if status.is_success() {
                     res.json::<PermissionsResponse>()
-                        .map(|response| response.data)
+                        .map(|mut response| {
+                            response.data.sort_by(|a, b| {
+                                // Unwrapping because comparing strings always returns `Some(_)`
+                                a.permission_id.partial_cmp(&b.permission_id).unwrap()
+                            });
+                            response.data
+                        })
                         .map_err(|_| {
                             CliError::ActionError(
                                 "Request was successful, but received an invalid response".into(),


### PR DESCRIPTION
Updates the `splinter permissions` command to order permissions
alphabetically by ID.

Signed-off-by: Logan Seeley <seeley@bitwise.io>