### PR TITLE
Add `splinter-circuit-abandon` command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "circuit-auth-type",
+    "circuit-abandon",
     "circuit-disband",
     "circuit-purge",
     "health",
@@ -82,6 +83,7 @@ experimental = [
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
+circuit-abandon = ["splinter/circuit-abandon"]
 circuit-disband = ["splinter/circuit-disband"]
 circuit-purge = ["splinter/circuit-purge"]
 circuit-template = ["splinter/circuit-template"]

--- a/cli/man/splinter-circuit-abandon.1.md
+++ b/cli/man/splinter-circuit-abandon.1.md
@@ -1,0 +1,87 @@
+% SPLINTER-CIRCUIT-ABANDON(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-abandon** — Submits a request to abandon the specified circuit.
+
+SYNOPSIS
+========
+**splinter circuit abandon** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID
+
+DESCRIPTION
+===========
+Request to abandon a circuit by specifying the circuit ID of the circuit to be
+abandoned. Abandoning a circuit  will remove the circuit's networking ability
+for the abandoning node. This will also notify other circuit members that the
+circuit has been abandoned, but does not require further action from other
+circuit members.
+
+The generated ID of the existing circuit can be viewed using the
+`splinter-circuit-list` command and this circuit ID is used to specify the
+circuit to be abandoned.
+
+This operation is not able to be performed on circuits that are not active at
+the time of the request. As this operation does disconnect the specified circuit
+from its networking capability for the abandoning node, other circuit members
+should take care to notice when the circuit is abandoned so as not to attempt to
+communicate with this circuit member, as this abandoning circuit member has
+disabled the circuit's routing capability from their end. This removes the
+nodes ability to communicate over this circuit.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be disbanded.
+
+
+EXAMPLES
+========
+* The existing circuit has ID `1234-ABCDE`.
+
+The following command displays a member node requesting to abandon the circuit:
+```
+$ splinter circuit abandon \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
+  1234-ABCDE \
+```
+
+ENVIRONMENT
+===========
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-disband(1)`
+| `splinter-circuit-list(1)`
+| `splinter-circuit-purge(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-disband.1.md
+++ b/cli/man/splinter-circuit-disband.1.md
@@ -87,9 +87,9 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
-| `splinter-circuit-show(1)`
 | `splinter-circuit-purge(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter-circuit-purge.1.md
+++ b/cli/man/splinter-circuit-purge.1.md
@@ -78,8 +78,9 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
-| `splinter-circuit-list(1)`
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-disband(1)`
+| `splinter-circuit-list(1)`
 | `splinter-circuit-show(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter.1.md
+++ b/cli/man/splinter.1.md
@@ -85,6 +85,7 @@ Many `splinter` subcommands accept the following environment variable:
 SEE ALSO
 ========
 | `splinter-cert-generate(1)`
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-disband(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -16,6 +16,8 @@ use cylinder::{secp256k1::Secp256k1Context, Context, PrivateKey};
 use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
+#[cfg(feature = "circuit-abandon")]
+use splinter::protos::admin::CircuitAbandon;
 #[cfg(feature = "circuit-disband")]
 use splinter::protos::admin::CircuitDisbandRequest;
 #[cfg(feature = "circuit-purge")]
@@ -27,6 +29,8 @@ use splinter::protos::admin::{
 
 use crate::error::CliError;
 
+#[cfg(feature = "circuit-abandon")]
+use super::AbandonedCircuit;
 #[cfg(feature = "circuit-disband")]
 use super::CircuitDisband;
 #[cfg(feature = "circuit-purge")]
@@ -185,5 +189,25 @@ impl CircuitAction<CircuitPurgeRequest> for CircuitPurge {
 impl ApplyToEnvelope for CircuitPurgeRequest {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_purge_request(self);
+    }
+}
+
+#[cfg(feature = "circuit-abandon")]
+impl CircuitAction<CircuitAbandon> for AbandonedCircuit {
+    fn action_type(&self) -> Action {
+        Action::CIRCUIT_ABANDON
+    }
+
+    fn into_proto(self) -> Result<CircuitAbandon, CliError> {
+        let mut abandon = CircuitAbandon::new();
+        abandon.set_circuit_id(self.circuit_id);
+        Ok(abandon)
+    }
+}
+
+#[cfg(feature = "circuit-abandon")]
+impl ApplyToEnvelope for CircuitAbandon {
+    fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
+        circuit_management_payload.set_circuit_abandon(self);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -505,7 +505,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
     #[cfg(feature = "circuit-purge")]
     let circuit_command = circuit_command.subcommand(
         SubCommand::with_name("purge")
-            .about("Purge an existing disbanded circuit")
+            .about("Purge an existing inactive circuit")
             .arg(
                 Arg::with_name("url")
                     .short("U")
@@ -527,6 +527,34 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                     .takes_value(true)
                     .required(true)
                     .help("ID of the circuit to be purged"),
+            ),
+    );
+
+    #[cfg(feature = "circuit-abandon")]
+    let circuit_command = circuit_command.subcommand(
+        SubCommand::with_name("abandon")
+            .about("Abandon an existing circuit")
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .takes_value(true)
+                    .help("URL of Splinter Daemon"),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Path to private key file"),
+            )
+            .arg(
+                Arg::with_name("circuit_id")
+                    .value_name("circuit-id")
+                    .takes_value(true)
+                    .required(true)
+                    .help("ID of the circuit to be abandoned"),
             ),
     );
 
@@ -1486,6 +1514,9 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     #[cfg(feature = "circuit-purge")]
     let circuit_command = circuit_command.with_command("purge", circuit::CircuitPurgeAction);
+
+    #[cfg(feature = "circuit-abandon")]
+    let circuit_command = circuit_command.with_command("abandon", circuit::CircuitAbandonAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(


### PR DESCRIPTION
This PR adds the `splinter-circuit-abandon` command and related man page entry. This action submits a `CircuitAbandon` payload to the admin service. 

You can test using gameroom:
First, set the `CARGO_ARGS` environment variable to pull in the `circuit-abandon` feature:
`$ CARGO_ARGS='-- --features=stable,circuit-abandon'`

Next, start up gameroom: 
`$ docker-compose -f examples/gameroom/docker-compose.yaml up --build`

Then, get the respective private keys for alice and bob from the registry: 
`docker-compose -f examples/gameroom/docker-compose.yaml run generate-registry bash`
Then use `cat /registry/alice.priv` and `cat /registry/bob.priv` to copy over these keys. 

Then, go into the alpha node container and create a circuit (example based on values from the gameroom docker-compose file):
```
$ splinter circuit propose --url http://splinterd-node-acme:8085 --node acme-node-000::tcps://splinterd-node-acme:8044 --node bubba-node-000::tcps://splinterd-node-bubba:8044 --service scAA::acme-node-000 --service scBB::bubba-node-000 --service-type *::scabbard --management test --service-arg *::admin_keys=$ALICE_PUB_KEY --service-peer-group scAA,scBB --key <path_to_alice_priv_key>
```

Then, go into the beta node to vote on the circuit you just proposed (based on the generated ID of the circuit you just created). And optionally, go back into the alpha node or stay in the beta node and run the following command to abandon the circuit: 

`$ splinter circuit abandon <CIRCUIT_ID> -U http://splinterd-node-acme:8085 --key <path_to_alice_priv_key>` 

At this point, depending on which node you've abandoned the circuit from, you will see messages pertaining to the command you just ran. From the abandoning node, you should see messages like this (messages based on abandoning the circuit from the acme node) : 

```
      splinterd-acme      | [2021-02-11 20:39:37.803] T["actix-rt:worker:0"] DEBUG [splinter::admin::service::shared] received abandon request for circuit <CIRCUIT_ID>
      splinterd-acme      | [2021-02-11 20:39:37.822] T["actix-rt:worker:0"] DEBUG [splinter::admin::service::shared] Stopping service: scAA
      splinterd-acme      | [2021-02-11 20:39:37.822] T["actix-rt:worker:0"] DEBUG [scabbard::service] Stopping scabbard service with id scAA
      splinterd-acme      | [2021-02-11 20:39:38.011] T["consensus-scAA"] INFO [splinter::consensus::two_phase] received shutdown
      splinterd-acme      | [2021-02-11 20:39:38.014] T["NetworkDispatchLoop"] DEBUG [splinter::circuit::handlers::circuit_message] Handle CircuitMessage SERVICE_DISCONNECT_REQUEST from orchestator::acme [57 bytes]
      splinterd-acme      | [2021-02-11 20:39:38.014] T["CircuitDispatchLoop"] DEBUG [splinter::circuit::handlers::service_handlers] Handle Service Disconnect Request circuit: "<CIRCUIT_ID>" service_id: "scAA" correlation_id: "aefd65df-6d9f-49a5-bc72-fa7b4a6f9a74"
      splinterd-acme      | [2021-02-11 20:39:38.016] T["Peer Manager"] DEBUG [splinter::peer] Removing peer: bubba
```

And from the node that will receive a notification about the abandoning (In this example, this node is bubba):

```
    splinterd-bubba       | [2021-02-11 20:39:37.908] T["NetworkDispatchLoop"] DEBUG [splinter::circuit::handlers::circuit_message] Handle CircuitMessage ADMIN_DIRECT_MESSAGE from splinterd-acme [87 bytes]
    splinterd-bubba       | [2021-02-11 20:39:37.909] T["CircuitDispatchLoop"] DEBUG [splinter::circuit::handlers::admin_message] Handle Admin Direct Message on admin (admin::splinterd-acme => admin::splinterd-bubba) [33 bytes]
    splinterd-bubba       | [2021-02-11 20:39:37.910] T["Service admin::beta"] DEBUG [splinter::admin::service] received admin message message_type: ABANDONED_CIRCUIT abandoned_circuit {circuit_id: "<CIRCUIT_ID>" member_node_id: "acme"}
    splinterd-bubba       | [2021-02-11 20:39:37.910] T["Service admin::beta"] DEBUG [splinter::admin::service] Member acme has abandoned circuit <CIRCUIT_ID>
```
 
 At this point, from the abandoning node, you can run `splinter circuit list --circuit-status abandoned` to see the circuit that you have abandoned. NOTE: this will only appear for the node that abandoned the circuit. At this point, the other node will still see the circuit as `Active`.
 
 Also note that if you attempt to create a circuit using the gameroom UI, you will not be able to abandon it as it will have a `circuit_version` of 1. So, if using gameroom, you must use the CLI to create the circuit to ensure it has a valid circuit version.  