### PR TITLE
Change log level to warn for notification of circuit abandon

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -777,7 +777,7 @@ impl Service for AdminService {
                 let circuit_id = abandoned_circuit.get_circuit_id();
                 let member_node_id = abandoned_circuit.get_member_node_id();
 
-                debug!(
+                warn!(
                     "Member {} has abandoned circuit {}",
                     member_node_id, circuit_id
                 );


### PR DESCRIPTION
Having a member of a circuit abandon the circuit is expected
but will break the operations of the circuit. As such this
log level should be set to warn.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>