### PR TITLE
Update ServiceProcessor, ServiceOrchestrator to have builders, shutdown handles

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -962,6 +962,7 @@ mod tests {
     use crate::network::auth::AuthorizationManager;
     use crate::network::connection_manager::authorizers::{Authorizers, InprocAuthorizer};
     use crate::network::connection_manager::ConnectionManager;
+    use crate::orchestrator::ServiceOrchestratorBuilder;
     use crate::peer::PeerManager;
     use crate::protos::admin;
     use crate::service::{error, ServiceNetworkRegistry, ServiceNetworkSender};
@@ -1029,8 +1030,12 @@ mod tests {
         let orchestrator_connection = orchestrator_transport
             .connect("inproc://orchestator")
             .expect("failed to create connection");
-        let (orchestrator, _) = ServiceOrchestrator::new(vec![], orchestrator_connection, 1, 1, 1)
-            .expect("failed to create orchestrator");
+        let orchestrator = ServiceOrchestratorBuilder::new()
+            .with_connection(orchestrator_connection)
+            .build()
+            .expect("failed to create orchestrator")
+            .run()
+            .expect("failed to start orchestrator");
 
         let context = Secp256k1Context::new();
         let private_key = context.new_random_private_key();

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3201,6 +3201,7 @@ mod tests {
     use crate::network::auth::AuthorizationManager;
     use crate::network::connection_manager::authorizers::{Authorizers, InprocAuthorizer};
     use crate::network::connection_manager::ConnectionManager;
+    use crate::orchestrator::ServiceOrchestratorBuilder;
     use crate::peer::{PeerManager, PeerManagerConnector};
     use crate::protocol::authorization::{
         AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest, ConnectResponse,
@@ -3245,8 +3246,12 @@ mod tests {
         let orchestrator_connection = orchestrator_transport
             .connect("inproc://orchestator")
             .expect("failed to create connection");
-        let (orchestrator, _) = ServiceOrchestrator::new(vec![], orchestrator_connection, 1, 1, 1)
-            .expect("failed to create orchestrator");
+        let orchestrator = ServiceOrchestratorBuilder::new()
+            .with_connection(orchestrator_connection)
+            .build()
+            .expect("failed to create orchestrator")
+            .run()
+            .expect("failed to start orchestrator");
         let store = setup_admin_service_store();
         #[cfg(feature = "admin-service-event-store")]
         let event_store = store.clone_boxed();
@@ -3378,8 +3383,12 @@ mod tests {
         let orchestrator_connection = orchestrator_transport
             .connect("inproc://admin-service")
             .expect("failed to create connection");
-        let (orchestrator, _) = ServiceOrchestrator::new(vec![], orchestrator_connection, 1, 1, 1)
-            .expect("failed to create orchestrator");
+        let orchestrator = ServiceOrchestratorBuilder::new()
+            .with_connection(orchestrator_connection)
+            .build()
+            .expect("failed to create orchestrator")
+            .run()
+            .expect("failed to start orchestrator");
         let store = setup_admin_service_store();
         #[cfg(feature = "admin-service-event-store")]
         let event_store = store.clone_boxed();
@@ -5500,8 +5509,12 @@ mod tests {
         let orchestrator_connection = orchestrator_transport
             .connect("inproc://orchestator")
             .expect("failed to create connection");
-        let (orchestrator, _) = ServiceOrchestrator::new(vec![], orchestrator_connection, 1, 1, 1)
-            .expect("failed to create orchestrator");
+        let orchestrator = ServiceOrchestratorBuilder::new()
+            .with_connection(orchestrator_connection)
+            .build()
+            .expect("failed to create orchestrator")
+            .run()
+            .expect("failed to start orchestrator");
         let store = setup_admin_service_store();
         #[cfg(feature = "admin-service-event-store")]
         let event_store = store.clone_boxed();
@@ -6753,9 +6766,13 @@ mod tests {
         let orchestrator_connection = transport
             .connect("inproc://orchestator-service")
             .expect("failed to create connection");
-        let (orchestrator, _) = ServiceOrchestrator::new(vec![], orchestrator_connection, 1, 1, 1)
-            .expect("failed to create orchestrator");
-        orchestrator
+
+        ServiceOrchestratorBuilder::new()
+            .with_connection(orchestrator_connection)
+            .build()
+            .expect("failed to create orchestrator")
+            .run()
+            .expect("failed to start orchestrator")
     }
 
     fn splinter_node(node_id: &str, endpoints: &[String]) -> admin::SplinterNode {

--- a/libsplinter/src/orchestrator/builder.rs
+++ b/libsplinter/src/orchestrator/builder.rs
@@ -1,0 +1,121 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for constructing new service orchestrators.
+
+use crate::error::InvalidStateError;
+use crate::service::ServiceFactory;
+use crate::transport::Connection;
+
+use super::runnable::RunnableServiceOrchestrator;
+
+const DEFAULT_INCOMING_CAPACITY: usize = 8;
+const DEFAULT_OUTGOING_CAPACITY: usize = 8;
+const DEFAULT_CHANNEL_CAPACITY: usize = 8;
+
+/// Builds new [RunnableServiceOrchestrator] instances.
+#[derive(Default)]
+pub struct ServiceOrchestratorBuilder {
+    connection: Option<Box<dyn Connection>>,
+    incoming_capacity: Option<usize>,
+    outgoing_capacity: Option<usize>,
+    channel_capacity: Option<usize>,
+    service_factories: Vec<Box<dyn ServiceFactory>>,
+}
+
+impl ServiceOrchestratorBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the connection for receiving service messages by the resulting ServiceOrchestrator.
+    ///
+    /// This field is required to construct the final ServiceOrchestrator.
+    pub fn with_connection(mut self, connection: Box<dyn Connection>) -> Self {
+        self.connection = Some(connection);
+        self
+    }
+
+    /// Sets the incoming message capacity.
+    ///
+    /// This limits the amount of messages that may be buffered by the service orchestrator before
+    /// blocking new messages.
+    pub fn with_incoming_capacity(mut self, incoming_capacity: usize) -> Self {
+        self.incoming_capacity = Some(incoming_capacity);
+        self
+    }
+
+    /// Sets the outgoing message capacity.
+    ///
+    /// This limits the amount of messages that may be buffered by the service orchestrator when being
+    /// sent to external connections.
+    pub fn with_outgoing_capacity(mut self, outgoing_capacity: usize) -> Self {
+        self.outgoing_capacity = Some(outgoing_capacity);
+        self
+    }
+
+    /// Sets the internal channel capacity.
+    ///
+    /// This limits the number of messages that may be buffered when passed between the internal
+    /// threads.
+    pub fn with_channel_capacity(mut self, channel_capacity: usize) -> Self {
+        self.channel_capacity = Some(channel_capacity);
+        self
+    }
+
+    /// Adds a service factory which will be used to create service instances.
+    ///
+    /// This function may be called more than once to add additional service factories.
+    pub fn with_service_factory(mut self, service_factory: Box<dyn ServiceFactory>) -> Self {
+        self.service_factories.push(service_factory);
+
+        self
+    }
+
+    /// Construct the RunnableServiceOrchestrator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InvalidStateError, if any required fields are missing.
+    pub fn build(self) -> Result<RunnableServiceOrchestrator, InvalidStateError> {
+        let connection = self.connection.ok_or_else(|| {
+            InvalidStateError::with_message("A service orchestrator requires a connection".into())
+        })?;
+
+        let incoming_capacity = self.incoming_capacity.unwrap_or(DEFAULT_INCOMING_CAPACITY);
+        let outgoing_capacity = self.outgoing_capacity.unwrap_or(DEFAULT_OUTGOING_CAPACITY);
+        let channel_capacity = self.channel_capacity.unwrap_or(DEFAULT_CHANNEL_CAPACITY);
+
+        let supported_service_types_vec = self
+            .service_factories
+            .iter()
+            .map(|factory| factory.available_service_types().to_vec())
+            .collect::<Vec<Vec<String>>>();
+
+        let mut supported_service_types = vec![];
+        for mut service_types in supported_service_types_vec {
+            supported_service_types.append(&mut service_types);
+        }
+
+        Ok(RunnableServiceOrchestrator {
+            connection,
+            service_factories: self.service_factories,
+            supported_service_types,
+            incoming_capacity,
+            outgoing_capacity,
+            channel_capacity,
+        })
+    }
+}

--- a/libsplinter/src/orchestrator/error.rs
+++ b/libsplinter/src/orchestrator/error.rs
@@ -19,7 +19,7 @@ use crate::service::FactoryCreateError;
 use super::ServiceDefinition;
 
 #[derive(Debug)]
-pub struct NewOrchestratorError(pub Box<dyn Error + Send>);
+pub struct NewOrchestratorError(pub Box<dyn Error>);
 
 impl Error for NewOrchestratorError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {

--- a/libsplinter/src/orchestrator/runnable.rs
+++ b/libsplinter/src/orchestrator/runnable.rs
@@ -1,0 +1,154 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A module containing a configured, but not started ServiceOrchestrator.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use uuid::Uuid;
+
+use crate::error::InternalError;
+use crate::mesh::Mesh;
+use crate::network::reply::InboundRouter;
+use crate::service::ServiceFactory;
+use crate::transport::Connection;
+
+use super::{JoinHandles, ServiceOrchestrator};
+
+/// A runnable service orchestrator is configured, but not started ServiceOrchestrator. It may only
+/// be used for operations that can be done during that state, such as starting the orchestrator.
+pub struct RunnableServiceOrchestrator {
+    pub(super) connection: Box<dyn Connection>,
+    pub(super) incoming_capacity: usize,
+    pub(super) outgoing_capacity: usize,
+    pub(super) channel_capacity: usize,
+    pub(super) service_factories: Vec<Box<dyn ServiceFactory>>,
+    pub(super) supported_service_types: Vec<String>,
+}
+
+impl RunnableServiceOrchestrator {
+    /// Starts the ServiceOrchestrator.
+    ///
+    /// This transforms the instance into a [ServiceOrchestrator], resulting in the orchestrator
+    /// being in a started state.
+    ///
+    /// # Returns
+    ///
+    /// A running [ServiceOrchestrator].  This instance can have operations applied to it, such as
+    /// creating or destroying services.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [InternalError] if the orchestrator cannot be started.
+    pub fn run(self) -> Result<ServiceOrchestrator, InternalError> {
+        let service_factories = self.service_factories;
+        let supported_service_types = self.supported_service_types;
+
+        let services = Arc::new(Mutex::new(HashMap::new()));
+        let stopped_services = Arc::new(Mutex::new(HashMap::new()));
+
+        let mesh = Mesh::new(self.incoming_capacity, self.outgoing_capacity);
+        let mesh_id = format!("{}", Uuid::new_v4());
+
+        mesh.add(self.connection, mesh_id.to_string())
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let running = Arc::new(AtomicBool::new(true));
+
+        let (network_sender, network_receiver) = crossbeam_channel::bounded(self.channel_capacity);
+        let (inbound_sender, inbound_receiver) = crossbeam_channel::bounded(self.channel_capacity);
+        let inbound_router = InboundRouter::new(Box::new(inbound_sender));
+
+        // Start thread that handles incoming messages from a splinter node.
+        let incoming_mesh = mesh.clone();
+        let incoming_running = running.clone();
+        let incoming_router = inbound_router.clone();
+        let incoming_join_handle = thread::Builder::new()
+            .name("Orchestrator Incoming".into())
+            .spawn(move || {
+                if let Err(err) =
+                    super::run_incoming_loop(incoming_mesh, incoming_running, incoming_router)
+                {
+                    error!(
+                        "Terminating orchestrator incoming thread due to error: {}",
+                        err
+                    );
+                    Err(err)
+                } else {
+                    Ok(())
+                }
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        // Start thread that handles messages that do not have a matching correlation id.
+        let inbound_services = services.clone();
+        let inbound_running = running.clone();
+        let inbound_join_handle = thread::Builder::new()
+            .name("Orchestrator Inbound".into())
+            .spawn(move || {
+                if let Err(err) =
+                    super::run_inbound_loop(inbound_services, inbound_receiver, inbound_running)
+                {
+                    error!(
+                        "Terminating orchestrator inbound thread due to error: {}",
+                        err
+                    );
+                    Err(err)
+                } else {
+                    Ok(())
+                }
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        // Start thread that handles outgoing messages that need to be sent to the splinter node.
+        let outgoing_running = running.clone();
+        let outgoing_join_handle = thread::Builder::new()
+            .name("Orchestrator Outgoing".into())
+            .spawn(move || {
+                if let Err(err) =
+                    super::run_outgoing_loop(mesh, outgoing_running, network_receiver, mesh_id)
+                {
+                    error!(
+                        "Terminating orchestrator outgoing thread due to error: {}",
+                        err
+                    );
+                    Err(err)
+                } else {
+                    Ok(())
+                }
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let join_handles = JoinHandles::new(vec![
+            incoming_join_handle,
+            inbound_join_handle,
+            outgoing_join_handle,
+        ]);
+
+        info!("Service orchestrator started");
+        Ok(ServiceOrchestrator {
+            services,
+            stopped_services,
+            service_factories,
+            supported_service_types,
+            network_sender,
+            inbound_router,
+            running,
+            join_handles: Some(join_handles),
+        })
+    }
+}

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -53,6 +53,7 @@ pub use factory::ServiceFactory;
 pub use processor::registry::StandardServiceNetworkRegistry;
 pub use processor::JoinHandles;
 pub use processor::ServiceProcessor;
+#[cfg(not(feature = "shutdown"))]
 pub use processor::ShutdownHandle;
 
 pub use error::{

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -53,6 +53,7 @@ pub use factory::ServiceFactory;
 pub use processor::registry::StandardServiceNetworkRegistry;
 pub use processor::JoinHandles;
 pub use processor::ServiceProcessor;
+pub use processor::ServiceProcessorBuilder;
 #[cfg(not(feature = "shutdown"))]
 pub use processor::ShutdownHandle;
 

--- a/libsplinter/src/service/processor/builder.rs
+++ b/libsplinter/src/service/processor/builder.rs
@@ -1,0 +1,138 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for constructing new service processors.
+
+use crate::error::InvalidStateError;
+use crate::service::Service;
+use crate::transport::Connection;
+
+use super::ServiceProcessor;
+
+const DEFAULT_INCOMING_CAPACITY: usize = 8;
+const DEFAULT_OUTGOING_CAPACITY: usize = 8;
+const DEFAULT_CHANNEL_CAPACITY: usize = 8;
+
+/// Builds new ServiceProcessors.
+#[derive(Default)]
+pub struct ServiceProcessorBuilder {
+    connection: Option<Box<dyn Connection>>,
+    circuit: Option<String>,
+    incoming_capacity: Option<usize>,
+    outgoing_capacity: Option<usize>,
+    channel_capacity: Option<usize>,
+    services: Vec<Box<dyn Service>>,
+}
+
+impl ServiceProcessorBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the connection for receiving service messages by the resulting ServiceProcessor.
+    ///
+    /// This field is required to construct the final ServiceProcessor.
+    pub fn with_connection(mut self, connection: Box<dyn Connection>) -> Self {
+        self.connection = Some(connection);
+        self
+    }
+
+    /// Sets the circuit associated with all of the services in this processor.
+    ///
+    /// This field is required to construct the final ServiceProcessor.
+    pub fn with_circuit(mut self, circuit: String) -> Self {
+        self.circuit = Some(circuit);
+        self
+    }
+
+    /// Sets the incoming message capacity.
+    ///
+    /// This limits the amount of messages that may be buffered by the service processor before
+    /// blocking new messages.
+    pub fn with_incoming_capacity(mut self, incoming_capacity: usize) -> Self {
+        self.incoming_capacity = Some(incoming_capacity);
+        self
+    }
+
+    /// Sets the outgoing message capacity.
+    ///
+    /// This limits the amount of messages that may be buffered by the service processor when being
+    /// sent to external connections.
+    pub fn with_outgoing_capacity(mut self, outgoing_capacity: usize) -> Self {
+        self.outgoing_capacity = Some(outgoing_capacity);
+        self
+    }
+
+    /// Sets the internal channel capacity.
+    ///
+    /// This limits the number of messages that may be buffered when passed between the internal
+    /// threads.
+    pub fn with_channel_capacity(mut self, channel_capacity: usize) -> Self {
+        self.channel_capacity = Some(channel_capacity);
+        self
+    }
+
+    /// Adds a service to be managed by the resulting ServiceProcessor.
+    ///
+    /// This function may be called more than once to add additional services.  It must be called
+    /// at least once to construct a valid service processor.
+    pub fn with_service(mut self, service: Box<dyn Service>) -> Self {
+        self.services.push(service);
+
+        self
+    }
+
+    /// Construct the ServiceProcessor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InvalidStateError, if any required fields are missing.
+    pub fn build(self) -> Result<ServiceProcessor, InvalidStateError> {
+        let connection = self.connection.ok_or_else(|| {
+            InvalidStateError::with_message("A service processor requires a connection".into())
+        })?;
+
+        let circuit = self.circuit.ok_or_else(|| {
+            InvalidStateError::with_message("A service processor requires a circuit".into())
+        })?;
+
+        let incoming_capacity = self.incoming_capacity.unwrap_or(DEFAULT_INCOMING_CAPACITY);
+        let outgoing_capacity = self.outgoing_capacity.unwrap_or(DEFAULT_OUTGOING_CAPACITY);
+        let channel_capacity = self.channel_capacity.unwrap_or(DEFAULT_CHANNEL_CAPACITY);
+
+        if self.services.is_empty() {
+            return Err(InvalidStateError::with_message(
+                "At least one service is required by a service processor".into(),
+            ));
+        }
+
+        let mut processor = ServiceProcessor::new(
+            connection,
+            circuit,
+            incoming_capacity,
+            outgoing_capacity,
+            channel_capacity,
+        )
+        .map_err(|e| InvalidStateError::with_message(e.to_string()))?;
+
+        for service in self.services.into_iter() {
+            processor
+                .add_service(service)
+                .map_err(|e| InvalidStateError::with_message(e.to_string()))?;
+        }
+
+        Ok(processor)
+    }
+}

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -35,6 +35,8 @@ use crate::protos::circuit::{
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::service::error::ServiceProcessorError;
 use crate::service::{Service, ServiceMessageContext};
+#[cfg(feature = "shutdown")]
+use crate::threading::shutdown::ShutdownHandle;
 use crate::transport::Connection;
 use crate::{rwlock_read_unwrap, rwlock_write_unwrap};
 
@@ -68,6 +70,8 @@ macro_rules! to_process_err {
         |err| process_err!(err, $($arg)*)
     }
 }
+
+type ShutdownSignalFn = Box<dyn Fn() -> Result<(), ServiceProcessorError> + Send>;
 
 /// The ServiceProcessor handles the networking for services. This includes talking to the
 /// splinter node, connecting for authorization, registering the services, and routing
@@ -139,6 +143,7 @@ impl ServiceProcessor {
         }
     }
 
+    #[cfg(not(feature = "shutdown"))]
     /// Once the service processor is started it will handle incoming messages from the splinter
     /// node and route it to a running service.
     ///
@@ -148,6 +153,33 @@ impl ServiceProcessor {
     ) -> Result<
         (
             ShutdownHandle,
+            JoinHandles<Result<(), ServiceProcessorError>>,
+        ),
+        ServiceProcessorError,
+    > {
+        self.do_start()
+            .map(|(do_shutdown, join_handles)| (ShutdownHandle { do_shutdown }, join_handles))
+    }
+
+    #[cfg(feature = "shutdown")]
+    /// Once the service processor is started it will handle incoming messages from the splinter
+    /// node and route it to a running service.
+    ///
+    /// Returns a [ShutdownHandle] impelmentation so the service can be properly shutdown.
+    pub fn start(self) -> Result<Box<dyn ShutdownHandle>, ServiceProcessorError> {
+        self.do_start().map(|(do_shutdown, join_handles)| {
+            Box::from(ServiceProcessorShutdownHandle {
+                signal_shutdown: do_shutdown,
+                join_handles: Some(join_handles),
+            }) as Box<dyn ShutdownHandle>
+        })
+    }
+
+    fn do_start(
+        self,
+    ) -> Result<
+        (
+            ShutdownSignalFn,
             JoinHandles<Result<(), ServiceProcessorError>>,
         ),
         ServiceProcessorError,
@@ -309,7 +341,7 @@ impl ServiceProcessor {
         });
 
         Ok((
-            ShutdownHandle { do_shutdown },
+            do_shutdown,
             JoinHandles::new(vec![
                 incoming_join_handle,
                 outgoing_join_handle,
@@ -440,10 +472,6 @@ fn process_inbound_msg_with_correlation_id(
     Ok(())
 }
 
-pub struct ShutdownHandle {
-    do_shutdown: Box<dyn Fn() -> Result<(), ServiceProcessorError> + Send>,
-}
-
 pub struct JoinHandles<T> {
     join_handles: Vec<JoinHandle<T>>,
 }
@@ -464,9 +492,53 @@ impl<T> JoinHandles<T> {
     }
 }
 
+#[cfg(not(feature = "shutdown"))]
+pub struct ShutdownHandle {
+    do_shutdown: Box<dyn Fn() -> Result<(), ServiceProcessorError> + Send>,
+}
+
+#[cfg(not(feature = "shutdown"))]
 impl ShutdownHandle {
     pub fn shutdown(&self) -> Result<(), ServiceProcessorError> {
         (*self.do_shutdown)()
+    }
+}
+
+#[cfg(feature = "shutdown")]
+struct ServiceProcessorShutdownHandle {
+    signal_shutdown: Box<dyn Fn() -> Result<(), ServiceProcessorError> + Send>,
+    join_handles: Option<JoinHandles<Result<(), ServiceProcessorError>>>,
+}
+
+#[cfg(feature = "shutdown")]
+impl ShutdownHandle for ServiceProcessorShutdownHandle {
+    fn signal_shutdown(&mut self) {
+        if let Err(err) = (*self.signal_shutdown)() {
+            error!("Unable to signal service processor to shutdown: {}", err);
+        }
+    }
+
+    fn wait_for_shutdown(&mut self, _: Duration) -> Result<(), crate::error::InternalError> {
+        if let Some(join_handles) = self.join_handles.take() {
+            match join_handles.join_all() {
+                Ok(results) => {
+                    results
+                        .into_iter()
+                        .filter(Result::is_err)
+                        .map(Result::unwrap_err)
+                        .for_each(|err| {
+                            error!("{}", err);
+                        });
+                }
+                Err(_) => {
+                    return Err(crate::error::InternalError::with_message(
+                        "Unable to join service processor threads".into(),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
 pub(crate) mod registry;
 mod sender;
 
@@ -42,6 +43,8 @@ use crate::{rwlock_read_unwrap, rwlock_write_unwrap};
 
 use self::registry::StandardServiceNetworkRegistry;
 use self::sender::{ProcessorMessage, ServiceMessage};
+
+pub use builder::ServiceProcessorBuilder;
 
 // Recv timeout in secs
 const TIMEOUT_SEC: u64 = 2;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -91,7 +91,7 @@ experimental = [
     "circuit-abandon",
     "circuit-disband",
     "circuit-purge",
-    "health",
+    "health-service",
     "https-bind",
     "oauth",
     "service-arg-validation",
@@ -126,6 +126,7 @@ circuit-disband = ["splinter/circuit-disband"]
 circuit-purge = ["splinter/circuit-purge"]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
+health-service = ["health", "splinter/shutdown"]
 https-bind = ["splinter/https-bind"]
 oauth = [
     "splinter/oauth"

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -96,6 +96,7 @@ experimental = [
     "oauth",
     "service-arg-validation",
     "service-endpoint",
+    "shutdown",
     "ws-transport",
 ]
 
@@ -135,6 +136,7 @@ service-arg-validation = [
     "splinter/service-arg-validation",
 ]
 service-endpoint = []
+shutdown = ["splinter/shutdown"]
 ws-transport = ["splinter/ws-transport"]
 
 [package.metadata.deb]


### PR DESCRIPTION
This change implements the new ShutdownHandle crate for the ServiceProcessor, replacing its previous combination of handle and JoinHandles, when the "shutdown" feature is enabled.

Likewise it makes several changes to the daemon code to handle this experimental feature:

- Removes the need to send handles to the ctrl-c handler
- Removes the separate threads used to startup both the admin and health service processors
- Reworks the health service feature to include the requirement on the "shutdown" feature, as both are experimental. 
- Removes the need for an external atomic bool for shutdown, as this could put the processor into an inconsistent state if one is triggered, but the other isn't.

Likewise, it implements ShutdownHandle for ServiceOrchestrator, but in doing so, it splits the orchestrator into an builder, a runnable (not started) and a started instance. 