### PR TITLE
Add `CircuitStatus` to `CircuitPredicate`

### DIFF
--- a/cli/man/splinter-circuit-list.1.md
+++ b/cli/man/splinter-circuit-list.1.md
@@ -22,7 +22,8 @@ with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it possible to
 verify that circuits have been successfully created as well as being able to
 access the generated circuit ID assigned to a circuit. The information displayed
 will be the same for all member nodes. The circuits listed have been accepted by
-all members.
+all members and are currently active, meaning their `circuit_status` is
+`Active`.
 
 FLAGS
 =====
@@ -54,6 +55,10 @@ OPTIONS
 : Filter the circuits list by a node ID that is present in the circuits’ members
   list.
 
+`--circuit-status` CIRCUIT-STATUS
+: Filter the circuit proposals list by their circuit status. Possible values
+  for the `circuit-status` filter are `active`, `disbanded` and `abandoned`.
+
 `-U`, `--url` URL
 : Specifies the URL for the `splinterd` REST API. The URL is required unless
   `$SPLINTER_REST_API_URL` is set.
@@ -62,10 +67,10 @@ EXAMPLES
 ========
 This command displays information about circuits with a default `human`
 formatting, meaning the information is displayed in a table. The `--member`
-option allows for filtering the circuits.
+and `--circuit-status` options allow for filtering the circuits.
 
-The following command does not specify any filters, therefore all circuits
-the local node, `alpha-node-000` is a member of are displayed.
+The following command does not specify any filters, therefore all active
+circuits the local node, `alpha-node-000` is a member of are displayed.
 ```
 $ splinter circuit list \
   --url URL-of-alpha-node-splinterd-REST-API
@@ -75,20 +80,35 @@ ID            NAME      MANAGEMENT    MEMBERS
 56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
-The next command specifies a `--member` filter, therefore all circuits
-the local node, `alpha-node-000` is a part of including the `gamma-node-000` node
-ID will be listed.
+The next command specifies a `--member` filter, therefore all
+active circuits the local node, `alpha-node-000` is a part of including the
+`gamma-node-000` node ID will be listed.
 ```
 $ splinter circuit list \
-  member gamma-node-000 \
+  --member gamma-node-000 \
   --url URL-of-alpha-node-splinterd-REST-API
 ID            NAME      MANAGEMENT    MEMBERS
 43210-ABCDE   circuit1  mgmt001       alpha-node-000;gamma-node-000
 56789-ABCDE   -         mgmt002       alpha-node-000;gamma-node-000
 ```
 
-Since all of the circuits listed have been accepted by each member, the same
-circuit information will be displayed for member nodes.
+The next command specifies a `--circuit-status` filter, therefore all
+circuits the local node, `alpha-node-000` is a part of that have the provided
+`circuit_status` will be listed. Note: The circuits listed have a
+`circuit_status` of `Disbanded`. Therefore, these circuits will not be listed
+using `splinter circuit list` with no filters as only `Active` circuits are
+listed by default.
+```
+$ splinter circuit list \
+  --circuit-status disbanded \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            NAME      MANAGEMENT    MEMBERS
+43210-GHIJK   circuit0  mgmt001       alpha-node-000;gamma-node-000
+56789-GHIJK   -         mgmt001       alpha-node-000;beta-node-000
+```
+
+Since all of the active circuits listed have been accepted by each member, the
+same circuit information will be displayed for member nodes.
 
 From the perspective of the `gamma-node-000` node, this command will display the
 following with no filters:

--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -76,13 +76,14 @@ The information displayed below will appear the same on all proposed member node
 If all member nodes vote to accept the circuit, the `splinter-circuit-show`
 command will display the same information, without the `Vote` as all nodes would
 have accepted the proposal. If any of the member nodes vote to reject the circuit,
-the proposal will not be viewable by any nodes.
+the proposal will be removed and is not viewable by any nodes.
 
 ```
 $ splinter circuit show 01234-ABCDE \
   ---url URL-of-alpha-node-splinterd-REST-API
 Proposal to create: 01234-ABCDE
     Display Name: -
+    Circuit Status: Active
     Version: 2
     Management Type: mgmt001
 
