### PR TITLE
Add type for `requester` in `AdminServiceEvent`

### DIFF
--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -717,13 +717,16 @@ pub enum Vote {
     Reject,
 }
 
+/// Represents the `requester`'s public key associated with an `AdminServiceEvent`
+pub type PublicKey = Vec<u8>;
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "eventType", content = "message")]
 pub enum AdminServiceEvent {
     ProposalSubmitted(CircuitProposal),
-    ProposalVote((CircuitProposal, Vec<u8>)),
-    ProposalAccepted((CircuitProposal, Vec<u8>)),
-    ProposalRejected((CircuitProposal, Vec<u8>)),
+    ProposalVote((CircuitProposal, PublicKey)),
+    ProposalAccepted((CircuitProposal, PublicKey)),
+    ProposalRejected((CircuitProposal, PublicKey)),
     CircuitReady(CircuitProposal),
     CircuitDisbanded(CircuitProposal),
 }

--- a/libsplinter/src/admin/store/event.rs
+++ b/libsplinter/src/admin/store/event.rs
@@ -20,6 +20,9 @@ use super::CircuitProposal;
 use crate::admin::service::messages;
 use crate::error::InvalidStateError;
 
+/// Represents the `requester`'s public key associated with an `AdminServiceEvent`
+pub type PublicKey = Vec<u8>;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// Representation of an `AdminServiceEvent` defined by the admin messages
 pub struct AdminServiceEvent {
@@ -32,9 +35,9 @@ pub struct AdminServiceEvent {
 /// Native representation of the `AdminServiceEvent` enum variants
 pub enum EventType {
     ProposalSubmitted,
-    ProposalVote { requester: Vec<u8> },
-    ProposalAccepted { requester: Vec<u8> },
-    ProposalRejected { requester: Vec<u8> },
+    ProposalVote { requester: PublicKey },
+    ProposalAccepted { requester: PublicKey },
+    ProposalRejected { requester: PublicKey },
     CircuitReady,
     CircuitDisbanded,
 }


### PR DESCRIPTION
Adds a type, `PublicKey`, to represent the `requester` field in an
`AdminServiceEvent`. Previously, this was just `Vec<u8>`, so adding the
`PublicKey` type around this field makes the field's purpose more
obvious.

Signed-off-by: Shannyn Telander <telander@bitwise.io>