### PR TITLE
Modify OpenIdProfileProvider for azure account profile photos

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -36,6 +36,7 @@ actix-web-actors = { version = "1.0", optional = true }
 actix-web-3 = { package = "actix-web", version = "3", optional = true, features = ["openssl"] }
 atomicwrites = "0.2"
 awc = { version = "0.2", optional = true }
+base64 = { version = "0.12", optional = true }
 bcrypt = {version = "0.6", optional = true}
 byteorder = "1"
 crossbeam-channel = "0.3"
@@ -141,7 +142,7 @@ biome = []
 biome-credentials = ["bcrypt", "biome"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
-biome-profile = ["biome"]
+biome-profile = ["biome", "base64"]
 circuit-abandon = []
 circuit-disband = []
 circuit-purge = []


### PR DESCRIPTION
Modify the OpenIdProfileProvider to make a call to the microsoft graph api endpoint for retrieving profile pictures if Azure is being used as the OpenID provider for auth.

The microsoft graph api `/photo/$value` endpoint returns the binary data for the photo. This data is converted to a base64 string and set as the 'picture' field in the OpenIdProfileResponse struct.