### PR TITLE
Move threading::shutdown into threading::lifecycle

### DIFF
--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -40,7 +40,7 @@ use crate::service::{
     Service, ServiceFactory, ServiceMessageContext, StandardServiceNetworkRegistry,
 };
 #[cfg(feature = "shutdown")]
-use crate::threading::shutdown::ShutdownHandle;
+use crate::threading::lifecycle::ShutdownHandle;
 use crate::transport::Connection;
 
 pub use self::builder::ServiceOrchestratorBuilder;

--- a/libsplinter/src/rest_api/actix_web_3/api.rs
+++ b/libsplinter/src/rest_api/actix_web_3/api.rs
@@ -28,7 +28,7 @@ use openssl::ssl::SslAcceptorBuilder;
 
 use crate::error::InternalError;
 use crate::rest_api::RestApiServerError;
-use crate::threading::shutdown::ShutdownHandle;
+use crate::threading::lifecycle::ShutdownHandle;
 
 use super::ResourceProvider;
 

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -37,7 +37,7 @@ use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::service::error::ServiceProcessorError;
 use crate::service::{Service, ServiceMessageContext};
 #[cfg(feature = "shutdown")]
-use crate::threading::shutdown::ShutdownHandle;
+use crate::threading::lifecycle::ShutdownHandle;
 use crate::transport::Connection;
 use crate::{rwlock_read_unwrap, rwlock_write_unwrap};
 

--- a/libsplinter/src/threading/lifecycle.rs
+++ b/libsplinter/src/threading/lifecycle.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Traits and functions related to shutting down components.
+//! Traits and functions related to the lifecycle of components.
 
 use crate::error::InternalError;
 

--- a/libsplinter/src/threading/mod.rs
+++ b/libsplinter/src/threading/mod.rs
@@ -15,6 +15,6 @@
 //! This module will contain components that will be used to support different threading models
 
 pub(crate) mod error;
-pub(crate) mod pacemaker;
 #[cfg(feature = "shutdown")]
-pub mod shutdown;
+pub mod lifecycle;
+pub(crate) mod pacemaker;

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -81,7 +81,7 @@ use splinter::service;
 #[cfg(feature = "service-arg-validation")]
 use splinter::service::validation::ServiceArgValidator;
 #[cfg(feature = "shutdown")]
-use splinter::threading::shutdown::ShutdownHandle;
+use splinter::threading::lifecycle::ShutdownHandle;
 use splinter::transport::{
     inproc::InprocTransport, multi::MultiTransport, AcceptError, ConnectError, Connection,
     Incoming, ListenError, Listener, Transport,

--- a/splinterd/src/node/running.rs
+++ b/splinterd/src/node/running.rs
@@ -20,7 +20,7 @@ use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::error::InternalError;
 use splinter::rest_api::actix_web_1::RestApiShutdownHandle;
 use splinter::rest_api::actix_web_3::RestApi;
-use splinter::threading::shutdown::ShutdownHandle;
+use splinter::threading::lifecycle::ShutdownHandle;
 
 pub(super) enum NodeRestApiVariant {
     ActixWeb1(RestApiShutdownHandle, JoinHandle<()>),

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -15,7 +15,7 @@
 //! Contains the implementation of `Network`.
 
 use splinter::error::{InternalError, InvalidArgumentError};
-use splinter::threading::shutdown::ShutdownHandle;
+use splinter::threading::lifecycle::ShutdownHandle;
 use splinterd::node::{Node, NodeBuilder, RestApiVariant};
 
 pub struct Network {

--- a/splinterd/tests/framework/shutdown.rs
+++ b/splinterd/tests/framework/shutdown.rs
@@ -20,7 +20,7 @@ macro_rules! shutdown {
     ($($handle:expr),*) => {
         {
             use splinter::error::InternalError;
-            use splinter::threading::shutdown::ShutdownHandle;
+            use splinter::threading::lifecycle::ShutdownHandle;
            $(
                 $handle.signal_shutdown();
            )*


### PR DESCRIPTION
This move provides a location for future threading
lifecycle traits to be added.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>