### PR TITLE
Add threading::shutdown module

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -115,6 +115,7 @@ experimental = [
     "role-based-authorization-store-postgres",
     "service-arg-validation",
     "service-network",
+    "shutdown",
     "ws-transport",
     "zmq-transport",
 ]
@@ -161,6 +162,7 @@ rest-api-cors = []
 role-based-authorization-store-postgres = ["authorization", "postgres"]
 service-arg-validation = []
 service-network = []
+shutdown = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]
 store-factory = []
 ws-transport = ["tungstenite"]

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -90,7 +90,7 @@ pub mod service;
 pub mod sets;
 #[cfg(feature = "store-factory")]
 pub mod store;
-mod threading;
+pub mod threading;
 pub mod transport;
 
 #[cfg(feature = "rest-api")]

--- a/libsplinter/src/threading/mod.rs
+++ b/libsplinter/src/threading/mod.rs
@@ -14,5 +14,7 @@
 
 //! This module will contain components that will be used to support different threading models
 
-pub mod error;
-pub mod pacemaker;
+pub(crate) mod error;
+pub(crate) mod pacemaker;
+#[cfg(feature = "shutdown")]
+pub mod shutdown;

--- a/libsplinter/src/threading/shutdown.rs
+++ b/libsplinter/src/threading/shutdown.rs
@@ -1,0 +1,83 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits and functions related to shutting down components.
+
+use std::time::Duration;
+
+use crate::error::InternalError;
+
+// The value of this default timeout seemed appropriate for a maximum shutdown duration during
+// tests, but is otherwise arbitrary.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `ShutdownHandle` is a trait which defines an interface for shutting down components which have
+/// threads. It may also be used on non-threaded components which require cleanup at the end of
+/// their lifecycle.
+///
+/// Two functions are defined which correspond to a structured two-phase shutdown sequence. The
+/// first is `signal_shutdown` which instructs a component to begin the process of shutting down.
+/// The second is `wait_for_shutdown` which will wait for shutdown to be complete; this typically
+/// involves joining threads.
+///
+/// If multiple components are being shutdown, call `signal_shutdown` on all componets that can
+/// safely shutdown in parallel, then call `wait_for_shutdown` on all of the components. The length
+/// of time spent shutting down will be approximately the time of the slowest component.
+pub trait ShutdownHandle {
+    /// Instructs the component to begin shutting down.
+    ///
+    /// For components with treads, this should break out of any loops and ready the threads for
+    /// being joined.
+    fn signal_shutdown(&mut self);
+
+    /// Waits until the the component has completely shutdown, or until timeout.
+    ///
+    /// For components with threads, the threads should be joined during the call to
+    /// `wait_for_shutdown`.
+    ///
+    /// Because of technical limitations in some underlying implementations, the duration of the
+    /// call may take much longer than the `timeout` value provided.
+    fn wait_for_shutdown(&mut self, timeout: Duration) -> Result<(), InternalError>;
+}
+
+/// Calls `signal_shutdown` and `wait_for_shutdown` on the provided `ShutdownHandle`s.
+///
+/// Any errors which occur will be translated into an `InternalError`, and any source information
+/// will be lost. Thus, robust implementations will prefer to implement a variant of this function
+/// themselves. However, this simple version is extremely useful in situations such as testing.
+pub fn shutdown(mut handles: Vec<Box<dyn ShutdownHandle>>) -> Result<(), InternalError> {
+    for handle in handles.iter_mut() {
+        handle.signal_shutdown();
+    }
+
+    let mut errors: Vec<InternalError> = Vec::new();
+    for handle in handles.iter_mut() {
+        if let Err(err) = handle.wait_for_shutdown(DEFAULT_TIMEOUT) {
+            errors.push(err);
+        }
+    }
+
+    match errors.len() {
+        0 => Ok(()),
+        1 => Err(errors.remove(0)),
+        _ => Err(InternalError::with_message(format!(
+            "Multiple errors occurred during shutdown: {}",
+            errors
+                .into_iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))),
+    }
+}


### PR DESCRIPTION
A new ShutdownHandle trait is defined here. Anything which runs a thread
will need to implement ShutdownHandle in the future, which will
standardize libsplinter's approach to shutdown (a.k.a. joining threads).

A shutdown function is defined which may be used to initiate and handle
shutdown.

This approach differs from some of the current code in libsplinter which
defines separate traits for signaling shutdown and waiting for shutdown.
The primary reason for joining them together in ShutdownHandle is so
that code like that in the shutdown() function can be written. This
places some new constraints on the implementations, which must now
provide both on a single struct.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>