### PR TITLE
Remove timeout from wait_for_shutdown()

### DIFF
--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -376,7 +376,7 @@ impl ShutdownHandle for ServiceOrchestratorShutdownHandle {
         self.running.store(false, Ordering::SeqCst);
     }
 
-    fn wait_for_shutdown(&mut self, _timeout: Duration) -> Result<(), InternalError> {
+    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
         if let Some(join_handles) = self.join_handles.take() {
             match join_handles.join_all() {
                 Ok(results) => {

--- a/libsplinter/src/rest_api/actix_web_3/api.rs
+++ b/libsplinter/src/rest_api/actix_web_3/api.rs
@@ -20,7 +20,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
 use actix_0_10::System as ActixSystem;
 use actix_web_3::{dev::Server, middleware, App, HttpServer};
@@ -157,7 +156,7 @@ impl ShutdownHandle for RestApi {
         self.shutdown_future = Some(Box::pin(self.server.stop(true)));
     }
 
-    fn wait_for_shutdown(&mut self, _timeout: Duration) -> Result<(), InternalError> {
+    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
         match (self.shutdown_future.take(), self.join_handle.take()) {
             (Some(f), Some(join_handle)) => {
                 block_on(f);

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -534,7 +534,7 @@ impl ShutdownHandle for ServiceProcessorShutdownHandle {
         }
     }
 
-    fn wait_for_shutdown(&mut self, _: Duration) -> Result<(), crate::error::InternalError> {
+    fn wait_for_shutdown(&mut self) -> Result<(), crate::error::InternalError> {
         if let Some(join_handles) = self.join_handles.take() {
             match join_handles.join_all() {
                 Ok(results) => {
@@ -736,7 +736,7 @@ pub mod tests {
 
                 #[cfg(feature = "shutdown")]
                 shutdown_handle
-                    .wait_for_shutdown(Duration::from_secs(10))
+                    .wait_for_shutdown()
                     .expect("Unable to cleanly shutdown");
                 #[cfg(not(feature = "shutdown"))]
                 join_handles
@@ -867,7 +867,7 @@ pub mod tests {
 
                 #[cfg(feature = "shutdown")]
                 shutdown_handle
-                    .wait_for_shutdown(Duration::from_secs(10))
+                    .wait_for_shutdown()
                     .expect("Unable to cleanly shutdown");
                 #[cfg(not(feature = "shutdown"))]
                 join_handles

--- a/splinterd/src/node/running.rs
+++ b/splinterd/src/node/running.rs
@@ -15,7 +15,6 @@
 //! Contains the implementation of `Node`.
 
 use std::thread::JoinHandle;
-use std::time::Duration;
 
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::error::InternalError;
@@ -57,7 +56,7 @@ impl ShutdownHandle for Node {
         }
     }
 
-    fn wait_for_shutdown(&mut self, timeout: Duration) -> Result<(), InternalError> {
+    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
         match self.rest_api_variant.take() {
             Some(NodeRestApiVariant::ActixWeb1(shutdown_handle, join_handle)) => {
                 shutdown_handle
@@ -71,7 +70,7 @@ impl ShutdownHandle for Node {
                 Ok(())
             }
             Some(NodeRestApiVariant::ActixWeb3(mut rest_api)) => {
-                rest_api.wait_for_shutdown(timeout)?;
+                rest_api.wait_for_shutdown()?;
                 Ok(())
             }
             None => Err(InternalError::with_message(


### PR DESCRIPTION
Previously, wait_for_shutdown() took a Duration which was intended to
be a timeout. After a few implementations of the function, it seems
both impossible to implement and undesirable (in that it would leave
random threads unjoined).

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>