### PR TITLE
Stabilize biome-oauth-user-store-postgres and oauth-inflight-request-store-postgres

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -110,7 +110,6 @@ experimental = [
     "circuit-disband",
     "circuit-purge",
     "https-bind",
-    "oauth-inflight-request-store-postgres",
     "registry-database",
     "role-based-authorization-store-postgres",
     "service-arg-validation",
@@ -143,7 +142,6 @@ events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
-oauth-inflight-request-store-postgres = ["oauth", "postgres"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
 registry-database = ["diesel"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -106,7 +106,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-notifications",
-    "biome-oauth-user-store-postgres",
     "biome-profile",
     "circuit-disband",
     "circuit-purge",
@@ -135,7 +134,6 @@ biome = []
 biome-credentials = ["bcrypt", "biome"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
-biome-oauth-user-store-postgres = ["oauth", "postgres"]
 biome-profile = ["biome"]
 circuit-disband = []
 circuit-purge = ["circuit-disband"]

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -89,7 +89,7 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::sqlite::Sqlit
     }
 }
 
-#[cfg(feature = "biome-oauth-user-store-postgres")]
+#[cfg(feature = "postgres")]
 impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::pg::PgConnection> {
     fn add_session(
         &self,

--- a/libsplinter/src/biome/oauth/store/diesel/operations/add_session.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/add_session.rs
@@ -78,7 +78,7 @@ impl<'a> OAuthUserSessionStoreAddSession
     }
 }
 
-#[cfg(feature = "biome-oauth-user-store-postgres")]
+#[cfg(feature = "postgres")]
 impl<'a> OAuthUserSessionStoreAddSession
     for OAuthUserSessionStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/biome/oauth/store/error.rs
+++ b/libsplinter/src/biome/oauth/store/error.rs
@@ -17,7 +17,7 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(any(feature = "biome-oauth-user-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 use crate::error::ConstraintViolationType;
 use crate::error::{
     ConstraintViolationError, InternalError, InvalidArgumentError, InvalidStateError,
@@ -54,14 +54,14 @@ impl fmt::Display for OAuthUserSessionStoreError {
     }
 }
 
-#[cfg(any(feature = "biome-oauth-user-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 impl From<diesel::r2d2::PoolError> for OAuthUserSessionStoreError {
     fn from(err: diesel::r2d2::PoolError) -> Self {
         OAuthUserSessionStoreError::Internal(InternalError::from_source(Box::new(err)))
     }
 }
 
-#[cfg(any(feature = "biome-oauth-user-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 impl From<diesel::result::Error> for OAuthUserSessionStoreError {
     fn from(err: diesel::result::Error) -> Self {
         match err {

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -19,7 +19,7 @@
 //! * It provides a correlation between an OAuth subject identifier and a Biome user ID
 //! * It stores tokens and other data for an OAuth user's sessions
 
-#[cfg(any(feature = "biome-oauth-user-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 pub(in crate::biome) mod diesel;
 mod error;
 pub(in crate::biome) mod memory;

--- a/libsplinter/src/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/oauth/store/diesel/mod.rs
@@ -85,7 +85,7 @@ impl InflightOAuthRequestStore
     }
 }
 
-#[cfg(feature = "oauth-inflight-request-store-postgres")]
+#[cfg(feature = "postgres")]
 impl InflightOAuthRequestStore for DieselInflightOAuthRequestStore<diesel::pg::PgConnection> {
     fn insert_request(
         &self,

--- a/libsplinter/src/oauth/store/mod.rs
+++ b/libsplinter/src/oauth/store/mod.rs
@@ -14,14 +14,14 @@
 
 //! Defines an API to manage in-flight OAuth2 requests.
 
-#[cfg(any(feature = "oauth-inflight-request-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 mod diesel;
 mod error;
 mod memory;
 
 use super::PendingAuthorization;
 
-#[cfg(any(feature = "oauth-inflight-request-store-postgres", feature = "sqlite"))]
+#[cfg(feature = "diesel")]
 pub use self::diesel::DieselInflightOAuthRequestStore;
 pub use error::InflightOAuthRequestStoreError;
 pub use memory::MemoryInflightOAuthRequestStore;

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -50,18 +50,11 @@ impl StoreFactory for PgStoreFactory {
         ))
     }
 
-    #[cfg(feature = "biome-oauth-user-store-postgres")]
+    #[cfg(feature = "oauth")]
     fn get_biome_oauth_user_session_store(&self) -> Box<dyn crate::biome::OAuthUserSessionStore> {
         Box::new(crate::biome::DieselOAuthUserSessionStore::new(
             self.pool.clone(),
         ))
-    }
-
-    #[cfg(all(feature = "oauth", not(feature = "biome-oauth-user-store-postgres")))]
-    fn get_biome_oauth_user_session_store(&self) -> Box<dyn crate::biome::OAuthUserSessionStore> {
-        // This configuration cannot be reached within this implementation as the whole struct is
-        // guarded by "postgres". It merely satisfies the compiler.
-        unreachable!()
     }
 
     #[cfg(feature = "admin-service")]

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -64,23 +64,13 @@ impl StoreFactory for PgStoreFactory {
         ))
     }
 
-    #[cfg(feature = "oauth-inflight-request-store-postgres")]
+    #[cfg(feature = "oauth")]
     fn get_oauth_inflight_request_store(
         &self,
     ) -> Box<dyn crate::oauth::store::InflightOAuthRequestStore> {
         Box::new(crate::oauth::store::DieselInflightOAuthRequestStore::new(
             self.pool.clone(),
         ))
-    }
-
-    #[cfg(all(
-        feature = "oauth",
-        not(feature = "oauth-inflight-request-store-postgres")
-    ))]
-    fn get_oauth_inflight_request_store(
-        &self,
-    ) -> Box<dyn crate::oauth::store::InflightOAuthRequestStore> {
-        unimplemented!()
     }
 
     #[cfg(feature = "registry-database")]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -126,7 +126,6 @@ database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 https-bind = ["splinter/https-bind"]
 oauth = [
-    "splinter/oauth-inflight-request-store-postgres",
     "splinter/oauth"
 ]
 registry-database = ["splinter/registry-database"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -126,7 +126,6 @@ database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 https-bind = ["splinter/https-bind"]
 oauth = [
-    "splinter/biome-oauth-user-store-postgres",
     "splinter/oauth-inflight-request-store-postgres",
     "splinter/oauth"
 ]


### PR DESCRIPTION
This change stabilizes the feature "biome-oauth-user-store-postgres" and "oauth-inflight-request-store-postgres" by remove them. 

Where applicable, the feature guard is either replaced with "diesel" (in instances where this was used in conjunction with "sqlite") or "postgres".
