### PR TITLE
Add new memory features that depends on sqlite

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -83,6 +83,7 @@ stable = [
     "cylinder-jwt",
     "default",
     "events",
+    "memory",
     "oauth",
     "postgres",
     "registry",
@@ -141,6 +142,7 @@ circuit-template = ["admin-service", "glob"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
+memory = ["sqlite"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 oauth-inflight-request-store-postgres = ["oauth", "postgres"]
 postgres = ["diesel/postgres", "diesel_migrations"]

--- a/libsplinter/src/store/memory.rs
+++ b/libsplinter/src/store/memory.rs
@@ -14,7 +14,6 @@
 
 //! Implementation of a `StoreFactory` for in memory
 
-#[cfg(feature = "sqlite")]
 use diesel::{
     r2d2::{ConnectionManager, Pool},
     sqlite::SqliteConnection,
@@ -114,7 +113,7 @@ impl StoreFactory for MemoryStoreFactory {
         Box::new(self.biome_oauth_user_session_store.clone())
     }
 
-    #[cfg(all(feature = "admin-service", feature = "sqlite"))]
+    #[cfg(feature = "admin-service")]
     fn get_admin_service_store(&self) -> Box<dyn crate::admin::store::AdminServiceStore> {
         let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
         let pool = Pool::builder()
@@ -132,11 +131,6 @@ impl StoreFactory for MemoryStoreFactory {
         ))
     }
 
-    #[cfg(all(feature = "admin-service", not(feature = "sqlite")))]
-    fn get_admin_service_store(&self) -> Box<dyn crate::admin::store::AdminServiceStore> {
-        unimplemented!()
-    }
-
     #[cfg(feature = "oauth")]
     fn get_oauth_inflight_request_store(
         &self,
@@ -144,7 +138,7 @@ impl StoreFactory for MemoryStoreFactory {
         Box::new(self.inflight_request_store.clone())
     }
 
-    #[cfg(all(feature = "registry-database", feature = "sqlite"))]
+    #[cfg(feature = "registry-database")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
         let pool = Pool::builder()
@@ -160,12 +154,7 @@ impl StoreFactory for MemoryStoreFactory {
         Box::new(crate::registry::DieselRegistry::new(pool))
     }
 
-    #[cfg(all(feature = "registry-database", not(feature = "sqlite")))]
-    fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
-        unimplemented!()
-    }
-
-    #[cfg(all(feature = "authorization", feature = "sqlite"))]
+    #[cfg(feature = "authorization")]
     fn get_role_based_authorization_store(
         &self,
     ) -> Box<dyn crate::rest_api::auth::authorization::rbac::store::RoleBasedAuthorizationStore>
@@ -182,13 +171,6 @@ impl StoreFactory for MemoryStoreFactory {
         .expect("Failed to run migrations");
 
         Box::new(crate::rest_api::auth::authorization::rbac::store::DieselRoleBasedAuthorizationStore::new(pool))
-    }
-
-    #[cfg(all(feature = "authorization", not(feature = "sqlite")))]
-    fn get_role_based_authorization_store(
-        &self,
-    ) -> Box<dyn crate::rest_api::auth::roles::store::RoleBasedAuthorizationStore> {
-        unimplemented!()
     }
 
     #[cfg(feature = "biome-profile")]

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -14,7 +14,7 @@
 
 //! Contains a `StoreFactory` trait, which is an abstract factory for building stores
 //! backed by a single storage mechanism (e.g. database)
-
+#[cfg(feature = "memory")]
 pub mod memory;
 #[cfg(feature = "postgres")]
 pub mod postgres;
@@ -85,6 +85,7 @@ pub fn create_store_factory(
     connection_uri: ConnectionUri,
 ) -> Result<Box<dyn StoreFactory>, InternalError> {
     match connection_uri {
+        #[cfg(feature = "memory")]
         ConnectionUri::Memory => Ok(Box::new(memory::MemoryStoreFactory::new())),
         #[cfg(feature = "postgres")]
         ConnectionUri::Postgres(url) => {
@@ -122,6 +123,7 @@ pub fn create_store_factory(
 
 /// The possible connection types and identifiers for a `StoreFactory`
 pub enum ConnectionUri {
+    #[cfg(feature = "memory")]
     Memory,
     #[cfg(feature = "postgres")]
     Postgres(String),
@@ -134,6 +136,7 @@ impl FromStr for ConnectionUri {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            #[cfg(feature = "memory")]
             "memory" => Ok(ConnectionUri::Memory),
             #[cfg(feature = "postgres")]
             _ if s.starts_with("postgres://") => Ok(ConnectionUri::Postgres(s.into())),

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -57,6 +57,7 @@ path = "../libsplinter"
 features = [
   "admin-service",
   "cylinder-jwt",
+  "memory",
   "registry",
   "registry-remote",
   "rest-api",


### PR DESCRIPTION
Many memory implementation of stores are sqlite
stores using :memory: as the connection string. Adding
this feature allows the crate to enforce that sqlite
will be available when using the memory implementations
from the StoreFactory and the unimplemented!()
implementation used if sqlite was not available can
be removed.

The memory feature is added as stable in libsplinter
and pulled in by splinterd.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>