### PR TITLE
Remove Serialize/Deserialize from Node struct

### DIFF
--- a/cli/src/action/registry/mod.rs
+++ b/cli/src/action/registry/mod.rs
@@ -16,7 +16,7 @@
 mod api;
 
 use clap::ArgMatches;
-use splinter::registry::Node;
+use splinter::registry::{Node, YamlNode};
 #[cfg(feature = "registry")]
 use std::collections::HashMap;
 use std::fs::File;
@@ -45,7 +45,7 @@ impl Action for RegistryGenerateAction {
 
         let output_file = args.value_of("file").unwrap_or(DEFAULT_OUTPUT_FILE);
 
-        let mut nodes: Vec<Node> = if Path::new(output_file).exists() {
+        let mut nodes: Vec<YamlNode> = if Path::new(output_file).exists() {
             let file = File::open(output_file).map_err(|err| {
                 CliError::ActionError(format!(
                     "Failed to open '{}': {}",
@@ -137,7 +137,7 @@ impl Action for RegistryGenerateAction {
             }
         }
 
-        nodes.push(node);
+        nodes.push(YamlNode::from(node));
 
         let yaml = serde_yaml::to_vec(&nodes).map_err(|err| {
             CliError::ActionError(format!("Cannot format node list into yaml: {}", err))

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -39,12 +39,12 @@ use std::iter::ExactSizeIterator;
 pub use self::diesel::DieselRegistry;
 pub use error::{InvalidNodeError, RegistryError};
 pub use unified::UnifiedRegistry;
-pub use yaml::LocalYamlRegistry;
+pub use yaml::{LocalYamlRegistry, YamlNode};
 #[cfg(feature = "registry-remote")]
 pub use yaml::{RemoteYamlRegistry, RemoteYamlShutdownHandle};
 
 /// Native representation of a node in a registry.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Node {
     /// The Splinter identity of the node; must be non-empty and unique in the registry.
     identity: String,

--- a/libsplinter/src/registry/rest_api/resources/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/resources/nodes_identity.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
-use crate::registry::Node;
+use crate::registry::{error::InvalidNodeError, Node};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct NodeResponse<'a> {
@@ -34,5 +35,39 @@ impl<'a> From<&'a Node> for NodeResponse<'a> {
             keys: &node.keys,
             metadata: &node.metadata,
         }
+    }
+}
+
+/// Used to deserialize add and update requests
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct NewNode {
+    /// The Splinter identity of the node; must be non-empty and unique in the registry.
+    pub identity: String,
+    /// The endpoints the node can be reached at; at least one endpoint must be provided, and each
+    /// endpoint must be non-empty and unique in the registry.
+    pub endpoints: Vec<String>,
+    /// A human-readable name for the node; must be non-empty.
+    pub display_name: String,
+    /// The list of public keys that are permitted to act on behalf of the node; at least one key
+    /// must be provided, and each key must be non-empty.
+    pub keys: Vec<String>,
+    /// A map with node metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+impl TryFrom<NewNode> for Node {
+    type Error = InvalidNodeError;
+
+    fn try_from(node: NewNode) -> Result<Self, Self::Error> {
+        let mut builder = Node::builder(node.identity)
+            .with_endpoints(node.endpoints)
+            .with_display_name(node.display_name)
+            .with_keys(node.keys);
+
+        for (k, v) in node.metadata {
+            builder = builder.with_metadata(k, v);
+        }
+
+        builder.build()
     }
 }

--- a/libsplinter/src/registry/yaml/mod.rs
+++ b/libsplinter/src/registry/yaml/mod.rs
@@ -14,10 +14,90 @@
 
 //! YAML file-backed registry implementations.
 
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
 mod local;
 #[cfg(feature = "registry-remote")]
 mod remote;
 
+pub use crate::registry::error::InvalidNodeError;
+
+use super::Node;
+
 pub use local::LocalYamlRegistry;
 #[cfg(feature = "registry-remote")]
 pub use remote::{RemoteYamlRegistry, ShutdownHandle as RemoteYamlShutdownHandle};
+
+/// Yaml representation of a node in a registry.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct YamlNode {
+    /// The Splinter identity of the node; must be non-empty and unique in the registry.
+    identity: String,
+    /// The endpoints the node can be reached at; at least one endpoint must be provided, and each
+    /// endpoint must be non-empty and unique in the registry.
+    endpoints: Vec<String>,
+    /// A human-readable name for the node; must be non-empty.
+    display_name: String,
+    /// The list of public keys that are permitted to act on behalf of the node; at least one key
+    /// must be provided, and each key must be non-empty.
+    keys: Vec<String>,
+    /// A map with node metadata.
+    metadata: HashMap<String, String>,
+}
+
+impl YamlNode {
+    /// The Splinter identity of the node;
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+
+    /// The endpoints the node can be reached at
+    pub fn endpoints(&self) -> &[String] {
+        &self.endpoints
+    }
+
+    /// A human-readable name for the node
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    /// The list of public keys that are permitted to act on behalf of the node
+    pub fn keys(&self) -> &[String] {
+        &self.keys
+    }
+
+    /// A map with node metadata.
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+}
+
+impl From<Node> for YamlNode {
+    fn from(node: Node) -> Self {
+        YamlNode {
+            identity: node.identity().into(),
+            endpoints: node.endpoints().into(),
+            display_name: node.display_name().into(),
+            keys: node.keys().into(),
+            metadata: node.metadata().clone(),
+        }
+    }
+}
+
+impl TryFrom<YamlNode> for Node {
+    type Error = InvalidNodeError;
+
+    fn try_from(node: YamlNode) -> Result<Self, Self::Error> {
+        let mut builder = Node::builder(node.identity)
+            .with_endpoints(node.endpoints)
+            .with_display_name(node.display_name)
+            .with_keys(node.keys);
+
+        for (k, v) in node.metadata {
+            builder = builder.with_metadata(k, v);
+        }
+
+        builder.build()
+    }
+}


### PR DESCRIPTION
The struct itself should be derive Serialize/Deserialize
itself. Instead, the different components should implement
their own structs to handler serialization.

To remove Serialize/Deserialize from Node, a YamlNode for
the yaml implementation had to be added, as well as a
NewNode struct to be used by the REST API add/update
routes.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>