### PR TITLE
Remove separate list for `disband` circuit proposals in admin service

### DIFF
--- a/libsplinter/protos/admin.proto
+++ b/libsplinter/protos/admin.proto
@@ -310,8 +310,7 @@ message AdminMessage {
         CONSENSUS_MESSAGE = 1;
         PROPOSED_CIRCUIT = 2;
         MEMBER_READY = 3;
-        DISBANDED_CIRCUIT = 4;
-        ABANDONED_CIRCUIT = 5;
+        ABANDONED_CIRCUIT = 4;
 
         SERVICE_PROTOCOL_VERSION_REQUEST = 100;
         SERVICE_PROTOCOL_VERSION_RESPONSE = 101;
@@ -322,8 +321,7 @@ message AdminMessage {
     bytes consensus_message = 2;
     ProposedCircuit proposed_circuit = 3;
     MemberReady member_ready = 4;
-    DisbandedCircuit disbanded_circuit = 5;
-    AbandonedCircuit abandoned_circuit = 6;
+    AbandonedCircuit abandoned_circuit = 5;
 
     // Messages to agree on protocol version
     ServiceProtocolVersionRequest protocol_request = 100;
@@ -342,12 +340,6 @@ message ProposedCircuit {
 }
 
 message MemberReady {
-    string circuit_id = 1;
-    string member_node_id = 2;
-}
-
-message DisbandedCircuit {
-    // the circuit being disbanded
     string circuit_id = 1;
     string member_node_id = 2;
 }

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -717,19 +717,6 @@ impl Service for AdminService {
 
                 Ok(())
             }
-            #[cfg(feature = "circuit-disband")]
-            AdminMessage_Type::DISBANDED_CIRCUIT => {
-                let disbanded_circuit = admin_message.get_disbanded_circuit();
-                let circuit_id = disbanded_circuit.get_circuit_id();
-                let member_node_id = disbanded_circuit.get_member_node_id();
-
-                let mut shared = self.admin_service_shared.lock().map_err(|_| {
-                    ServiceError::PoisonedLock("the admin shared lock was poisoned".into())
-                })?;
-                shared
-                    .add_member_ready_to_disband(circuit_id, member_node_id)
-                    .map_err(|err| ServiceError::UnableToHandleMessage(Box::new(err)))
-            }
             #[cfg(feature = "circuit-abandon")]
             AdminMessage_Type::ABANDONED_CIRCUIT => {
                 let abandoned_circuit = admin_message.get_abandoned_circuit();
@@ -745,7 +732,7 @@ impl Service for AdminService {
             AdminMessage_Type::UNSET => Err(ServiceError::InvalidMessageFormat(Box::new(
                 AdminError::MessageTypeUnset,
             ))),
-            #[cfg(any(not(feature = "circuit-disband"), not(feature = "circuit-abandon")))]
+            #[cfg(not(feature = "circuit-abandon"))]
             _ => Err(ServiceError::UnableToHandleMessage(Box::new(
                 AdminError::MessageTypeUnhandled,
             ))),

--- a/libsplinter/src/admin/store/circuit_proposal.rs
+++ b/libsplinter/src/admin/store/circuit_proposal.rs
@@ -512,6 +512,25 @@ impl From<&messages::ProposalType> for ProposalType {
     }
 }
 
+impl TryFrom<&admin::CircuitProposal_ProposalType> for ProposalType {
+    type Error = InvalidStateError;
+
+    fn try_from(
+        proto_proposal_type: &admin::CircuitProposal_ProposalType,
+    ) -> Result<Self, Self::Error> {
+        match *proto_proposal_type {
+            admin::CircuitProposal_ProposalType::CREATE => Ok(ProposalType::Create),
+            admin::CircuitProposal_ProposalType::UPDATE_ROSTER => Ok(ProposalType::UpdateRoster),
+            admin::CircuitProposal_ProposalType::ADD_NODE => Ok(ProposalType::AddNode),
+            admin::CircuitProposal_ProposalType::REMOVE_NODE => Ok(ProposalType::RemoveNode),
+            admin::CircuitProposal_ProposalType::DISBAND => Ok(ProposalType::Disband),
+            admin::CircuitProposal_ProposalType::UNSET_PROPOSAL_TYPE => Err(
+                InvalidStateError::with_message("ProposalType is unset".to_string()),
+            ),
+        }
+    }
+}
+
 impl From<&messages::VoteRecord> for VoteRecord {
     fn from(admin_vote_record: &messages::VoteRecord) -> Self {
         VoteRecord {


### PR DESCRIPTION
This PR removes the separate list that held circuit proposals associated with a `CircuitDisbandRequest`. The circuit proposals associated with a disband request are now put in the `uninitialized_circuits` list, where other circuits that have been committed to state but must have their services handled. This also removes the separate methods used to handle the votes for a proposal associated with a `disband` request to verify whether the services must be initialized or stopped based on the associated circuit proposal.

This requires checking if the associated proposal is in state (for the remote nodes receiving the request) or finding the proposal stored in the `uninitialized_circuits` list if the circuit has already been committed to state but the services have yet to be stopped (a scenario encountered by the requesting node). 