### PR TITLE
Add `purge` functionality to admin service, CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ experimental = [
     "authorization-handler-rbac",
     "circuit-auth-type",
     "circuit-disband",
+    "circuit-purge",
     "health",
     "https-certs",
     "permissions",
@@ -81,6 +82,7 @@ authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
 circuit-disband = ["splinter/circuit-disband"]
+circuit-purge = ["circuit-disband", "splinter/circuit-purge"]
 circuit-template = ["splinter/circuit-template"]
 
 health = []

--- a/cli/man/splinter-circuit-disband.1.md
+++ b/cli/man/splinter-circuit-disband.1.md
@@ -90,5 +90,6 @@ SEE ALSO
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-show(1)`
+| `splinter-circuit-purge(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-purge.1.md
+++ b/cli/man/splinter-circuit-purge.1.md
@@ -1,0 +1,85 @@
+% SPLINTER-CIRCUIT-PURGE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-purge** — Submits a request to purge the specified circuit.
+
+SYNOPSIS
+========
+**splinter circuit purge** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID
+
+DESCRIPTION
+===========
+Request to purge a circuit by specifying the circuit ID of the circuit to be
+removed from the node's storage. A circuit is only available to be purged
+if it has already been disbanded and are only available locally. Disbanding a
+circuit removes a circuit's networking functionality.
+
+The generated ID of the existing disbanded circuit can be viewed using the
+`splinter-circuit-list`, with the `--circuit-status` option of `disbanded`.
+
+The purge request is only available for members of the node, as the circuit is
+only available to the node locally. If the circuit has not been disbanded, it
+is not able to be purged. Once a circuit has been purged, it is removed from
+the node's storage and is no longer viewable.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be purged.
+
+EXAMPLES
+========
+* The existing disbanded circuit has ID `1234-ABCDE`.
+
+The following command displays a member node requesting to purge the circuit:
+```
+$ splinter circuit purge \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
+  1234-ABCDE \
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-list(1)`
+| `splinter-circuit-disband(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter.1.md
+++ b/cli/man/splinter.1.md
@@ -85,9 +85,11 @@ Many `splinter` subcommands accept the following environment variable:
 SEE ALSO
 ========
 | `splinter-cert-generate(1)`
+| `splinter-circuit-disband(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-propose(1)`
+| `splinter-circuit-purge(1)`
 | `splinter-circuit-show(1)`
 | `splinter-circuit-template-arguments(1)`
 | `splinter-circuit-template-list(1)`

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -680,6 +680,69 @@ fn propose_circuit_disband(url: &str, key: Option<&str>, circuit_id: &str) -> Re
     }
 }
 
+#[cfg(feature = "circuit-purge")]
+struct CircuitPurge {
+    circuit_id: String,
+}
+
+#[cfg(feature = "circuit-purge")]
+pub struct CircuitPurgeAction;
+
+#[cfg(feature = "circuit-purge")]
+impl Action for CircuitPurgeAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
+        let key = args.value_of("private_key_file");
+
+        let circuit_id = args
+            .value_of("circuit_id")
+            .ok_or_else(|| CliError::ActionError("'circuit-id' argument is required".into()))?;
+
+        request_purge_circuit(&url, key, circuit_id)
+    }
+}
+
+#[cfg(feature = "circuit-purge")]
+fn request_purge_circuit(url: &str, key: Option<&str>, circuit_id: &str) -> Result<(), CliError> {
+    let client = SplinterRestClientBuilder::new()
+        .with_url(url.to_string())
+        .with_auth(create_cylinder_jwt_auth(key)?)
+        .build()?;
+
+    let private_key_hex = read_private_key(key.unwrap_or("splinter"))?;
+
+    let requester_node = client.get_node_status()?.node_id;
+    let circuit = client.fetch_circuit(circuit_id)?;
+
+    if let Some(circuit) = circuit {
+        // Check if the fetched circuit has a `circuit_status` or if the `circuit_status` is `Active`
+        // to verify the `CircuitPurgeRequest` is valid.
+        if circuit.circuit_status.is_none() || circuit.circuit_status == Some(CircuitStatus::Active)
+        {
+            return Err(CliError::ActionError(format!(
+                "Circuit '{}' is active",
+                circuit_id
+            )));
+        }
+        let circuit_purge_request = CircuitPurge {
+            circuit_id: circuit_id.into(),
+        };
+        let signed_payload =
+            make_signed_payload(&requester_node, &private_key_hex, circuit_purge_request)?;
+        client.submit_admin_payload(signed_payload)
+    } else {
+        Err(CliError::ActionError(format!(
+            "Circuit '{}' does not exist",
+            circuit_id
+        )))
+    }
+}
+
 pub struct CircuitListAction;
 
 impl Action for CircuitListAction {

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -18,6 +18,8 @@ use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
 #[cfg(feature = "circuit-disband")]
 use splinter::protos::admin::CircuitDisbandRequest;
+#[cfg(feature = "circuit-purge")]
+use splinter::protos::admin::CircuitPurgeRequest;
 use splinter::protos::admin::{
     CircuitCreateRequest, CircuitManagementPayload, CircuitManagementPayload_Action as Action,
     CircuitManagementPayload_Header as Header, CircuitProposalVote, CircuitProposalVote_Vote,
@@ -27,6 +29,8 @@ use crate::error::CliError;
 
 #[cfg(feature = "circuit-disband")]
 use super::CircuitDisband;
+#[cfg(feature = "circuit-purge")]
+use super::CircuitPurge;
 use super::{CircuitVote, Vote};
 
 /// A circuit action that has a type and can be converted into a protobuf-serializable struct.
@@ -161,5 +165,25 @@ impl CircuitAction<CircuitDisbandRequest> for CircuitDisband {
 impl ApplyToEnvelope for CircuitDisbandRequest {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_disband_request(self);
+    }
+}
+
+#[cfg(feature = "circuit-purge")]
+impl CircuitAction<CircuitPurgeRequest> for CircuitPurge {
+    fn action_type(&self) -> Action {
+        Action::CIRCUIT_PURGE_REQUEST
+    }
+
+    fn into_proto(self) -> Result<CircuitPurgeRequest, CliError> {
+        let mut purge_request = CircuitPurgeRequest::new();
+        purge_request.set_circuit_id(self.circuit_id);
+        Ok(purge_request)
+    }
+}
+
+#[cfg(feature = "circuit-purge")]
+impl ApplyToEnvelope for CircuitPurgeRequest {
+    fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
+        circuit_management_payload.set_circuit_purge_request(self);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -502,6 +502,34 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             ),
     );
 
+    #[cfg(feature = "circuit-purge")]
+    let circuit_command = circuit_command.subcommand(
+        SubCommand::with_name("purge")
+            .about("Purge an existing disbanded circuit")
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .takes_value(true)
+                    .help("URL of Splinter Daemon"),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Path to private key file"),
+            )
+            .arg(
+                Arg::with_name("circuit_id")
+                    .value_name("circuit-id")
+                    .takes_value(true)
+                    .required(true)
+                    .help("ID of the circuit to be purged"),
+            ),
+    );
+
     #[cfg(not(feature = "https-certs"))]
     let cert_generate_subcommand = SubCommand::with_name("generate")
         .long_about(
@@ -1154,6 +1182,9 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     #[cfg(feature = "circuit-disband")]
     let circuit_command = circuit_command.with_command("disband", circuit::CircuitDisbandAction);
+
+    #[cfg(feature = "circuit-purge")]
+    let circuit_command = circuit_command.with_command("purge", circuit::CircuitPurgeAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -108,6 +108,7 @@ experimental = [
     "biome-oauth-user-store-postgres",
     "biome-profile",
     "circuit-disband",
+    "circuit-purge",
     "https-bind",
     "oauth-inflight-request-store-postgres",
     "registry-database",
@@ -135,6 +136,7 @@ biome-notifications = ["biome"]
 biome-oauth-user-store-postgres = ["oauth", "postgres"]
 biome-profile = ["biome"]
 circuit-disband = []
+circuit-purge = ["circuit-disband"]
 circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -185,7 +185,8 @@ message CircuitManagementPayload {
          CIRCUIT_UPDATE_APPLICATION_METADATA_REQUEST = 6;
          CIRCUIT_JOIN_REQUEST = 7;
          CIRCUIT_DISBAND_REQUEST = 8;
-         CIRCUIT_ABANDON = 9;
+         CIRCUIT_PURGE_REQUEST = 9;
+         CIRCUIT_ABANDON = 10;
     }
 
     message Header {
@@ -216,7 +217,8 @@ message CircuitManagementPayload {
         circuit_update_application_metadata_request = 8;
     CircuitJoinRequest circuit_join_request = 9;
     CircuitDisbandRequest circuit_disband_request = 10;
-    CircuitAbandon circuit_abandon = 11;
+    CircuitPurgeRequest circuit_purge_request = 11;
+    CircuitAbandon circuit_abandon = 12;
 }
 
 message CircuitProposalVote {
@@ -289,6 +291,11 @@ message CircuitJoinRequest {
 
 message CircuitDisbandRequest {
     // The unique circuit name
+    string circuit_id = 1;
+}
+
+message CircuitPurgeRequest {
+    // The unique circuit id of the inactive circuit to be purged
     string circuit_id = 1;
 }
 

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -87,6 +87,7 @@ experimental = [
     "authorization-handler-rbac",
     "biome-profile",
     "circuit-disband",
+    "circuit-purge",
     "health",
     "https-bind",
     "oauth",
@@ -118,6 +119,7 @@ biome-credentials = ["database", "splinter/biome-credentials"]
 biome-key-management = ["database", "splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile"]
 circuit-disband = ["splinter/circuit-disband"]
+circuit-purge = ["splinter/circuit-purge", "circuit-disband"]
 database = ["splinter/postgres", "splinter/sqlite"]
 https-bind = ["splinter/https-bind"]
 oauth = [


### PR DESCRIPTION
Adds the `CircuitPurgeRequest` to the admin proto, and implements the handling of this request in the admin service. Also adds this functionality to the CLI, via the `splinter circuit purge` command. 

To test: Create/run two splinter nodes. Create a circuit as you normally would. Once the circuit is created and `Active`, use `splinter circuit disband` to disband the circuit you just created. (Similar to creating a circuit, you also must vote on the disband proposal). Once the circuit is fully disbanded, use `splinter circuit purge` to remove the disbanded from the admin store. If you check the database of the node you purged the circuit from, you should not see the circuit that was just created. Or if you use `splinter circuit show <CIRCUIT_ID>`, you should get a 404