### PR TITLE
Add --rm-all to 'role update' subcommand

### DIFF
--- a/cli/man/splinter-role-update.1.md
+++ b/cli/man/splinter-role-update.1.md
@@ -38,6 +38,10 @@ FLAGS
 `--rm-all`
 : Remove all of the permissions currently associated with the role.
 
+`-f`, `--force`
+: Ignore errors based on duplicate values or adding and removing the same
+  permission.
+
 OPTIONS
 =======
 `-k`, `--key` PRIVATE-KEY-FILE

--- a/cli/man/splinter-role-update.1.md
+++ b/cli/man/splinter-role-update.1.md
@@ -35,6 +35,9 @@ FLAGS
 : Increases verbosity (the opposite of -q). Specify multiple times for more
   output.
 
+`--rm-all`
+: Remove all of the permissions currently associated with the role.
+
 OPTIONS
 =======
 `-k`, `--key` PRIVATE-KEY-FILE

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -992,6 +992,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 ),
                         )
                         .arg(
+                            Arg::with_name("force")
+                                .short("f")
+                                .long("force")
+                                .help("Ignore errors, such as adding and removing the same value."),
+                        )
+                        .arg(
                             Arg::with_name("role_id")
                                 .required(true)
                                 .takes_value(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -979,7 +979,17 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .takes_value(true)
                                 .multiple(true)
                                 .number_of_values(1)
+                                .conflicts_with("rm_all")
                                 .help("A permission to be removed from the role"),
+                        )
+                        .arg(
+                            Arg::with_name("rm_all")
+                                .long("rm-all")
+                                .conflicts_with("rm_permission")
+                                .help(
+                                    "Remove all of the permissions currently associated with the \
+                                    role",
+                                ),
                         )
                         .arg(
                             Arg::with_name("role_id")


### PR DESCRIPTION
This PR adds a `--rm-all` flag to the `role update` subcommand.  This allows the user to remove the current permissions from the role without needing to enumerate them.

Additionally, 

- if the user adds and removes the same permission, the command will return an error.
- if the user attempts to remove a permission that does not currently belong to the role, return an error 