### PR TITLE
Implement NetworkSubsystem for Nodes used in the integrations tests

### DIFF
--- a/libsplinter/src/admin/client/reqwest.rs
+++ b/libsplinter/src/admin/client/reqwest.rs
@@ -17,10 +17,10 @@
 use reqwest::{blocking::Client, header, StatusCode};
 
 use crate::error::InternalError;
+use crate::protocol::ADMIN_PROTOCOL_VERSION;
 
 use super::{AdminServiceClient, CircuitListSlice, CircuitSlice, ProposalListSlice, ProposalSlice};
 
-const ADMIN_PROTOCOL_VERSION: &str = "1";
 const PAGING_LIMIT: u32 = 100;
 
 #[derive(Deserialize)]

--- a/libsplinter/src/network/dispatch/mod.rs
+++ b/libsplinter/src/network/dispatch/mod.rs
@@ -28,7 +28,7 @@ use std::hash::Hash;
 pub use context::MessageContext;
 pub use r#loop::{
     dispatch_channel, DispatchLoop, DispatchLoopBuilder, DispatchLoopError,
-    DispatchLoopShutdownSignaler, DispatchMessageReceiver, DispatchMessageSender,
+    DispatchMessageReceiver, DispatchMessageSender,
 };
 
 /// A wrapper for a PeerId.

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -28,8 +28,10 @@ use std::thread;
 
 use protobuf::Message;
 
+use crate::error::InternalError;
 use crate::network::dispatch::DispatchMessageSender;
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::threading::lifecycle::ShutdownHandle;
 use crate::transport::matrix::{
     ConnectionMatrixReceiver, ConnectionMatrixRecvError, ConnectionMatrixSender,
 };
@@ -90,7 +92,6 @@ pub struct PeerInterconnect {
     dispatched_sender: Sender<SendRequest>,
     recv_join_handle: thread::JoinHandle<()>,
     send_join_handle: thread::JoinHandle<()>,
-    shutdown_signaler: ShutdownSignaler,
 }
 
 impl PeerInterconnect {
@@ -98,26 +99,30 @@ impl PeerInterconnect {
     pub fn new_network_sender(&self) -> NetworkMessageSender {
         NetworkMessageSender::new(self.dispatched_sender.clone())
     }
+}
 
-    /// Returns a `ShutdownHandle` that can be used to shutdown `PeerInterconnect`
-    #[deprecated(since = "0.5.1", note = "Please use shutdown_signaler() instead.")]
-    pub fn shutdown_handle(&self) -> ShutdownHandle {
-        ShutdownHandle::from(self.shutdown_signaler.clone())
+impl ShutdownHandle for PeerInterconnect {
+    /// Instructs the component to begin shutting down.
+    ///
+    /// For components with threads, this should break out of any loops and ready the threads for
+    /// being joined.
+    fn signal_shutdown(&mut self) {
+        if self.dispatched_sender.send(SendRequest::Shutdown).is_err() {
+            warn!("Peer Interconnect is no longer running");
+        }
     }
 
-    /// Returns a `ShutdownSignaler` for this `PeerManager`
-    pub fn shutdown_signaler(&self) -> ShutdownSignaler {
-        self.shutdown_signaler.clone()
-    }
-
-    /// Waits for the send and receive thread to shutdown
-    pub fn await_shutdown(self) {
+    /// Waits until the the component has completely shutdown.
+    ///
+    /// For components with threads, the threads should be joined during the call to
+    /// `wait_for_shutdown`.
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
         debug!("Shutting down peer interconnect receiver...");
         if let Err(err) = self.send_join_handle.join() {
-            error!(
+            return Err(InternalError::with_message(format!(
                 "Peer interconnect send thread did not shutdown correctly: {:?}",
                 err
-            );
+            )));
         };
         debug!("Shutting down peer interconnect receiver (complete)");
 
@@ -129,17 +134,7 @@ impl PeerInterconnect {
             );
         }
         debug!("Shutting down peer interconnect sender (complete)");
-    }
-
-    #[deprecated(
-        since = "0.5.1",
-        note = "Please use shutdown_signaler().shutdown() and await_shutdown() instead."
-    )]
-    /// Calls shutdown on the shutdown handle and then waits for the `PeerInterconnect` threads to
-    /// finish
-    pub fn shutdown_and_wait(self) {
-        self.shutdown_signaler().shutdown();
-        self.await_shutdown();
+        Ok(())
     }
 }
 
@@ -286,12 +281,9 @@ where
             })?;
 
         Ok(PeerInterconnect {
-            dispatched_sender: dispatched_sender.clone(),
+            dispatched_sender,
             recv_join_handle,
             send_join_handle,
-            shutdown_signaler: ShutdownSignaler {
-                sender: dispatched_sender,
-            },
         })
     }
 }
@@ -433,46 +425,6 @@ where
     }
 }
 
