### PR TITLE
Fix builds that don't include splinterd

### DIFF
--- a/ci/splinter-dev
+++ b/ci/splinter-dev
@@ -58,6 +58,7 @@ WORKDIR /build
 RUN USER=root cargo new --bin cli
 RUN USER=root cargo new --lib libsplinter
 RUN USER=root cargo new --bin splinterd
+RUN cp libsplinter/src/lib.rs splinterd/src/lib.rs
 
 # Create empty Cargo projects for gameroom
 RUN USER=root cargo new --bin examples/gameroom/cli


### PR DESCRIPTION
Commit 8ea35717 added a lib to splinter that causes Docker builds that don't
have splinterd dependencies to fail because of the workspace Cargo.toml.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>