### PR TITLE
RBAC REST API: Fix 404 on update

### DIFF
--- a/libsplinter/src/error/constraint_violation.rs
+++ b/libsplinter/src/error/constraint_violation.rs
@@ -27,6 +27,7 @@ use std::fmt;
 pub enum ConstraintViolationType {
     Unique,
     ForeignKey,
+    NotFound,
     Other(String),
 }
 
@@ -35,6 +36,7 @@ impl fmt::Display for ConstraintViolationType {
         match &self {
             ConstraintViolationType::Unique => write!(f, "Unique"),
             ConstraintViolationType::ForeignKey => write!(f, "Foreign Key"),
+            ConstraintViolationType::NotFound => f.write_str("Not Found"),
             ConstraintViolationType::Other(ref msg) => write!(f, "{}", msg),
         }
     }

--- a/libsplinter/src/error/constraint_violation.rs
+++ b/libsplinter/src/error/constraint_violation.rs
@@ -23,7 +23,7 @@ use std::fmt;
 /// violated. For example, if an operation tries to insert an entry that would
 /// cause a duplicate in a unique column, the ConstraintViolationType::Unique
 /// should be used.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ConstraintViolationType {
     Unique,
     ForeignKey,
@@ -105,6 +105,11 @@ impl ConstraintViolationError {
             violation_type,
             source: Some(source),
         }
+    }
+
+    /// Returns the violation type that triggered the error.
+    pub fn violation_type(&self) -> &ConstraintViolationType {
+        &self.violation_type
     }
 }
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
@@ -1464,8 +1464,10 @@ mod tests {
                 assignments.insert(key, assignment);
                 Ok(())
             } else {
-                Err(RoleBasedAuthorizationStoreError::InvalidState(
-                    InvalidStateError::with_message("No assignment found".into()),
+                Err(RoleBasedAuthorizationStoreError::ConstraintViolation(
+                    ConstraintViolationError::with_violation_type(
+                        ConstraintViolationType::NotFound,
+                    ),
                 ))
             }
         }

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
@@ -291,8 +291,11 @@ fn patch_assignment(
                                 HttpResponse::BadRequest()
                                     .json(ErrorResponse::bad_request(&err.to_string()))
                             }
-                            Err(BlockingError::Error(ConstraintViolation(msg))) => {
+                            Err(BlockingError::Error(NotFound(msg))) => {
                                 HttpResponse::NotFound().json(ErrorResponse::not_found(&msg))
+                            }
+                            Err(BlockingError::Error(ConstraintViolation(msg))) => {
+                                HttpResponse::Conflict().json(ErrorResponse::conflict(&msg))
                             }
                             Err(err) => {
                                 error!("Unable to update assignment: {}", err);
@@ -326,15 +329,13 @@ fn update_assignment(
                     .update_assignment(updated_assignment)
                     .map_err(SendableRoleBasedAuthorizationStoreError::from)
             } else {
-                Err(
-                    SendableRoleBasedAuthorizationStoreError::ConstraintViolation(format!(
-                        "assignment for {} not found",
-                        match identity {
-                            Identity::Key(key) => key,
-                            Identity::User(user) => user,
-                        }
-                    )),
-                )
+                Err(SendableRoleBasedAuthorizationStoreError::NotFound(format!(
+                    "assignment for {} not found",
+                    match identity {
+                        Identity::Key(key) => key,
+                        Identity::User(user) => user,
+                    }
+                )))
             }
         })
 }

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
@@ -262,8 +262,11 @@ fn patch_role(
                                 HttpResponse::BadRequest()
                                     .json(ErrorResponse::bad_request(&err.to_string()))
                             }
-                            Err(BlockingError::Error(ConstraintViolation(msg))) => {
+                            Err(BlockingError::Error(NotFound(msg))) => {
                                 HttpResponse::NotFound().json(ErrorResponse::not_found(&msg))
+                            }
+                            Err(BlockingError::Error(ConstraintViolation(msg))) => {
+                                HttpResponse::Conflict().json(ErrorResponse::conflict(&msg))
                             }
                             Err(err) => {
                                 error!("Unable to add role: {}", err);
@@ -308,12 +311,10 @@ fn update_role(
                     .update_role(updated_role)
                     .map_err(SendableRoleBasedAuthorizationStoreError::from)
             } else {
-                Err(
-                    SendableRoleBasedAuthorizationStoreError::ConstraintViolation(format!(
-                        "role {} not found",
-                        role_id
-                    )),
-                )
+                Err(SendableRoleBasedAuthorizationStoreError::NotFound(format!(
+                    "role {} not found",
+                    role_id
+                )))
             }
         })
 }

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
@@ -619,6 +619,29 @@ mod tests {
             stored_role.permissions()
         );
     }
