### PR TITLE
Support authorization stabilization in docker compose files

### DIFF
--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -145,10 +145,13 @@ mod test {
     };
 
     static SPLINTERD_URL: &str = "http://splinterd-node:8085";
-    static AUTHORIZATION: &str = "Bearer Cylinder:eyJhbGciOiJzZWNwMjU2azEiLCJ0eXAiOiJjeWxpbmRlcitq\
-        d3QifQ==.eyJpc3MiOiIwMjc5YmU2NjdlZjlkY2JiYWM1NWEwNjI5NWNlODcwYjA3MDI5YmZjZGIyZGNlMjhkOTU5Z\
-        jI4MTViMTZmODE3OTgifQ==.71Vw3+m9R4b8iZUzhRHOAtX/hO5WYA9PgMe27/CeZ6NhIXFYkBBzreoIGpHbfJ8UxT\
-        +1MLUgjsQB8TISafneRA==";
+    /// The public key for this JWT is:
+    /// 02091a06cc46c5e0d88e89284936edb16800b03b56a8f1b7ec292f232b7c8385a2
+    static AUTHORIZATION: &str =
+        "Bearer Cylinder:eyJhbGciOiJzZWNwMjU2azEiLCJ0eXAiOiJjeWxpbmRlcitqd\
+        3QifQ==.eyJpc3MiOiIwMjA5MWEwNmNjNDZjNWUwZDg4ZTg5Mjg0OTM2ZWRiMTY4MDBiMDNiNTZhOGYxYjdlYzI5MmY\
+        yMzJiN2M4Mzg1YTIifQ==.tOMakxmebss0WGWcvKCQhYo2AAo3aaMDPS28y9nfVnMXiYq98Be08CdxB0gXCY5qYHZSw\
+        53+kjuIG+8gPhXLBA==";
 
     #[actix_rt::test]
     /// Tests a GET /registry/nodes/{identity} request returns the expected node.

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -182,6 +182,10 @@ services:
           then
             splinter admin keygen acme -d /keys
           fi && \
+          if [ ! -f /etc/splinter/allow_keys ]
+          then
+            echo $$(cat /keys/acme.pub) > /etc/splinter/allow_keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-acme -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
@@ -303,6 +307,10 @@ services:
           if [ ! -f /keys/bubba.priv ]
           then
             splinter admin keygen bubba -d /keys
+          fi && \
+          if [ ! -f /etc/splinter/allow_keys ]
+          then
+            echo $$(cat /keys/bubba.pub) > /etc/splinter/allow_keys
           fi && \
           until PGPASSWORD=admin psql -h splinterd-db-bubba -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -211,6 +211,10 @@ services:
           then
             splinter admin keygen acme -d /keys
           fi && \
+          if [ ! -f /etc/splinter/allow_keys ]
+          then
+            echo $$(cat /keys/acme.pub) > /etc/splinter/allow_keys
+          fi && \
           until PGPASSWORD=admin psql -h splinterd-db-acme -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1
@@ -355,6 +359,10 @@ services:
           if [ ! -f /keys/bubba.priv ]
           then
             splinter admin keygen bubba -d /keys
+          fi && \
+          if [ ! -f /etc/splinter/allow_keys ]
+          then
+            echo $$(cat /keys/bubba.pub) > /etc/splinter/allow_keys
           fi && \
           until PGPASSWORD=admin psql -h splinterd-db-bubba -U admin -d splinter -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -111,6 +111,10 @@ services:
         then
           splinter admin keygen cypress -d /keys
         fi && \
+        if [ ! -f /etc/splinter/allow_keys ]
+        then
+          echo $$(cat /keys/cypress.pub) > /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=admin psql -h splinterd-db-node -U admin -d splinter -c '\q'; do
           >&2 echo \"Database is unavailable - sleeping\"
           sleep 1

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -65,6 +65,11 @@ services:
         - REPO_VERSION=${REPO_VERSION}
     entrypoint: |
       bash -c "
+        # Grant permissions to the Cylinder key used for authorization by the tests
+        if [ ! -f /etc/splinter/allow_keys ]
+        then
+          echo "02091a06cc46c5e0d88e89284936edb16800b03b56a8f1b7ec292f232b7c8385a2" > /etc/splinter/allow_keys
+        fi && \
         until PGPASSWORD=gameroom_test psql -h db-test -U gameroom_test -c '\q'; do
             >&2 echo \"Database is unavailable - sleeping\"
             sleep 1

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -555,6 +555,12 @@ impl SplinterDaemon {
             {
                 authorization_handlers
                     .push(Box::new(RoleBasedAuthorizationHandler::new(rbac_store)));
+                rest_api_builder = rest_api_builder.add_resources(
+                    RoleBasedAuthorizationResourceProvider::new(
+                        store_factory.get_role_based_authorization_store(),
+                    )
+                    .resources(),
+                );
             }
 
             rest_api_builder = rest_api_builder
@@ -577,13 +583,7 @@ impl SplinterDaemon {
                             advertised_endpoints.clone(),
                         )
                     },
-                ))
-                .add_resources(
-                    RoleBasedAuthorizationResourceProvider::new(
-                        store_factory.get_role_based_authorization_store(),
-                    )
-                    .resources(),
-                );
+                ));
         }
         #[cfg(not(feature = "authorization"))]
         {


### PR DESCRIPTION
Updates docker compose files to populate the allow keys file. This will be required when the `authorization` and `authorization-handler-allow-keys` features are stabilized.