### PR TITLE
Maintenance mode RBAC integration

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-01-150745_add_admin_role/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-01-150745_add_admin_role/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DELETE FROM roles WHERE id='admin';

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-01-150745_add_admin_role/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-01-150745_add_admin_role/up.sql
@@ -1,0 +1,17 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+INSERT INTO roles VALUES ('admin', 'Administrator');
+INSERT INTO role_permissions VALUES ('admin', '*');

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-01-150745_add_admin_role/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-01-150745_add_admin_role/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DELETE FROM roles WHERE id='admin';

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-01-150745_add_admin_role/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-01-150745_add_admin_role/up.sql
@@ -1,0 +1,17 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+INSERT INTO roles VALUES ('admin', 'Administrator');
+INSERT INTO role_permissions VALUES ('admin', '*');

--- a/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
@@ -99,7 +99,7 @@ mod tests {
     fn get_and_post() {
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_maintenance_resource(
-                MaintenanceModeAuthorizationHandler::new(),
+                MaintenanceModeAuthorizationHandler::default(),
             )]);
 
         let url = Url::parse(&format!("http://{}/authorization/maintenance", bind_url))
@@ -182,7 +182,7 @@ mod tests {
     ///    still enabled
     #[test]
     fn post_idempotent() {
-        let handler = MaintenanceModeAuthorizationHandler::new();
+        let handler = MaintenanceModeAuthorizationHandler::default();
 
         let (shutdown_handle, join_handle, bind_url) =
             run_rest_api_on_open_port(vec![make_maintenance_resource(handler.clone())]);

--- a/libsplinter/src/rest_api/auth/authorization/rbac/handler.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/handler.rs
@@ -19,7 +19,7 @@ use crate::rest_api::auth::{
     identity::Identity,
 };
 
-use super::store::RoleBasedAuthorizationStore;
+use super::store::{RoleBasedAuthorizationStore, ADMIN_ROLE_ID};
 
 /// A Role-based authorization handler.
 ///
@@ -52,7 +52,10 @@ impl AuthorizationHandler for RoleBasedAuthorizationHandler {
                 .role_based_auth_store
                 .get_assigned_roles(&identity)
                 .map_err(|err| InternalError::from_source(Box::new(err)))?
-                .find(|role| role.permissions().iter().any(|perm| perm == permission_id))
+                .find(|role| {
+                    role.id() == ADMIN_ROLE_ID
+                        || role.permissions().iter().any(|perm| perm == permission_id)
+                })
                 .map(|_| AuthorizationHandlerResult::Allow)
                 .unwrap_or(AuthorizationHandlerResult::Continue)),
             None => Ok(AuthorizationHandlerResult::Continue),
@@ -93,6 +96,22 @@ mod tests {
     #[test]
     fn allow_user_identity_with_assignment() {
         test_allow_identity_with_assignment(
+            Identity::User("some-user-id".into()),
+            StoreIdentity::User("some-user-id".into()),
+        );
+    }
+
+    #[test]
+    fn allow_key_identity_admin() {
+        test_allow_identity_admin(
+            Identity::Key("abc123".into()),
+            StoreIdentity::Key("abc123".into()),
+        );
+    }
+
+    #[test]
+    fn allow_user_identity_admin() {
+        test_allow_identity_admin(
             Identity::User("some-user-id".into()),
             StoreIdentity::User("some-user-id".into()),
         );
@@ -183,6 +202,31 @@ mod tests {
         // Check a permission in the second role
         let result = handler
             .has_permission(&identity, "z")
+            .expect("Should have returned an auth result");
+
+        assert!(matches!(result, AuthorizationHandlerResult::Allow));
+    }
+
+    /// This test checks that an identity that is assigned the admin role will return Allow when
+    /// queried.
+    fn test_allow_identity_admin(identity: Identity, store_identity: StoreIdentity) {
+        let role_based_auth_store = create_role_based_authorization_store();
+
+        let assignment = AssignmentBuilder::new()
+            .with_identity(store_identity)
+            .with_roles(vec![ADMIN_ROLE_ID.to_string()])
+            .build()
+            .expect("Unable to build assignment");
+
+        role_based_auth_store
+            .add_assignment(assignment)
+            .expect("Unable to add assignment");
+
+        let handler = RoleBasedAuthorizationHandler::new(role_based_auth_store);
+
+        // Check an arbitrary permission
+        let result = handler
+            .has_permission(&identity, "perm")
             .expect("Should have returned an auth result");
 
         assert!(matches!(result, AuthorizationHandlerResult::Allow));

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
@@ -201,6 +201,21 @@ pub enum Identity {
     User(String),
 }
 
+impl From<&crate::rest_api::auth::identity::Identity> for Option<Identity> {
+    fn from(identity: &crate::rest_api::auth::identity::Identity) -> Self {
+        match identity {
+            // RoleBasedAuthorization does not currently support custom identities
+            crate::rest_api::auth::identity::Identity::Custom(_) => None,
+            crate::rest_api::auth::identity::Identity::Key(key) => {
+                Some(Identity::Key(key.to_string()))
+            }
+            crate::rest_api::auth::identity::Identity::User(user_id) => {
+                Some(Identity::User(user_id.to_string()))
+            }
+        }
+    }
+}
+
 /// An assignment of roles to a particular identity.
 #[derive(Clone)]
 pub struct Assignment {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
@@ -25,6 +25,8 @@ pub use self::diesel::DieselRoleBasedAuthorizationStore;
 
 pub use error::RoleBasedAuthorizationStoreError;
 
+pub const ADMIN_ROLE_ID: &str = "admin";
+
 /// A Role is a named set of permissions.
 #[derive(Clone)]
 pub struct Role {


### PR DESCRIPTION
This change effectively allows users and keys to be given a special `admin` role in the RBAC store. The maintenance mode authorization handler checks for this role and will allow any users/keys that have it perform write operations even when maintenance mode is enabled.

# Testing

1. Start splinterd:

```bash
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features=experimental -- database migrate
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features=experimental -- cert generate
SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features experimental -- --rest-api-endpoint http://localhost:8080 --tls-insecure -vv
```

2. Ensure the allow keys file is empty:

```bash
> /tmp/splinter/data/allow_keys
```

2. Generate a key pair for yourself if you don't already have one:

```bash
cargo run --manifest-path cli/Cargo.toml --features=experimental -- keygen
```

3. Display your public key to use in the next step:

```bash
cat ~/.cylinder/keys/$USER.pub
```

4. Assign the admin role to the key you just created:

```bash
sqlite3 /tmp/splinter/data/splinter_state.db
> INSERT INTO identities VALUES ('<your_key>', 1);
> INSERT INTO assignments VALUES ('<your_key>', 'admin');
```

5. Enable maintenance mode:

```bash
cargo run --manifest-path cli/Cargo.toml --features=experimental -- maintenance enable --url http://localhost:8080
```

6. Disable maintenance mode (this is a write operation and is only permitted because your key has the "admin" role in the RBAC store):

```bash
cargo run --manifest-path cli/Cargo.toml --features=experimental -- maintenance disable --url http://localhost:8080
```