### PR TITLE
Remove splinterd compile err for no DB backend

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -46,11 +46,6 @@ use std::thread;
 use error::UserError;
 use transport::build_transport;
 
-#[cfg(not(any(feature = "database-postgres", feature = "database-sqlite")))]
-compile_error!(
-    "At least one database backend feature must be enabled: 'database-postgres', 'database-sqlite'"
-);
-
 fn create_config(_toml_path: Option<&str>, _matches: ArgMatches) -> Result<Config, UserError> {
     let mut builder = ConfigBuilder::new();
 


### PR DESCRIPTION
Removes the compile error in splinterd that would occur when no database
backend features are enabled. This prevented building splinterd with no
default features. Now, if no database backend is enabled, DB URLs will
always be invalid.

Signed-off-by: Logan Seeley <seeley@bitwise.io>