### PR TITLE
Remove service state when purging a circuit

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -2644,10 +2644,10 @@ impl AdminServiceShared {
     }
 
     #[cfg(feature = "circuit-disband")]
-    /// Shutdown all services that this node was running on the disbanded circuit using the service
+    /// Stops all services that this node was running on the disbanded circuit using the service
     /// orchestrator. This may not include all services if they are not supported locally. It is
     /// expected that some services will be stopped externally.
-    pub fn shutdown_services(&mut self, circuit: &Circuit) -> Result<(), AdminSharedError> {
+    pub fn stop_services(&mut self, circuit: &Circuit) -> Result<(), AdminSharedError> {
         let orchestrator =
             self.orchestrator
                 .lock()
@@ -2670,7 +2670,7 @@ impl AdminServiceShared {
 
         // Shutdown all services the orchestrator has a factory for
         for service in services {
-            debug!("Removing service: {}", service.service_id.clone());
+            debug!("Stopping service: {}", service.service_id.clone());
             let service_definition = ServiceDefinition {
                 circuit: circuit.circuit_id.clone(),
                 service_id: service.service_id.clone(),
@@ -2678,7 +2678,7 @@ impl AdminServiceShared {
             };
 
             orchestrator
-                .shutdown_service(&service_definition)
+                .stop_service(&service_definition)
                 .map_err(|err| AdminSharedError::ServiceShutdownFailed {
                     context: format!(
                         "Unable to shutdown service {} on circuit {}",
@@ -2769,7 +2769,7 @@ impl AdminServiceShared {
             // Circuit has been disbanded: all associated services will be shut
             // down, the circuit removed from the routing table, and peer refs
             // for this circuit will be removed.
-            self.shutdown_services(circuit_proposal.get_circuit_proposal())?;
+            self.stop_services(circuit_proposal.get_circuit_proposal())?;
             // Removing the circuit from the routing table
             self.routing_table_writer
                 .remove_circuit(circuit_proposal.get_circuit_id())

--- a/libsplinter/src/orchestrator/error.rs
+++ b/libsplinter/src/orchestrator/error.rs
@@ -95,6 +95,41 @@ impl From<FactoryCreateError> for InitializeServiceError {
 }
 
 #[derive(Debug)]
+pub enum AddServiceError {
+    LockPoisoned,
+    UnknownType,
+    FactoryCreateError(Box<dyn Error + Send>),
+}
+
+impl Error for AddServiceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            AddServiceError::LockPoisoned => None,
+            AddServiceError::UnknownType => None,
+            AddServiceError::FactoryCreateError(err) => Some(&**err),
+        }
+    }
+}
+
+impl std::fmt::Display for AddServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            AddServiceError::LockPoisoned => write!(f, "internal lock poisoned"),
+            AddServiceError::UnknownType => write!(f, "service type unknown"),
+            AddServiceError::FactoryCreateError(err) => {
+                write!(f, "failed to create service factory: {}", err)
+            }
+        }
+    }
+}
+
+impl From<FactoryCreateError> for AddServiceError {
+    fn from(err: FactoryCreateError) -> Self {
+        AddServiceError::FactoryCreateError(Box::new(err))
+    }
+}
+
+#[derive(Debug)]
 pub enum ShutdownServiceError {
     LockPoisoned,
     ShutdownFailed((ServiceDefinition, Box<dyn Error + Send>)),


### PR DESCRIPTION
This PR makes updates to the scabbard service's `destroy` function to enable state LMDB files to also be removed (implemented within `ScabbardState`) and makes updates to the service orchestrator to account for this update. Mainly, this PR adds a new list of `stopped_services` within the orchestrator. This makes a greater differentiation within the orchestrator between stopping and destroying a circuit by splitting up the `shutdown_service` function, as `stop` will stop the circuit, and now `destroy` also removes the state files. This allows for circuits to be disbanded or abandoned with service functionality removed, and then the purge functionality is able to completely clean up the state pertaining to a circuit (including the state files) as the service is not _completely_ removed from the orchestrator, but rather moved into the `stopped_services`. 

Before the disband functionality used the `shutdown_service` orchestrator method, which both stopped and destroyed the services but did not remove the state LMDB files.  

This also updates the `re_initialize_services` method in the admin service to fetch all circuits from the admin store (rather than just the `Active` ones) to allow for services that have previously been stopped through disbanding or abandoning to be added back to the orchestrator so the associated services are able to be purged (meaning the service is destroyed rather than just stopped, and state LMDB files will be removed). Previous to this update, the `purge` request would fail because the orchestrator was unable to find the service because it was never created between restarts.

This ultimately can be tested by running two splinter nodes, creating then disbanding a circuit and then using the `splinter circuit purge` command to remove the circuit from the node's DB as well as any scabbard state files used by the node's associated services on the circuit that was purged. The reinitializing updates may be tested in a similar way, but by also restarting your node(s) between creating+disbanding the circuit, and then purging it. The `purge` should succeed even after a re-start.