### PR TITLE
Scabbard v2

### DIFF
--- a/cli/packaging/scabbard_circuit_template.yaml
+++ b/cli/packaging/scabbard_circuit_template.yaml
@@ -19,4 +19,6 @@ rules:
           value: [$(ADMIN_KEYS)]
         - key: 'peer_services'
           value: '$(ALL_OTHER_SERVICES)'
+        - key: 'version'
+          value: '2'
         first-service: 'a000'

--- a/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
+++ b/examples/gameroom/daemon/packaging/gameroom_circuit_template.yaml
@@ -24,6 +24,8 @@ rules:
           value: [$(ADMIN_KEYS)]
         - key: 'peer_services'
           value: '$(ALL_OTHER_SERVICES)'
+        - key: 'version'
+          value: '2'
         first-service: 'a000'
     set-metadata:
         encoding: json

--- a/services/scabbard/libscabbard/protos/scabbard.proto
+++ b/services/scabbard/libscabbard/protos/scabbard.proto
@@ -19,6 +19,7 @@ message ScabbardMessage {
         UNSET = 0;
         CONSENSUS_MESSAGE = 1;
         PROPOSED_BATCH = 2;
+        NEW_BATCH = 3;
     }
 
     Type message_type = 1;
@@ -28,6 +29,9 @@ message ScabbardMessage {
 
     // Set if type is PROPOSED_BATCH
     ProposedBatch proposed_batch = 3;
+
+    // Set if type is NEW_BATCH
+    bytes new_batch = 4;
 }
 
 message ProposedBatch {

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -406,20 +406,21 @@ mod tests {
     fn network_sender() {
         let service_sender = MockServiceNetworkSender::new();
         let mut peer_services = HashSet::new();
-        peer_services.insert("1".to_string());
-        peer_services.insert("2".to_string());
+        peer_services.insert("svc1".to_string());
+        peer_services.insert("svc2".to_string());
 
         let shared = Arc::new(Mutex::new(ScabbardShared::new(
             VecDeque::new(),
             Some(Box::new(service_sender.clone())),
             peer_services.clone(),
+            "svc0".to_string(),
             Secp256k1Context::new().new_verifier(),
         )));
-        let consensus_sender = ScabbardConsensusNetworkSender::new("0".into(), shared);
+        let consensus_sender = ScabbardConsensusNetworkSender::new("svc0".into(), shared);
 
         // Test send_to
         consensus_sender
-            .send_to(&"1".as_bytes().into(), vec![0])
+            .send_to(&"svc1".as_bytes().into(), vec![0])
             .expect("failed to send");
 
         let (recipient, message) = service_sender
@@ -429,7 +430,7 @@ mod tests {
             .get(0)
             .expect("1st message not sent")
             .clone();
-        assert_eq!(recipient, "1".to_string());
+        assert_eq!(recipient, "svc1".to_string());
 
         let scabbard_message: ScabbardMessage =
             Message::parse_from_bytes(&message).expect("failed to parse 1st scabbard message");
@@ -442,7 +443,7 @@ mod tests {
             ConsensusMessage::try_from(scabbard_message.get_consensus_message())
                 .expect("failed to parse 1st consensus message");
         assert_eq!(consensus_message.message, vec![0]);
-        assert_eq!(consensus_message.origin_id, "0".as_bytes().into());
+        assert_eq!(consensus_message.origin_id, "svc0".as_bytes().into());
 
         // Test broadcast
         consensus_sender.broadcast(vec![1]).expect("failed to send");
@@ -468,7 +469,7 @@ mod tests {
             ConsensusMessage::try_from(scabbard_message.get_consensus_message())
                 .expect("failed to parse 2nd consensus message");
         assert_eq!(consensus_message.message, vec![1]);
-        assert_eq!(consensus_message.origin_id, "0".as_bytes().into());
+        assert_eq!(consensus_message.origin_id, "svc0".as_bytes().into());
 
         // Second broadcast message
         let (recipient, message) = service_sender
@@ -491,7 +492,7 @@ mod tests {
             ConsensusMessage::try_from(scabbard_message.get_consensus_message())
                 .expect("failed to parse 3rd consensus message");
         assert_eq!(consensus_message.message, vec![1]);
-        assert_eq!(consensus_message.origin_id, "0".as_bytes().into());
+        assert_eq!(consensus_message.origin_id, "svc0".as_bytes().into());
     }
 
     #[derive(Clone, Debug)]

--- a/services/scabbard/libscabbard/src/service/error.rs
+++ b/services/scabbard/libscabbard/src/service/error.rs
@@ -27,6 +27,7 @@ pub enum ScabbardError {
     BatchVerificationFailed(Box<dyn Error + Send>),
     ConsensusFailed(ScabbardConsensusManagerError),
     InitializationFailed(Box<dyn Error + Send>),
+    Internal(Box<dyn Error + Send>),
     LockPoisoned,
     MessageTypeUnset,
     NotConnected,
@@ -39,6 +40,7 @@ impl Error for ScabbardError {
             ScabbardError::BatchVerificationFailed(err) => Some(&**err),
             ScabbardError::ConsensusFailed(err) => Some(err),
             ScabbardError::InitializationFailed(err) => Some(&**err),
+            ScabbardError::Internal(err) => Some(&**err),
             ScabbardError::LockPoisoned => None,
             ScabbardError::MessageTypeUnset => None,
             ScabbardError::NotConnected => None,
@@ -56,6 +58,9 @@ impl std::fmt::Display for ScabbardError {
             ScabbardError::ConsensusFailed(err) => write!(f, "scabbard consensus failed: {}", err),
             ScabbardError::InitializationFailed(err) => {
                 write!(f, "failed to initialize scabbard: {}", err)
+            }
+            ScabbardError::Internal(err) => {
+                write!(f, "internal error occurred: {}", err)
             }
             ScabbardError::LockPoisoned => write!(f, "internal lock poisoned"),
             ScabbardError::MessageTypeUnset => write!(f, "received message with unset type"),

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -116,7 +116,7 @@ impl ServiceFactory for ScabbardFactory {
     /// - `coordinator_timeout`: the length of time (in milliseconds) that the network has to
     ///   commit a proposal before the coordinator rejects it (if not provided, default is 30
     ///   seconds)
-    /// - `version`: the protocol version for scabbard (possible values: "1") (default: "1")
+    /// - `version`: the protocol version for scabbard (possible values: "1", "2") (default: "1")
     fn create(
         &self,
         service_id: String,

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -65,6 +65,7 @@ const DEFAULT_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
 #[derive(Clone)]
 pub enum ScabbardVersion {
     V1,
+    V2,
 }
 
 impl TryFrom<Option<&str>> for ScabbardVersion {
@@ -73,6 +74,7 @@ impl TryFrom<Option<&str>> for ScabbardVersion {
     fn try_from(str_opt: Option<&str>) -> Result<Self, Self::Error> {
         match str_opt {
             Some("1") => Ok(Self::V1),
+            Some("2") => Ok(Self::V2),
             Some(v) => Err(format!("Unsupported scabbard version: {}", v)),
             None => Ok(Self::V1),
         }

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -119,7 +119,13 @@ impl Scabbard {
         // default value will be used (30 seconds).
         coordinator_timeout: Option<Duration>,
     ) -> Result<Self, ScabbardError> {
-        let shared = ScabbardShared::new(VecDeque::new(), None, peer_services, signature_verifier);
+        let shared = ScabbardShared::new(
+            VecDeque::new(),
+            None,
+            peer_services,
+            service_id.clone(),
+            signature_verifier,
+        );
 
         let (state_db_path, receipt_db_path) =
             compute_db_paths(&service_id, circuit_id, state_db_dir, receipt_db_dir)?;

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -281,6 +281,7 @@ impl Service for Scabbard {
         consensus.replace(
             ScabbardConsensusManager::new(
                 self.service_id().into(),
+                self.version.clone(),
                 self.shared.clone(),
                 self.state.clone(),
                 self.coordinator_timeout,

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -130,7 +130,7 @@ mod tests {
         service::Service,
     };
 
-    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard};
+    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard, ScabbardVersion};
 
     const MOCK_CIRCUIT_ID: &str = "abcde-01234";
     const MOCK_SERVICE_ID: &str = "ABCD";
@@ -199,6 +199,7 @@ mod tests {
         let scabbard = Scabbard::new(
             MOCK_SERVICE_ID.into(),
             MOCK_CIRCUIT_ID,
+            ScabbardVersion::V1,
             Default::default(),
             paths.temp_dir.path(),
             TEMP_DB_SIZE,

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -105,7 +105,7 @@ mod tests {
         service::Service,
     };
 
-    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard};
+    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard, ScabbardVersion};
 
     const MOCK_CIRCUIT_ID: &str = "abcde-01234";
     const MOCK_SERVICE_ID: &str = "ABCD";
@@ -164,6 +164,7 @@ mod tests {
         let scabbard = Scabbard::new(
             MOCK_SERVICE_ID.into(),
             MOCK_CIRCUIT_ID,
+            ScabbardVersion::V1,
             Default::default(),
             paths.temp_dir.path(),
             TEMP_DB_SIZE,

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -97,7 +97,7 @@ mod tests {
         service::Service,
     };
 
-    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard};
+    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard, ScabbardVersion};
 
     const MOCK_CIRCUIT_ID: &str = "abcde-01234";
     const MOCK_SERVICE_ID: &str = "ABCD";
@@ -155,6 +155,7 @@ mod tests {
         let scabbard = Scabbard::new(
             MOCK_SERVICE_ID.into(),
             MOCK_CIRCUIT_ID,
+            ScabbardVersion::V1,
             Default::default(),
             paths.temp_dir.path(),
             TEMP_DB_SIZE,

--- a/services/scabbard/libscabbard/src/service/shared.rs
+++ b/services/scabbard/libscabbard/src/service/shared.rs
@@ -20,7 +20,10 @@ use transact::protocol::batch::BatchPair;
 use transact::protocol::transaction::{HashMethod, TransactionHeader};
 use transact::protos::FromBytes;
 
-use splinter::{consensus::ProposalId, service::ServiceNetworkSender};
+use splinter::{
+    consensus::{PeerId, ProposalId},
+    service::ServiceNetworkSender,
+};
 
 use crate::hex::parse_hex;
 
@@ -36,6 +39,11 @@ pub struct ScabbardShared {
     network_sender: Option<Box<dyn ServiceNetworkSender>>,
     /// List of service IDs that this service is configured to communicate and share state with.
     peer_services: HashSet<String>,
+    /// The two-phase commit coordinator. This is the service that will create all proposals, so all
+    /// submitted batches should be sent to this service.
+    coordinator_service_id: String,
+    /// This service's ID
+    service_id: String,
     /// Tracks which batches are currently being evaluated, indexed by corresponding proposal IDs.
     proposed_batches: HashMap<ProposalId, BatchPair>,
     signature_verifier: Box<dyn SignatureVerifier>,
@@ -46,15 +54,41 @@ impl ScabbardShared {
         batch_queue: VecDeque<BatchPair>,
         network_sender: Option<Box<dyn ServiceNetworkSender>>,
         peer_services: HashSet<String>,
+        service_id: String,
         signature_verifier: Box<dyn SignatureVerifier>,
     ) -> Self {
+        // The two-phase commit coordinator is the node with the lowest peer ID. Peer IDs are
+        // computed from service IDs.
+        let coordinator_service_id = String::from_utf8(
+            peer_services
+                .iter()
+                .chain(std::iter::once(&service_id))
+                .map(|service_id| PeerId::from(service_id.as_bytes()))
+                .min()
+                .expect("There will always be at least one service (self)")
+                .into(),
+        )
+        .expect("String -> PeerId -> String conversion should not fail");
+
         ScabbardShared {
             batch_queue,
             network_sender,
             peer_services,
+            coordinator_service_id,
+            service_id,
             proposed_batches: HashMap::new(),
             signature_verifier,
         }
+    }
+
+    /// Determines if this service is the coordinator.
+    pub fn is_coordinator(&self) -> bool {
+        self.service_id == self.coordinator_service_id
+    }
+
+    /// Gets the service ID of the two-phase commit coordinator.
+    pub fn coordinator_service_id(&self) -> &str {
+        &self.coordinator_service_id
     }
 
     pub fn add_batch_to_queue(&mut self, batch: BatchPair) {
@@ -194,5 +228,78 @@ impl ScabbardShared {
         }
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cylinder::{secp256k1::Secp256k1Context, VerifierFactory};
+    use splinter::service::{ServiceMessageContext, ServiceSendError};
+
+    /// Verifies that the `is_coordinator` and `coordinator_service_id` methods work properly.
+    ///
+    /// 1. Create a `ScabbardShared` instance for a coordinator (has a service ID lower than all of
+    ///    its peers) and verify that it properly determines that the coordinator is itself.
+    /// 2. Create a `ScabbardShared` instance for a non-coordinator (does not have a service ID
+    ///    lower than all of its peers) and verify that it properly determines who the coordinator
+    ///    is (not itself).
+    #[test]
+    fn coordinator() {
+        let context = Secp256k1Context::new();
+
+        let mut peer_services = HashSet::new();
+        peer_services.insert("svc1".to_string());
+        peer_services.insert("svc2".to_string());
+
+        let coordinator_shared = ScabbardShared::new(
+            VecDeque::new(),
+            Some(Box::new(MockServiceNetworkSender)),
+            peer_services.clone(),
+            "svc0".to_string(),
+            context.new_verifier(),
+        );
+        assert!(coordinator_shared.is_coordinator());
+        assert_eq!(coordinator_shared.coordinator_service_id(), "svc0");
+
+        let non_coordinator_shared = ScabbardShared::new(
+            VecDeque::new(),
+            Some(Box::new(MockServiceNetworkSender)),
+            peer_services,
+            "svc3".to_string(),
+            context.new_verifier(),
+        );
+        assert!(!non_coordinator_shared.is_coordinator());
+        assert_eq!(non_coordinator_shared.coordinator_service_id(), "svc1");
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct MockServiceNetworkSender;
+
+    impl ServiceNetworkSender for MockServiceNetworkSender {
+        fn send(&self, _recipient: &str, _message: &[u8]) -> Result<(), ServiceSendError> {
+            unimplemented!()
+        }
+
+        fn send_and_await(
+            &self,
+            _recipient: &str,
+            _message: &[u8],
+        ) -> Result<Vec<u8>, ServiceSendError> {
+            unimplemented!()
+        }
+
+        fn reply(
+            &self,
+            _message_origin: &ServiceMessageContext,
+            _message: &[u8],
+        ) -> Result<(), ServiceSendError> {
+            unimplemented!()
+        }
+
+        fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
+            Box::new(self.clone())
+        }
     }
 }


### PR DESCRIPTION
Adds versioning to the scabbard service and creates a new version 2 of scabbard that uses version 2 of the two-phase commit consensus algorithm. This fixes a bug where hash mismatch errors occurred because multiple proposals were created at the same height.

# Testing

1. Build and run gameroom:

```bash
$ docker-compose -f examples/gameroom/docker-compose.yaml build
$ docker-compose -f examples/gameroom/docker-compose.yaml up
```

2. In a new terminal window, get alice and bob's keys and save them in your current directory:

```bash
$ docker-compose -f examples/gameroom/docker-compose.yaml run generate-registry bash
# cat /registry/alice.priv
<alice's private key>
# cat /registry/alice.pub
<alice's public key>
# cat /registry/bob.priv
<bob's private key>
# cat /registry/bob.pub
<bob's public key>
# exit
$ echo "<alice's private key>" > alice.priv
$ echo "<alice's public key>" > alice.pub
$ echo "<bob's private key>" > bob.priv
$ echo "<bob's public key>" > bob.pub
```

3. Create a new circuit:

```bash
$ export SPLINTER_CIRCUIT_TEMPLATE_PATH=./cli/packaging/
$ splinter circuit propose \
  --node acme-node-000::tcps://splinterd-node-acme:8044 \
  --node bubba-node-000::tcps://splinterd-node-bubba:8044 \
  --template scabbard_circuit_template \
  --template-arg SIGNER_PUB_KEY=$(cat alice.pub) \
  --url http://0.0.0.0:8088 \
  -k ./alice.priv \
  --management test
$ export CIRCUIT_ID=<circuit ID>
$ splinter circuit vote $CIRCUIT_ID --accept --url http://0.0.0.0:8089 -k ./bob.priv
```

4. Download [smallbank_0.0.1.tar.gz](https://github.com/Cargill/splinter/files/6065243/smallbank_0.0.1.tar.gz), change the extension to `.scar`, and move the file to your current directory.

5. Setup smallbank for the new circuit:

```bash
$ scabbard cr create smallbank \
  --owners $(cat alice.pub) \
  --key ./alice.priv \
  --url http://0.0.0.0:8088 \
  --service-id $CIRCUIT_ID::a000
$ scabbard contract upload smallbank:0.0.1 \
  --path . \
  --key ./alice.priv \
  --url http://0.0.0.0:8088 \
 --service-id $CIRCUIT_ID::a000
$ scabbard  ns create 332514 \
    --owners $(cat alice.pub) \
    --key ./alice.priv \
    --url http://0.0.0.0:8088 \
    --service-id $CIRCUIT_ID::a000
$ scabbard perm 332514 smallbank --read --write \
  --key ./alice.priv \
  --url http://0.0.0.0:8088 \
  --service-id $CIRCUIT_ID::a000
$ scabbard contract list -U 'http://0.0.0.0:8088' \
  --service-id $CIRCUIT_ID::a000 --key ./alice.priv
```

6. Using the transact CLI, run a smallbank workload targetting both nodes:

```bash
$ transact workload \
  --target-rate 1-5 \
  --key ./alice.priv \
  --workload smallbank \
  --update 5 \
  --smallbank-num-accounts 5 \
  --targets "http://0.0.0.0:8089/scabbard/$CIRCUIT_ID/a001;http://0.0.0.0:8088/scabbard/$CIRCUIT_ID/a000"
```

Verify that no hash mismatch errors occur