### PR TITLE
Example splinterd config cleanup for default database value change

### DIFF
--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -88,9 +88,10 @@ tls_rest_api_key = "/etc/splinter/node_012/certs/rest_api.key"
 # (default [{network_endpoints}])
 advertised_endpoints = ["tcps://127.0.0.1:8044"]
 
-# Endpoint used for database communication
-# (default "127.0.0.1:5432")
-database = "127.0.0.1:5432"
+# Endpoint used for database communication, either a PostgreSQL URI or SQLite
+# connection string
+# (default "/var/lib/splinter_state.db")
+database = "/var/lib/splinter_state.db"
 
 # Read-only registry files
 # (default []; empty list)

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -44,6 +44,7 @@ rest_api_endpoint = "127.0.0.1:8080"
 # (default []; empty list)
 peers = []
 
+# Deprecated, use `database` instead
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory".
 # (default "yaml")

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -46,6 +46,7 @@ peers = [
     "127.0.0.1:8044"
 ]
 
+# Deprecated, use `database` instead
 # The type of storage that should be used to store circuit state. Option are
 # currently "yaml" or "memory".
 # (default "yaml")

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -64,9 +64,10 @@ tls_cert_dir = "/etc/splinter/node_345/certs"
 # (default [{network_endpoints}])
 advertised_endpoints = ["tcps://127.0.0.1:8046"]
 
-# Endpoint used for database communication
-# (default "127.0.0.1:5432")
-database = "127.0.0.1:5433"
+# Endpoint used for database communication, either a PostgreSQL URI or SQLite
+# connection string
+# (default "/var/lib/splinter_state.db")
+database = "/var/lib/splinter_state.db"
 
 # Read-only registry files
 # (default []; empty list)

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -1183,10 +1183,11 @@ mod tests {
         );
         #[cfg(feature = "database")]
         // The `DefaultPartialConfigBuilder` is the only config with a value for `database` (source
-        // should be `Default`).
+        // should be `Default`). Should have default state file name with `EnvPartialConfigBuilder`
+        // value for `state_dir`.
         assert_eq!(
             (final_config.database(), final_config.database_source()),
-            ("127.0.0.1:5432", &ConfigSource::Default)
+            ("test/state/splinter_state.db", &ConfigSource::Default)
         );
         // The `DefaultPartialConfigBuilder` is the only config with a value for
         // `registry_auto_refresh` (source should be `Default`).


### PR DESCRIPTION
This was missed when the change was made. Also fixes a test that is ignored so the update was missed. 