-/// Handle for shutting down the `PeerInterconnect`.
-/// Deprecated, use ShutdownSignaler instead.
-#[derive(Clone)]
-pub struct ShutdownHandle {
-    sender: Sender<SendRequest>,
-}
-
-impl ShutdownHandle {
-    /// Sends a shutdown notification to `PeerInterconnect` and the associated dipatcher thread
-    /// and `ConnectionMatrix`
-    pub fn shutdown(&self) {
-        if self.sender.send(SendRequest::Shutdown).is_err() {
-            warn!("Peer Interconnect is no longer running");
-        }
-    }
-}
-
-impl From<ShutdownSignaler> for ShutdownHandle {
-    fn from(signaler: ShutdownSignaler) -> Self {
-        ShutdownHandle {
-            sender: signaler.sender,
-        }
-    }
-}
-
-/// Handle for shutting down the `PeerInterconnect`
-#[derive(Clone)]
-pub struct ShutdownSignaler {
-    sender: Sender<SendRequest>,
-}
-
-impl ShutdownSignaler {
-    /// Sends a shutdown message to the `PeerManager` and `Pacemaker`
-    pub fn shutdown(&self) {
-        if self.sender.send(SendRequest::Shutdown).is_err() {
-            warn!("Peer Interconnect is no longer running");
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -606,7 +558,7 @@ pub mod tests {
         let (send, recv) = channel();
 
         let (dispatcher_sender, dispatcher_receiver) = dispatch_channel();
-        let interconnect = PeerInterconnectBuilder::new()
+        let mut interconnect = PeerInterconnectBuilder::new()
             .with_peer_connector(peer_connector.clone())
             .with_message_receiver(mesh1.get_receiver())
             .with_message_sender(mesh1.get_sender())
@@ -674,8 +626,10 @@ pub mod tests {
         mesh1.signal_shutdown();
         mesh1.wait_for_shutdown().expect("Unable to shutdown mesh");
 
-        interconnect.shutdown_signaler().shutdown();
-        interconnect.await_shutdown();
+        interconnect.signal_shutdown();
+        interconnect
+            .wait_for_shutdown()
+            .expect("Unable to shutdown interconnect");
     }
 
     // Verify that PeerInterconnect can be shutdown after start but without any messages being
@@ -704,7 +658,7 @@ pub mod tests {
             .expect("Cannot start peer_manager");
         let peer_connector = peer_manager.connector();
         let (dispatcher_sender, _dispatched_receiver) = dispatch_channel();
-        let interconnect = PeerInterconnectBuilder::new()
+        let mut interconnect = PeerInterconnectBuilder::new()
             .with_peer_connector(peer_connector)
             .with_message_receiver(mesh.get_receiver())
             .with_message_sender(mesh.get_sender())
@@ -723,8 +677,10 @@ pub mod tests {
         mesh.signal_shutdown();
         mesh.wait_for_shutdown().expect("Unable to shutdown mesh");
 
-        interconnect.shutdown_signaler().shutdown();
-        interconnect.await_shutdown();
+        interconnect.signal_shutdown();
+        interconnect
+            .wait_for_shutdown()
+            .expect("Unable to shutdown interconnect");
     }
 
     struct Shutdown {}

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -81,7 +81,7 @@ pub fn create_store_factory(
 ) -> Result<Box<dyn StoreFactory>, InternalError> {
     match connection_uri {
         #[cfg(feature = "memory")]
-        ConnectionUri::Memory => Ok(Box::new(memory::MemoryStoreFactory::new())),
+        ConnectionUri::Memory => Ok(Box::new(memory::MemoryStoreFactory::new()?)),
         #[cfg(feature = "postgres")]
         ConnectionUri::Postgres(url) => {
             let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);

--- a/splinterd/src/lib.rs
+++ b/splinterd/src/lib.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#[cfg(feature = "node")]
+#[macro_use]
+extern crate log;
 #[cfg(feature = "node")]
 pub mod node;

--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -84,9 +84,10 @@ impl AdminSubsystemBuilder {
 
         let admin_timeout = self.admin_timeout.unwrap_or(DEFAULT_ADMIN_TIMEOUT);
 
-        let store_factory = self
-            .store_factory
-            .unwrap_or_else(|| Box::new(MemoryStoreFactory::new()));
+        let store_factory = match self.store_factory {
+            Some(store_factory) => store_factory,
+            None => Box::new(MemoryStoreFactory::new()?),
+        };
 
         let peer_connector = self.peer_connector.take().ok_or_else(|| {
             InternalError::with_message(

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -15,6 +15,7 @@
 //! Contains the implementation of `NodeBuilder`.
 
 pub(super) mod admin;
+pub(super) mod network;
 
 use std::time::Duration;
 

--- a/splinterd/src/node/builder/network.rs
+++ b/splinterd/src/node/builder/network.rs
@@ -1,0 +1,90 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for the NetworkSubsystem
+
+use std::time::Duration;
+
+use rand::{thread_rng, Rng};
+use splinter::error::InternalError;
+use splinter::transport::multi::MultiTransport;
+use splinter::transport::socket::TcpTransport;
+
+use crate::node::runnable::network::RunnableNetworkSubsystem;
+
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Default)]
+pub struct NetworkSubsystemBuilder {
+    node_id: Option<String>,
+    heartbeat_interval: Option<Duration>,
+    strict_ref_counts: bool,
+    network_endpoints: Option<Vec<String>>,
+}
+
+impl NetworkSubsystemBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specifies the id for the node. Defaults to a random node id.
+    pub fn with_node_id(mut self, node_id: String) -> Self {
+        self.node_id = Some(node_id);
+        self
+    }
+
+    /// Specifies the heartbeat interval between peer connections. Defaults to 30 seconds.
+    pub fn with_heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
+        self.heartbeat_interval = Some(heartbeat_interval);
+        self
+    }
+
+    /// Configure whether or not strict reference counts will be used in the peer manager. Defaults
+    /// to false.
+    pub fn with_strict_ref_counts(mut self, strict_ref_counts: bool) -> Self {
+        self.strict_ref_counts = strict_ref_counts;
+        self
+    }
+
+    /// Specifies the network endpoints for the node
+    pub fn with_network_endpoints(mut self, network_endpoints: Vec<String>) -> Self {
+        self.network_endpoints = Some(network_endpoints);
+        self
+    }
+
+    pub fn build(mut self) -> Result<RunnableNetworkSubsystem, InternalError> {
+        let node_id = self
+            .node_id
+            .take()
+            .unwrap_or_else(|| format!("n{}", thread_rng().gen::<u16>().to_string()));
+
+        // keep as option, if not provided will be set to tcp://127.0.0.1:0
+        let network_endpoints = self.network_endpoints;
+
+        let heartbeat_interval = self
+            .heartbeat_interval
+            .take()
+            .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL);
+
+        let transport = MultiTransport::new(vec![Box::new(TcpTransport::default())]);
+
+        Ok(RunnableNetworkSubsystem {
+            node_id,
+            transport,
+            heartbeat_interval,
+            strict_ref_counts: self.strict_ref_counts,
+            network_endpoints,
+        })
+    }
+}

--- a/splinterd/src/node/builder/network.rs
+++ b/splinterd/src/node/builder/network.rs
@@ -16,7 +16,6 @@
 
 use std::time::Duration;
 
-use rand::{thread_rng, Rng};
 use splinter::error::InternalError;
 use splinter::transport::multi::MultiTransport;
 use splinter::transport::socket::TcpTransport;
@@ -64,10 +63,11 @@ impl NetworkSubsystemBuilder {
     }
 
     pub fn build(mut self) -> Result<RunnableNetworkSubsystem, InternalError> {
-        let node_id = self
-            .node_id
-            .take()
-            .unwrap_or_else(|| format!("n{}", thread_rng().gen::<u16>().to_string()));
+        let node_id = self.node_id.take().ok_or_else(|| {
+            InternalError::with_message(
+                "Cannot build NetworkSubsystem without a node id".to_string(),
+            )
+        })?;
 
         // keep as option, if not provided will be set to tcp://127.0.0.1:0
         let network_endpoints = self.network_endpoints;

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -39,6 +39,7 @@ pub struct RunnableNode {
     pub(super) admin_subsystem_builder: AdminSubsystemBuilder,
     pub(super) rest_api_variant: RunnableNodeRestApiVariant,
     pub(super) runnable_network_subsystem: RunnableNetworkSubsystem,
+    pub(super) node_id: String,
 }
 
 impl RunnableNode {
@@ -54,6 +55,8 @@ impl RunnableNode {
             .build()?;
 
         let mut admin_subsystem = runnable_admin_subsystem.run()?;
+
+        let node_id = self.node_id;
 
         let rest_api_variant = match self.rest_api_variant {
             RunnableNodeRestApiVariant::ActixWeb1(rest_api) => {
@@ -127,6 +130,7 @@ impl RunnableNode {
             network_subsystem,
             rest_api_variant,
             rest_api_port,
+            node_id,
         })
     }
 }

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -23,9 +23,10 @@ use splinter::error::InternalError;
 use splinter::rest_api::actix_web_1::RestApi;
 use splinter::rest_api::actix_web_3::RunnableRestApi;
 
+use super::builder::admin::AdminSubsystemBuilder;
 use super::{Node, NodeRestApiVariant};
 
-use self::admin::RunnableAdminSubsystem;
+use self::network::RunnableNetworkSubsystem;
 
 pub(super) enum RunnableNodeRestApiVariant {
     ActixWeb1(RestApi),
@@ -35,14 +36,24 @@ pub(super) enum RunnableNodeRestApiVariant {
 /// A fully configured and runnable instance of a node.
 pub struct RunnableNode {
     pub(super) admin_signer: Box<dyn cylinder::Signer>,
-    pub(super) runnable_admin_subsystem: RunnableAdminSubsystem,
+    pub(super) admin_subsystem_builder: AdminSubsystemBuilder,
     pub(super) rest_api_variant: RunnableNodeRestApiVariant,
+    pub(super) runnable_network_subsystem: RunnableNetworkSubsystem,
 }
 
 impl RunnableNode {
     /// Starts up the Node.
     pub fn run(self) -> Result<Node, InternalError> {
-        let mut admin_subsystem = self.runnable_admin_subsystem.run()?;
+        let network_subsystem = self.runnable_network_subsystem.run()?;
+
+        let runnable_admin_subsystem = self
+            .admin_subsystem_builder
+            .with_peer_connector(network_subsystem.peer_connector())
+            .with_routing_writer(network_subsystem.routing_table_writer())
+            .with_service_transport(network_subsystem.service_transport())
+            .build()?;
+
+        let mut admin_subsystem = runnable_admin_subsystem.run()?;
 
         let rest_api_variant = match self.rest_api_variant {
             RunnableNodeRestApiVariant::ActixWeb1(rest_api) => {
@@ -113,6 +124,7 @@ impl RunnableNode {
         Ok(Node {
             admin_signer: self.admin_signer,
             admin_subsystem,
+            network_subsystem,
             rest_api_variant,
             rest_api_port,
         })

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -15,6 +15,7 @@
 //! Contains the implementation of `RunnableNode`.
 
 pub(super) mod admin;
+pub(super) mod network;
 
 use std::net::{Ipv4Addr, SocketAddr};
 

--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -1,0 +1,364 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::thread;
+use std::time::Duration;
+
+use splinter::admin::service::admin_service_id;
+use splinter::circuit::handlers::{
+    AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
+    CircuitMessageHandler, ServiceConnectRequestHandler, ServiceDisconnectRequestHandler,
+};
+use splinter::circuit::routing::{memory::RoutingTable, RoutingTableReader, RoutingTableWriter};
+use splinter::error::InternalError;
+use splinter::mesh::Mesh;
+use splinter::network::auth::AuthorizationManager;
+use splinter::network::connection_manager::{
+    authorizers::Authorizers, authorizers::InprocAuthorizer, ConnectionManager, Connector,
+};
+use splinter::network::dispatch::{
+    dispatch_channel, DispatchLoopBuilder, DispatchMessageSender, Dispatcher,
+};
+use splinter::network::handlers::{NetworkEchoHandler, NetworkHeartbeatHandler};
+use splinter::peer::interconnect::NetworkMessageSender;
+use splinter::peer::{interconnect::PeerInterconnectBuilder, PeerManager};
+use splinter::protos::circuit::CircuitMessageType;
+use splinter::protos::network::NetworkMessageType;
+use splinter::transport::{
+    inproc::InprocTransport, multi::MultiTransport, AcceptError, Incoming, Listener, Transport,
+};
+
+use crate::node::running::network::NetworkSubsystem;
+
+pub struct RunnableNetworkSubsystem {
+    pub node_id: String,
+    pub transport: MultiTransport,
+    pub heartbeat_interval: Duration,
+    pub strict_ref_counts: bool,
+    pub network_endpoints: Option<Vec<String>>,
+}
+
+impl RunnableNetworkSubsystem {
+    pub fn run(self) -> Result<NetworkSubsystem, InternalError> {
+        let node_id = self.node_id;
+        let heartbeat_interval = self.heartbeat_interval;
+        let mut transport = self.transport;
+
+        let service_transport = InprocTransport::default();
+        transport.add_transport(Box::new(service_transport.clone()));
+
+        let internal_service_listeners = Self::build_internal_service_listeners(&mut transport)?;
+
+        let mut network_endpoints = vec![];
+        let mut network_listeners = vec![];
+        // setup listener for specified network endpoints. If no endpoints are specified set up 1
+        // endpoint for some available port and set that to the network endpoints
+        if let Some(specified_network_endpoints) = self.network_endpoints {
+            network_listeners.append(&mut Self::build_network_listeners(
+                &mut transport,
+                &specified_network_endpoints,
+            )?);
+            network_endpoints = specified_network_endpoints;
+        } else {
+            network_listeners.append(&mut Self::build_network_listeners(
+                &mut transport,
+                &["tcp://127.0.0.1:0".to_string()],
+            )?);
+            for network_listener in network_listeners.iter() {
+                network_endpoints.push(network_listener.endpoint().clone())
+            }
+        }
+
+        let mesh = Mesh::new(512, 128);
+
+        // Configure connection manager
+        let connection_manager = Self::build_connection_manager(
+            &node_id,
+            Box::new(transport),
+            &mesh,
+            heartbeat_interval,
+        )?;
+        let connection_connector = connection_manager.connector();
+
+        let peer_manager = Self::build_peer_manager(
+            &node_id,
+            connection_connector.clone(),
+            self.strict_ref_counts,
+        )?;
+
+        let (network_dispatcher_sender, network_dispatch_receiver) = dispatch_channel();
+        let interconnect = PeerInterconnectBuilder::new()
+            .with_peer_connector(peer_manager.connector())
+            .with_message_receiver(mesh.get_receiver())
+            .with_message_sender(mesh.get_sender())
+            .with_network_dispatcher_sender(network_dispatcher_sender.clone())
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let network_sender = interconnect.new_network_sender();
+        let routing_table = RoutingTable::default();
+        let routing_writer: Box<dyn RoutingTableWriter> = Box::new(routing_table.clone());
+        let routing_reader: Box<dyn RoutingTableReader> = Box::new(routing_table.clone());
+
+        // Set up the Circuit dispatcher
+        let circuit_dispatcher = Self::set_up_circuit_dispatcher(
+            network_sender.clone(),
+            &node_id,
+            routing_reader,
+            routing_writer,
+        );
+        let circuit_dispatch_loop = DispatchLoopBuilder::new()
+            .with_dispatcher(circuit_dispatcher)
+            .with_thread_name("CircuitDispatchLoop".to_string())
+            .build()
+            .map_err(InternalError::with_message)?;
+
+        let circuit_dispatch_sender = circuit_dispatch_loop.new_dispatcher_sender();
+
+        // Set up the Network dispatcher
+        let network_dispatcher =
+            Self::set_up_network_dispatcher(network_sender, &node_id, circuit_dispatch_sender);
+
+        let network_dispatch_loop = DispatchLoopBuilder::new()
+            .with_dispatcher(network_dispatcher)
+            .with_thread_name("NetworkDispatchLoop".to_string())
+            .with_dispatch_channel((network_dispatcher_sender, network_dispatch_receiver))
+            .build()
+            .map_err(InternalError::with_message)?;
+
+        let mut network_listener_joinhandles =
+            Self::listen_for_incoming_peers(network_listeners, &connection_connector);
+
+        let service_listener_joinhandle =
+            Self::listen_for_services(internal_service_listeners, &connection_connector);
+
+        network_listener_joinhandles.push(service_listener_joinhandle);
+
+        Ok(NetworkSubsystem {
+            node_id,
+            peer_manager,
+            connection_manager,
+            routing_table,
+            _network_listener_joinhandles: network_listener_joinhandles,
+            network_endpoints,
+            circuit_dispatch_loop,
+            network_dispatch_loop,
+            interconnect,
+            service_transport,
+            mesh,
+        })
+    }
+
+    fn build_internal_service_listeners(
+        transport: &mut dyn Transport,
+    ) -> Result<Vec<Box<dyn Listener>>, InternalError> {
+        Ok(vec![
+            transport
+                .listen("inproc://admin-service")
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
+            transport
+                .listen("inproc://orchestator")
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
+        ])
+    }
+
+    fn build_network_listeners(
+        transport: &mut dyn Transport,
+        network_endpoints: &[String],
+    ) -> Result<Vec<Box<dyn Listener>>, InternalError> {
+        let mut listeners = vec![];
+
+        for network_endpoint in network_endpoints {
+            listeners.push(
+                transport
+                    .listen(&network_endpoint)
+                    .map_err(|e| InternalError::from_source(Box::new(e)))?,
+            )
+        }
+
+        Ok(listeners)
+    }
+
+    fn build_connection_manager(
+        node_id: &str,
+        transport: Box<dyn Transport + Send>,
+        mesh: &Mesh,
+        heartbeat_interval: Duration,
+    ) -> Result<ConnectionManager, InternalError> {
+        let inproc_ids = vec![
+            (
+                "inproc://orchestator".to_string(),
+                format!("orchestator::{}", node_id),
+            ),
+            (
+                "inproc://admin-service".to_string(),
+                admin_service_id(node_id),
+            ),
+        ];
+
+        // Set up Authorization
+        let inproc_authorizer = InprocAuthorizer::new(inproc_ids);
+
+        let authorization_manager = AuthorizationManager::new(node_id.to_string())
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let mut authorizers = Authorizers::new();
+        authorizers.add_authorizer("inproc", inproc_authorizer);
+        authorizers.add_authorizer("", authorization_manager.authorization_connector());
+
+        ConnectionManager::builder()
+            .with_authorizer(Box::new(authorizers))
+            .with_matrix_life_cycle(mesh.get_life_cycle())
+            .with_matrix_sender(mesh.get_sender())
+            .with_transport(transport)
+            .with_heartbeat_interval(heartbeat_interval.as_secs())
+            .start()
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+
+    fn build_peer_manager(
+        node_id: &str,
+        connection_connector: Connector,
+        strict_ref_counts: bool,
+    ) -> Result<PeerManager, InternalError> {
+        PeerManager::builder()
+            .with_connector(connection_connector)
+            .with_identity(node_id.to_string())
+            .with_strict_ref_counts(strict_ref_counts)
+            .start()
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+
+    fn set_up_circuit_dispatcher(
+        network_sender: NetworkMessageSender,
+        node_id: &str,
+        routing_reader: Box<dyn RoutingTableReader>,
+        routing_writer: Box<dyn RoutingTableWriter>,
+    ) -> Dispatcher<CircuitMessageType> {
+        let mut dispatcher = Dispatcher::<CircuitMessageType>::new(Box::new(network_sender));
+
+        let service_connect_request_handler = ServiceConnectRequestHandler::new(
+            node_id.to_string(),
+            routing_reader.clone(),
+            routing_writer.clone(),
+        );
+        dispatcher.set_handler(Box::new(service_connect_request_handler));
+
+        let service_disconnect_request_handler =
+            ServiceDisconnectRequestHandler::new(routing_reader.clone(), routing_writer.clone());
+        dispatcher.set_handler(Box::new(service_disconnect_request_handler));
+
+        let direct_message_handler =
+            CircuitDirectMessageHandler::new(node_id.to_string(), routing_reader.clone());
+        dispatcher.set_handler(Box::new(direct_message_handler));
+
+        let circuit_error_handler =
+            CircuitErrorHandler::new(node_id.to_string(), routing_reader.clone());
+        dispatcher.set_handler(Box::new(circuit_error_handler));
+
+        // Circuit Admin handlers
+        let admin_direct_message_handler =
+            AdminDirectMessageHandler::new(node_id.to_string(), routing_reader);
+        dispatcher.set_handler(Box::new(admin_direct_message_handler));
+
+        dispatcher
+    }
+
+    fn set_up_network_dispatcher(
+        network_sender: NetworkMessageSender,
+        node_id: &str,
+        circuit_sender: DispatchMessageSender<CircuitMessageType>,
+    ) -> Dispatcher<NetworkMessageType> {
+        let mut dispatcher = Dispatcher::<NetworkMessageType>::new(Box::new(network_sender));
+
+        let network_echo_handler = NetworkEchoHandler::new(node_id.to_string());
+        dispatcher.set_handler(Box::new(network_echo_handler));
+
+        let network_heartbeat_handler = NetworkHeartbeatHandler::new();
+        // do not add auth guard
+        dispatcher.set_handler(Box::new(network_heartbeat_handler));
+
+        let circuit_message_handler = CircuitMessageHandler::new(circuit_sender);
+        dispatcher.set_handler(Box::new(circuit_message_handler));
+
+        dispatcher
+    }
+
+    fn listen_for_incoming_peers(
+        network_listeners: Vec<Box<dyn Listener>>,
+        connection_connector: &Connector,
+    ) -> Vec<thread::JoinHandle<()>> {
+        // setup threads to listen on the network ports and add incoming connections to the network
+        // these threads will just be dropped on shutdown
+        network_listeners
+            .into_iter()
+            .map(|mut network_listener| {
+                let connection_connector_clone = connection_connector.clone();
+                thread::spawn(move || {
+                    let endpoint = network_listener.endpoint();
+                    for connection_result in network_listener.incoming() {
+                        let connection = match connection_result {
+                            Ok(connection) => connection,
+                            Err(AcceptError::ProtocolError(msg)) => {
+                                warn!("Failed to accept connection on {}: {}", endpoint, msg);
+                                continue;
+                            }
+                            Err(AcceptError::IoError(err)) => {
+                                warn!("Failed to accept connection on {}: {}", endpoint, err);
+                                continue;
+                            }
+                        };
+                        debug!("Received connection from {}", connection.remote_endpoint());
+                        if let Err(err) =
+                            connection_connector_clone.add_inbound_connection(connection)
+                        {
+                            error!(
+                                "Unable to add inbound connection to connection manager: {}",
+                                err
+                            );
+                            error!("Exiting listener thread for {}", endpoint);
+                            break;
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn listen_for_services(
+        internal_service_listeners: Vec<Box<dyn Listener>>,
+        connection_connector: &Connector,
+    ) -> thread::JoinHandle<()> {
+        // this thread will just be dropped on shutdown
+        let connection_connector = connection_connector.clone();
+        thread::spawn(move || {
+            // accept the internal service connections
+            for mut listener in internal_service_listeners.into_iter() {
+                match listener.incoming().next() {
+                    Some(Ok(connection)) => {
+                        let remote_endpoint = connection.remote_endpoint();
+                        if let Err(err) = connection_connector.add_inbound_connection(connection) {
+                            error!("Unable to add peer {}: {}", remote_endpoint, err)
+                        }
+                    }
+                    Some(Err(err)) => {
+                        error!("Accept Error: {:?}", err);
+                        break;
+                    }
+                    None => {}
+                }
+            }
+        })
+    }
+}

--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -146,7 +146,6 @@ impl RunnableNetworkSubsystem {
         network_listener_joinhandles.push(service_listener_joinhandle);
 
         Ok(NetworkSubsystem {
-            node_id,
             peer_manager,
             connection_manager,
             routing_table,

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -39,11 +39,12 @@ pub struct Node {
     pub(super) rest_api_variant: NodeRestApiVariant,
     pub(super) rest_api_port: u16,
     pub(super) network_subsystem: network::NetworkSubsystem,
+    pub(super) node_id: String,
 }
 
 impl Node {
     pub fn node_id(&self) -> &str {
-        self.network_subsystem.node_id()
+        &self.node_id
     }
 
     pub fn rest_api_port(self: &Node) -> u16 {

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -15,6 +15,7 @@
 //! Contains the implementation of `Node`.
 
 pub mod admin;
+pub mod network;
 
 use std::thread::JoinHandle;
 

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -38,11 +38,12 @@ pub struct Node {
     pub(super) admin_subsystem: admin::AdminSubsystem,
     pub(super) rest_api_variant: NodeRestApiVariant,
     pub(super) rest_api_port: u16,
+    pub(super) network_subsystem: network::NetworkSubsystem,
 }
 
 impl Node {
     pub fn node_id(&self) -> &str {
-        self.admin_subsystem.node_id()
+        self.network_subsystem.node_id()
     }
 
     pub fn rest_api_port(self: &Node) -> u16 {
@@ -55,6 +56,10 @@ impl Node {
 
     pub fn registry_writer(&self) -> &dyn RegistryWriter {
         self.admin_subsystem.registry_writer()
+    }
+
+    pub fn network_endpoints(&self) -> &[String] {
+        self.network_subsystem.network_endpoints()
     }
 
     pub fn admin_service_client(self: &Node) -> Box<dyn AdminServiceClient> {
@@ -73,7 +78,7 @@ impl ShutdownHandle for Node {
         }
     }
 
-    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
         let mut errors = vec![];
 
         match self.rest_api_variant {
@@ -95,6 +100,12 @@ impl ShutdownHandle for Node {
         }
 
         if let Err(err) = self.admin_subsystem.wait_for_shutdown() {
+            errors.push(err);
+        }
+
+        // can't shutdown network until after admin subsystem
+        self.network_subsystem.signal_shutdown();
+        if let Err(err) = self.network_subsystem.wait_for_shutdown() {
             errors.push(err);
         }
 

--- a/splinterd/src/node/running/network.rs
+++ b/splinterd/src/node/running/network.rs
@@ -29,7 +29,6 @@ use splinter::transport::inproc::InprocTransport;
 
 /// A running admin subsystem.
 pub struct NetworkSubsystem {
-    pub(crate) node_id: String,
     pub(crate) connection_manager: ConnectionManager,
     pub(crate) peer_manager: PeerManager,
     pub(crate) routing_table: RoutingTable,
@@ -43,11 +42,6 @@ pub struct NetworkSubsystem {
 }
 
 impl NetworkSubsystem {
-    /// Returns the current node ID.
-    pub fn node_id(&self) -> &str {
-        &self.node_id
-    }
-
     /// Returns a peer connector for the node's peer_manager
     pub fn peer_connector(&self) -> PeerManagerConnector {
         self.peer_manager.connector()

--- a/splinterd/src/node/running/network.rs
+++ b/splinterd/src/node/running/network.rs
@@ -1,0 +1,121 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module defines the running network subsystem.
+
+use std::thread::JoinHandle;
+
+use splinter::circuit::routing::{memory::RoutingTable, RoutingTableWriter};
+use splinter::error::InternalError;
+use splinter::mesh::Mesh;
+use splinter::network::connection_manager::ConnectionManager;
+use splinter::network::dispatch::DispatchLoop;
+use splinter::peer::{interconnect::PeerInterconnect, PeerManager, PeerManagerConnector};
+use splinter::protos::circuit::CircuitMessageType;
+use splinter::protos::network::NetworkMessageType;
+use splinter::threading::lifecycle::ShutdownHandle;
+use splinter::transport::inproc::InprocTransport;
+
+/// A running admin subsystem.
+pub struct NetworkSubsystem {
+    pub(crate) node_id: String,
+    pub(crate) connection_manager: ConnectionManager,
+    pub(crate) peer_manager: PeerManager,
+    pub(crate) routing_table: RoutingTable,
+    pub(crate) _network_listener_joinhandles: Vec<JoinHandle<()>>,
+    pub(crate) network_endpoints: Vec<String>,
+    pub(crate) circuit_dispatch_loop: DispatchLoop<CircuitMessageType>,
+    pub(crate) network_dispatch_loop: DispatchLoop<NetworkMessageType>,
+    pub(crate) interconnect: PeerInterconnect,
+    pub(crate) service_transport: InprocTransport,
+    pub(crate) mesh: Mesh,
+}
+
+impl NetworkSubsystem {
+    /// Returns the current node ID.
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    /// Returns a peer connector for the node's peer_manager
+    pub fn peer_connector(&self) -> PeerManagerConnector {
+        self.peer_manager.connector()
+    }
+
+    /// Returns a routing_table_writer for the routing table
+    pub fn routing_table_writer(&self) -> Box<dyn RoutingTableWriter> {
+        Box::new(self.routing_table.clone())
+    }
+
+    /// Returns the network endpoints for the node
+    pub fn network_endpoints(&self) -> &[String] {
+        &self.network_endpoints
+    }
+
+    /// Returns the network endpoints for the node
+    pub fn service_transport(&self) -> InprocTransport {
+        self.service_transport.clone()
+    }
+}
+
+impl ShutdownHandle for NetworkSubsystem {
+    fn signal_shutdown(&mut self) {
+        self.interconnect.signal_shutdown();
+        self.peer_manager.signal_shutdown();
+        self.connection_manager.signal_shutdown();
+        self.circuit_dispatch_loop.signal_shutdown();
+        self.network_dispatch_loop.signal_shutdown();
+        self.mesh.signal_shutdown();
+    }
+
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        let mut errors = vec![];
+        if let Err(err) = self.interconnect.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        if let Err(err) = self.peer_manager.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        if let Err(err) = self.connection_manager.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        if let Err(err) = self.circuit_dispatch_loop.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        if let Err(err) = self.network_dispatch_loop.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        if let Err(err) = self.mesh.wait_for_shutdown() {
+            errors.push(err)
+        }
+
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.remove(0)),
+            _ => Err(InternalError::with_message(format!(
+                "Multiple errors occurred during shutdown: {}",
+                errors
+                    .into_iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))),
+        }
+    }
+}

--- a/splinterd/tests/admin/circuit_lifecycle.rs
+++ b/splinterd/tests/admin/circuit_lifecycle.rs
@@ -38,7 +38,7 @@ use splinterd::node::{Node, RestApiVariant};
 fn make_create_circuit_payload(
     circuit_id: &str,
     requester: &str,
-    node_info: HashMap<String, String>,
+    node_info: HashMap<String, Vec<String>>,
     signer: &dyn Signer,
 ) -> Vec<u8> {
     // Get the public key to create the `CircuitCreateRequest` and to also set the `requester`
@@ -165,7 +165,7 @@ fn make_circuit_disband_payload(circuit_id: &str, requester: &str, signer: &dyn 
 /// Creates the `CircuitCreateRequest` for the `CircuitManagementPayload` to propose a circuit
 fn setup_circuit(
     circuit_id: &str,
-    node_info: HashMap<String, String>,
+    node_info: HashMap<String, Vec<String>>,
     public_key: &str,
 ) -> CircuitCreateRequest {
     // The services require the service IDs from its peer services, which will be generated
@@ -206,10 +206,10 @@ fn setup_circuit(
 
     let nodes: Vec<SplinterNode> = node_info
         .iter()
-        .map(|(node_id, endpoint)| {
+        .map(|(node_id, endpoints)| {
             SplinterNodeBuilder::new()
                 .with_node_id(&node_id)
-                .with_endpoints(vec![endpoint.to_string()].as_ref())
+                .with_endpoints(endpoints)
                 .build()
                 .expect("Unable to build SplinterNode")
         })
@@ -241,15 +241,15 @@ fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, node_b: &Node) {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            "tcp://localhost:8000".to_string(),
+            node_a.network_endpoints().to_vec(),
         ),
         (
             node_b.node_id().to_string(),
-            "tcp://localhost:8001".to_string(),
+            node_b.network_endpoints().to_vec(),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, String>>();
+    .collect::<HashMap<String, Vec<String>>>();
 
     let circuit_payload_bytes = make_create_circuit_payload(
         &circuit_id,
@@ -339,19 +339,19 @@ fn commit_3_party_circuit(circuit_id: &str, node_a: &Node, node_b: &Node, node_c
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            "tcp://localhost:8000".to_string(),
+            node_a.network_endpoints().to_vec(),
         ),
         (
             node_b.node_id().to_string(),
-            "tcp://localhost:8001".to_string(),
+            node_b.network_endpoints().to_vec(),
         ),
         (
             node_c.node_id().to_string(),
-            "tcp://localhost:8002".to_string(),
+            node_c.network_endpoints().to_vec(),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, String>>();
+    .collect::<HashMap<String, Vec<String>>>();
 
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(
@@ -584,15 +584,15 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            "tcp://localhost:8000".to_string(),
+            node_a.network_endpoints().to_vec(),
         ),
         (
             node_b.node_id().to_string(),
-            "tcp://localhost:8001".to_string(),
+            node_b.network_endpoints().to_vec(),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, String>>();
+    .collect::<HashMap<String, Vec<String>>>();
     let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(
@@ -704,19 +704,19 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            "tcp://localhost:8000".to_string(),
+            node_a.network_endpoints().to_vec(),
         ),
         (
             node_b.node_id().to_string(),
-            "tcp://localhost:8001".to_string(),
+            node_b.network_endpoints().to_vec(),
         ),
         (
             node_c.node_id().to_string(),
-            "tcp://localhost:8002".to_string(),
+            node_c.network_endpoints().to_vec(),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, String>>();
+    .collect::<HashMap<String, Vec<String>>>();
     let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -49,19 +49,19 @@ impl Network {
             registry_info.push((
                 node.node_id().to_string(),
                 public_key,
-                format!("tcp://localhost:8{:0>3}", i),
+                node.network_endpoints().to_vec(),
             ));
             self.nodes.push(node);
         }
 
         for node in &self.nodes {
             let registry_writer = node.registry_writer();
-            for (node_id, pub_key, endpoint) in &registry_info {
+            for (node_id, pub_key, endpoints) in &registry_info {
                 registry_writer
                     .add_node(
                         RegistryNode::builder(node_id)
                             .with_display_name(node_id)
-                            .with_endpoint(endpoint)
+                            .with_endpoints(endpoints.to_vec())
                             .with_key(pub_key.as_hex())
                             .build()
                             .map_err(|e| InternalError::from_source(Box::new(e)))?,

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -36,7 +36,7 @@ impl Network {
     pub fn add_nodes_with_defaults(mut self, count: i32) -> Result<Network, InternalError> {
         let mut registry_info = vec![];
         let context = Secp256k1Context::new();
-        for i in 0..count {
+        for _ in 0..count {
             let signer = context.new_signer(context.new_random_private_key());
             let public_key = signer
                 .public_key()


### PR DESCRIPTION
The NetworkSubsystem contains the configuration for all of the network components of a Node including
the ConnectionManager, PeerManager, Dispatcher Handlers and network listeners.

The PR includes a bug fix for MemoryStorageFactory so that all sqlite memory implementations use the same instance.

At this point the test_2_party_circuit_creation passes (after a little reorg). The other tests fail due issues unrelated to the testing framework. 