### PR TITLE
Add `CircuitDisbandRequest` functionality to CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "circuit-auth-type",
+    "circuit-disband",
     "health",
     "https-certs",
     "permissions",
@@ -79,6 +80,7 @@ experimental = [
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
+circuit-disband = ["splinter/circuit-disband"]
 circuit-template = ["splinter/circuit-template"]
 
 health = []

--- a/cli/man/splinter-circuit-disband.1.md
+++ b/cli/man/splinter-circuit-disband.1.md
@@ -1,0 +1,94 @@
+% SPLINTER-CIRCUIT-DISBAND(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-disband** — Submits a request to disband the specified circuit.
+
+SYNOPSIS
+========
+**splinter circuit disband** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID
+
+DESCRIPTION
+===========
+Request to disband a circuit by specifying the circuit ID of the circuit to be
+disbanded. Disbanding a circuit removes a circuit's networking functionality.
+Once all members of the circuit have accepted the request to disband the
+circuit, the circuit is only available offline. This functionality is currently
+behind the experimental `circuit-disband` feature and must be enabled to use
+this command.
+
+The `disband` command creates a new circuit proposal to reflect the disbanded
+state, with the proposed circuit's `circuit_status` field set to `Disbanded`.
+This proposal is then able to be voted on, similar to other circuit proposals.
+
+The generated ID of the existing circuit can be viewed using the
+`splinter-circuit-list` command and this circuit ID is used to specify the
+circuit to be disbanded. Once the disband request has been submitted,
+the proposal created (and other circuit proposals) can be viewed using the
+`splinter-circuit-proposals` command.
+
+The disband proposal must be accepted by all members before the existing
+circuit is updated to reflect the disbanded state. If all nodes have agreed to
+disband the circuit, the disbanded circuit may be viewed using the
+`splinter-circuit-show` command.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be disbanded.
+
+EXAMPLES
+========
+* The proposed circuit has ID `1234-ABCDE`.
+
+The following command displays a member node requesting to disband the circuit:
+```
+$ splinter circuit disband \
+  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-proposed-member-node-splinterd-REST-API \
+  1234-ABCDE \
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-list(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-proposals.1.md
+++ b/cli/man/splinter-circuit-proposals.1.md
@@ -18,10 +18,12 @@ DESCRIPTION
 ===========
 Lists all of the circuit proposals that the local node is a proposed member of.
 This command displays abbreviated information pertaining to proposed circuits in
-columns, with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it
-possible to verify that circuit proposals have been successfully proposed as
-well as being able to access the generated circuit ID assigned to a proposal.
-Circuit proposals have not necessarily been voted on by all proposed members.
+columns, with the headers `ID`, `NAME`, `MANAGEMENT`, `MEMBERS`, and
+`PROPOSAL_TYPE`. This makes it possible to verify that circuit proposals have
+been successfully proposed as well as being able to access the generated
+circuit ID assigned to a proposal. This also makes it possible to verify the
+intention of the circuit proposal. Circuit proposals have not necessarily been
+voted on by all proposed members.
 
 FLAGS
 =====
@@ -73,10 +75,10 @@ proposals the local node, `alpha-node-000` is a part of are displayed.
 ```
 $ splinter circuit proposals \
   --url URL-of-alpha-node-splinterd-REST-API
-ID           NAME      MANAGEMENT    MEMBERS
-01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000
-43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE  -         mgmt002       alpha-node-000;gamma-node-000
+ID           NAME      MANAGEMENT    MEMBERS                       PROPOSAL_TYPE
+01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000  Create
+43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000 Create
+56789-ABCDE  -         mgmt002       alpha-node-000;gamma-node-000 Create
 ```
 
 The next command specifies a `--management-type` filter, therefore all circuit
@@ -86,9 +88,9 @@ proposals the local node, `alpha-node-000` is a part of with a
 $ splinter circuit proposals \
   --management-type mgmt001 \
   --url URL-of-alpha-node-splinterd-REST-API
-ID           NAME      MANAGEMENT    MEMBERS
-01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000
-43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000
+ID           NAME      MANAGEMENT    MEMBERS                       PROPOSAL_TYPE
+01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000  Create
+43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000 Create
 ```
 
 The next command specifies a `--member` filter, therefore all circuit proposals
@@ -98,9 +100,22 @@ node ID will be listed.
 $ splinter circuit proposals \
   member gamma-node-000 \
   --url URL-of-alpha-node-splinterd-REST-API
-ID            NAME      MANAGEMENT    MEMBERS
-43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
-56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
+ID            NAME      MANAGEMENT    MEMBERS                       PROPOSAL_TYPE
+43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000 Create
+56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000 Create
+```
+
+The next command does not specify any filters, therefore all circuit
+proposals the local node, `alpha-node-000` is a part of are displayed. This
+includes a circuit proposal to disband an existing circuit, `01234-FGHIJ`.
+```
+$ splinter circuit proposals \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID           NAME      MANAGEMENT    MEMBERS                       PROPOSAL_TYPE
+01234-ABCDE  -         mgmt001       alpha-node-000;beta-node-000  Create
+43210-ABCDE  circuit1  mgmt001       alpha-node-000;gamma-node-000 Create
+56789-ABCDE  -         mgmt002       alpha-node-000;gamma-node-000 Create
+01234-FGHIJ  circuit0  mgmt002       alpha-node-000;gamma-node-000 Disband
 ```
 
 ENVIRONMENT VARIABLES

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -331,7 +331,12 @@ pub struct ProposalSlice {
 
 impl fmt::Display for ProposalSlice {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut display_string = format!("Proposal to create: {}\n    ", self.circuit_id,);
+        let mut display_string;
+        if self.proposal_type == "Disband" {
+            display_string = format!("Proposal to disband: {}\n    ", self.circuit_id);
+        } else {
+            display_string = format!("Proposal to create: {}\n    ", self.circuit_id);
+        }
 
         if let Some(display_name) = &self.circuit.display_name {
             display_string += &format!("Display Name: {}\n    ", display_name);

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -626,6 +626,60 @@ fn vote_on_circuit_proposal(
     }
 }
 
+#[cfg(feature = "circuit-disband")]
+struct CircuitDisband {
+    circuit_id: String,
+}
+
+#[cfg(feature = "circuit-disband")]
+pub struct CircuitDisbandAction;
+
+#[cfg(feature = "circuit-disband")]
+impl Action for CircuitDisbandAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
+        let key = args.value_of("private_key_file");
+
+        let circuit_id = args
+            .value_of("circuit_id")
+            .ok_or_else(|| CliError::ActionError("'circuit-id' argument is required".into()))?;
+
+        propose_circuit_disband(&url, key, circuit_id)
+    }
+}
+
+#[cfg(feature = "circuit-disband")]
+fn propose_circuit_disband(url: &str, key: Option<&str>, circuit_id: &str) -> Result<(), CliError> {
+    let client = SplinterRestClientBuilder::new()
+        .with_url(url.to_string())
+        .with_auth(create_cylinder_jwt_auth(key)?)
+        .build()?;
+
+    let private_key_hex = read_private_key(key.unwrap_or("splinter"))?;
+
+    let requester_node = client.get_node_status()?.node_id;
+    let circuit = client.fetch_circuit(circuit_id)?;
+
+    if circuit.is_some() {
+        let circuit_disband_request = CircuitDisband {
+            circuit_id: circuit_id.into(),
+        };
+        let signed_payload =
+            make_signed_payload(&requester_node, &private_key_hex, circuit_disband_request)?;
+        client.submit_admin_payload(signed_payload)
+    } else {
+        Err(CliError::ActionError(format!(
+            "Circuit '{}' does not exist",
+            circuit_id
+        )))
+    }
+}
+
 pub struct CircuitListAction;
 
 impl Action for CircuitListAction {

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -199,7 +199,7 @@ impl Action for CircuitProposeAction {
                 make_signed_payload(&requester_node, &private_key_hex, create_circuit)?;
             client.submit_admin_payload(signed_payload)?;
 
-            info!("The circuit proposal was submited successfully");
+            info!("The circuit proposal was submitted successfully");
         }
 
         info!("{}", circuit_slice);
@@ -904,6 +904,7 @@ fn list_proposals(
         "MANAGEMENT".to_string(),
         "MEMBERS".to_string(),
         "COMMENTS".to_string(),
+        "PROPOSAL_TYPE".to_string(),
     ]);
     proposals.data.iter().for_each(|proposal| {
         let display_name = {
@@ -943,6 +944,7 @@ fn list_proposals(
             proposal.circuit.management_type.to_string(),
             members,
             comments,
+            proposal.proposal_type.to_string(),
         ]);
     });
 

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -16,6 +16,8 @@ use cylinder::{secp256k1::Secp256k1Context, Context, PrivateKey};
 use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
+#[cfg(feature = "circuit-disband")]
+use splinter::protos::admin::CircuitDisbandRequest;
 use splinter::protos::admin::{
     CircuitCreateRequest, CircuitManagementPayload, CircuitManagementPayload_Action as Action,
     CircuitManagementPayload_Header as Header, CircuitProposalVote, CircuitProposalVote_Vote,
@@ -23,6 +25,8 @@ use splinter::protos::admin::{
 
 use crate::error::CliError;
 
+#[cfg(feature = "circuit-disband")]
+use super::CircuitDisband;
 use super::{CircuitVote, Vote};
 
 /// A circuit action that has a type and can be converted into a protobuf-serializable struct.
@@ -137,5 +141,25 @@ impl CircuitAction<CircuitProposalVote> for CircuitVote {
 impl ApplyToEnvelope for CircuitProposalVote {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_proposal_vote(self);
+    }
+}
+
+#[cfg(feature = "circuit-disband")]
+impl CircuitAction<CircuitDisbandRequest> for CircuitDisband {
+    fn action_type(&self) -> Action {
+        Action::CIRCUIT_DISBAND_REQUEST
+    }
+
+    fn into_proto(self) -> Result<CircuitDisbandRequest, CliError> {
+        let mut disband_request = CircuitDisbandRequest::new();
+        disband_request.set_circuit_id(self.circuit_id);
+        Ok(disband_request)
+    }
+}
+
+#[cfg(feature = "circuit-disband")]
+impl ApplyToEnvelope for CircuitDisbandRequest {
+    fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
+        circuit_management_payload.set_circuit_disband_request(self);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -474,6 +474,34 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 ),
         );
 
+    #[cfg(feature = "circuit-disband")]
+    let circuit_command = circuit_command.subcommand(
+        SubCommand::with_name("disband")
+            .about("Propose to disband an existing circuit")
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .takes_value(true)
+                    .help("URL of Splinter Daemon"),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Path to private key file"),
+            )
+            .arg(
+                Arg::with_name("circuit_id")
+                    .value_name("circuit-id")
+                    .takes_value(true)
+                    .required(true)
+                    .help("ID of the proposed circuit"),
+            ),
+    );
+
     #[cfg(not(feature = "https-certs"))]
     let cert_generate_subcommand = SubCommand::with_name("generate")
         .long_about(
@@ -1123,6 +1151,9 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         .with_command("list", circuit::CircuitListAction)
         .with_command("show", circuit::CircuitShowAction)
         .with_command("proposals", circuit::CircuitProposalsAction);
+
+    #[cfg(feature = "circuit-disband")]
+    let circuit_command = circuit_command.with_command("disband", circuit::CircuitDisbandAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -303,6 +303,7 @@ message AdminMessage {
         CONSENSUS_MESSAGE = 1;
         PROPOSED_CIRCUIT = 2;
         MEMBER_READY = 3;
+        DISBANDED_CIRCUIT = 4;
 
         SERVICE_PROTOCOL_VERSION_REQUEST = 100;
         SERVICE_PROTOCOL_VERSION_RESPONSE = 101;
@@ -313,6 +314,7 @@ message AdminMessage {
     bytes consensus_message = 2;
     ProposedCircuit proposed_circuit = 3;
     MemberReady member_ready = 4;
+    DisbandedCircuit disbanded_circuit = 5;
 
     // Messages to agree on protocol version
     ServiceProtocolVersionRequest protocol_request = 100;
@@ -331,6 +333,12 @@ message ProposedCircuit {
 }
 
 message MemberReady {
+    string circuit_id = 1;
+    string member_node_id = 2;
+}
+
+message DisbandedCircuit {
+    // the circuit being disbanded
     string circuit_id = 1;
     string member_node_id = 2;
 }

--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -298,6 +298,8 @@ impl std::fmt::Display for AdminConsensusManagerError {
 pub enum AdminError {
     ConsensusFailed(AdminConsensusManagerError),
     MessageTypeUnset,
+    #[cfg(not(feature = "circuit-disband"))]
+    MessageTypeUnhandled,
 }
 
 impl Error for AdminError {
@@ -305,6 +307,8 @@ impl Error for AdminError {
         match self {
             AdminError::ConsensusFailed(err) => Some(err),
             AdminError::MessageTypeUnset => None,
+            #[cfg(not(feature = "circuit-disband"))]
+            AdminError::MessageTypeUnhandled => None,
         }
     }
 }
@@ -314,6 +318,8 @@ impl std::fmt::Display for AdminError {
         match self {
             AdminError::ConsensusFailed(err) => write!(f, "admin consensus failed: {}", err),
             AdminError::MessageTypeUnset => write!(f, "received message with unset type"),
+            #[cfg(not(feature = "circuit-disband"))]
+            AdminError::MessageTypeUnhandled => write!(f, "unable to handle the message"),
         }
     }
 }

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -40,6 +40,8 @@ use crate::peer::{PeerManagerConnector, PeerRef};
 use crate::protocol::{
     ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION, CIRCUIT_PROTOCOL_VERSION,
 };
+#[cfg(feature = "circuit-disband")]
+use crate::protos::admin::DisbandedCircuit;
 #[cfg(feature = "service-arg-validation")]
 use crate::protos::admin::SplinterService;
 use crate::protos::admin::{
@@ -109,6 +111,12 @@ struct CircuitProposalContext {
 }
 
 struct UninitializedCircuit {
+    pub circuit: Option<CircuitProposal>,
+    pub ready_members: HashSet<String>,
+}
+
+#[cfg(feature = "circuit-disband")]
+struct PendingDisbandedCircuit {
     pub circuit: Option<CircuitProposal>,
     pub ready_members: HashSet<String>,
 }
@@ -231,6 +239,9 @@ pub struct AdminServiceShared {
 
     #[cfg(feature = "admin-service-event-store")]
     admin_event_store: Box<dyn AdminServiceEventStore>,
+    #[cfg(feature = "circuit-disband")]
+    // List of circuits to be completely disbanded once all nodes have agreed
+    pending_consensus_disbanded_circuits: HashMap<String, PendingDisbandedCircuit>,
 }
 
 impl AdminServiceShared {
@@ -285,6 +296,8 @@ impl AdminServiceShared {
             routing_table_writer,
             #[cfg(feature = "admin-service-event-store")]
             admin_event_store,
+            #[cfg(feature = "circuit-disband")]
+            pending_consensus_disbanded_circuits: HashMap::new(),
         })
     }
 
@@ -403,28 +416,7 @@ impl AdminServiceShared {
                         // field set.
                         #[cfg(feature = "circuit-disband")]
                         {
-                            if circuit_proposal.get_circuit_proposal().get_circuit_status()
-                                == Circuit_CircuitStatus::DISBANDED
-                            {
-                                // Circuit has been disbanded: all associated services will be shut
-                                // down, the circuit removed from the routing table, and peer refs
-                                // for this circuit will be removed.
-                                self.shutdown_services(circuit_proposal.get_circuit_proposal())?;
-                                // Removing the circuit from the routing table
-                                self.routing_table_writer
-                                    .remove_circuit(circuit_id)
-                                    .map_err(|_| {
-                                        AdminSharedError::SplinterStateError(format!(
-                                            "Unable to remove circuit from routing table: {}",
-                                            circuit_id
-                                        ))
-                                    })?;
-                                // Removing the circuit's peer refs
-                                for member in circuit_proposal.get_circuit_proposal().get_members()
-                                {
-                                    self.remove_peer_ref(member.get_node_id());
-                                }
-
+                            if status == Circuit_CircuitStatus::DISBANDED {
                                 let store_circuit =
                                     StoreCircuit::try_from(circuit_proposal.get_circuit_proposal())
                                         .map_err(|err| {
@@ -433,38 +425,58 @@ impl AdminServiceShared {
                                             err.to_string()
                                         ))
                                         })?;
+
+                                if store_circuit.circuit_status() != &StoreCircuitStatus::Disbanded
+                                {
+                                    return Err(AdminSharedError::SplinterStateError(format!(
+                                        "Circuit should be disbanded: {}",
+                                        circuit_id
+                                    )));
+                                }
                                 // Updating the corresponding `active` circuit from the admin store
+                                // and then removing the corresponding `CircuitProposal` from the
+                                // disband request
                                 self.admin_store
-                                    .update_circuit(store_circuit)
+                                    .update_circuit(store_circuit.clone())
                                     .map_err(|_| {
                                         AdminSharedError::SplinterStateError(format!(
                                             "Unable to update circuit {}",
                                             circuit_id
                                         ))
+                                    })
+                                    .and_then(|_| {
+                                        self.remove_proposal(store_circuit.circuit_id())
                                     })?;
-                                // Verifying the upgraded disbanded circuit is now available
-                                let circuit =
-                                    self.admin_store.get_circuit(circuit_id)?.ok_or_else(|| {
-                                        AdminSharedError::SplinterStateError(format!(
-                                            "Unable to get circuit that was just set: {}",
-                                            circuit_id
-                                        ))
-                                    })?;
-                                if circuit.circuit_status() != &StoreCircuitStatus::Disbanded {
-                                    return Err(AdminSharedError::SplinterStateError(format!(
-                                        "Set circuit should be disbanded: {}",
-                                        circuit_id
-                                    )));
-                                }
 
-                                // send message about circuit disband being committed
+                                // send message about circuit disband proposal being accepted
                                 let circuit_proposal_proto =
                                     messages::CircuitProposal::from_proto(circuit_proposal.clone())
                                         .map_err(AdminSharedError::InvalidMessageFormat)?;
-                                let event = messages::AdminServiceEvent::CircuitDisbanded(
+                                let event = messages::AdminServiceEvent::ProposalAccepted((
                                     circuit_proposal_proto,
-                                );
+                                    circuit_proposal_context.signer_public_key.clone(),
+                                ));
                                 self.send_event(&mgmt_type, event);
+                                // send DISBANDED_CIRCUIT message to all other members' admin
+                                // services
+                                if let Some(ref network_sender) = self.network_sender {
+                                    let mut disbanded_circuit = DisbandedCircuit::new();
+                                    disbanded_circuit.set_circuit_id(circuit_id.to_string());
+                                    disbanded_circuit.set_member_node_id(self.node_id.clone());
+                                    let mut msg = AdminMessage::new();
+                                    msg.set_message_type(AdminMessage_Type::DISBANDED_CIRCUIT);
+                                    msg.set_disbanded_circuit(disbanded_circuit);
+
+                                    let envelope_bytes =
+                                        msg.write_to_bytes().map_err(MarshallingError::from)?;
+                                    for member in store_circuit.members().iter() {
+                                        if member != &self.node_id {
+                                            network_sender
+                                                .send(&admin_service_id(member), &envelope_bytes)?;
+                                        }
+                                    }
+                                }
+                                self.add_pending_disbanded_circuit(circuit_proposal.clone())?;
                             }
                         }
                         if status == Circuit_CircuitStatus::ACTIVE
@@ -2200,7 +2212,8 @@ impl AdminServiceShared {
             )));
         }
 
-        // Verifying the circuit has not already been disbanded or abandoned
+        // Verifying the circuit has not already been disbanded or abandoned and has a valid
+        // version to perform the disband request
         let stored_circuit = self
             .admin_store
             .get_circuit(circuit.get_circuit_id())
@@ -2222,10 +2235,12 @@ impl AdminServiceShared {
                 "Attempting to disband an inactive circuit {}",
                 circuit.get_circuit_id()
             )));
-        } else if stored_circuit.circuit_version() < CIRCUIT_PROTOCOL_VERSION {
+        }
+
+        if stored_circuit.circuit_version() < CIRCUIT_PROTOCOL_VERSION {
             return Err(AdminSharedError::ValidationFailed(format!(
                 "Attempting to disband a circuit with version {}, must be {}",
-                circuit.get_circuit_id(),
+                stored_circuit.circuit_version(),
                 CIRCUIT_PROTOCOL_VERSION,
             )));
         }
@@ -2458,6 +2473,38 @@ impl AdminServiceShared {
     }
 
     #[cfg(feature = "circuit-disband")]
+    fn add_pending_disbanded_circuit(
+        &mut self,
+        circuit: CircuitProposal,
+    ) -> Result<(), AdminSharedError> {
+        let circuit_id = circuit.get_circuit_id().to_string();
+        match self
+            .pending_consensus_disbanded_circuits
+            .get_mut(&circuit_id)
+        {
+            Some(pending_disband_circuit) => pending_disband_circuit.circuit = Some(circuit),
+            None => {
+                self.pending_consensus_disbanded_circuits.insert(
+                    circuit_id.to_string(),
+                    PendingDisbandedCircuit {
+                        circuit: Some(circuit),
+                        ready_members: HashSet::new(),
+                    },
+                );
+            }
+        }
+
+        // Add self as ready
+        self.pending_consensus_disbanded_circuits
+            .get_mut(&circuit_id)
+            .expect("Pending disbanded circuit not set")
+            .ready_members
+            .insert(self.node_id.clone());
+
+        self.cleanup_disbanded_circuit_if_members_ready(&circuit_id)
+    }
+
+    #[cfg(feature = "circuit-disband")]
     /// Shutdown all services that this node was running on the disbanded circuit using the service
     /// orchestrator. This may not include all services if they are not supported locally. It is
     /// expected that some services will be stopped externally.
@@ -2484,6 +2531,7 @@ impl AdminServiceShared {
 
         // Shutdown all services the orchestrator has a factory for
         for service in services {
+            debug!("Removing service: {}", service.service_id.clone());
             let service_definition = ServiceDefinition {
                 circuit: circuit.circuit_id.clone(),
                 service_id: service.service_id.clone(),
@@ -2499,6 +2547,103 @@ impl AdminServiceShared {
                     ),
                     source: Some(err),
                 })?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "circuit-disband")]
+    pub fn add_member_ready_to_disband(
+        &mut self,
+        circuit_id: &str,
+        member_node_id: &str,
+    ) -> Result<(), AdminSharedError> {
+        // Check if the `DisbandedCircuit` message is associated with a pending disband proposal
+        if self
+            .pending_consensus_disbanded_circuits
+            .get(circuit_id)
+            .is_none()
+        {
+            self.pending_consensus_disbanded_circuits.insert(
+                circuit_id.to_string(),
+                PendingDisbandedCircuit {
+                    circuit: None,
+                    ready_members: HashSet::new(),
+                },
+            );
+        }
+        self.pending_consensus_disbanded_circuits
+            .get_mut(circuit_id)
+            .expect("Pending disband circuit not set")
+            .ready_members
+            .insert(member_node_id.to_string());
+
+        self.cleanup_disbanded_circuit_if_members_ready(circuit_id)
+    }
+
+    #[cfg(feature = "circuit-disband")]
+    /// Verify all members are ready before cleaning up after the disbanded circuit, i.e. removing
+    /// peer refs, removing the circuit from the routing table, and shutting down the circuit's
+    /// associated services.
+    pub fn cleanup_disbanded_circuit_if_members_ready(
+        &mut self,
+        circuit_id: &str,
+    ) -> Result<(), AdminSharedError> {
+        let ready = {
+            if let Some(disbanded_circuit) =
+                self.pending_consensus_disbanded_circuits.get(circuit_id)
+            {
+                if let Some(ref circuit_proposal) = disbanded_circuit.circuit {
+                    let all_members = circuit_proposal
+                        .get_circuit_proposal()
+                        .members
+                        .iter()
+                        .map(|node| node.node_id.clone())
+                        .collect::<HashSet<String>>();
+                    all_members.is_subset(&disbanded_circuit.ready_members)
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        if ready {
+            let circuit_proposal = self
+                .pending_consensus_disbanded_circuits
+                .remove(circuit_id)
+                .expect("Pending disband circuit not set")
+                .circuit
+                .expect("Pending disband circuit's circuit proposal not set");
+            // send message about circuit acceptance
+            let circuit_proposal_proto =
+                messages::CircuitProposal::from_proto(circuit_proposal.clone())
+                    .map_err(AdminSharedError::InvalidMessageFormat)?;
+            let mgmt_type = circuit_proposal
+                .get_circuit_proposal()
+                .circuit_management_type
+                .clone();
+            let event = messages::AdminServiceEvent::CircuitDisbanded(circuit_proposal_proto);
+            self.send_event(&mgmt_type, event);
+
+            // Circuit has been disbanded: all associated services will be shut
+            // down, the circuit removed from the routing table, and peer refs
+            // for this circuit will be removed.
+            self.shutdown_services(circuit_proposal.get_circuit_proposal())?;
+            // Removing the circuit from the routing table
+            self.routing_table_writer
+                .remove_circuit(circuit_proposal.get_circuit_id())
+                .map_err(|_| {
+                    AdminSharedError::SplinterStateError(format!(
+                        "Unable to remove circuit from routing table: {}",
+                        circuit_id
+                    ))
+                })?;
+            // Removing the circuit's peer refs
+            for member in circuit_proposal.get_circuit_proposal().get_members() {
+                self.remove_peer_ref(member.get_node_id());
+            }
         }
 
         Ok(())

--- a/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
@@ -62,6 +62,9 @@ where
         nodes_info.into_iter().for_each(|(node, node_endpoint)| {
             if let Some(endpoint_list) = node_map.get_mut(&node.node_id) {
                 endpoint_list.push(node_endpoint.endpoint);
+                // Ensure only unique endpoints are added to the node's endpoint list
+                endpoint_list.sort();
+                endpoint_list.dedup();
             } else {
                 node_map.insert(node.node_id.to_string(), vec![node_endpoint.endpoint]);
             }

--- a/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_circuit.rs
@@ -61,6 +61,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),
                     circuit::circuit_management_type.eq(circuit_model.circuit_management_type),
+                    circuit::circuit_status.eq(circuit_model.circuit_status),
                 ))
                 .execute(self.conn)?;
             // Delete existing data associated with the `Circuit`
@@ -69,6 +70,10 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             delete(
                 service_argument::table
                     .filter(service_argument::circuit_id.eq(circuit.circuit_id())),
+            )
+            .execute(self.conn)?;
+            delete(
+                circuit_member::table.filter(circuit_member::circuit_id.eq(circuit.circuit_id())),
             )
             .execute(self.conn)?;
             // Insert new data associate with the `Circuit`
@@ -115,6 +120,7 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
                     circuit::durability.eq(circuit_model.durability),
                     circuit::routes.eq(circuit_model.routes),
                     circuit::circuit_management_type.eq(circuit_model.circuit_management_type),
+                    circuit::circuit_status.eq(circuit_model.circuit_status),
                 ))
                 .execute(self.conn)?;
             // Delete existing data associated with the `Circuit`
@@ -123,6 +129,10 @@ impl<'a> AdminServiceStoreUpdateCircuitOperation
             delete(
                 service_argument::table
                     .filter(service_argument::circuit_id.eq(circuit.circuit_id())),
+            )
+            .execute(self.conn)?;
+            delete(
+                circuit_member::table.filter(circuit_member::circuit_id.eq(circuit.circuit_id())),
             )
             .execute(self.conn)?;
             // Insert new data associate with the `Circuit`

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -86,6 +86,7 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-profile",
+    "circuit-disband",
     "health",
     "https-bind",
     "oauth",
@@ -116,6 +117,7 @@ authorization-handler-rbac = [
 biome-credentials = ["database", "splinter/biome-credentials"]
 biome-key-management = ["database", "splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile"]
+circuit-disband = ["splinter/circuit-disband"]
 database = ["splinter/postgres", "splinter/sqlite"]
 https-bind = ["splinter/https-bind"]
 oauth = [


### PR DESCRIPTION
Makes a few updates to the current `CircuitDisbandRequest` implementation, including:

- Adds a queue for circuits that are being disbanded, similar to the `pending_consensus_proposals`, for the disband proposal to wait until all member nodes have reached consensus and sent the `DisbandedCircuit` message. Once all members have sent this message, the disband is finalized (services shut down, peer refs removed, circuit removed from routing table)
- To support the process described above, added a `DisbandedCircuit` admin message to be sent between members of a circuit being disbanded, to signal that the disbanded circuit has been accepted and committed to state
- Handling of this admin message, similar to the `MemberReady` message, in which the receiver adds the member node it received the message from to a `ready_members` list associated with the disband proposal. 
- Also adds functions to support the functionality explained above, mainly to add a circuit to the `pending_consensus_disbanded_circuits`, and check if/when members are ready to finalize the disband

Also adds the `CircuitDisbandRequest` functionality to the CLI, behind the experimental `circuit-disband` feature and updates how proposals are displayed to more accurately reflect their intention.

To test: Run two splinter nodes with `--features=stable,circuit-disband`. Create a circuit as you normally would, then use `splinter circuit disband <circuit_id>` to propose disbanding the circuit you just created. Vote to accept this proposal from the member node. Verify in the logs that the `DisbandedCircuit` was sent between the nodes. Currently, all circuits are still displayed so you will still see the disbanded circuit using the `splinter circuit list` so you can check the database to view the Circuit, where the `circuit_status` should be 2 (which is equivalent to the DB's i16 representation of the `Disbanded` variant.)