### PR TITLE
Add AdminServiceClient and RequestAdminServiceClient

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -99,6 +99,7 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "admin-service-client",
     "admin-service-event-store",
     "admin-service-event-store-postgres",
     "authorization",
@@ -110,6 +111,7 @@ experimental = [
     "biome-profile",
     "circuit-disband",
     "circuit-purge",
+    "client-reqwest",
     "https-bind",
     "oauth-inflight-request-store-postgres",
     "registry-database",
@@ -125,6 +127,7 @@ experimental = [
 benchmark = []
 
 admin-service = []
+admin-service-client = []
 admin-service-event-store = ["admin-service"]
 admin-service-event-store-postgres = ["postgres", "admin-service-event-store"]
 authorization-handler-allow-keys = ["authorization"]
@@ -140,6 +143,7 @@ biome-profile = ["biome"]
 circuit-disband = []
 circuit-purge = ["circuit-disband"]
 circuit-template = ["admin-service", "glob"]
+client-reqwest = ["reqwest"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]

--- a/libsplinter/src/admin/client/mod.rs
+++ b/libsplinter/src/admin/client/mod.rs
@@ -1,0 +1,122 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits and implementations useful for communicating with the Splinter admin service as
+//! a client.
+
+#[cfg(feature = "client-reqwest")]
+mod reqwest;
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::InternalError;
+
+pub use self::reqwest::ReqwestAdminServiceClient;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Paging {
+    pub current: String,
+    pub offset: usize,
+    pub limit: usize,
+    pub total: usize,
+    pub first: String,
+    pub prev: String,
+    pub next: String,
+    pub last: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircuitServiceSlice {
+    pub service_id: String,
+    pub service_type: String,
+    pub node_id: String,
+    pub arguments: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircuitSlice {
+    pub id: String,
+    pub members: Vec<String>,
+    pub roster: Vec<CircuitServiceSlice>,
+    pub management_type: String,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircuitListSlice {
+    pub data: Vec<CircuitSlice>,
+    pub paging: Paging,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircuitMembers {
+    pub node_id: String,
+    pub endpoints: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CircuitService {
+    pub service_id: String,
+    pub service_type: String,
+    pub node_id: String,
+    pub arguments: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalCircuitSlice {
+    pub circuit_id: String,
+    pub members: Vec<CircuitMembers>,
+    pub roster: Vec<CircuitService>,
+    pub management_type: String,
+    pub comments: Option<String>,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VoteRecord {
+    pub public_key: String,
+    pub vote: String,
+    pub voter_node_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalSlice {
+    pub proposal_type: String,
+    pub circuit_id: String,
+    pub circuit_hash: String,
+    pub circuit: ProposalCircuitSlice,
+    pub votes: Vec<VoteRecord>,
+    pub requester: String,
+    pub requester_node_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposalListSlice {
+    pub data: Vec<ProposalSlice>,
+    pub paging: Paging,
+}
+
+pub trait AdminServiceClient {
+    fn submit_admin_payload(&self, payload: Vec<u8>) -> Result<(), InternalError>;
+    fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, InternalError>;
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<CircuitSlice>, InternalError>;
+    fn list_proposals(
+        &self,
+        management_type_filter: Option<&str>,
+        member_filter: Option<&str>,
+    ) -> Result<ProposalListSlice, InternalError>;
+    fn fetch_proposal(&self, circuit_id: &str) -> Result<Option<ProposalSlice>, InternalError>;
+}

--- a/libsplinter/src/admin/client/reqwest.rs
+++ b/libsplinter/src/admin/client/reqwest.rs
@@ -1,0 +1,281 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the Reqwest-based implementation of AdminServiceClient.
+
+use reqwest::{blocking::Client, header, StatusCode};
+
+use crate::error::InternalError;
+
+use super::{AdminServiceClient, CircuitListSlice, CircuitSlice, ProposalListSlice, ProposalSlice};
+
+const ADMIN_PROTOCOL_VERSION: &str = "1";
+const PAGING_LIMIT: u32 = 100;
+
+#[derive(Deserialize)]
+struct ServerError {
+    pub message: String,
+}
+
+pub struct ReqwestAdminServiceClient {
+    url: String,
+    auth: String,
+}
+
+impl ReqwestAdminServiceClient {
+    pub fn new(url: String, auth: String) -> Self {
+        ReqwestAdminServiceClient { url, auth }
+    }
+}
+
+impl AdminServiceClient for ReqwestAdminServiceClient {
+    /// Submits an admin payload to this client's Splinter node.
+    fn submit_admin_payload(&self, payload: Vec<u8>) -> Result<(), InternalError> {
+        let request = Client::new()
+            .post(&format!("{}/admin/submit", self.url))
+            .header(header::CONTENT_TYPE, "octet-stream")
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .body(payload)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to submit admin payload".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            InternalError::with_message(format!(
+                                "Admin payload submit request failed with status code '{}', but \
+                                 error response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to submit admin payload: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, InternalError> {
+        let mut url = format!("{}/admin/circuits?limit={}", self.url, PAGING_LIMIT);
+        if let Some(filter) = filter {
+            url = format!("{}&filter={}", &url, &filter);
+        }
+
+        let request = Client::new()
+            .get(&url)
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        let response = request.send();
+
+        response
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to list circuits".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<CircuitListSlice>().map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|err| {
+                            InternalError::from_source_with_message(
+                                err.into(),
+                                format!(
+                                    "Circuit list request failed with status code '{}', but error \
+                                 response was not valid",
+                                    status
+                                ),
+                            )
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to list circuits: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<CircuitSlice>, InternalError> {
+        let request = Client::new()
+            .get(&format!("{}/admin/circuits/{}", self.url, circuit_id))
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to fetch circuit".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<CircuitSlice>().map(Some).map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else if status == StatusCode::NOT_FOUND {
+                    Ok(None)
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            InternalError::with_message(format!(
+                                "Circuit fetch request failed with status code '{}', but error \
+                                 response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to fetch circuit: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    fn list_proposals(
+        &self,
+        management_type_filter: Option<&str>,
+        member_filter: Option<&str>,
+    ) -> Result<ProposalListSlice, InternalError> {
+        let mut filters = vec![];
+        if let Some(management_type) = management_type_filter {
+            filters.push(format!("management_type={}", management_type));
+        }
+        if let Some(member) = member_filter {
+            filters.push(format!("member={}", member));
+        }
+
+        let mut url = format!("{}/admin/proposals?limit={}", self.url, PAGING_LIMIT);
+        if !filters.is_empty() {
+            url.push_str(&format!("&{}", filters.join("&")));
+        }
+
+        let request = Client::new()
+            .get(&url)
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to list proposals".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<ProposalListSlice>().map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            InternalError::with_message(format!(
+                                "Proposal list request failed with status code '{}', but error \
+                                 response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to list proposals: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    fn fetch_proposal(&self, circuit_id: &str) -> Result<Option<ProposalSlice>, InternalError> {
+        let request = Client::new()
+            .get(&format!("{}/admin/proposals/{}", self.url, circuit_id))
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to fetch proposal".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<ProposalSlice>().map(Some).map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else if status == StatusCode::NOT_FOUND {
+                    Ok(None)
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            InternalError::with_message(format!(
+                                "Proposal fetch request failed with status code '{}', but error \
+                                 response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to fetch proposal: {}",
+                        message
+                    )))
+                }
+            })
+    }
+}

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "admin-service-client")]
+pub mod client;
 pub mod error;
 pub mod messages;
 #[cfg(feature = "rest-api")]


### PR DESCRIPTION
This code is a modified version of the code in the splinter CLI's
action::circuit::api module. Modifications have been made to make the
API a trait with an implementation.

When this is stabilized, the CLI should use this implementation instead
of its own.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>