+    /// This test verifies the following
+    /// 1. Updating an non-existent role should return false
+    #[test]
+    fn sqlite_update_nonexistent_role() {
+        let pool = create_connection_pool_and_migrate();
+
+        let role_based_auth_store = DieselRoleBasedAuthorizationStore::new(pool);
+
+        let role = RoleBuilder::new()
+            .with_id("test-nonexistent-role".into())
+            .with_display_name("Test Role".into())
+            .with_permissions(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        let res = role_based_auth_store.update_role(role);
+
+        assert!(matches!(
+            res,
+            Err(RoleBasedAuthorizationStoreError::ConstraintViolation(err))
+                if err.violation_type() == &ConstraintViolationType::NotFound
+        ));
+    }
 
     /// This tests verifies the following:
     /// 1. Adds a role and verifies that it has been inserted
@@ -954,6 +977,49 @@ mod tests {
             stored_assignment.identity()
         );
         assert_eq!(&vec!["test-role-2".to_string()], stored_assignment.roles());
+    }
+
+    #[test]
+    fn sqlite_test_update_nonexistent_assignment() {
+        let pool = create_connection_pool_and_migrate();
+
+        let role_based_auth_store = DieselRoleBasedAuthorizationStore::new(pool.clone());
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-1".into())
+            .with_display_name("Test Role 1".into())
+            .with_permissions(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let role = RoleBuilder::new()
+            .with_id("test-role-2".into())
+            .with_display_name("Test Role 2".into())
+            .with_permissions(vec!["x".to_string(), "y".to_string(), "z".to_string()])
+            .build()
+            .expect("Unable to build role");
+
+        role_based_auth_store
+            .add_role(role)
+            .expect("Unable to add role");
+
+        let assignment = AssignmentBuilder::new()
+            .with_identity(Identity::User("some-nonexistent-user-id".into()))
+            .with_roles(vec!["test-role-1".to_string()])
+            .build()
+            .expect("Unable to build assignment");
+
+        let res = role_based_auth_store.update_assignment(assignment);
+
+        assert!(matches!(
+            res,
+            Err(RoleBasedAuthorizationStoreError::ConstraintViolation(err))
+                if err.violation_type() == &ConstraintViolationType::NotFound
+        ));
     }
 
     /// This test verifies the following:

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
@@ -17,6 +17,7 @@ use diesel::{
     prelude::*,
 };
 
+use crate::error::{ConstraintViolationError, ConstraintViolationType};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{RoleModel, RolePermissionModel},
@@ -39,11 +40,19 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
 
         self.conn.transaction::<_, _, _>(|| {
-            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
+            let updated = update(roles::table.find(&role.id))
+                .set(roles::display_name.eq(&role.display_name))
                 .execute(self.conn)?;
 
-            update(roles::table.find(&role.id))
-                .set(roles::display_name.eq(&role.display_name))
+            if updated == 0 {
+                return Err(RoleBasedAuthorizationStoreError::ConstraintViolation(
+                    ConstraintViolationError::with_violation_type(
+                        ConstraintViolationType::NotFound,
+                    ),
+                ));
+            }
+
+            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
                 .execute(self.conn)?;
 
             insert_into(role_permissions::table)
@@ -63,11 +72,19 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
 
         self.conn.transaction::<_, _, _>(|| {
-            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
+            let updated = update(roles::table.find(&role.id))
+                .set(roles::display_name.eq(&role.display_name))
                 .execute(self.conn)?;
 
-            update(roles::table.find(&role.id))
-                .set(roles::display_name.eq(&role.display_name))
+            if updated == 0 {
+                return Err(RoleBasedAuthorizationStoreError::ConstraintViolation(
+                    ConstraintViolationError::with_violation_type(
+                        ConstraintViolationType::NotFound,
+                    ),
+                ));
+            }
+
+            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
                 .execute(self.conn)?;
 
             insert_into(role_permissions::table)

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
@@ -353,7 +353,7 @@ pub trait RoleBasedAuthorizationStore: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns a `InvalidState` error if the role does not exist.
+    /// Returns a `ConstraintViolation` error if the role does not exist.
     fn update_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError>;
 
     /// Removes a role.
@@ -395,7 +395,7 @@ pub trait RoleBasedAuthorizationStore: Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns a `InvalidState` error if the assignment does not exist.
+    /// Returns a `ConstraintViolation` error if the assignment does not exist.
     fn update_assignment(
         &self,
         assignment: Assignment,


### PR DESCRIPTION
This PR fixes an issue where an update on a nonexistent role or assignment doesn't properly report a 404 vs constraint violations.

Likewise, it fixes an issue where foreign key violations were not properly being reported as constraint violations, causing a 500 error, not a 409