### PR TITLE
Stabilize registry-database experimental feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -117,7 +117,6 @@ experimental = [
     "circuit-purge",
     "client-reqwest",
     "https-bind",
-    "registry-database",
     "rest-api-actix-web-3",
     "role-based-authorization-store-postgres",
     "run",
@@ -156,7 +155,6 @@ memory = ["sqlite"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
-registry-database = ["diesel"]
 registry-remote = ["reqwest", "registry"]
 rest-api = [
     "actix",

--- a/libsplinter/src/registry/error.rs
+++ b/libsplinter/src/registry/error.rs
@@ -15,7 +15,7 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "registry-database")]
+#[cfg(feature = "diesel")]
 use crate::error::ConstraintViolationType;
 use crate::error::{
     ConstraintViolationError, InternalError, InvalidStateError, ResourceTemporarilyUnavailableError,
@@ -59,7 +59,7 @@ impl fmt::Display for RegistryError {
     }
 }
 
-#[cfg(feature = "registry-database")]
+#[cfg(feature = "diesel")]
 impl From<diesel::r2d2::PoolError> for RegistryError {
     fn from(err: diesel::r2d2::PoolError) -> Self {
         RegistryError::ResourceTemporarilyUnavailableError(
@@ -131,7 +131,7 @@ impl fmt::Display for InvalidNodeError {
     }
 }
 
-#[cfg(feature = "registry-database")]
+#[cfg(feature = "diesel")]
 impl From<diesel::result::Error> for RegistryError {
     fn from(err: diesel::result::Error) -> Self {
         match err {

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -24,7 +24,7 @@
 //! [`RegistryWriter`]: trait.RegistryWriter.html
 //! [`RwRegistry`]: trait.RwRegistry.html
 
-#[cfg(feature = "registry-database")]
+#[cfg(feature = "diesel")]
 mod diesel;
 mod error;
 #[cfg(feature = "rest-api")]
@@ -35,7 +35,7 @@ mod yaml;
 use std::collections::HashMap;
 use std::iter::ExactSizeIterator;
 
-#[cfg(feature = "registry-database")]
+#[cfg(feature = "diesel")]
 pub use self::diesel::DieselRegistry;
 pub use error::{InvalidNodeError, RegistryError};
 pub use unified::UnifiedRegistry;

--- a/libsplinter/src/store/memory.rs
+++ b/libsplinter/src/store/memory.rs
@@ -133,7 +133,7 @@ impl StoreFactory for MemoryStoreFactory {
         Box::new(self.inflight_request_store.clone())
     }
 
-    #[cfg(feature = "registry-database")]
+    #[cfg(feature = "registry")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
         let pool = Pool::builder()

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -58,7 +58,7 @@ pub trait StoreFactory {
         &self,
     ) -> Box<dyn crate::oauth::store::InflightOAuthRequestStore>;
 
-    #[cfg(feature = "registry-database")]
+    #[cfg(feature = "registry")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry>;
 
     #[cfg(feature = "authorization-handler-rbac")]

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -73,7 +73,7 @@ impl StoreFactory for PgStoreFactory {
         ))
     }
 
-    #[cfg(feature = "registry-database")]
+    #[cfg(feature = "registry")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -75,7 +75,7 @@ impl StoreFactory for SqliteStoreFactory {
         ))
     }
 
-    #[cfg(feature = "registry-database")]
+    #[cfg(feature = "registry")]
     fn get_registry_store(&self) -> Box<dyn crate::registry::RwRegistry> {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -94,7 +94,6 @@ experimental = [
     "health",
     "https-bind",
     "oauth",
-    "registry-database",
     "service-arg-validation",
     "service-endpoint",
     "ws-transport",
@@ -130,7 +129,6 @@ https-bind = ["splinter/https-bind"]
 oauth = [
     "splinter/oauth"
 ]
-registry-database = ["splinter/registry-database"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [
     "scabbard/service-arg-validation",


### PR DESCRIPTION
This commit stabilize the experimental features by
removing the registry-databse features and replacing
it with registry or diesel where appropriate.

Also updates splinterd to for the removal of the features
and updates splinterd to use the database backends
instead. This removes the ability to use a yaml
registry as the local registry.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>