### PR TITLE
Add scabbard to Nodes

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -65,12 +65,14 @@ experimental = [
   # The following features are experimental:
   "authorization",
   "circuit-purge",
+  "factory-builder",
 ]
 
 authorization = ["splinter/authorization"]
 circuit-purge = ["splinter/circuit-purge"]
 client = ["reqwest"]
 events = ["splinter/events"]
+factory-builder = []
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
 service-arg-validation = ["splinter/service-arg-validation"]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -54,6 +54,8 @@ use error::ScabbardError;
 #[cfg(feature = "service-arg-validation")]
 pub use factory::ScabbardArgValidator;
 pub use factory::ScabbardFactory;
+#[cfg(feature = "factory-builder")]
+pub use factory::ScabbardFactoryBuilder;
 use shared::ScabbardShared;
 pub use state::{
     BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent, StateIter,

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -134,6 +134,7 @@ database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
 node = [
+    "scabbard/factory-builder",
     "splinter/admin-service-client",
     "splinter/client-reqwest",
     "splinter/rest-api-actix-web-3",

--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -16,13 +16,15 @@
 
 use std::time::Duration;
 
-use cylinder::{secp256k1::Secp256k1Context, Context};
+use cylinder::{secp256k1::Secp256k1Context, Context, VerifierFactory};
+use scabbard::service::ScabbardFactoryBuilder;
 use splinter::circuit::routing::RoutingTableWriter;
 use splinter::error::InternalError;
 use splinter::peer::PeerManagerConnector;
 use splinter::store::{memory::MemoryStoreFactory, StoreFactory};
 use splinter::transport::inproc::InprocTransport;
 
+use crate::node::builder::scabbard::ScabbardConfig;
 use crate::node::runnable::admin::RunnableAdminSubsystem;
 
 const DEFAULT_ADMIN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -36,6 +38,7 @@ pub struct AdminSubsystemBuilder {
     routing_writer: Option<Box<dyn RoutingTableWriter>>,
     service_transport: Option<InprocTransport>,
     signing_context: Option<Box<dyn Context>>,
+    scabbard_config: Option<ScabbardConfig>,
 }
 
 impl AdminSubsystemBuilder {
@@ -85,6 +88,12 @@ impl AdminSubsystemBuilder {
         self
     }
 
+    /// Make scabbard services available to circuits created by this admin subsystem.
+    pub fn with_scabbard(mut self, scabbard_config: ScabbardConfig) -> Self {
+        self.scabbard_config = Some(scabbard_config);
+        self
+    }
+
     pub fn build(mut self) -> Result<RunnableAdminSubsystem, InternalError> {
         let node_id = self.node_id.take().ok_or_else(|| {
             InternalError::with_message("Cannot build AdminSubsystem without a node id".to_string())
@@ -121,6 +130,22 @@ impl AdminSubsystemBuilder {
 
         let admin_service_verifier = signing_context.new_verifier();
 
+        let scabbard_service_factory = self
+            .scabbard_config
+            .map(|config| {
+                ScabbardFactoryBuilder::new()
+                    .with_state_db_dir(config.data_dir.to_string_lossy().into())
+                    .with_state_db_size(config.database_size)
+                    .with_receipt_db_dir(config.data_dir.to_string_lossy().into())
+                    .with_receipt_db_size(config.database_size)
+                    .with_signature_verifier_factory(Box::new(VerifierFactoryWrapper(
+                        signing_context,
+                    )))
+                    .build()
+                    .map_err(|e| InternalError::from_source(Box::new(e)))
+            })
+            .transpose()?;
+
         Ok(RunnableAdminSubsystem {
             node_id,
             admin_timeout,
@@ -129,6 +154,15 @@ impl AdminSubsystemBuilder {
             routing_writer,
             service_transport,
             admin_service_verifier,
+            scabbard_service_factory,
         })
+    }
+}
+
+struct VerifierFactoryWrapper(Box<dyn Context>);
+
+impl VerifierFactory for VerifierFactoryWrapper {
+    fn new_verifier(&self) -> Box<dyn cylinder::Verifier> {
+        self.0.new_verifier()
     }
 }

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -16,6 +16,7 @@
 
 pub(super) mod admin;
 pub(super) mod network;
+pub(super) mod scabbard;
 
 use std::time::Duration;
 
@@ -32,7 +33,7 @@ use splinter::rest_api::auth::{
 use splinter::rest_api::RestApiBind;
 use splinter::store::StoreFactory;
 
-use super::{RunnableNode, RunnableNodeRestApiVariant};
+use super::{RunnableNode, RunnableNodeRestApiVariant, ScabbardConfig};
 
 use self::admin::AdminSubsystemBuilder;
 use self::network::NetworkSubsystemBuilder;
@@ -139,6 +140,12 @@ impl NodeBuilder {
         self.network_subsystem_builder = self
             .network_subsystem_builder
             .with_network_endpoints(network_endpoints);
+        self
+    }
+
+    /// Make scabbard services available for circuits.
+    pub fn with_scabbard(mut self, scabbard_config: ScabbardConfig) -> Self {
+        self.admin_subsystem_builder = self.admin_subsystem_builder.with_scabbard(scabbard_config);
         self
     }
 

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -156,13 +156,16 @@ impl NodeBuilder {
 
         let runnable_network_subsystem = network_subsystem_builder.build()?;
 
-        let admin_subsystem_builder = self.admin_subsystem_builder.with_node_id(node_id.clone());
-
+        let context = Secp256k1Context::new();
         let admin_signer = self.admin_signer.take().unwrap_or_else(|| {
-            let context = Secp256k1Context::new();
             let pk = context.new_random_private_key();
             context.new_signer(pk)
         });
+
+        let admin_subsystem_builder = self
+            .admin_subsystem_builder
+            .with_node_id(node_id.clone())
+            .with_signing_context(Box::new(context));
 
         let rest_api_variant = match self.rest_api_variant {
             RestApiVariant::ActixWeb1 => {

--- a/splinterd/src/node/builder/scabbard.rs
+++ b/splinterd/src/node/builder/scabbard.rs
@@ -1,0 +1,72 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for Scabbard configuration
+
+use std::path::PathBuf;
+
+use splinter::error::InternalError;
+
+const DEFAULT_TEST_DB_SIZE: usize = 120 * 1024 * 1024;
+
+/// Builder for scabbard configuration
+#[derive(Default)]
+pub struct ScabbardConfigBuilder {
+    data_dir: Option<PathBuf>,
+    database_size: Option<usize>,
+}
+
+impl ScabbardConfigBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the directory where service data will be stored.
+    pub fn with_data_dir(mut self, path: PathBuf) -> Self {
+        self.data_dir = Some(path);
+        self
+    }
+
+    /// Sets the size of the LMDB databases that will be created per scabbard service.
+    pub fn with_database_size(mut self, database_size: usize) -> Self {
+        self.database_size = Some(database_size);
+        self
+    }
+
+    /// Constructs the ScabbardConfig.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InternalError if the data directory has been ommitted.
+    pub fn build(self) -> Result<ScabbardConfig, InternalError> {
+        let database_size = self.database_size.unwrap_or(DEFAULT_TEST_DB_SIZE);
+        let data_dir = self
+            .data_dir
+            .ok_or_else(|| InternalError::with_message("A data directory is required.".into()))?;
+
+        Ok(ScabbardConfig {
+            database_size,
+            data_dir,
+        })
+    }
+}
+
+/// Configuration for the use of Scabbard service
+pub struct ScabbardConfig {
+    /// The directory where service data will be stored.
+    pub(crate) data_dir: PathBuf,
+    /// The size of the LMDB databases that will be generated per scabbard service instance.
+    pub(crate) database_size: usize,
+}

--- a/splinterd/src/node/mod.rs
+++ b/splinterd/src/node/mod.rs
@@ -18,6 +18,7 @@ mod builder;
 mod runnable;
 mod running;
 
+pub use builder::scabbard::{ScabbardConfig, ScabbardConfigBuilder};
 pub use builder::{NodeBuilder, RestApiVariant};
 pub use runnable::RunnableNode;
 use runnable::RunnableNodeRestApiVariant;


### PR DESCRIPTION
This PR updates Node (and its subsystems) to allow scabbard services to be created.  The scabbard service is configured via a simplified struct which combines the target directory and sizes into single values., for the purposes of the tests.

Additionally,
- It adds a ScabbardFactoryBuilder, which provides names for the values and handes sensible defaults. (This is added as an experimental feature).