### PR TITLE
Update ShutdownHandle.wait_for_shutdown to take Box<Self> 

### DIFF
--- a/libsplinter/src/rest_api/actix_web_3/api.rs
+++ b/libsplinter/src/rest_api/actix_web_3/api.rs
@@ -156,8 +156,8 @@ impl ShutdownHandle for RestApi {
         self.shutdown_future = Some(Box::pin(self.server.stop(true)));
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
-        match (self.shutdown_future.take(), self.join_handle.take()) {
+    fn wait_for_shutdown(self: Box<Self>) -> Result<(), InternalError> {
+        match (self.shutdown_future, self.join_handle) {
             (Some(f), Some(join_handle)) => {
                 block_on(f);
                 join_handle.join().map_err(|_| {

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -168,7 +168,7 @@ impl ServiceProcessor {
         self.do_start().map(|(do_shutdown, join_handles)| {
             Box::from(ServiceProcessorShutdownHandle {
                 signal_shutdown: do_shutdown,
-                join_handles: Some(join_handles),
+                join_handles,
             }) as Box<dyn ShutdownHandle>
         })
     }
@@ -523,7 +523,7 @@ impl ShutdownHandle {
 #[cfg(feature = "shutdown")]
 struct ServiceProcessorShutdownHandle {
     signal_shutdown: Box<dyn Fn() -> Result<(), ServiceProcessorError> + Send>,
-    join_handles: Option<JoinHandles<Result<(), ServiceProcessorError>>>,
+    join_handles: JoinHandles<Result<(), ServiceProcessorError>>,
 }
 
 #[cfg(feature = "shutdown")]
@@ -534,23 +534,21 @@ impl ShutdownHandle for ServiceProcessorShutdownHandle {
         }
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), crate::error::InternalError> {
-        if let Some(join_handles) = self.join_handles.take() {
-            match join_handles.join_all() {
-                Ok(results) => {
-                    results
-                        .into_iter()
-                        .filter(Result::is_err)
-                        .map(Result::unwrap_err)
-                        .for_each(|err| {
-                            error!("{}", err);
-                        });
-                }
-                Err(_) => {
-                    return Err(crate::error::InternalError::with_message(
-                        "Unable to join service processor threads".into(),
-                    ));
-                }
+    fn wait_for_shutdown(self: Box<Self>) -> Result<(), crate::error::InternalError> {
+        match self.join_handles.join_all() {
+            Ok(results) => {
+                results
+                    .into_iter()
+                    .filter(Result::is_err)
+                    .map(Result::unwrap_err)
+                    .for_each(|err| {
+                        error!("{}", err);
+                    });
+            }
+            Err(_) => {
+                return Err(crate::error::InternalError::with_message(
+                    "Unable to join service processor threads".into(),
+                ));
             }
         }
 

--- a/libsplinter/src/threading/shutdown.rs
+++ b/libsplinter/src/threading/shutdown.rs
@@ -39,7 +39,7 @@ pub trait ShutdownHandle {
     ///
     /// For components with threads, the threads should be joined during the call to
     /// `wait_for_shutdown`.
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError>;
+    fn wait_for_shutdown(self: Box<Self>) -> Result<(), InternalError>;
 }
 
 /// Calls `signal_shutdown` and `wait_for_shutdown` on the provided `ShutdownHandle`s.
@@ -53,7 +53,7 @@ pub fn shutdown(mut handles: Vec<Box<dyn ShutdownHandle>>) -> Result<(), Interna
     }
 
     let mut errors: Vec<InternalError> = Vec::new();
-    for handle in handles.iter_mut() {
+    for handle in handles.into_iter() {
         if let Err(err) = handle.wait_for_shutdown() {
             errors.push(err);
         }

--- a/splinterd/src/node/running.rs
+++ b/splinterd/src/node/running.rs
@@ -56,8 +56,8 @@ impl ShutdownHandle for Node {
         }
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
-        match self.rest_api_variant.take() {
+    fn wait_for_shutdown(self: Box<Self>) -> Result<(), InternalError> {
+        match self.rest_api_variant {
             Some(NodeRestApiVariant::ActixWeb1(shutdown_handle, join_handle)) => {
                 shutdown_handle
                     .shutdown()
@@ -69,8 +69,8 @@ impl ShutdownHandle for Node {
                 })?;
                 Ok(())
             }
-            Some(NodeRestApiVariant::ActixWeb3(mut rest_api)) => {
-                rest_api.wait_for_shutdown()?;
+            Some(NodeRestApiVariant::ActixWeb3(rest_api)) => {
+                Box::new(rest_api).wait_for_shutdown()?;
                 Ok(())
             }
             None => Err(InternalError::with_message(

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -14,8 +14,6 @@
 
 //! Contains the implementation of `Network`.
 
-use std::time::Duration;
-
 use splinter::error::{InternalError, InvalidArgumentError};
 use splinter::threading::shutdown::ShutdownHandle;
 use splinterd::node::{Node, NodeBuilder, RestApiVariant};
@@ -68,9 +66,9 @@ impl ShutdownHandle for Network {
         }
     }
 
-    fn wait_for_shutdown(&mut self, timeout: Duration) -> Result<(), InternalError> {
+    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
         for node in self.nodes.iter_mut() {
-            node.wait_for_shutdown(timeout)?;
+            node.wait_for_shutdown()?;
         }
 
         Ok(())

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -66,9 +66,9 @@ impl ShutdownHandle for Network {
         }
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
-        for node in self.nodes.iter_mut() {
-            node.wait_for_shutdown()?;
+    fn wait_for_shutdown(self: Box<Self>) -> Result<(), InternalError> {
+        for node in self.nodes.into_iter() {
+            Box::new(node).wait_for_shutdown()?;
         }
 
         Ok(())


### PR DESCRIPTION
Ideally, wait_for_shutdown would consume the object itself.
Before talking &mut self would result in the structs being
left in an invalid state. However, since ShutdownHandle
is a trait it must take a Box of itself instead.

The resulting implementation allows for consuming the struct
on wait_for_shutdown, but does require wrapping some structs
in a Box only to shutdown.