### PR TITLE
Update ShutdownHandle.wait_for_shutdown to take self

### DIFF
--- a/libsplinter/src/rest_api/actix_web_3/api.rs
+++ b/libsplinter/src/rest_api/actix_web_3/api.rs
@@ -156,7 +156,7 @@ impl ShutdownHandle for RestApi {
         self.shutdown_future = Some(Box::pin(self.server.stop(true)));
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
         match (self.shutdown_future.take(), self.join_handle.take()) {
             (Some(f), Some(join_handle)) => {
                 block_on(f);

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -54,6 +54,8 @@ pub use processor::registry::StandardServiceNetworkRegistry;
 pub use processor::JoinHandles;
 pub use processor::ServiceProcessor;
 pub use processor::ServiceProcessorBuilder;
+#[cfg(feature = "shutdown")]
+pub use processor::ServiceProcessorShutdownHandle;
 #[cfg(not(feature = "shutdown"))]
 pub use processor::ShutdownHandle;
 

--- a/libsplinter/src/threading/shutdown.rs
+++ b/libsplinter/src/threading/shutdown.rs
@@ -39,36 +39,5 @@ pub trait ShutdownHandle {
     ///
     /// For components with threads, the threads should be joined during the call to
     /// `wait_for_shutdown`.
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError>;
-}
-
-/// Calls `signal_shutdown` and `wait_for_shutdown` on the provided `ShutdownHandle`s.
-///
-/// Any errors which occur will be translated into an `InternalError`, and any source information
-/// will be lost. Thus, robust implementations will prefer to implement a variant of this function
-/// themselves. However, this simple version is extremely useful in situations such as testing.
-pub fn shutdown(mut handles: Vec<Box<dyn ShutdownHandle>>) -> Result<(), InternalError> {
-    for handle in handles.iter_mut() {
-        handle.signal_shutdown();
-    }
-
-    let mut errors: Vec<InternalError> = Vec::new();
-    for handle in handles.iter_mut() {
-        if let Err(err) = handle.wait_for_shutdown() {
-            errors.push(err);
-        }
-    }
-
-    match errors.len() {
-        0 => Ok(()),
-        1 => Err(errors.remove(0)),
-        _ => Err(InternalError::with_message(format!(
-            "Multiple errors occurred during shutdown: {}",
-            errors
-                .into_iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ))),
-    }
+    fn wait_for_shutdown(self) -> Result<(), InternalError>;
 }

--- a/splinterd/src/node/running.rs
+++ b/splinterd/src/node/running.rs
@@ -56,7 +56,7 @@ impl ShutdownHandle for Node {
         }
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
         match self.rest_api_variant.take() {
             Some(NodeRestApiVariant::ActixWeb1(shutdown_handle, join_handle)) => {
                 shutdown_handle
@@ -69,7 +69,7 @@ impl ShutdownHandle for Node {
                 })?;
                 Ok(())
             }
-            Some(NodeRestApiVariant::ActixWeb3(mut rest_api)) => {
+            Some(NodeRestApiVariant::ActixWeb3(rest_api)) => {
                 rest_api.wait_for_shutdown()?;
                 Ok(())
             }

--- a/splinterd/tests/admin/circuit_list.rs
+++ b/splinterd/tests/admin/circuit_list.rs
@@ -15,7 +15,6 @@
 //! A framework for running a network of Splinter nodes in a single process, usually for
 //! integration testing purposes.
 
-use splinter::threading::shutdown::shutdown;
 use splinterd::node::RestApiVariant;
 
 use crate::framework::network::Network;
@@ -34,7 +33,7 @@ fn single_node_network(rest_api_variant: RestApiVariant) {
     let list_slice = client.list_circuits(None).unwrap();
     assert_eq!(list_slice.data, vec![]);
 
-    shutdown(vec![Box::new(network)]).unwrap();
+    shutdown!(network).unwrap();
 }
 
 /// Executes the single node network test with Actix Web 1.

--- a/splinterd/tests/admin_service.rs
+++ b/splinterd/tests/admin_service.rs
@@ -14,5 +14,8 @@
 
 //! Splinter integration tests.
 
-mod admin;
+// macros_use must come before any modules that make use of the macro
+#[macro_use]
 mod framework;
+
+mod admin;

--- a/splinterd/tests/framework/mod.rs
+++ b/splinterd/tests/framework/mod.rs
@@ -17,3 +17,6 @@
 
 #[cfg(feature = "node")]
 pub mod network;
+#[macro_use]
+#[cfg(feature = "node")]
+pub mod shutdown;

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -66,8 +66,8 @@ impl ShutdownHandle for Network {
         }
     }
 
-    fn wait_for_shutdown(&mut self) -> Result<(), InternalError> {
-        for node in self.nodes.iter_mut() {
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        for node in self.nodes.into_iter() {
             node.wait_for_shutdown()?;
         }
 

--- a/splinterd/tests/framework/shutdown.rs
+++ b/splinterd/tests/framework/shutdown.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides a macro that can be used to shutdown multiple structs that implement the
+//! `ShutdownHandle` trait
+
+#[macro_export]
+macro_rules! shutdown {
+    ($($handle:expr),*) => {
+        {
+            use splinter::error::InternalError;
+            use splinter::threading::shutdown::ShutdownHandle;
+           $(
+                $handle.signal_shutdown();
+           )*
+            let mut errors = vec![];
+
+           $(
+                if let Err(err) = $handle.wait_for_shutdown() {
+                    errors.push(err);
+                }
+           )*
+
+            match errors.len() {
+                0 => Ok(()),
+                1 => Err(errors.remove(0)),
+                _ => Err(InternalError::with_message(
+                        format!(
+                        "Multiple errors occurred during shutdown: {}",
+                        errors
+                            .into_iter()
+                            .map(|e| e.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                        )
+                   )
+                ),
+            }
+        }
+    };
+}


### PR DESCRIPTION
This changes the method to consume the struct that is being
shutdown, thus avoiding leaving the struct in an invalid state.

Due to constraints on traits, updating wait_for_shutdown to
take self also makes it so the trait can no longer be Boxed
and call wait_for_shutdown at the same time. All methods
that returned or took a Boxed<ShutdownHandle> have either been
removed or updated to return the underlying struct directly.

Also adds a macro a shutdown! to testing::framework::shutdown;

This macro can be used multiple components at once that
implement the trait ShutdownHandle. This can be used without
boxing the structs themselves.

This commit also updates the tests to use shutdown! instead of
the removed shutdown function.