### PR TITLE
Add AdminService builder

### DIFF
--- a/libsplinter/src/admin/service/builder.rs
+++ b/libsplinter/src/admin/service/builder.rs
@@ -1,0 +1,244 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for the AdminService
+
+#[cfg(feature = "service-arg-validation")]
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use cylinder::Verifier as SignatureVerifier;
+
+use crate::admin::store::AdminServiceStore;
+use crate::circuit::routing::RoutingTableWriter;
+use crate::error::InvalidStateError;
+use crate::keys::KeyPermissionManager;
+use crate::orchestrator::ServiceOrchestrator;
+use crate::peer::PeerManagerConnector;
+#[cfg(feature = "service-arg-validation")]
+use crate::service::validation::ServiceArgValidator;
+
+use super::shared::AdminServiceShared;
+use super::{admin_service_id, AdminKeyVerifier, AdminService};
+
+const DEFAULT_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
+
+/// AdminService builder.
+///
+/// This builder constructs an AdminService.  The Admin service created is prepared for use in a
+/// ServiceProcessor.  It is not started once built, but must be started via the Service::start
+/// method.
+#[derive(Default)]
+pub struct AdminServiceBuilder {
+    node_id: Option<String>,
+    orchestrator: Option<ServiceOrchestrator>,
+    #[cfg(feature = "service-arg-validation")]
+    service_arg_validators: HashMap<String, Box<dyn ServiceArgValidator + Send>>,
+    peer_connector: Option<PeerManagerConnector>,
+    admin_store: Option<Box<dyn AdminServiceStore>>,
+    signature_verifier: Option<Box<dyn SignatureVerifier>>,
+    key_verifier: Option<Box<dyn AdminKeyVerifier>>,
+    key_permission_manager: Option<Box<dyn KeyPermissionManager>>,
+    coordinator_timeout: Option<Duration>,
+    routing_table_writer: Option<Box<dyn RoutingTableWriter>>,
+    #[cfg(feature = "admin-service-event-store")]
+    event_store: Option<Box<dyn AdminServiceStore>>,
+}
+
+impl AdminServiceBuilder {
+    /// Constructs a new AdminServiceBuilder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the node for the service.
+    pub fn with_node_id(mut self, node_id: String) -> Self {
+        self.node_id = Some(node_id);
+        self
+    }
+
+    /// Sets the service orchestrator.
+    pub fn with_service_orchestrator(mut self, orchestrator: ServiceOrchestrator) -> Self {
+        self.orchestrator = Some(orchestrator);
+        self
+    }
+
+    /// Sets the service argument validators.
+    ///
+    /// The service argument validators are mapped by service type.
+    #[cfg(feature = "service-arg-validation")]
+    pub fn with_service_arg_validators(
+        mut self,
+        service_arg_validators: HashMap<String, Box<dyn ServiceArgValidator + Send>>,
+    ) -> Self {
+        self.service_arg_validators = service_arg_validators;
+        self
+    }
+
+    /// Sets the peer manager connector.
+    pub fn with_peer_manager_connector(mut self, peer_connector: PeerManagerConnector) -> Self {
+        self.peer_connector = Some(peer_connector);
+        self
+    }
+
+    /// Sets the admin service store instance.
+    pub fn with_admin_service_store(
+        mut self,
+        admin_service_store: Box<dyn AdminServiceStore>,
+    ) -> Self {
+        self.admin_store = Some(admin_service_store);
+        self
+    }
+
+    /// Sets the signature verifier instance.
+    pub fn with_signature_verifier(
+        mut self,
+        signature_verifier: Box<dyn SignatureVerifier>,
+    ) -> Self {
+        self.signature_verifier = Some(signature_verifier);
+        self
+    }
+
+    /// Sets the admin key verifier instance.
+    pub fn with_admin_key_verifier(
+        mut self,
+        admin_key_verifier: Box<dyn AdminKeyVerifier>,
+    ) -> Self {
+        self.key_verifier = Some(admin_key_verifier);
+        self
+    }
+
+    /// Sets the key permission manager instance.
+    pub fn with_key_permission_manager(
+        mut self,
+        key_permission_manager: Box<dyn KeyPermissionManager>,
+    ) -> Self {
+        self.key_permission_manager = Some(key_permission_manager);
+        self
+    }
+
+    /// Sets the coordinator timeout for the two-phase commit consensus engine.
+    pub fn with_coordinator_timeout(mut self, coordinator_timeout: Duration) -> Self {
+        self.coordinator_timeout = Some(coordinator_timeout);
+        self
+    }
+
+    /// Sets the routing table writer instance.
+    pub fn with_routing_table_writer(
+        mut self,
+        routing_table_writer: Box<dyn RoutingTableWriter>,
+    ) -> Self {
+        self.routing_table_writer = Some(routing_table_writer);
+        self
+    }
+
+    #[cfg(feature = "admin-service-event-store")]
+    /// Sets the admin event store instance.
+    pub fn with_admin_event_store(mut self, event_store: Box<dyn AdminServiceStore>) -> Self {
+        self.event_store = Some(event_store);
+
+        self
+    }
+
+    /// Constructs the AdminServce.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [InvalidStateError] if any required properties are missing.
+    pub fn build(self) -> Result<super::AdminService, InvalidStateError> {
+        let coordinator_timeout = self
+            .coordinator_timeout
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_COORDINATOR_TIMEOUT));
+
+        let orchestrator = self.orchestrator.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires a service_orchestrator".into(),
+            )
+        })?;
+        let orchestrator = Arc::new(Mutex::new(orchestrator));
+
+        let node_id = self.node_id.ok_or_else(|| {
+            InvalidStateError::with_message("An admin service requires a node_id".into())
+        })?;
+
+        #[cfg(feature = "service-arg-validation")]
+        let service_arg_validators = self.service_arg_validators;
+
+        let admin_store = self.admin_store.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires an admin_service_store".into(),
+            )
+        })?;
+
+        let peer_connector = self.peer_connector.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires a peer_manager_connector".into(),
+            )
+        })?;
+
+        let signature_verifier = self.signature_verifier.ok_or_else(|| {
+            InvalidStateError::with_message("An admin service requires a signature_verifier".into())
+        })?;
+
+        let key_verifier = self.key_verifier.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires an admin_key_verifier".into(),
+            )
+        })?;
+        let key_permission_manager = self.key_permission_manager.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires a key_permission_manager".into(),
+            )
+        })?;
+
+        let routing_table_writer = self.routing_table_writer.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "An admin service requires an routing_table_writer".into(),
+            )
+        })?;
+
+        #[cfg(feature = "admin-service-event-store")]
+        let admin_event_store = self.event_store.ok_or_else(|| {
+            InvalidStateError::with_message("An admin service requires an admin_event_store".into())
+        })?;
+
+        let service_id = admin_service_id(&node_id);
+        let admin_service_shared = Arc::new(Mutex::new(AdminServiceShared::new(
+            node_id.clone(),
+            orchestrator.clone(),
+            #[cfg(feature = "service-arg-validation")]
+            service_arg_validators,
+            peer_connector.clone(),
+            admin_store,
+            signature_verifier,
+            key_verifier,
+            key_permission_manager,
+            routing_table_writer,
+            #[cfg(feature = "admin-service-event-store")]
+            admin_event_store,
+        )));
+
+        Ok(AdminService {
+            service_id,
+            node_id,
+            admin_service_shared,
+            orchestrator,
+            coordinator_timeout,
+            consensus: None,
+            peer_connector,
+            peer_notification_run_state: None,
+        })
+    }
+}

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
 mod consensus;
 pub(crate) mod error;
 #[cfg(not(feature = "admin-service-event-store"))]
