### PR TITLE
RBAC assignment issue with deleted role

### DIFF
--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -23,8 +23,10 @@ pub mod sqlite;
 
 use std::str::FromStr;
 
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "sqlite", not(test)))]
 use self::sqlite::ForeignKeyCustomizer;
+#[cfg(all(feature = "sqlite", test))]
+pub use self::sqlite::ForeignKeyCustomizer;
 #[cfg(feature = "diesel")]
 use diesel::r2d2::{ConnectionManager, Pool};
 


### PR DESCRIPTION
This change fixes an issue where when a role is deleted, and thereexists an assignment with a single reference to the role, the role could no longer be loaded, causing a 500 server error down stream.  The root cause was using the builder to create the assignment from the database. This builder has a requirement that the roles list cannot be empty, but
that constraint doesn't apply in this direction, due to deletions.

Building the assignment directly corrected the issue.  A test has been added to avoid any regressions.

Creating the test required making the `ForeignKeyCustomizer` public to test code.
