### PR TITLE
Separate Service Purge from Destory

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -622,6 +622,10 @@ impl Service for AdminService {
         }
     }
 
+    fn purge(&mut self) -> Result<(), crate::error::InternalError> {
+        Ok(())
+    }
+
     fn handle_message(
         &self,
         message_bytes: &[u8],

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -47,6 +47,8 @@ pub mod validation;
 
 use std::any::Any;
 
+use crate::error::InternalError;
+
 pub use factory::ServiceFactory;
 pub use processor::registry::StandardServiceNetworkRegistry;
 pub use processor::JoinHandles;
@@ -138,6 +140,9 @@ pub trait Service: Send {
     /// Consumes the service (which, given the use of dyn traits,
     /// this must take a boxed Service instance).
     fn destroy(self: Box<Self>) -> Result<(), ServiceDestroyError>;
+
+    /// Purge any persistent state maintained by this service.
+    fn purge(&mut self) -> Result<(), InternalError>;
 
     /// Handle any incoming message intended for this service instance.
     ///

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -843,6 +843,10 @@ pub mod tests {
             unimplemented!()
         }
 
+        fn purge(&mut self) -> Result<(), crate::error::InternalError> {
+            unimplemented!()
+        }
+
         fn handle_message(
             &self,
             message_bytes: &[u8],
@@ -927,6 +931,10 @@ pub mod tests {
         /// Consumes the service (which, given the use of dyn traits,
         /// this must take a boxed Service instance).
         fn destroy(self: Box<Self>) -> Result<(), ServiceDestroyError> {
+            unimplemented!()
+        }
+
+        fn purge(&mut self) -> Result<(), crate::error::InternalError> {
             unimplemented!()
         }
 

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -77,6 +77,11 @@ impl Service for HealthService {
         Ok(())
     }
 
+    fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
+        info!("Purging health service");
+        Ok(())
+    }
+
     fn handle_message(
         &self,
         _message_bytes: &[u8],

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -309,13 +309,18 @@ impl Service for Scabbard {
         {
             Err(ServiceDestroyError::NotStopped)
         } else {
-            self.state
-                .lock()
-                .map_err(|_| ServiceDestroyError::PoisonedLock("consensus lock poisoned".into()))?
-                .remove_db_files()
-                .map_err(|err| ServiceDestroyError::Internal(Box::new(err)))?;
             Ok(())
         }
+    }
+
+    fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
+        self.state
+            .lock()
+            .map_err(|_| {
+                splinter::error::InternalError::with_message("consensus lock poisoned".into())
+            })?
+            .remove_db_files()
+            .map_err(|err| splinter::error::InternalError::from_source(Box::new(err)))
     }
 
     fn handle_message(


### PR DESCRIPTION
This change separates service::destroy from the purge operation.  These are distinct operations: one is an object life-cycle operation, the other is specific operation for cleaning up persistent state.

This split fixes an issue where destroy was called in the `shutdown_all_services` method of the `Orchestrator`, resulting in deleting scabbard data and, at node restart, making the services brand new instances, including no contracts.

# Test

Build gameroom with stable features and start it as normal.  Go through the process of creating a gameroom.

Stop and start the acme node:

```
$ docker-compose -f examples/gameroom/docker-compose.yaml stop splinterd-node-acme
$ docker-compose -f examples/gameroom/docker-compose.yaml start splinterd-node-acme
```

Before this fix: the gameroom would not be usable, with an error message of 

```
splinterd-node-acme     | [2021-02-15 19:54:54.767] T["consensus-a001"] ERROR [splinter::consensus::two_phase] Error while creating proposal: proposal manager error occurred: scabbard state error: transaction failed: "Contract does not exist: xo, 0.3.3"
```

After this fix: the gameroom can still be used to create games or make moves.