### PR TITLE
Stabilize role-based-authorization-store-postgres

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -118,7 +118,6 @@ experimental = [
     "https-bind",
     "oauth-profile",
     "rest-api-actix-web-3",
-    "role-based-authorization-store-postgres",
     "service-arg-validation",
     "service-network",
     "ws-transport",
@@ -165,7 +164,6 @@ rest-api = [
 rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
-role-based-authorization-store-postgres = ["authorization", "postgres"]
 service-arg-validation = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
@@ -190,7 +190,7 @@ impl RoleBasedAuthorizationStore
     }
 }
 
-#[cfg(feature = "role-based-authorization-store-postgres")]
+#[cfg(feature = "postgres")]
 impl RoleBasedAuthorizationStore for DieselRoleBasedAuthorizationStore<diesel::pg::PgConnection> {
     /// Returns the role for the given ID, if one exists.
     fn get_role(&self, id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError> {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_assignment.rs
@@ -54,7 +54,7 @@ impl<'a> RoleBasedAuthorizationStoreAddAssignment
     }
 }
 
-#[cfg(feature = "role-based-authorization-store-postgres")]
+#[cfg(feature = "postgres")]
 impl<'a> RoleBasedAuthorizationStoreAddAssignment
     for RoleBasedAuthorizationStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_role.rs
@@ -47,7 +47,7 @@ impl<'a> RoleBasedAuthorizationStoreAddRole
     }
 }
 
-#[cfg(feature = "role-based-authorization-store-postgres")]
+#[cfg(feature = "postgres")]
 impl<'a> RoleBasedAuthorizationStoreAddRole
     for RoleBasedAuthorizationStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_assignment.rs
@@ -74,7 +74,7 @@ impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
     }
 }
 
-#[cfg(feature = "role-based-authorization-store-postgres")]
+#[cfg(feature = "postgres")]
 impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
     for RoleBasedAuthorizationStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
@@ -64,7 +64,7 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
     }
 }
 
-#[cfg(feature = "role-based-authorization-store-postgres")]
+#[cfg(feature = "postgres")]
 impl<'a> RoleBasedAuthorizationStoreUpdateRole
     for RoleBasedAuthorizationStoreOperations<'a, diesel::pg::PgConnection>
 {

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -78,7 +78,7 @@ impl StoreFactory for PgStoreFactory {
         Box::new(crate::registry::DieselRegistry::new(self.pool.clone()))
     }
 
-    #[cfg(feature = "role-based-authorization-store-postgres")]
+    #[cfg(feature = "authorization-handler-rbac")]
     fn get_role_based_authorization_store(
         &self,
     ) -> Box<dyn crate::rest_api::auth::authorization::rbac::store::RoleBasedAuthorizationStore>
@@ -88,17 +88,6 @@ impl StoreFactory for PgStoreFactory {
                 self.pool.clone(),
             ),
         )
-    }
-
-    #[cfg(all(
-        feature = "authorization-handler-rbac",
-        not(feature = "role-based-authorization-store-postgres")
-    ))]
-    fn get_role_based_authorization_store(
-        &self,
-    ) -> Box<dyn crate::rest_api::auth::authorization::rbac::store::RoleBasedAuthorizationStore>
-    {
-        unimplemented!()
     }
 
     #[cfg(feature = "biome-profile")]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -117,7 +117,6 @@ authorization-handler-maintenance = [
 ]
 authorization-handler-rbac = [
     "splinter/authorization-handler-rbac",
-    "splinter/role-based-authorization-store-postgres",
 ]
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]


### PR DESCRIPTION
This change stabilizes the feature "role-based-authorization-store-postgres" by removing it.  Where applicable, the feature guard is replaced with "postgres".