### PR TITLE
Add disband integration tests

### DIFF
--- a/splinterd/tests/admin/circuit_lifecycle.rs
+++ b/splinterd/tests/admin/circuit_lifecycle.rs
@@ -522,7 +522,7 @@ pub fn test_2_party_circuit_creation() {
 
     commit_2_party_circuit(circuit_id, node_a, node_b);
 
-    shutdown!(network).unwrap();
+    shutdown!(network).expect("Unable to shutdown network");
 }
 
 /// Test that a 3-party circuit may be created on a 3-node network.

--- a/splinterd/tests/admin/circuit_lifecycle.rs
+++ b/splinterd/tests/admin/circuit_lifecycle.rs
@@ -22,7 +22,7 @@ use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 
 use crate::framework::network::Network;
-use splinter::admin::client::{AdminServiceClient, ProposalSlice};
+use splinter::admin::client::ProposalSlice;
 use splinter::admin::messages::{
     AuthorizationType, CircuitProposalVote, CreateCircuitBuilder, DurabilityType, PersistenceType,
     RouteType, SplinterNode, SplinterNodeBuilder, SplinterService, SplinterServiceBuilder, Vote,
@@ -31,7 +31,7 @@ use splinter::protos::admin::{
     CircuitCreateRequest, CircuitDisbandRequest, CircuitManagementPayload,
     CircuitManagementPayload_Action, CircuitManagementPayload_Header,
 };
-use splinterd::node::RestApiVariant;
+use splinterd::node::{Node, RestApiVariant};
 
 /// Makes the `CircuitManagementPayload` to create a circuit and returns the bytes of this
 /// payload
@@ -176,7 +176,7 @@ fn setup_circuit(
     let mut service_builders: Vec<(String, SplinterServiceBuilder)> = vec![];
     let mut service_ids: Vec<String> = vec![];
     for (idx, node_id) in node_info.keys().enumerate() {
-        let service_id = format!("sc0{}", idx);
+        let service_id = format!("sc{:0>2}", idx);
         service_ids.push(service_id.clone());
         let builder = SplinterServiceBuilder::new()
             .with_service_id(service_id.as_ref())
@@ -208,7 +208,7 @@ fn setup_circuit(
         .iter()
         .map(|(node_id, endpoint)| {
             SplinterNodeBuilder::new()
-                .with_node_id(node_id)
+                .with_node_id(&node_id)
                 .with_endpoints(vec![endpoint.to_string()].as_ref())
                 .build()
                 .expect("Unable to build SplinterNode")
@@ -227,6 +227,7 @@ fn setup_circuit(
         .with_application_metadata(b"test_data")
         .with_comments("test circuit")
         .with_display_name("test_circuit")
+        .with_circuit_version(2)
         .build()
         .expect("Unable to build `CreateCircuit`");
     create_circuit_message
@@ -235,18 +236,31 @@ fn setup_circuit(
 }
 
 /// Commit a 2-party circuit on a network that is already running
-fn commit_2_party_circuit(
-    circuit_id: &str,
-    node_a_client: &Box<dyn AdminServiceClient>,
-    node_a_signer: &dyn Signer,
-    node_b_client: &Box<dyn AdminServiceClient>,
-    node_b_signer: &dyn Signer,
-    node_info: HashMap<String, String>,
-) {
-    let circuit_payload_bytes =
-        make_create_circuit_payload(&circuit_id, "node_a", node_info.clone(), node_a_signer);
+fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, node_b: &Node) {
+    // Create the list of node details needed to build the `CircuitCreateRequest`
+    let node_info = vec![
+        (
+            node_a.node_id().to_string(),
+            "tcp://localhost:8000".to_string(),
+        ),
+        (
+            node_b.node_id().to_string(),
+            "tcp://localhost:8001".to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect::<HashMap<String, String>>();
+
+    let circuit_payload_bytes = make_create_circuit_payload(
+        &circuit_id,
+        node_a.node_id(),
+        node_info,
+        &*node_a.admin_signer().clone_box(),
+    );
     // Submit the `CircuitManagementPayload` to the first node
-    let res = node_a_client.submit_admin_payload(circuit_payload_bytes);
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be committed for the second node
@@ -256,7 +270,8 @@ fn commit_2_party_circuit(
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect proposal in time");
         }
-        let proposals = node_b_client
+        let proposals = node_b
+            .admin_service_client()
             .list_proposals(None, None)
             .expect("Unable to list proposals from node_b")
             .data;
@@ -269,7 +284,8 @@ fn commit_2_party_circuit(
     }
 
     // Validate the same proposal is available to the first node
-    let proposal_a = node_a_client
+    let proposal_a = node_a
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
         .expect("Unable to fetch proposal from node_a")
         .unwrap();
@@ -277,9 +293,15 @@ fn commit_2_party_circuit(
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_b", node_b_signer, true);
-    let res = node_b_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the circuit to be committed for the second node
@@ -289,7 +311,8 @@ fn commit_2_party_circuit(
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect circuit in time");
         }
-        let circuits = node_b_client
+        let circuits = node_b
+            .admin_service_client()
             .list_circuits(None)
             .expect("Unable to list circuits from node_b")
             .data;
@@ -302,7 +325,8 @@ fn commit_2_party_circuit(
     }
 
     // Validate the circuit is available to the first node
-    let circuit_a = node_a_client
+    let circuit_a = node_a
+        .admin_service_client()
         .fetch_circuit(&circuit_id)
         .expect("Unable to fetch circuit from node_a")
         .unwrap();
@@ -310,21 +334,36 @@ fn commit_2_party_circuit(
 }
 
 /// Commit a 3-party circuit on a network that is already running
-fn commit_3_party_circuit(
-    circuit_id: &str,
-    node_a_client: &Box<dyn AdminServiceClient>,
-    node_a_signer: &dyn Signer,
-    node_b_client: &Box<dyn AdminServiceClient>,
-    node_b_signer: &dyn Signer,
-    node_c_client: &Box<dyn AdminServiceClient>,
-    node_c_signer: &dyn Signer,
-    node_info: HashMap<String, String>,
-) {
+fn commit_3_party_circuit(circuit_id: &str, node_a: &Node, node_b: &Node, node_c: &Node) {
+    // Create the list of node details needed to build the `CircuitCreateRequest`
+    let node_info = vec![
+        (
+            node_a.node_id().to_string(),
+            "tcp://localhost:8000".to_string(),
+        ),
+        (
+            node_b.node_id().to_string(),
+            "tcp://localhost:8001".to_string(),
+        ),
+        (
+            node_c.node_id().to_string(),
+            "tcp://localhost:8002".to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect::<HashMap<String, String>>();
+
     // Create the `CircuitManagementPayload` to be sent to a node
-    let circuit_payload_bytes =
-        make_create_circuit_payload(&circuit_id, "node_a", node_info.clone(), node_a_signer);
+    let circuit_payload_bytes = make_create_circuit_payload(
+        &circuit_id,
+        node_a.node_id(),
+        node_info,
+        &*node_a.admin_signer().clone_box(),
+    );
     // Submit the `CircuitManagementPayload` to the first node
-    let res = node_a_client.submit_admin_payload(circuit_payload_bytes);
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be committed for the remote nodes
@@ -335,11 +374,13 @@ fn commit_3_party_circuit(
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect proposal in time");
         }
-        let proposals_b = node_b_client
+        let proposals_b = node_b
+            .admin_service_client()
             .list_proposals(None, None)
             .expect("Unable to list proposals from node_b")
             .data;
-        let proposals_c = node_c_client
+        let proposals_c = node_c
+            .admin_service_client()
             .list_proposals(None, None)
             .expect("Unable to list proposals from node_c")
             .data;
@@ -352,7 +393,8 @@ fn commit_3_party_circuit(
         }
     }
     // Validate the same proposal is available to the first node
-    let proposal_a = node_a_client
+    let proposal_a = node_a
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
         .expect("Unable to fetch proposal from node_a")
         .unwrap();
@@ -361,9 +403,15 @@ fn commit_3_party_circuit(
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_b", node_b_signer, true);
-    let res = node_b_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the vote from this node to appear on the proposal for the remote nodes
@@ -376,11 +424,13 @@ fn commit_3_party_circuit(
         }
         // The proposal should already be available to each of these nodes, so we are able to
         // unwrap the result of the `fetch_proposal` call
-        proposal_a = node_a_client
+        proposal_a = node_a
+            .admin_service_client()
             .fetch_proposal(&circuit_id)
             .expect("Unable to fetch proposal from node_a")
             .unwrap();
-        proposal_c = node_c_client
+        proposal_c = node_c
+            .admin_service_client()
             .fetch_proposal(&circuit_id)
             .expect("Unable to fetch proposal from node_c")
             .unwrap();
@@ -389,7 +439,8 @@ fn commit_3_party_circuit(
         }
     }
     // Validate the extra vote records are also available for the voting node
-    let proposal_b = node_b_client
+    let proposal_b = node_b
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
         .expect("Unable to fetch proposal from node_b")
         .unwrap();
@@ -398,9 +449,15 @@ fn commit_3_party_circuit(
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_c", node_c_signer, true);
-    let res = node_c_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_c.node_id(),
+        &*node_c.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_c
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the circuit to be committed for the other nodes
@@ -411,11 +468,13 @@ fn commit_3_party_circuit(
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect circuit in time");
         }
-        let circuits_a = node_a_client
+        let circuits_a = node_a
+            .admin_service_client()
             .list_circuits(None)
             .expect("Unable to list circuits from node_a")
             .data;
-        let circuits_b = node_b_client
+        let circuits_b = node_b
+            .admin_service_client()
             .list_circuits(None)
             .expect("Unable to list circuits from node_b")
             .data;
@@ -429,7 +488,8 @@ fn commit_3_party_circuit(
     }
 
     // Validate the circuit is available to the first node
-    let circuit_c = node_c_client
+    let circuit_c = node_c
+        .admin_service_client()
         .fetch_circuit(&circuit_id)
         .expect("Unable to fetch circuit from node_c")
         .unwrap();
@@ -452,33 +512,15 @@ pub fn test_2_party_circuit_creation() {
     let mut network = Network::new()
         .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
         .add_nodes_with_defaults(2)
-        .expect("Unable to start 2-node_actixWeb1 network");
-    // Create a context in order to produce private keys for the nodes
-    // Collect the node information to be used to populate the payloads
-    let mut node_info = HashMap::new();
-    // Get the node and node's client for the first node
-    let node_a = network.node(0).expect("Unable to get node_a");
-    let node_a_client = node_a.admin_service_client();
-    let node_a_signer = node_a.admin_signer().clone_box();
-    // Get the node and node's client for the second node
-    let node_b = network.node(1).expect("Unable to get node_b");
-    let node_b_client = node_b.admin_service_client();
-    let node_b_signer = node_b.admin_signer().clone_box();
-    // Using `node_b` here for the second node as a placeholder
-    node_info.insert(
-        "node_b".to_string(),
-        format!("http://localhost:{}", node_b.rest_api_port()),
-    );
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+
     let circuit_id = "ABCDE-01234";
 
-    commit_2_party_circuit(
-        circuit_id,
-        &node_a_client,
-        &*node_a_signer,
-        &node_b_client,
-        &*node_b_signer,
-        node_info,
-    );
+    commit_2_party_circuit(circuit_id, node_a, node_b);
 
     shutdown!(network).unwrap();
 }
@@ -503,48 +545,16 @@ pub fn test_3_party_circuit_creation() {
     let mut network = Network::new()
         .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
         .add_nodes_with_defaults(3)
-        .expect("Unable to start 3-node_actixWeb1 network");
-    // Collect the node information to be used to populate the payloads
-    let mut node_info = HashMap::new();
-    // Get the node and node's client for the first node
-    let node_a = network.node(0).expect("Unable to get node_a");
-    let node_a_client = node_a.admin_service_client();
-    let node_a_signer = node_a.admin_signer().clone_box();
-    // Using `node_a` here for the first node as a placeholder
-    node_info.insert(
-        "node_a".to_string(),
-        format!("http://localhost:{}", node_a.rest_api_port()),
-    );
-    // Get the node and node's client for the second node
-    let node_b = network.node(1).expect("Unable to get node_b");
-    let node_b_client = node_b.admin_service_client();
-    let node_b_signer = node_b.admin_signer().clone_box();
-    // Using `node_b` here for the second node as a placeholder
-    node_info.insert(
-        "node_b".to_string(),
-        format!("http://localhost:{}", node_b.rest_api_port()),
-    );
-    // Get the node and node's client for the third node
-    let node_c = network.node(2).expect("Unable to get node_c");
-    let node_c_client = node_c.admin_service_client();
-    let node_c_signer = node_c.admin_signer().clone_box();
-    // Using `node_c` here for the third node as a placeholder
-    node_info.insert(
-        "node_c".to_string(),
-        format!("http://localhost:{}", node_c.rest_api_port()),
-    );
-    let circuit_id = "ABCDE-01234";
+        .expect("Unable to start 3-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    // Get the third node in the network
+    let node_c = network.node(2).expect("Unable to get third node");
 
-    commit_3_party_circuit(
-        circuit_id,
-        &node_a_client,
-        &*node_a_signer,
-        &node_b_client,
-        &*node_b_signer,
-        &node_c_client,
-        &*node_c_signer,
-        node_info,
-    );
+    let circuit_id = "ABCDE-01234";
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
 
     shutdown!(network).expect("Unable to shutdown network");
 }
@@ -566,33 +576,35 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
     let mut network = Network::new()
         .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
         .add_nodes_with_defaults(2)
-        .expect("Unable to start 2-node_actixWeb1 network");
-    // Collect the node information to be used to populate the payloads
-    let mut node_info = HashMap::new();
-    // Get the node and node's client for the first node
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
     let node_a = network.node(0).expect("Unable to get node_a");
-    let node_a_client = node_a.admin_service_client();
-    let node_a_signer = node_a.admin_signer().clone_box();
-    // Using `node_a` here for the first node as a placeholder
-    node_info.insert(
-        "node_a".to_string(),
-        format!("http://localhost:{}", node_a.rest_api_port()),
-    );
-    // Get the node and node's client for the second node
+    // Get the second node from the network
     let node_b = network.node(1).expect("Unable to get node_b");
-    let node_b_client = node_b.admin_service_client();
-    let node_b_signer = node_b.admin_signer().clone_box();
-    // Using `node_b` here for the second node as a placeholder
-    node_info.insert(
-        "node_b".to_string(),
-        format!("http://localhost:{}", node_b.rest_api_port()),
-    );
+    let node_info = vec![
+        (
+            node_a.node_id().to_string(),
+            "tcp://localhost:8000".to_string(),
+        ),
+        (
+            node_b.node_id().to_string(),
+            "tcp://localhost:8001".to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect::<HashMap<String, String>>();
     let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
-    let circuit_payload_bytes =
-        make_create_circuit_payload(&circuit_id, "node_a", node_info.clone(), &*node_a_signer);
+    let circuit_payload_bytes = make_create_circuit_payload(
+        &circuit_id,
+        node_a.node_id(),
+        node_info,
+        &*node_a.admin_signer().clone_box(),
+    );
     // Submit the `CircuitManagementPayload` to the first node
-    let res = node_a_client.submit_admin_payload(circuit_payload_bytes);
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be committed for the second node
@@ -602,9 +614,10 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect proposal in time");
         }
-        let proposals = node_b_client
+        let proposals = node_b
+            .admin_service_client()
             .list_proposals(None, None)
-            .expect("Unable to list proposals from node_b")
+            .expect("Unable to list proposals from second node")
             .data;
         if !proposals.is_empty() {
             // Unwrap the first item in the list as we've already validated this list is not empty
@@ -613,17 +626,24 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         }
     }
     // Validate the same proposal is available to the first node
-    let proposal_a = node_a_client
+    let proposal_a = node_a
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
-        .expect("Unable to fetch proposal from node_a")
+        .expect("Unable to fetch proposal from first node")
         .unwrap();
     assert_eq!(proposal_a, proposal_b);
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `false` for the `accept` argument to create a vote to reject the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_b", &*node_b_signer, false);
-    let res = node_b_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        false,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be removed for the first node
@@ -632,9 +652,10 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect removed proposal in time");
         }
-        if node_a_client
+        if node_a
+            .admin_service_client()
             .list_proposals(None, None)
-            .expect("Unable to list proposals from node_a")
+            .expect("Unable to list proposals from first node")
             .data
             .is_empty()
         {
@@ -642,9 +663,10 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         }
     }
     // Validate the proposal has been removed for the second node
-    let proposals_slice_b = node_b_client
+    let proposals_slice_b = node_b
+        .admin_service_client()
         .list_proposals(None, None)
-        .expect("Unable to list proposals from node_b");
+        .expect("Unable to list proposals from second node");
     assert!(proposals_slice_b.data.is_empty());
 
     shutdown!(network).expect("Unable to shutdown network");
@@ -672,42 +694,41 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
     let mut network = Network::new()
         .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
         .add_nodes_with_defaults(3)
-        .expect("Unable to start 3-node_actixWeb1 network");
-    // Collect the node information to be used to populate the payloads
-    let mut node_info = HashMap::new();
-    // Get the node and node's client for the first node
-    let node_a = network.node(0).expect("Unable to get node_a");
-    let node_a_client = node_a.admin_service_client();
-    let node_a_signer = node_a.admin_signer().clone_box();
-    // Using `node_a` here for the first node as a placeholder
-    node_info.insert(
-        "node_a".to_string(),
-        format!("http://localhost:{}", node_a.rest_api_port()),
-    );
-    // Get the node and node's client for the second node
-    let node_b = network.node(1).expect("Unable to get node_b");
-    let node_b_client = node_b.admin_service_client();
-    let node_b_signer = node_b.admin_signer().clone_box();
-    // Using `node_b` here for the second node as a placeholder
-    node_info.insert(
-        "node_b".to_string(),
-        format!("http://localhost:{}", node_b.rest_api_port()),
-    );
-    // Get the node and node's client for the third node
-    let node_c = network.node(2).expect("Unable to get node_c");
-    let node_c_client = node_c.admin_service_client();
-    let node_c_signer = node_c.admin_signer().clone_box();
-    // Using `node_c` here for the third node as a placeholder
-    node_info.insert(
-        "node_c".to_string(),
-        format!("http://localhost:{}", node_c.rest_api_port()),
-    );
+        .expect("Unable to start 3-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    // Get the third node in the network
+    let node_c = network.node(2).expect("Unable to get third node");
+    let node_info = vec![
+        (
+            node_a.node_id().to_string(),
+            "tcp://localhost:8000".to_string(),
+        ),
+        (
+            node_b.node_id().to_string(),
+            "tcp://localhost:8001".to_string(),
+        ),
+        (
+            node_c.node_id().to_string(),
+            "tcp://localhost:8002".to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect::<HashMap<String, String>>();
     let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
-    let circuit_payload_bytes =
-        make_create_circuit_payload(&circuit_id, "node_a", node_info.clone(), &*node_a_signer);
+    let circuit_payload_bytes = make_create_circuit_payload(
+        &circuit_id,
+        node_a.node_id(),
+        node_info,
+        &*node_a.admin_signer().clone_box(),
+    );
     // Submit the `CircuitManagementPayload` to the first node
-    let res = node_a_client.submit_admin_payload(circuit_payload_bytes);
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be committed for the remote nodes
@@ -718,13 +739,15 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect proposal in time");
         }
-        let proposals_b = node_b_client
+        let proposals_b = node_b
+            .admin_service_client()
             .list_proposals(None, None)
-            .expect("Unable to list proposals from node_b")
+            .expect("Unable to list proposals from second node")
             .data;
-        let proposals_c = node_c_client
+        let proposals_c = node_c
+            .admin_service_client()
             .list_proposals(None, None)
-            .expect("Unable to list proposals from node_c")
+            .expect("Unable to list proposals from third node")
             .data;
         if !(proposals_b.is_empty() && proposals_c.is_empty()) {
             // Unwrap the first element in each list as we've already validated the lists are not
@@ -735,18 +758,25 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         }
     }
     // Validate the same proposal is available to the first node
-    let proposal_a = node_a_client
+    let proposal_a = node_a
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
-        .expect("Unable to fetch proposal from node_a")
+        .expect("Unable to fetch proposal from first node")
         .unwrap();
     assert_eq!(proposal_a, proposal_b);
     assert_eq!(proposal_b, proposal_c);
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_b", &*node_b_signer, true);
-    let res = node_b_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the vote from this node to appear on the proposal for the remote nodes
@@ -759,31 +789,40 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         }
         // The proposal should already be available to each of these nodes, so we are able to
         // unwrap the result of the `fetch_proposal` call
-        proposal_a = node_a_client
+        proposal_a = node_a
+            .admin_service_client()
             .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from node_a")
+            .expect("Unable to fetch proposal from first node")
             .unwrap();
-        proposal_c = node_c_client
+        proposal_c = node_c
+            .admin_service_client()
             .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from node_c")
+            .expect("Unable to fetch proposal from third node")
             .unwrap();
         if proposal_a.votes.len() == 2 && proposal_c.votes.len() == 2 {
             break;
         }
     }
     // Validate the extra vote records are also available for the voting node
-    let proposal_b = node_b_client
+    let proposal_b = node_b
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
-        .expect("Unable to fetch proposal from node_b")
+        .expect("Unable to fetch proposal from second node")
         .unwrap();
     assert_eq!(proposal_a, proposal_b);
     assert_eq!(proposal_b, proposal_c);
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `false` for the `accept` argument to create a vote to reject the proposal
-    let vote_payload_bytes =
-        make_circuit_proposal_vote_payload(proposal_a, "node_c", &*node_c_signer, false);
-    let res = node_c_client.submit_admin_payload(vote_payload_bytes);
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_c.node_id(),
+        &*node_c.admin_signer().clone_box(),
+        false,
+    );
+    let res = node_c
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
     // Wait for the proposal to be removed for the other nodes
@@ -792,21 +831,24 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         if Instant::now().duration_since(start) > Duration::from_secs(60) {
             panic!("Failed to detect removed proposal in time");
         }
-        if node_a_client
+        if node_a
+            .admin_service_client()
             .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from node_a")
+            .expect("Unable to fetch proposal from first node")
             .is_none()
-            && node_b_client
+            && node_b
+                .admin_service_client()
                 .fetch_proposal(&circuit_id)
-                .expect("Unable to fetch proposal from node_b")
+                .expect("Unable to fetch proposal from second node")
                 .is_none()
         {
             break;
         }
     }
-    let removed_proposal = node_c_client
+    let removed_proposal = node_c
+        .admin_service_client()
         .fetch_proposal(&circuit_id)
-        .expect("Unable to fetch proposal from node_c");
+        .expect("Unable to fetch proposal from third node");
     assert!(removed_proposal.is_none());
 
     shutdown!(network).expect("Unable to shutdown network");

--- a/splinterd/tests/admin/circuit_lifecycle.rs
+++ b/splinterd/tests/admin/circuit_lifecycle.rs
@@ -853,3 +853,657 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
 
     shutdown!(network).expect("Unable to shutdown network");
 }
+
+/// Test that a 2-party circuit may be created on a 2-node network. This test then validates the
+/// circuit is able to be disbanded. Furthermore, this test validates the disbanded circuit is
+/// still accessible to each node and the circuit definition is as expected, after disbanding.
+///
+/// 1. Create a circuit between 2 nodes
+/// 2. Create and submit a `CircuitDisbandRequest` from the first node
+/// 3. Wait until the disband proposal is available to the second node, using `list_proposals`
+/// 4. Verify the same disband proposal is available on each node
+/// 5. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
+/// 6. Wait until the circuit is no longer available as an active circuit on the first node,
+///    using `list_circuits`
+/// 7. Validate the circuit is no longer active on the second node
+/// 8. Validate the disbanded circuit is still available to each node, though disbanded, and that
+///    the disbanded circuit is the same for each node
+#[test]
+#[ignore]
+pub fn test_2_party_circuit_lifecycle() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(2)
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    let circuit_id = "ABCDE-01234";
+    // Commit the circuit to state
+    commit_2_party_circuit(&circuit_id, node_a, node_b);
+
+    // Create disband request to be sent from the first node
+    let disband_payload = make_circuit_disband_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(disband_payload);
+    assert!(res.is_ok());
+
+    // Wait for the disband proposal to be committed for the second node
+    let proposal_b;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        let proposals = node_b
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from second node")
+            .data;
+        if !proposals.is_empty() {
+            // Unwrap the first proposal in this list as we've already validated the list is
+            // not empty
+            proposal_b = proposals.get(0).unwrap().clone();
+            break;
+        }
+    }
+
+    // Validate the same proposal is available to the first node
+    let proposal_a = node_a
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from first node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_a.proposal_type, "Disband");
+
+    // Create `CircuitProposalVote` to accept the disband proposal
+    // Uses `true` for the `accept` argument to create a vote to accept the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_b,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the circuit to be removed from the first node
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        // If the circuit no longer appears in the list of active circuits, the circuit
+        // has been successfully disbanded.
+        if node_a
+            .admin_service_client()
+            .list_circuits(None)
+            .expect("Unable to list circuits from first node")
+            .data
+            .is_empty()
+        {
+            break;
+        }
+    }
+
+    // Validate the circuit is no longer active for the second node
+    assert!(node_b
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from second node")
+        .data
+        .is_empty());
+    // Validate the disbanded circuit is the same for both nodes
+    let disbanded_circuit_a = node_a
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from first node")
+        .unwrap();
+    let disbanded_circuit_b = node_b
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from second node")
+        .unwrap();
+    assert_eq!(disbanded_circuit_a, disbanded_circuit_b);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// Test that a 2-party circuit may be created on a 2-node network. This test then validates a
+/// circuit member is able to propose to disband the circuit. This test then validates the disband
+/// request is able to be rejected by another circuit member, removing the disband proposal.
+///
+/// 1. Create a circuit between 2 nodes
+/// 2. Create and submit a `CircuitDisbandRequest` from the first node
+/// 3. Wait until the disband proposal is available to the second node, using `list_proposals`
+/// 4. Verify the same disband proposal is available on each node
+/// 5. Create and submit a `CircuitProposalVote` from the second node to reject the disband proposal
+/// 6. Wait until the disband proposal is no longer available to the second node,
+///    using `list_proposals`
+/// 7. Validate the proposal is no longer available on the second node
+/// 8. Validate the active circuit is still available to each node, using `list_circuits` which
+///    only returns active circuits
+#[test]
+#[ignore]
+pub fn test_2_party_circuit_disband_proposal_rejected() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(2)
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    let circuit_id = "ABCDE-01234";
+    // Commit the circuit to state
+    commit_2_party_circuit(&circuit_id, node_a, node_b);
+
+    // Create disband request to be sent from the first node
+    let disband_payload = make_circuit_disband_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(disband_payload);
+    assert!(res.is_ok());
+
+    // Wait for the disband proposal to be committed for the second node
+    let proposal_b;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        let proposals = node_b
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from second node")
+            .data;
+        if !proposals.is_empty() {
+            // Unwrap the first proposal in this list as we've already validated the list is
+            // not empty
+            proposal_b = proposals.get(0).unwrap().clone();
+            break;
+        }
+    }
+
+    // Validate the same proposal is available to the first node
+    let proposal_a = node_a
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from first node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_a.proposal_type, "Disband");
+
+    // Create `CircuitProposalVote` to accept the disband proposal
+    // Uses `false` for the `accept` argument to create a vote to reject the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_b,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        false,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the proposal to be removed from the first node
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        // If the proposal no longer appears in the list, the proposal has been removed as it was
+        // rejected
+        if node_a
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from first node")
+            .data
+            .is_empty()
+        {
+            break;
+        }
+    }
+
+    // Validate the proposal is no longer available for the second node
+    assert!(node_b
+        .admin_service_client()
+        .list_proposals(None, None)
+        .expect("Unable to list proposals from second node")
+        .data
+        .is_empty());
+
+    // Validate the active circuit is still available to each node
+    let active_circuits_a = node_a
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from first node")
+        .data;
+    assert!(active_circuits_a.len() == 1);
+    let active_circuits_b = node_b
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from second node")
+        .data;
+    assert!(active_circuits_b.len() == 1);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// Test that a 3-party circuit may be created on a 3-node network. This test then validates the
+/// circuit is able to be disbanded.
+///
+/// 1. Create a circuit between 3 nodes
+/// 2. Create and submit a `CircuitDisbandRequest` from the first node
+/// 3. Wait until the disband proposal is available to each node, using `list_proposals`
+/// 4. Verify the same disband proposal is present on each node
+/// 5. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
+/// 6. Wait until this vote is recorded on the proposal, using `fetch_proposal` and validating
+///    the `Vote` from the node that voted in the previous step appears on the proposal for each
+///    remote node
+/// 7. Validate the proposal has been updated and includes the `Vote` submitted in the previous
+///    steps for every node
+/// 8. Create and submit a `CircuitProposalVote` from the third node to accept the disband proposal
+/// 9. Wait until the active circuit is no longer available to the remote nodes, using
+///    `list_circuits`
+/// 10. Validate the circuit is no longer active on the last node to vote
+/// 11. Validate the disbanded circuit is still available to each node, though disbanded, and that
+///    the disbanded circuit is the same for each node
+#[test]
+#[ignore]
+pub fn test_3_party_circuit_lifecycle() {
+    // Start a 3-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(3)
+        .expect("Unable to start 3-node ActixWeb1 network");
+    // Get the first node from the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node from the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    // Get the third node from the network
+    let node_c = network.node(2).expect("Unable to get third node");
+
+    let circuit_id = "ABCDE-01234";
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+
+    // Create disband request to be sent from the first node
+    let disband_payload = make_circuit_disband_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(disband_payload);
+    assert!(res.is_ok());
+
+    // Wait for the disband proposal to be committed for the second and third node
+    let proposal_b;
+    let proposal_c;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        let proposals_b = node_b
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from second node")
+            .data;
+        let proposals_c = node_c
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from third node")
+            .data;
+        if !(proposals_b.is_empty() && proposals_c.is_empty()) {
+            // Unwrap the first elements in each list as we've already validated that both of
+            // the lists are not empty
+            proposal_b = proposals_b.get(0).unwrap().clone();
+            proposal_c = proposals_c.get(0).unwrap().clone();
+            break;
+        }
+    }
+
+    // Validate the same proposal is available to the first node
+    let proposal_a = node_a
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from first node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_b, proposal_c);
+    assert_eq!(proposal_a.proposal_type, "Disband");
+
+    // Create `CircuitProposalVote` to accept the disband proposal
+    // Uses `true` for the `accept` argument to create a vote to accept the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_b,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the vote from this node to appear on the proposal for the remote nodes
+    let mut proposal_a;
+    let mut proposal_c;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        // The proposal should already be available to each of these nodes, so we are able to
+        // unwrap the result of the `fetch_proposal` call
+        proposal_a = node_a
+            .admin_service_client()
+            .fetch_proposal(&circuit_id)
+            .expect("Unable to fetch proposal from first node")
+            .unwrap();
+        proposal_c = node_c
+            .admin_service_client()
+            .fetch_proposal(&circuit_id)
+            .expect("Unable to fetch proposal from third node")
+            .unwrap();
+        if proposal_a.votes.len() == 2 && proposal_c.votes.len() == 2 {
+            break;
+        }
+    }
+
+    // Validate the extra vote records are also available for the voting node
+    let proposal_b = node_b
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from second node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_b, proposal_c);
+
+    // Create the `CircuitProposalVote` to be sent to a node
+    // Uses `true` for the `accept` argument to create a vote to accept the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_c.node_id(),
+        &*node_c.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_c
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the circuit to be removed for the other nodes
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect circuit in time");
+        }
+        if node_a
+            .admin_service_client()
+            .list_circuits(None)
+            .expect("Unable to list circuits from first node")
+            .data
+            .is_empty()
+            && node_b
+                .admin_service_client()
+                .list_circuits(None)
+                .expect("Unable to list circuits from second node")
+                .data
+                .is_empty()
+        {
+            break;
+        }
+    }
+
+    // Validate the circuit is no longer active for the third and final node
+    assert!(node_c
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from third node")
+        .data
+        .is_empty());
+    // Validate the disbanded circuit is available and the same for each node
+    let disbanded_circuit_a = node_a
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from first node")
+        .unwrap();
+    let disbanded_circuit_b = node_b
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from second node")
+        .unwrap();
+    let disbanded_circuit_c = node_c
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from third node")
+        .unwrap();
+    assert_eq!(disbanded_circuit_a, disbanded_circuit_b);
+    assert_eq!(disbanded_circuit_b, disbanded_circuit_c);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// Test that a 3-party circuit may be created on a 3-node network. This test then validates the
+/// circuit is able to be disbanded.
+///
+/// 1. Create a circuit between 3 nodes
+/// 2. Create and submit a `CircuitDisbandRequest` from the first node
+/// 3. Wait until the disband proposal is available to each node, using `list_proposals`
+/// 4. Verify the same disband proposal is present on each node
+/// 5. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
+/// 6. Wait until this vote is recorded on the proposal, using `fetch_proposal` and validating
+///    the `Vote` from the node that voted in the previous step appears on the proposal for each
+///    remote node
+/// 7. Validate the proposal has been updated and includes the `Vote` submitted in the previous
+///    steps for every node
+/// 8. Create and submit a `CircuitProposalVote` from the third node to reject the disband proposal
+/// 9. Wait until the disband proposal is no longer available to the remote nodes, using
+///    `list_proposals`
+/// 10. Validate the disband proposal is no longer available for every node
+/// 11. Validate the circuit is still active for each node, using `list_circuits` which only returns
+///     active circuits
+#[test]
+#[ignore]
+pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
+    // Start a 3-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(3)
+        .expect("Unable to start 3-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    // Get the third node in the network
+    let node_c = network.node(2).expect("Unable to get third node");
+
+    let circuit_id = "ABCDE-01234";
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+
+    // Create disband request to be sent from the first node
+    let disband_payload = make_circuit_disband_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(disband_payload);
+    assert!(res.is_ok());
+
+    // Wait for the disband proposal to be committed for the second node
+    let proposal_b;
+    let proposal_c;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        let proposals_b = node_b
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from second node")
+            .data;
+        let proposals_c = node_c
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from third node")
+            .data;
+        if !(proposals_b.is_empty() && proposals_c.is_empty()) {
+            // Unwrap the first elements in each list as we've already validated that both of
+            // the lists are not empty
+            proposal_b = proposals_b.get(0).unwrap().clone();
+            proposal_c = proposals_c.get(0).unwrap().clone();
+            break;
+        }
+    }
+
+    // Validate the same proposal is available to the first node
+    let proposal_a = node_a
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from first node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_b, proposal_c);
+    assert_eq!(proposal_a.proposal_type, "Disband");
+
+    // Create `CircuitProposalVote` to accept the disband proposal
+    // Uses `true` for the `accept` argument to create a vote to accept the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_b,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the vote from this node to appear on the proposal for the remote nodes
+    let mut proposal_a;
+    let mut proposal_c;
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect proposal in time");
+        }
+        // The proposal should already be available to each of these nodes, so we are able to
+        // unwrap the result of the `fetch_proposal` call
+        proposal_a = node_a
+            .admin_service_client()
+            .fetch_proposal(&circuit_id)
+            .expect("Unable to fetch proposal from first node")
+            .unwrap();
+        proposal_c = node_c
+            .admin_service_client()
+            .fetch_proposal(&circuit_id)
+            .expect("Unable to fetch proposal from third node")
+            .unwrap();
+        if proposal_a.votes.len() == 2 && proposal_c.votes.len() == 2 {
+            break;
+        }
+    }
+
+    // Validate the extra vote records are also available for the voting node
+    let proposal_b = node_b
+        .admin_service_client()
+        .fetch_proposal(&circuit_id)
+        .expect("Unable to fetch proposal from second node")
+        .unwrap();
+    assert_eq!(proposal_a, proposal_b);
+    assert_eq!(proposal_b, proposal_c);
+
+    // Create the `CircuitProposalVote` to be sent to a node
+    // Uses `false` for the `accept` argument to create a vote to reject the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a,
+        node_c.node_id(),
+        &*node_c.admin_signer().clone_box(),
+        false,
+    );
+    let res = node_c
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for the disband proposal to be removed for the other nodes
+    let start = Instant::now();
+    loop {
+        if Instant::now().duration_since(start) > Duration::from_secs(60) {
+            panic!("Failed to detect circuit in time");
+        }
+        if node_a
+            .admin_service_client()
+            .list_proposals(None, None)
+            .expect("Unable to list proposals from first node")
+            .data
+            .is_empty()
+            && node_b
+                .admin_service_client()
+                .list_proposals(None, None)
+                .expect("Unable to list proposals from second node")
+                .data
+                .is_empty()
+        {
+            break;
+        }
+    }
+
+    // Validate the disband proposal is no longer active for the third and final node
+    assert!(node_c
+        .admin_service_client()
+        .list_proposals(None, None)
+        .expect("Unable to list proposals from third node")
+        .data
+        .is_empty());
+
+    // Validate the active circuit is still available to each node
+    let active_circuits_a = node_a
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from first node")
+        .data;
+    assert!(active_circuits_a.len() == 1);
+
+    let active_circuits_b = node_b
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from second node")
+        .data;
+    assert!(active_circuits_b.len() == 1);
+
+    let active_circuits_c = node_c
+        .admin_service_client()
+        .list_circuits(None)
+        .expect("Unable to list circuits from third node")
+        .data;
+    assert!(active_circuits_c.len() == 1);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -78,8 +78,8 @@ impl Network {
         self
     }
 
-    pub fn node(self: &mut Network, n: usize) -> Result<&mut Node, InvalidArgumentError> {
-        match self.nodes.get_mut(n) {
+    pub fn node(&self, n: usize) -> Result<&Node, InvalidArgumentError> {
+        match self.nodes.get(n) {
             Some(node) => Ok(node),
             None => Err(InvalidArgumentError::new(
                 "n".to_string(),


### PR DESCRIPTION
This PR updates the current circuit-creation tests to grab the node ID from the node (as this is now implemented) rather than using a placeholder of `node_*`. This also updates how the node information was stored and handed to the helper functions to allow for the order of the nodes' information to be maintained. 

This PR also adds tests for the circuit-disband process, including scenarios between 2 and 3 nodes.