### PR TITLE
`circuit-disband` and `circuit-purge` stabilization updates

### DIFF
--- a/cli/man/splinter-circuit-disband.1.md
+++ b/cli/man/splinter-circuit-disband.1.md
@@ -19,9 +19,7 @@ DESCRIPTION
 Request to disband a circuit by specifying the circuit ID of the circuit to be
 disbanded. Disbanding a circuit removes a circuit's networking functionality.
 Once all members of the circuit have accepted the request to disband the
-circuit, the circuit is only available offline. This functionality is currently
-behind the experimental `circuit-disband` feature and must be enabled to use
-this command.
+circuit, the circuit is only available offline.
 
 The `disband` command creates a new circuit proposal to reflect the disbanded
 state, with the proposed circuit's `circuit_status` field set to `Disbanded`.
@@ -75,8 +73,8 @@ EXAMPLES
 The following command displays a member node requesting to disband the circuit:
 ```
 $ splinter circuit disband \
-  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
-  --url URL-of-proposed-member-node-splinterd-REST-API \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
   1234-ABCDE \
 ```
 

--- a/cli/man/splinter-circuit-purge.1.md
+++ b/cli/man/splinter-circuit-purge.1.md
@@ -17,17 +17,25 @@ SYNOPSIS
 DESCRIPTION
 ===========
 Request to purge a circuit by specifying the circuit ID of the circuit to be
-removed from the node's storage. A circuit is only available to be purged
-if it has already been disbanded and are only available locally. Disbanding a
-circuit removes a circuit's networking functionality.
+removed from the node's storage. Internal service data associated with the
+circuit is also purged. A circuit is only able to be purged if it has already
+been deactivated and no longer supports networking. Disbanding a circuit
+removes a circuit's networking functionality, allowing for a circuit to be
+purged. A circuit may also be abandoned, causing the circuit's networking
+capability to be disabled for the abandoning node, so the abandoning node
+is able to purge the deactivated circuit.
 
-The generated ID of the existing disbanded circuit can be viewed using the
-`splinter-circuit-list`, with the `--circuit-status` option of `disbanded`.
+The generated ID of an existing deactivated circuit can be viewed using the
+`splinter-circuit-list`, with the `--circuit-status` option of either
+`disbanded` and/or `abandoned`.
 
-The purge request is only available for members of the node, as the circuit is
-only available to the node locally. If the circuit has not been disbanded, it
-is not able to be purged. Once a circuit has been purged, it is removed from
-the node's storage and is no longer viewable.
+The purge request only works for local circuits that have been deactivated. If
+the circuit is still considered active, it is not able to be purged. Once a
+circuit has been purged, the circuit is removed from the node's admin store and
+any internal Splinter service data will also be removed. If a circuit is using
+the Scabbard service, for example, the state LMDB files associated with the
+circuit are deleted. After purging, the circuit and internal service data are
+no longer available as this state has been deleted.
 
 FLAGS
 =====
@@ -61,7 +69,7 @@ ARGUMENTS
 
 EXAMPLES
 ========
-* The existing disbanded circuit has ID `1234-ABCDE`.
+* The existing inactive circuit has ID `1234-ABCDE`.
 
 The following command displays a member node requesting to purge the circuit:
 ```

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -15,6 +15,7 @@
 pub mod builders;
 
 use protobuf::{self, RepeatedField};
+use std::convert::TryInto;
 
 use crate::admin::store;
 #[cfg(feature = "admin-service-event-store")]
@@ -212,8 +213,12 @@ impl CreateCircuit {
 
         Ok(create_request)
     }
+}
 
-    pub fn into_circuit_proto(self) -> Result<admin::Circuit, MarshallingError> {
+impl TryInto<admin::Circuit> for CreateCircuit {
+    type Error = MarshallingError;
+
+    fn try_into(self) -> Result<admin::Circuit, Self::Error> {
         let mut circuit = admin::Circuit::new();
 
         circuit.set_circuit_id(self.circuit_id);

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -15,7 +15,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 #[cfg(feature = "circuit-disband")]
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::iter::ExactSizeIterator;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
@@ -2739,7 +2739,7 @@ impl AdminServiceShared {
             create_circuit_builder = create_circuit_builder.with_display_name(&display_name);
         }
 
-        let proposed_circuit = create_circuit_builder
+        let proposed_circuit: Circuit = create_circuit_builder
             .build()
             .map_err(|err| {
                 AdminSharedError::ValidationFailed(format!(
@@ -2747,7 +2747,7 @@ impl AdminServiceShared {
                     err
                 ))
             })?
-            .into_circuit_proto()
+            .try_into()
             .map_err(|err| {
                 AdminSharedError::ValidationFailed(format!(
                     "error occurred when trying to create proto circuit {}",


### PR DESCRIPTION
Makes a few of the requested updates for the `circuit-disband` and `circuit-purge` features, mainly:

 - Updates the `disband` and `purge` CLI man pages to more remove mentions of the features that currently exist and also removes the specific mentions of only purging disbanded circuits to more accurately show that abandoned circuits are also able to be purged.
 - Change the `into_proto_circuit` method implemented for the `CreateCircuit` struct into an implementation of `TryInto` for the `CreateCircuit` struct