@@ -58,6 +59,7 @@ use self::error::{AdminError, Sha256Error};
 use self::proposal_store::{AdminServiceProposals, ProposalStore};
 use self::shared::AdminServiceShared;
 
+pub use self::builder::AdminServiceBuilder;
 pub use self::error::AdminKeyVerifierError;
 pub use self::error::AdminServiceError;
 pub use self::error::AdminSubscriberError;

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -1027,22 +1027,26 @@ mod tests {
         #[cfg(feature = "admin-service-event-store")]
         let event_store = store.clone_boxed();
 
-        let mut admin_service = AdminService::new(
-            "test-node".into(),
-            orchestrator,
-            #[cfg(feature = "service-arg-validation")]
-            HashMap::new(),
-            peer_connector,
-            store,
-            signature_verifier,
-            Box::new(MockAdminKeyVerifier),
-            Box::new(AllowAllKeyPermissionManager),
-            None,
-            writer,
-            #[cfg(feature = "admin-service-event-store")]
-            event_store,
-        )
-        .expect("Service should have been created correctly");
+        let mut admin_service_builder = AdminServiceBuilder::new();
+
+        admin_service_builder = admin_service_builder
+            .with_node_id("test-node".into())
+            .with_service_orchestrator(orchestrator)
+            .with_peer_manager_connector(peer_connector)
+            .with_admin_service_store(store)
+            .with_signature_verifier(signature_verifier)
+            .with_admin_key_verifier(Box::new(MockAdminKeyVerifier))
+            .with_key_permission_manager(Box::new(AllowAllKeyPermissionManager))
+            .with_routing_table_writer(writer);
+
+        #[cfg(feature = "admin-service-event-store")]
+        {
+            admin_service_builder = admin_service_builder.with_admin_event_store(event_store);
+        }
+
+        let mut admin_service = admin_service_builder
+            .build()
+            .expect("Service should have been created correctly");
 
         let (tx, rx) = channel();
         admin_service

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -230,7 +230,7 @@ impl AdminService {
                 routing_table_writer,
                 #[cfg(feature = "admin-service-event-store")]
                 event_store,
-            )?)),
+            ))),
             orchestrator,
             coordinator_timeout,
             consensus: None,

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -263,13 +263,13 @@ impl AdminServiceShared {
         #[cfg(feature = "admin-service-event-store")] admin_service_event_store: Box<
             dyn AdminServiceStore,
         >,
-    ) -> Result<Self, ServiceError> {
+    ) -> Self {
         #[cfg(not(feature = "admin-service-event-store"))]
         let event_mailbox = Mailbox::new(DurableBTreeSet::new_boxed_with_bound(
             std::num::NonZeroUsize::new(DEFAULT_IN_MEMORY_EVENT_LIMIT).unwrap(),
         ));
 
-        Ok(AdminServiceShared {
+        AdminServiceShared {
             node_id,
             network_sender: None,
             uninitialized_circuits: Default::default(),
@@ -299,7 +299,7 @@ impl AdminServiceShared {
             event_store: admin_service_event_store,
             #[cfg(feature = "circuit-disband")]
             pending_consensus_disbanded_circuits: HashMap::new(),
-        })
+        }
     }
 
     pub fn node_id(&self) -> &str {
@@ -2994,8 +2994,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let service_sender = MockServiceNetworkSender::new();
         shared.set_network_sender(Some(Box::new(service_sender.clone())));
@@ -3128,8 +3127,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let service_sender = MockServiceNetworkSender::new();
         shared.set_network_sender(Some(Box::new(service_sender.clone())));
@@ -3229,8 +3227,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
 
         if let Err(err) = admin_shared.validate_create_circuit(
@@ -3275,8 +3272,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
 
         if let Ok(()) = admin_shared.validate_create_circuit(&circuit, PUB_KEY, "node_a", 1) {
@@ -3315,8 +3311,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
 
         if let Ok(_) = admin_shared.validate_create_circuit(
@@ -3359,8 +3354,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
 
         let pub_key = (0u8..50).collect::<Vec<_>>();
@@ -3414,8 +3408,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut service_bad = SplinterService::new();
@@ -3464,8 +3457,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut service_bad = SplinterService::new();
@@ -3517,8 +3509,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut service_ = SplinterService::new();
@@ -3567,8 +3558,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut service_ = SplinterService::new();
@@ -3617,8 +3607,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut service_a = SplinterService::new();
@@ -3672,8 +3661,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
         circuit.set_roster(RepeatedField::from_vec(vec![]));
 
@@ -3716,8 +3704,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_members(RepeatedField::from_vec(vec![]));
@@ -3762,8 +3749,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_b = SplinterNode::new();
@@ -3812,8 +3798,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_a = SplinterNode::new();
@@ -3869,8 +3854,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_a = SplinterNode::new();
@@ -3926,8 +3910,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_circuit_id("".to_string());
@@ -3971,8 +3954,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_circuit_id("invalid_circuit_id".to_string());
@@ -4016,8 +3998,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_a = SplinterNode::new();
@@ -4069,8 +4050,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_a = SplinterNode::new();
@@ -4122,8 +4102,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         let mut node_a = SplinterNode::new();
@@ -4175,8 +4154,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_authorization_type(Circuit_AuthorizationType::UNSET_AUTHORIZATION_TYPE);
@@ -4220,8 +4198,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_persistence(Circuit_PersistenceType::UNSET_PERSISTENCE_TYPE);
@@ -4265,8 +4242,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_durability(Circuit_DurabilityType::UNSET_DURABILITY_TYPE);
@@ -4310,8 +4286,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_routes(Circuit_RouteType::UNSET_ROUTE_TYPE);
@@ -4355,8 +4330,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let mut circuit = setup_test_circuit();
 
         circuit.set_circuit_management_type("".to_string());
@@ -4399,8 +4373,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
         let vote = setup_test_vote(&circuit);
         let proposal = setup_test_proposal(&circuit);
@@ -4445,8 +4418,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
         let vote = setup_test_vote(&circuit);
         let proposal = setup_test_proposal(&circuit);
@@ -4490,8 +4462,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
         let vote = setup_test_vote(&circuit);
         let proposal = setup_test_proposal(&circuit);
@@ -4535,8 +4506,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
         let vote = setup_test_vote(&circuit);
         let mut proposal = setup_test_proposal(&circuit);
@@ -4588,8 +4558,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
         let circuit = setup_test_circuit();
         let vote = setup_test_vote(&circuit);
         let mut proposal = setup_test_proposal(&circuit);
@@ -4639,8 +4608,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let circuit = setup_test_circuit();
 
@@ -4701,8 +4669,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let circuit = setup_test_circuit();
 
@@ -4764,8 +4731,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let circuit = setup_test_circuit();
 
@@ -4829,8 +4795,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let circuit = setup_test_circuit();
 
@@ -4899,8 +4864,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the circuit to be disbanded
         shared
@@ -4963,8 +4927,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the circuit to be disbanded
         shared
@@ -5025,8 +4988,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the v1 circuit to be attempted to disbanded
         admin_shared
@@ -5088,8 +5050,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         if let Ok(()) = admin_shared.validate_disband_circuit(
             &setup_test_circuit(),
@@ -5141,8 +5102,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the circuit to be disbanded
         admin_shared
@@ -5204,8 +5164,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         admin_shared
             .admin_store
@@ -5290,8 +5249,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         let service_sender = MockServiceNetworkSender::new();
         shared.set_network_sender(Some(Box::new(service_sender.clone())));
@@ -5403,8 +5361,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the disbanded circuit to be purged
         admin_shared
@@ -5467,8 +5424,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the circuit to be disbanded
         shared
@@ -5531,8 +5487,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the v1 circuit to be attempted to purge
         admin_shared
@@ -5594,8 +5549,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         if let Ok(()) = admin_shared.validate_purge_request(
             "01234-ABCDE",
@@ -5646,8 +5600,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the circuit to be purged
         admin_shared
@@ -5709,8 +5662,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the disbanded circuit to be purged
         admin_shared
@@ -5773,8 +5725,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         admin_shared
             .admin_store
@@ -5840,8 +5791,7 @@ mod tests {
             writer,
             #[cfg(feature = "admin-service-event-store")]
             event_store,
-        )
-        .unwrap();
+        );
 
         // Add the disbanded circuit to be purged
         admin_shared

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -493,7 +493,7 @@ impl SplinterDaemon {
             &*store_factory,
         )?;
 
-        let (admin_service, admin_notification_join) = AdminService::new(
+        let admin_service = AdminService::new(
             &self.node_id,
             orchestrator,
             #[cfg(feature = "service-arg-validation")]
@@ -795,9 +795,6 @@ impl SplinterDaemon {
         let _ = orchestator_join_handles.join_all();
         peer_manager_shutdown.shutdown();
         peer_manager.await_shutdown();
-        debug!("Shutting down admin service's peer manager notification receiver...");
-        let _ = admin_notification_join.join();
-        debug!("Shutting down admin service's peer manager notification receiver (complete)");
         connection_manager_shutdown.shutdown();
         connection_manager.await_shutdown();
         self.mesh.shutdown_signaler().shutdown();


### PR DESCRIPTION
This change replaces the `AdminService::new` constructor with a builder, `AdminServiceBuilder`.

In order to cleanly do this, it moves the start of a thread from the constructor to the `Service::start` implementation.  This thread-start was in the constructor to avoid a race condition where notifications would be lost if they can before the admin service subscribed. The fix here is to queue the notifications that are collected by the subscriber map, such that they are available to the first subscriber.  This makes it so order doesn't matter, at least as far as the first subscriber is concerned.

The original constructor is deprecated.