@@ -103,6 +104,42 @@ Proposal to create: 01234-ABCDE
             peer_services:
                 AA01
 ```
+
+The information displayed below will appear the same on all proposed member
+nodes for a circuit proposal to disband an existing circuit.
+If all member nodes vote to accept disbanding the circuit, the
+`splinter-circuit-show` command will display the same information, without the
+`Vote` as all nodes would have accepted the proposal. If any of the member
+nodes vote to reject disbanding the circuit, the proposal will be removed and
+is not viewable by any nodes.
+
+```
+$ splinter circuit show 01234-ABCDE \
+  ---url URL-of-alpha-node-splinterd-REST-API
+Proposal to disband: 56789-ABCDE
+    Display Name: Circuit1
+    Circuit Status: Disbanded
+    Version: 2
+    Management Type: mgmt001
+
+    alpha-001 (tcps://splinterd-node-alpha001:8044)
+        Vote: ACCEPT (implied as requester):
+            ALPHA-PUBLIC-KEY
+        Service: AA01
+            admin_keys:
+                ALPHA-PUBLIC-KEY
+            peer_services:
+                BB01
+
+    beta-001 (tcps://splinterd-node-beta001:8044)
+        Vote: PENDING
+        Service: AA01
+            admin_keys:
+                ALPHA-PUBLIC-KEY
+            peer_services:
+                AA01
+```
+
 
 ENVIRONMENT VARIABLES
 =====================

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -63,10 +63,17 @@ impl SplinterRestClient {
             })
     }
 
-    pub fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, CliError> {
+    pub fn list_circuits(
+        &self,
+        member_filter: Option<&str>,
+        status_filter: Option<&str>,
+    ) -> Result<CircuitListSlice, CliError> {
         let mut url = format!("{}/admin/circuits?limit={}", self.url, PAGING_LIMIT);
-        if let Some(filter) = filter {
-            url = format!("{}&filter={}", &url, &filter);
+        if let Some(member_filter) = member_filter {
+            url = format!("{}&filter={}", &url, &member_filter);
+        }
+        if let Some(status_filter) = status_filter {
+            url = format!("{}&status={}", &url, &status_filter);
         }
 
         Client::new()

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use reqwest::{blocking::Client, header, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::error::Result as JsonResult;
+use splinter::admin::messages::CircuitStatus;
 
 use crate::action::api::{ServerError, SplinterRestClient};
 use crate::error::CliError;
@@ -245,6 +246,7 @@ pub struct CircuitSlice {
     pub management_type: String,
     pub display_name: Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: Option<CircuitStatus>,
 }
 
 impl fmt::Display for CircuitSlice {
@@ -255,6 +257,12 @@ impl fmt::Display for CircuitSlice {
             display_string += &format!("Display Name: {}\n    ", display_name);
         } else {
             display_string += "Display Name: -\n    ";
+        }
+
+        if let Some(status) = &self.circuit_status {
+            display_string += &format!("Circuit Status: {}\n    ", status);
+        } else {
+            display_string += "Circuit Status: Active\n    ";
         }
 
         display_string += &format!(
@@ -331,6 +339,12 @@ impl fmt::Display for ProposalSlice {
             display_string += "Display Name: -\n    ";
         }
 
+        if let Some(status) = &self.circuit.circuit_status {
+            display_string += &format!("Circuit Status: {}\n    ", status);
+        } else {
+            display_string += "Circuit Status: Active\n    ";
+        }
+
         display_string += &format!(
             "Version: {}\n    Management Type: {}\n",
             self.circuit.circuit_version, self.circuit.management_type
@@ -393,6 +407,7 @@ pub struct ProposalCircuitSlice {
     pub comments: Option<String>,
     pub display_name: Option<String>,
     pub circuit_version: i32,
+    pub circuit_status: Option<CircuitStatus>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -635,7 +635,8 @@ impl Action for CircuitListAction {
             .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
             .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
 
-        let filter = arg_matches.and_then(|args| args.value_of("member"));
+        let member_filter = arg_matches.and_then(|args| args.value_of("member"));
+        let status_filter = arg_matches.and_then(|args| args.value_of("circuit_status"));
 
         let format = arg_matches
             .and_then(|args| {
@@ -649,13 +650,14 @@ impl Action for CircuitListAction {
 
         let key = arg_matches.and_then(|args| args.value_of("private_key_file"));
 
-        list_circuits(&url, filter, format, key)
+        list_circuits(&url, member_filter, status_filter, format, key)
     }
 }
 
 fn list_circuits(
     url: &str,
-    filter: Option<&str>,
+    member_filter: Option<&str>,
+    status_filter: Option<&str>,
     format: &str,
     key: Option<&str>,
 ) -> Result<(), CliError> {
@@ -664,7 +666,7 @@ fn list_circuits(
         .with_auth(create_cylinder_jwt_auth(key)?)
         .build()?;
 
-    let circuits = client.list_circuits(filter)?;
+    let circuits = client.list_circuits(member_filter, status_filter)?;
     let mut data = Vec::new();
     data.push(vec![
         "ID".to_string(),

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -527,6 +527,7 @@ impl TryFrom<&CreateCircuit> for CircuitSlice {
             management_type: circuit.circuit_management_type.clone(),
             display_name: circuit.display_name.clone(),
             circuit_version: circuit.circuit_version,
+            circuit_status: Some(circuit.circuit_status.clone()),
         })
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -345,6 +345,13 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .takes_value(true),
                 )
                 .arg(
+                    Arg::with_name("circuit_status")
+                        .long("circuit-status")
+                        .help("Filter circuits by a circuit status")
+                        .possible_values(&["active", "disbanded", "abandoned"])
+                        .takes_value(true),
+                )
+                .arg(
                     Arg::with_name("format")
                         .short("F")
                         .long("format")

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -70,3 +70,13 @@ impl<'a> From<&'a Service> for ServiceResponse<'a> {
         }
     }
 }
+
+impl From<String> for CircuitStatus {
+    fn from(str: String) -> Self {
+        match &*str {
+            "disbanded" => CircuitStatus::Disbanded,
+            "abandoned" => CircuitStatus::Abandoned,
+            _ => CircuitStatus::Active,
+        }
+    }
+}

--- a/libsplinter/src/admin/service/event/store/diesel/models.rs
+++ b/libsplinter/src/admin/service/event/store/diesel/models.rs
@@ -480,16 +480,6 @@ impl From<&messages::RouteType> for String {
     }
 }
 
-impl From<&messages::CircuitStatus> for String {
-    fn from(variant: &messages::CircuitStatus) -> Self {
-        match variant {
-            messages::CircuitStatus::Active => String::from("Active"),
-            messages::CircuitStatus::Disbanded => String::from("Disbanded"),
-            messages::CircuitStatus::Abandoned => String::from("Abandoned"),
-        }
-    }
-}
-
 impl From<&messages::CircuitStatus> for CircuitStatusModel {
     fn from(messages_status: &messages::CircuitStatus) -> Self {
         match *messages_status {

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -383,6 +383,16 @@ impl From<&store::CircuitStatus> for CircuitStatus {
     }
 }
 
+impl std::fmt::Display for CircuitStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CircuitStatus::Active => f.write_str("Active"),
+            CircuitStatus::Disbanded => f.write_str("Disbanded"),
+            CircuitStatus::Abandoned => f.write_str("Abandoned"),
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SplinterNode {
     pub node_id: String,

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -605,30 +605,6 @@ impl From<&RouteType> for String {
     }
 }
 
-impl TryFrom<String> for CircuitStatus {
-    type Error = AdminServiceStoreError;
-    fn try_from(variant: String) -> Result<Self, Self::Error> {
-        match variant.as_ref() {
-            "Active" => Ok(CircuitStatus::Active),
-            "Disbanded" => Ok(CircuitStatus::Disbanded),
-            "Abandoned" => Ok(CircuitStatus::Abandoned),
-            _ => Err(AdminServiceStoreError::InvalidStateError(
-                InvalidStateError::with_message("Unable to convert string to CircuitStatus".into()),
-            )),
-        }
-    }
-}
-
-impl From<&CircuitStatus> for String {
-    fn from(variant: &CircuitStatus) -> Self {
-        match variant {
-            CircuitStatus::Active => String::from("Active"),
-            CircuitStatus::Disbanded => String::from("Disbanded"),
-            CircuitStatus::Abandoned => String::from("Abandoned"),
-        }
-    }
-}
-
 #[repr(i16)]
 #[derive(Debug, Copy, Clone, PartialEq, FromSqlRow)]
 pub enum CircuitStatusModel {

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -125,6 +125,7 @@ impl PartialOrd for ServiceId {
 pub enum CircuitPredicate {
     ManagementTypeEq(String),
     MembersInclude(Vec<String>),
+    CircuitStatus(CircuitStatus),
 }
 
 impl CircuitPredicate {
@@ -142,6 +143,7 @@ impl CircuitPredicate {
                 }
                 true
             }
+            CircuitPredicate::CircuitStatus(status) => circuit.circuit_status() == status,
         }
     }
 
@@ -164,6 +166,9 @@ impl CircuitPredicate {
                     }
                 }
                 true
+            }
+            CircuitPredicate::CircuitStatus(status) => {
+                proposal.circuit().circuit_status() == status
             }
         }
     }

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -247,8 +247,10 @@ paths:
         This endpoint can be used to view all or some of the circuits that the
         node is a member of. If a node ID is provided via the "filter" query
         parameter, only circuits that have the given node ID as a member will be
-        returned; if no filter is provided, all of the node's circuits will be
-        returned.
+        returned. If a circuit status is provided via the "status" query
+        parameter, only circuits that have the given circuit status will be
+        returned; if no filter is provided, all of the node's `Active` circuits
+        will be returned.
       tags:
         - Circuits
       parameters:
@@ -271,6 +273,12 @@ paths:
         - name: filter
           in: query
           description: Node ID that must be present in the returned circuits
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Circuit status of the returned circuits
           required: false
           schema:
             type: string
@@ -2155,6 +2163,14 @@ components:
           description: Human readable name for the circuit
           type: string
           nullable: true
+        circuit_status:
+            description: The status of the circuit
+            type: string
+            nullable: true
+            enum:
+              - Active
+              - Disbanded
+              - Abandoned
 
     CircuitService:
       type: object


### PR DESCRIPTION
Adds a `CircuitStatus` circuit predicate to allow for filtering circuits and proposals based on the `circuit_status` field. This also affects the circuits returned by the admin store's `list_circuits` operation, as only `Active` circuits are returned by default. 

The `CircuitStatus` predicate is also added to the `/admin/proposals` and `/admin/circuits/` endpoints, via the `status` query parameter. 

Also adds a `circuit-status` option to the `splinter circuit list`, `splinter circuit proposals` commands. 

Also makes a small update to the data displayed via the `show` command, to display the `circuit_status` field of the circuit / proposed circuit. 