### PR TITLE
Scabbard proposal timeout fix

### DIFF
--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -66,6 +66,7 @@ impl ScabbardConsensusManager {
 
         let proposal_manager = ScabbardProposalManager::new(
             service_id.clone(),
+            version,
             proposal_update_tx.clone(),
             shared.clone(),
             state,
@@ -149,6 +150,7 @@ impl ScabbardConsensusManager {
 
 pub struct ScabbardProposalManager {
     service_id: String,
+    version: ScabbardVersion,
     proposal_update_sender: Sender<ProposalUpdate>,
     shared: Arc<Mutex<ScabbardShared>>,
     state: Arc<Mutex<ScabbardState>>,
@@ -157,12 +159,14 @@ pub struct ScabbardProposalManager {
 impl ScabbardProposalManager {
     pub fn new(
         service_id: String,
+        version: ScabbardVersion,
         proposal_update_sender: Sender<ProposalUpdate>,
         shared: Arc<Mutex<ScabbardShared>>,
         state: Arc<Mutex<ScabbardState>>,
     ) -> Self {
         ScabbardProposalManager {
             service_id,
+            version,
             proposal_update_sender,
             shared,
             state,

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -197,9 +197,13 @@ impl ProposalManager for ScabbardProposalManager {
 
             // Intentionally leaving out the previous_id and proposal_height fields, since this
             // service and two phase consensus don't use them. This means the proposal ID can just
-            // be the summary.
+            // be the summary (in v1) or batch ID (in v2).
+            let id = match self.version {
+                ScabbardVersion::V1 => expected_hash.as_bytes().into(),
+                ScabbardVersion::V2 => batch.batch().header_signature().as_bytes().into(),
+            };
             let proposal = Proposal {
-                id: expected_hash.as_bytes().into(),
+                id,
                 summary: expected_hash.as_bytes().into(),
                 ..Default::default()
             };

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -408,7 +408,7 @@ impl Service for Scabbard {
                 self.shared
                     .lock()
                     .map_err(|_| ServiceError::PoisonedLock("shared lock poisoned".into()))?
-                    .add_proposed_batch(proposal.id.clone(), batch);
+                    .add_open_proposal(proposal.clone(), batch);
 
                 self.consensus
                     .lock()

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -65,7 +65,7 @@ const SERVICE_TYPE: &str = "scabbard";
 const DEFAULT_COORDINATOR_TIMEOUT: u64 = 30; // 30 seconds
 
 /// Specifies the version of scabbard to use.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum ScabbardVersion {
     V1,
     V2,
@@ -315,7 +315,7 @@ impl Service for Scabbard {
         consensus.replace(
             ScabbardConsensusManager::new(
                 self.service_id().into(),
-                self.version.clone(),
+                self.version,
                 self.shared.clone(),
                 self.state.clone(),
                 self.coordinator_timeout,


### PR DESCRIPTION
Fixes a bug where timeouts would occasionally timeout. This bug was caused by separate proposals having the same proposal ID, which happened when the resulting state of a proposal was the same as the resulting state of another proposal. The fix is to ensure that all proposal IDs are unique by setting them to the IDs of the proposed batches, which are guaranteed by Transact to be unique.