### PR TITLE
Fix feature guards to avoid warnings

### DIFF
--- a/libsplinter/src/rest_api/auth/actix.rs
+++ b/libsplinter/src/rest_api/auth/actix.rs
@@ -190,6 +190,11 @@ where
                 debug!("Authenticated user {:?}", identity);
                 req.extensions_mut().insert(identity);
             }
+            #[cfg(any(
+                feature = "authorization",
+                feature = "biome-credentials",
+                feature = "oauth"
+            ))]
             AuthorizationResult::NoAuthorizationNecessary => {}
             AuthorizationResult::Unauthorized => {
                 return Box::new(


### PR DESCRIPTION
This change adds feature guards to the appropriate places to remove some warnings that occur when running `just lint` (specifically when linting with `--features stable`).
