### PR TITLE
Add `circuit-purge` feature guard to Service trait's `purge` method

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -602,6 +602,7 @@ impl Service for AdminService {
         }
     }
 
+    #[cfg(feature = "circuit-purge")]
     fn purge(&mut self) -> Result<(), crate::error::InternalError> {
         Ok(())
     }

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -208,6 +208,7 @@ impl ServiceOrchestrator {
         Ok(())
     }
 
+    #[cfg(feature = "circuit-purge")]
     /// Purge the specified service state, based on its service implementation.
     pub fn purge_service(
         &self,

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -47,6 +47,7 @@ pub mod validation;
 
 use std::any::Any;
 
+#[cfg(feature = "circuit-purge")]
 use crate::error::InternalError;
 
 pub use factory::ServiceFactory;
@@ -142,6 +143,7 @@ pub trait Service: Send {
     /// this must take a boxed Service instance).
     fn destroy(self: Box<Self>) -> Result<(), ServiceDestroyError>;
 
+    #[cfg(feature = "circuit-purge")]
     /// Purge any persistent state maintained by this service.
     fn purge(&mut self) -> Result<(), InternalError>;
 

--- a/libsplinter/src/service/processor/mod.rs
+++ b/libsplinter/src/service/processor/mod.rs
@@ -954,6 +954,7 @@ pub mod tests {
             Ok(())
         }
 
+        #[cfg(feature = "circuit-purge")]
         fn purge(&mut self) -> Result<(), crate::error::InternalError> {
             unimplemented!()
         }
@@ -1045,6 +1046,7 @@ pub mod tests {
             Ok(())
         }
 
+        #[cfg(feature = "circuit-purge")]
         fn purge(&mut self) -> Result<(), crate::error::InternalError> {
             unimplemented!()
         }

--- a/services/health/Cargo.toml
+++ b/services/health/Cargo.toml
@@ -38,6 +38,8 @@ experimental = [
     "stable",
     # The following features are experimental:
     "authorization",
+    "circuit-purge",
 ]
 
 authorization = ["splinter/authorization"]
+circuit-purge = ["splinter/circuit-purge"]

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -77,6 +77,7 @@ impl Service for HealthService {
         Ok(())
     }
 
+    #[cfg(feature = "circuit-purge")]
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
         info!("Purging health service");
         Ok(())

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -64,9 +64,11 @@ experimental = [
   "stable",
   # The following features are experimental:
   "authorization",
+  "circuit-purge",
 ]
 
 authorization = ["splinter/authorization"]
+circuit-purge = ["splinter/circuit-purge"]
 client = ["reqwest"]
 events = ["splinter/events"]
 rest-api = ["futures", "splinter/rest-api"]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -372,6 +372,7 @@ impl Service for Scabbard {
         }
     }
 
+    #[cfg(feature = "circuit-purge")]
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
         self.state
             .lock()

--- a/services/scabbard/libscabbard/src/service/state.rs
+++ b/services/scabbard/libscabbard/src/service/state.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fmt;
+#[cfg(feature = "circuit-purge")]
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{
@@ -74,7 +75,9 @@ pub struct ScabbardState {
     pending_changes: Option<(String, Vec<TransactionReceipt>)>,
     event_subscribers: Vec<Box<dyn StateSubscriber>>,
     batch_history: BatchHistory,
+    #[cfg(feature = "circuit-purge")]
     state_db_file: PathBuf,
+    #[cfg(feature = "circuit-purge")]
     receipt_db_file: PathBuf,
 }
 
@@ -89,7 +92,9 @@ impl ScabbardState {
         // Initialize the database
         let mut indexes = INDEXES.to_vec();
         indexes.push(CURRENT_STATE_ROOT_INDEX);
+        #[cfg(feature = "circuit-purge")]
         let state_db_file = state_db_path.to_path_buf();
+        #[cfg(feature = "circuit-purge")]
         let receipt_db_file = receipt_db_path.to_path_buf();
         let state_db_path = state_db_path.as_path().with_extension("lmdb");
         let receipt_db_path = receipt_db_path.as_path().with_extension("lmdb");
@@ -158,7 +163,9 @@ impl ScabbardState {
             pending_changes: None,
             event_subscribers: vec![],
             batch_history: BatchHistory::new(),
+            #[cfg(feature = "circuit-purge")]
             state_db_file,
+            #[cfg(feature = "circuit-purge")]
             receipt_db_file,
         })
     }
@@ -367,6 +374,7 @@ impl ScabbardState {
         self.event_subscribers.clear();
     }
 
+    #[cfg(feature = "circuit-purge")]
     /// Computes the files associated with the LMDB state, including lock files.
     pub fn remove_db_files(&self) -> Result<(), ScabbardStateError> {
         let state_db_path = self.state_db_file.with_extension("lmdb");

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -124,7 +124,11 @@ biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile"]
 circuit-abandon = ["splinter/circuit-abandon"]
 circuit-disband = ["splinter/circuit-disband"]
-circuit-purge = ["splinter/circuit-purge"]
+circuit-purge = [
+  "health/circuit-purge",
+  "scabbard/circuit-purge",
+  "splinter/circuit-purge",
+]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]


### PR DESCRIPTION
This PR adds a `circuit-purge` feature guard to the Service trait's `purge` method. This PR also adds pulling in the `circuit-purge` feature into the health and scabbard services, to also feature guard each service's implementation of the `purge` method. This also requires adding the `health/circuit-purge` and `scabbard/circuit-purge` into splinterd's `circuit-purge` feature, to allow for those services to be compiled with this feature.  