### PR TITLE
Add biome feature to guard `splinter::biome` mod

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -76,6 +76,7 @@ default = []
 
 stable = [
     "admin-service",
+    "biome",
     "biome-credentials",
     "biome-key-management",
     "circuit-template",
@@ -128,17 +129,18 @@ authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
 authorization = ["rest-api"]
 authorization-handler-rbac = ["authorization"]
-biome-credentials = ["bcrypt"]
-biome-key-management = []
-biome-notifications = []
+biome = []
+biome-credentials = ["bcrypt", "biome"]
+biome-key-management = ["biome"]
+biome-notifications = ["biome"]
 biome-oauth-user-store-postgres = ["oauth", "postgres"]
-biome-profile = []
+biome-profile = ["biome"]
 circuit-disband = []
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
-oauth = ["oauth2", "rest-api"]
+oauth = ["biome", "oauth2", "rest-api"]
 oauth-inflight-request-store-postgres = ["oauth", "postgres"]
 oauth-openid = ["oauth", "reqwest"]
 postgres = ["diesel/postgres", "diesel_migrations"]

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -62,13 +62,7 @@ macro_rules! mutex_lock_unwrap {
 #[cfg(feature = "admin-service")]
 pub mod admin;
 mod base62;
-#[cfg(any(
-    feature = "biome-credentials",
-    feature = "biome-key-management",
-    feature = "biome-notifications",
-    feature = "biome-profile",
-    feature = "oauth"
-))]
+#[cfg(feature = "biome")]
 pub mod biome;
 pub mod channel;
 pub mod circuit;


### PR DESCRIPTION
Adds the `biome` feature to libsplinter to guard the `splinter::biome`
module. All biome sub-features and oauth depend on this feature. This
simplifies the feature guard for the biome module.

Signed-off-by: Logan Seeley <seeley@bitwise.io>