### PR TITLE
Add root module to splinterd/tests

### DIFF
--- a/splinterd/tests/admin/circuit_list.rs
+++ b/splinterd/tests/admin/circuit_list.rs
@@ -18,7 +18,7 @@
 use splinter::threading::shutdown::shutdown;
 use splinterd::node::RestApiVariant;
 
-use framework::network::Network;
+use crate::framework::network::Network;
 
 /// Creates a single node network and confirms that the admin service's REST API is available
 /// by listing circuits (which will be empty).

--- a/splinterd/tests/admin_service.rs
+++ b/splinterd/tests/admin_service.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A framework for running a network of Splinter nodes in a single process for
-//! integration testing purposes.
+//! Splinter integration tests.
 
-#[cfg(feature = "node")]
-pub mod network;
+mod admin;
+mod framework;


### PR DESCRIPTION
This change adds a root module to the splinterd integration tests directory. Each source file in this root is compiled as a separate crate.

References to the framework module are updated accordingly.
