### PR TITLE
Reorder splinterd Dockerfile to fix experimental builds

### DIFF
--- a/splinterd/Dockerfile-installed-bionic
+++ b/splinterd/Dockerfile-installed-bionic
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# -------------=== splinterd docker build ===-------------
+# -------------=== splinterd build ===-------------
 
-FROM splintercommunity/splinter-dev:v7 as BUILDER
+FROM splintercommunity/splinter-dev:v7 as splinterd-builder
 
 ENV SPLINTER_FORCE_PANDOC=true
 
@@ -39,8 +39,7 @@ COPY examples/gameroom/daemon/Cargo.toml \
 COPY examples/gameroom/database/Cargo.toml \
      /build/examples/gameroom/database/Cargo.toml
 
-# Copy over source files
-COPY cli /build/cli
+# Copy over source files for splinterd
 COPY libsplinter /build/libsplinter
 COPY services/health /build/services/health
 COPY splinterd/ /build/splinterd
@@ -55,6 +54,42 @@ RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Car
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
 RUN mv /build/target/debian/splinter-daemon*.deb /tmp
 
+# Log the commit hash
+COPY .git/ /tmp/.git/
+WORKDIR /tmp
+RUN git rev-parse HEAD > /commit-hash
+
+# -------------=== splinter-cli build ===-------------
+
+FROM splintercommunity/splinter-dev:v7 as splinter-cli-builder
+
+ENV SPLINTER_FORCE_PANDOC=true
+
+# Copy over splinter files
+COPY Cargo.toml /build/Cargo.toml
+COPY cli/Cargo.toml /build/cli/Cargo.toml
+COPY libsplinter/build.rs /build/libsplinter/build.rs
+COPY libsplinter/Cargo.toml /build/libsplinter/Cargo.toml
+COPY libsplinter/protos /build/libsplinter/protos
+COPY splinterd/Cargo.toml /build/splinterd/Cargo.toml
+COPY services/health/Cargo.toml /build/services/health/Cargo.toml
+COPY services/scabbard/cli/Cargo.toml /build/services/scabbard/cli/Cargo.toml
+COPY services/scabbard/libscabbard/build.rs /build/services/scabbard/libscabbard/build.rs
+COPY services/scabbard/libscabbard/Cargo.toml /build/services/scabbard/libscabbard/Cargo.toml
+COPY services/scabbard/libscabbard/protos /build/services/scabbard/libscabbard/protos
+
+# Copy over example Cargo.toml files
+COPY examples/gameroom/cli/Cargo.toml \
+     /build/examples/gameroom/cli/Cargo.toml
+COPY examples/gameroom/daemon/Cargo.toml \
+     /build/examples/gameroom/daemon/Cargo.toml
+COPY examples/gameroom/database/Cargo.toml \
+     /build/examples/gameroom/database/Cargo.toml
+
+# Copy over source files for splinter-cli
+COPY cli /build/cli
+COPY libsplinter /build/libsplinter
+
 # Build splinter-cli
 WORKDIR /build/cli
 ARG REPO_VERSION
@@ -62,11 +97,6 @@ ARG CARGO_ARGS
 RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
 RUN cargo deb --deb-version $REPO_VERSION $CARGO_ARGS
 RUN mv /build/target/debian/splinter-cli*.deb /tmp
-
-# Log the commit hash
-COPY .git/ /tmp/.git/
-WORKDIR /tmp
-RUN git rev-parse HEAD > /commit-hash
 
 # -------------=== splinterd docker build ===-------------
 
@@ -77,8 +107,9 @@ RUN echo "CARGO_ARGS = '$CARGO_ARGS'" > CARGO_ARGS
 ARG SPLINTERD_ARGS
 RUN echo "SPLINTERD_ARGS = '$SPLINTERD_ARGS'" > SPLINTERD_ARGS
 
-COPY --from=builder /tmp/splinter-*.deb /tmp/
-COPY --from=builder /commit-hash /commit-hash
+COPY --from=splinter-cli-builder /tmp/splinter-*.deb /tmp/
+COPY --from=splinterd-builder /tmp/splinter-*.deb /tmp/
+COPY --from=splinterd-builder /commit-hash /commit-hash
 
 RUN apt-get update \
  && apt-get install -y -q \


### PR DESCRIPTION
Compile flags are only passed to dependencies of the crate being compiled but
the workspace Cargo.toml causes all crates to be recompiled. Because of this,
CLI builds will fail when run second because health and scabbard source files
with gated features are present but the --experimental flag is not being passed.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>