### PR TITLE
Update RegistryError to use top level errors

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -131,10 +131,11 @@ impl AdminKeyVerifier for dyn RegistryReader {
     /// registry and the node has the given key. Otherwise, the key is not permitted.
     fn is_permitted(&self, node_id: &str, key: &[u8]) -> Result<bool, AdminKeyVerifierError> {
         let node_opt = self.fetch_node(node_id).map_err(|err| {
-            AdminKeyVerifierError::new_with_source(
-                &format!("Failed to lookup node '{}' in registry", node_id),
-                Box::new(err),
-            )
+            AdminKeyVerifierError::new(&format!(
+                "Failed to lookup node '{}' in registry: {}",
+                node_id,
+                err.to_string()
+            ))
         })?;
         Ok(match node_opt {
             Some(node) => node.has_key(&to_hex(key)),

--- a/libsplinter/src/registry/diesel/mod.rs
+++ b/libsplinter/src/registry/diesel/mod.rs
@@ -209,6 +209,7 @@ pub mod tests {
 
         assert_eq!(node, get_node_1());
 
+        #[allow(deprecated)]
         if registry.insert_node(get_node_1()).is_ok() {
             panic!("Should have returned an error because of duplicate endpoint")
         }

--- a/libsplinter/src/registry/diesel/operations/delete_node.rs
+++ b/libsplinter/src/registry/diesel/operations/delete_node.rs
@@ -32,14 +32,7 @@ where
     fn delete_node(&self, identity: &str) -> Result<Option<Node>, RegistryError> {
         self.conn.transaction(|| {
             self.fetch_node(identity).and_then(|node| {
-                delete(splinter_nodes::table.find(identity))
-                    .execute(self.conn)
-                    .map_err(|err| {
-                        RegistryError::general_error_with_source(
-                            "Failed to delete node",
-                            Box::new(err),
-                        )
-                    })?;
+                delete(splinter_nodes::table.find(identity)).execute(self.conn)?;
                 Ok(node)
             })
         })

--- a/libsplinter/src/registry/diesel/operations/fetch_node.rs
+++ b/libsplinter/src/registry/diesel/operations/fetch_node.rs
@@ -16,6 +16,7 @@
 
 use diesel::prelude::*;
 
+use crate::error::InvalidStateError;
 use crate::registry::{
     diesel::{
         models::{NodeEndpointsModel, NodeKeysModel, NodeMetadataModel, NodesModel},
@@ -41,48 +42,24 @@ where
         let node = splinter_nodes::table
             .find(identity)
             .first::<NodesModel>(self.conn)
-            .optional()
-            .map_err(|err| {
-                RegistryError::general_error_with_source(
-                    "Failed to check if node exists",
-                    Box::new(err),
-                )
-            })?;
+            .optional()?;
 
         if let Some(node) = node {
             let endpoints = splinter_nodes_endpoints::table
                 .filter(splinter_nodes_endpoints::identity.eq(identity))
-                .load::<NodeEndpointsModel>(self.conn)
-                .map_err(|err| {
-                    RegistryError::general_error_with_source(
-                        "Failed to get node endpoints",
-                        Box::new(err),
-                    )
-                })?
+                .load::<NodeEndpointsModel>(self.conn)?
                 .into_iter()
                 .map(|endpoint| endpoint.endpoint)
                 .collect::<Vec<_>>();
             let keys = splinter_nodes_keys::table
                 .filter(splinter_nodes_keys::identity.eq(identity))
-                .load::<NodeKeysModel>(self.conn)
-                .map_err(|err| {
-                    RegistryError::general_error_with_source(
-                        "Failed to get node keys",
-                        Box::new(err),
-                    )
-                })?
+                .load::<NodeKeysModel>(self.conn)?
                 .into_iter()
                 .map(|key| key.key)
                 .collect::<Vec<_>>();
             let metadata = splinter_nodes_metadata::table
                 .filter(splinter_nodes_metadata::identity.eq(identity))
-                .load::<NodeMetadataModel>(self.conn)
-                .map_err(|err| {
-                    RegistryError::general_error_with_source(
-                        "Failed to get node metadata",
-                        Box::new(err),
-                    )
-                })?;
+                .load::<NodeMetadataModel>(self.conn)?;
 
             let mut builder = NodeBuilder::new(identity)
                 .with_display_name(node.display_name)
@@ -91,7 +68,9 @@ where
             for entry in metadata {
                 builder = builder.with_metadata(entry.key, entry.value);
             }
-            Ok(Some(builder.build()?))
+            Ok(Some(builder.build().map_err(|err| {
+                RegistryError::InvalidStateError(InvalidStateError::with_message(err.to_string()))
+            })?))
         } else {
             Ok(None)
         }

--- a/libsplinter/src/registry/diesel/operations/has_node.rs
+++ b/libsplinter/src/registry/diesel/operations/has_node.rs
@@ -33,16 +33,10 @@ where
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
 {
     fn has_node(&self, identity: &str) -> Result<bool, RegistryError> {
-        splinter_nodes::table
+        Ok(splinter_nodes::table
             .find(identity)
             .first::<NodesModel>(self.conn)
             .optional()
-            .map(|opt| opt.is_some())
-            .map_err(|err| {
-                RegistryError::general_error_with_source(
-                    "Failed to check if node exists",
-                    Box::new(err),
-                )
-            })
+            .map(|opt| opt.is_some())?)
     }
 }

--- a/libsplinter/src/registry/rest_api/error.rs
+++ b/libsplinter/src/registry/rest_api/error.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains an error tht can be sent from
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::InvalidStateError;
+use crate::registry::error::RegistryError;
+
+/// Represents errors that occur with node registry operations while using the REST API
+#[derive(Debug)]
+pub enum RegistryRestApiError {
+    /// Represents errors internal to the function
+    InternalError(String),
+    /// Represent invalid node errors
+    InvalidStateError(InvalidStateError),
+}
+
+impl Error for RegistryRestApiError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RegistryRestApiError::InternalError(_) => None,
+            RegistryRestApiError::InvalidStateError(err) => Some(err),
+        }
+    }
+}
+
+impl fmt::Display for RegistryRestApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RegistryRestApiError::InternalError(msg) => write!(f, "{}", msg),
+            RegistryRestApiError::InvalidStateError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl From<RegistryError> for RegistryRestApiError {
+    fn from(err: RegistryError) -> Self {
+        match err {
+            RegistryError::InvalidStateError(err) => RegistryRestApiError::InvalidStateError(err),
+            _ => RegistryRestApiError::InternalError(err.to_string()),
+        }
+    }
+}

--- a/libsplinter/src/registry/rest_api/mod.rs
+++ b/libsplinter/src/registry/rest_api/mod.rs
@@ -16,6 +16,7 @@
 
 #[cfg(feature = "rest-api-actix")]
 mod actix;
+mod error;
 mod resources;
 
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};

--- a/libsplinter/src/registry/unified.rs
+++ b/libsplinter/src/registry/unified.rs
@@ -239,7 +239,7 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::registry::InvalidNodeError;
+    use crate::error::InvalidStateError;
 
     fn new_node(id: &str, endpoint: &str, metadata: &[(&str, &str)]) -> Node {
         let mut builder = Node::builder(id).with_endpoint(endpoint).with_key("abcd");
@@ -721,11 +721,11 @@ mod test {
                 inner.insert(node.identity.clone(), node);
                 Ok(())
             } else {
-                Err(RegistryError::InvalidNode(
-                    InvalidNodeError::InvalidIdentity(
-                        node.identity,
-                        "Node does not exist in the registry".to_string(),
-                    ),
+                Err(RegistryError::InvalidStateError(
+                    InvalidStateError::with_message(format!(
+                        "Node does not exist in the registry: {}",
+                        node.identity
+                    )),
                 ))
             }
         }


### PR DESCRIPTION
Replaces the existing error types with InternalError,
InvalidState, ConstraintViolationError, and
ResourceTemporarilyUnavailableError.

Also adds a error that can be used in the REST API routes.
The Registry error can no longer be used in a web::block,
because Box<dyn Error> is guaranteed to be Send. The
new error will conver the RegistryError to either InvalidState,
which is required for returning a BadRequest, and
InternalError that will be logged and InternalServerError
is returned.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>