### PR TITLE
Convert identity_type DB enum type

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-09-042200_update-identity-enum/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-09-042200_update-identity-enum/down.sql
@@ -1,0 +1,33 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE identities
+   RENAME COLUMN identity_type TO id_type_enum;
+
+ALTER TABLE identities
+   ADD COLUMN identity_type INTEGER;
+
+UPDATE identities SET identity_type = (case
+                      when id_type_enum = 'key' then 1
+                      when id_type_enum = 'user' then 2
+                      -- default to user, as this is the arbitrary value
+                      else 2
+                    end);
+
+ALTER TABLE identities
+    ALTER COLUMN identity_type set NOT NULL;
+
+ALTER TABLE identities
+    DROP COLUMN id_type_enum;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-09-042200_update-identity-enum/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-02-09-042200_update-identity-enum/up.sql
@@ -1,0 +1,21 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE identity_type AS ENUM ('key', 'user');
+
+ALTER TABLE identities
+ALTER COLUMN identity_type
+SET DATA TYPE identity_type
+USING (enum_range(null::identity_type))[identity_type::int];

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-09-042200_update-identity-enum/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-09-042200_update-identity-enum/down.sql
@@ -1,0 +1,32 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE identities RENAME TO _identities_old;
+
+CREATE TABLE identities (
+    identity      TEXT    PRIMARY KEY,
+    identity_type INTEGER NOT NULL
+);
+
+INSERT INTO identities (identity, identity_type)
+  SELECT identity, (case
+                      when 'key' then 1
+                      when 'user' then 2
+                      -- default to user, as this is the arbitrary value
+                      else 2
+                    end)
+  FROM _identities_old;
+
+DROP TABLE _identities_old;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-09-042200_update-identity-enum/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-02-09-042200_update-identity-enum/up.sql
@@ -1,0 +1,32 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE identities RENAME TO _identities_old;
+
+CREATE TABLE identities (
+    identity      TEXT PRIMARY KEY,
+    identity_type TEXT CHECK( identity_type IN ('key','user') ) NOT NULL
+);
+
+INSERT INTO identities (identity, identity_type)
+  SELECT identity, (case
+                      when 1 then 'key'
+                      when 2 then 'user'
+                      -- default to user, as this is the arbitrary value
+                      else 'user'
+                    end)
+  FROM _identities_old;
+
+DROP TABLE _identities_old;

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assigned_roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assigned_roles.rs
@@ -18,7 +18,10 @@ use diesel::prelude::*;
 
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
-        models::{AssignmentModel, IdentityModel, RoleModel, RolePermissionModel},
+        models::{
+            AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping, RoleModel,
+            RolePermissionModel,
+        },
         schema::{identities, roles},
     },
     Identity, Role, RoleBasedAuthorizationStoreError,
@@ -39,6 +42,8 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    <C as diesel::Connection>::Backend: diesel::types::HasSqlType<IdentityModelTypeMapping>,
+    IdentityModelType: diesel::deserialize::FromSql<IdentityModelTypeMapping, C::Backend>,
 {
     fn get_assigned_roles(
         &self,

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assignment.rs
@@ -18,7 +18,7 @@ use diesel::prelude::*;
 
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
-        models::{AssignmentModel, IdentityModel},
+        models::{AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping},
         schema::identities,
     },
     Assignment, Identity, RoleBasedAuthorizationStoreError,
@@ -39,6 +39,8 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    <C as diesel::Connection>::Backend: diesel::types::HasSqlType<IdentityModelTypeMapping>,
+    IdentityModelType: diesel::deserialize::FromSql<IdentityModelTypeMapping, C::Backend>,
 {
     fn get_assignment(
         &self,

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_assignments.rs
@@ -18,7 +18,7 @@ use diesel::prelude::*;
 
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
-        models::{AssignmentModel, IdentityModel},
+        models::{AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping},
         schema::identities,
     },
     Assignment, RoleBasedAuthorizationStoreError,
@@ -38,6 +38,8 @@ where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
     i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+    <C as diesel::Connection>::Backend: diesel::types::HasSqlType<IdentityModelTypeMapping>,
+    IdentityModelType: diesel::deserialize::FromSql<IdentityModelTypeMapping, C::Backend>,
 {
     fn list_assignments(
         &self,

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_assignment.rs
@@ -15,7 +15,10 @@
 use diesel::{dsl::delete, prelude::*};
 
 use crate::rest_api::auth::authorization::rbac::store::{
-    diesel::schema::{assignments, identities},
+    diesel::{
+        models::IdentityModelTypeMapping,
+        schema::{assignments, identities},
+    },
     Identity, RoleBasedAuthorizationStoreError,
 };
 
@@ -33,6 +36,7 @@ impl<'a, C> RoleBasedAuthorizationStoreRemoveAssignment
 where
     C: diesel::Connection,
     String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    <C as diesel::Connection>::Backend: diesel::types::HasSqlType<IdentityModelTypeMapping>,
 {
     fn remove_assignment(
         &self,

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/schema.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/schema.rs
@@ -32,7 +32,9 @@ allow_tables_to_appear_in_same_query!(roles, role_permissions);
 table! {
     identities (identity) {
         identity -> Text,
-        identity_type -> SmallInt,
+        identity_type ->
+            // the macro output can't find this type if it isn't fully qualified.
+            crate::rest_api::auth::authorization::rbac::store::diesel::models::IdentityModelTypeMapping,
     }
 }
 


### PR DESCRIPTION
This change converts the data type on the columns for `identity_type` to an enum value.  In SQLite, this is a string with a check. In PostgreSQL, this is an actual enum type.  Both of these require a bit of tricky transformations when dealing with custom types, but the result is both a user-friendly query-able value (a readable string in the column vs an int) and strongly-typed values to and from the database.

# Testing

## Start a postgres instance:

```
docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres
```

## Setup a local splinter node

### Build and configure your environment:

```
$ cargo build --manifest-path cli/Cargo.toml --features experimental
$ cargo build --manifest-path splinterd/Cargo.toml --features experimental
$ export PATH=target/debug:$PATH
$ export SPLINTER_HOME=/tmp/splinter 
```

These operations for setup can be done in one terminal.

First, initialize your splinter instance:

```
$ splinter cert generate
$ splinter database migrate -C postgres://postgres:mypassword@localhost:5432/splinter
```

Also, generate a key and add it to the allow_keys file:
```
$ splinter keygen
$ cat ~/.cylinder/keys/$USER.pub >> /tmp/splinter/data/allow_keys
```

Start your splinter node:
```
$ splinterd --tls-insecure --enable-biome -vv --rest-api-endpoint http://127.0.0.1:8080 \
    --database postgres://postgres:mypassword@localhost:5432/splinter
```

Follow the remainder of the test instructions from #1171. 

