### PR TITLE
Add 'schema' to circuit version to clarify meaning

### DIFF
--- a/cli/man/splinter-circuit-show.1.md
+++ b/cli/man/splinter-circuit-show.1.md
@@ -84,7 +84,7 @@ $ splinter circuit show 01234-ABCDE \
 Proposal to create: 01234-ABCDE
     Display Name: -
     Circuit Status: Active
-    Version: 2
+    Schema Version: 2
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)
@@ -119,7 +119,7 @@ $ splinter circuit show 01234-ABCDE \
 Proposal to disband: 56789-ABCDE
     Display Name: Circuit1
     Circuit Status: Disbanded
-    Version: 2
+    Schema Version: 2
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -266,7 +266,7 @@ impl fmt::Display for CircuitSlice {
         }
 
         display_string += &format!(
-            "Version: {}\n    Management Type: {}\n",
+            "Schema Version: {}\n    Management Type: {}\n",
             self.circuit_version, self.management_type
         );
 
@@ -351,7 +351,7 @@ impl fmt::Display for ProposalSlice {
         }
 
         display_string += &format!(
-            "Version: {}\n    Management Type: {}\n",
+            "Schema Version: {}\n    Management Type: {}\n",
             self.circuit.circuit_version, self.circuit.management_type
         );
 

--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -112,7 +112,7 @@ message Circuit {
     // Human-readable display name for the circuit
     string display_name = 11;
 
-    // The version of the circuit
+    // The schema version of the circuit
     int32 circuit_version = 12;
 
     // The status of the circuit

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1901,7 +1901,7 @@ impl AdminServiceShared {
                 // verify that the circuit version is supported
                 if circuit.get_circuit_version() > CIRCUIT_PROTOCOL_VERSION {
                     return Err(AdminSharedError::ValidationFailed(format!(
-                        "Proposed circuit's version is unsupported: {}",
+                        "Proposed circuit's schema version is unsupported: {}",
                         circuit.get_circuit_version()
                     )));
                 }
@@ -1925,7 +1925,8 @@ impl AdminServiceShared {
                     0 => (),
                     _ => {
                         return Err(AdminSharedError::ValidationFailed(
-                            "Proposed circuit version is not supported by protocol 1".to_string(),
+                            "Proposed circuit schema version is not supported by protocol 1"
+                                .to_string(),
                         ))
                     }
                 }
@@ -2314,7 +2315,7 @@ impl AdminServiceShared {
 
         if stored_circuit.circuit_version() < CIRCUIT_PROTOCOL_VERSION {
             return Err(AdminSharedError::ValidationFailed(format!(
-                "Attempting to disband a circuit with version {}, must be {}",
+                "Attempting to disband a circuit with schema version {}, must be {}",
                 stored_circuit.circuit_version(),
                 CIRCUIT_PROTOCOL_VERSION,
             )));
@@ -2400,7 +2401,7 @@ impl AdminServiceShared {
 
         if stored_circuit.circuit_version() < CIRCUIT_PROTOCOL_VERSION {
             return Err(AdminSharedError::ValidationFailed(format!(
-                "Attempting to purge a circuit with version {}, must be {}",
+                "Attempting to purge a circuit with schema version {}, must be {}",
                 stored_circuit.circuit_version(),
                 CIRCUIT_PROTOCOL_VERSION,
             )));
@@ -4960,7 +4961,9 @@ mod tests {
         if let Ok(()) =
             shared.validate_disband_circuit(&setup_v1_test_circuit(), PUB_KEY, "node_a", 1)
         {
-            panic!("Should have been invalid because the admin service protocol version is 1");
+            panic!(
+                "Should have been invalid because the admin service protocol schema version is 1"
+            );
         }
 
         shutdown(mesh, cm, pm);
@@ -5023,7 +5026,9 @@ mod tests {
             "node_a",
             ADMIN_SERVICE_PROTOCOL_VERSION,
         ) {
-            panic!("Should have been invalid because the circuit being disbanded is version 1");
+            panic!(
+                "Should have been invalid because the circuit being disbanded is schema version 1"
+            );
         }
 
         shutdown(mesh, cm, pm);
@@ -5455,7 +5460,9 @@ mod tests {
             .expect("unable to add circuit to store");
 
         if let Ok(()) = shared.validate_purge_request("01234-ABCDE", PUB_KEY, "node_a", 1) {
-            panic!("Should have been invalid because the admin service protocol version is 1");
+            panic!(
+                "Should have been invalid because the admin service protocol schema version is 1"
+            );
         }
 
         shutdown(mesh, cm, pm);
@@ -5522,7 +5529,9 @@ mod tests {
             "node_a",
             ADMIN_SERVICE_PROTOCOL_VERSION,
         ) {
-            panic!("Should have been invalid because the circuit being disbanded is version 1");
+            panic!(
+                "Should have been invalid because the circuit being disbanded is schema version 1"
+            );
         }
 
         shutdown(mesh, cm, pm);


### PR DESCRIPTION
The word 'schema' has been added to the CLI, man pages,
and code comments to clarify that circuit version refers
to the schema of the data, not how many times the
circuit has been updated.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>