### PR TITLE
Registry client

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -117,6 +117,8 @@ experimental = [
     "client-reqwest",
     "https-bind",
     "oauth-profile",
+    "registry-client",
+    "registry-client-reqwest",
     "rest-api-actix-web-3",
     "service-arg-validation",
     "service-network",
@@ -151,6 +153,8 @@ memory = ["sqlite"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
+registry-client = ["registry"]
+registry-client-reqwest = ["registry-client", "reqwest"]
 registry-remote = ["reqwest", "registry"]
 rest-api = [
     "actix",

--- a/libsplinter/src/registry/client/mod.rs
+++ b/libsplinter/src/registry/client/mod.rs
@@ -1,0 +1,109 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits and implementations useful for communicating with the registry as a client.
+
+use std::fmt;
+
+#[cfg(feature = "registry-client-reqwest")]
+mod reqwest;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::error::InternalError;
+
+pub use self::reqwest::ReqwestRegistryClient;
+
+pub trait RegistryClient {
+    /// Adds a node to the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The node to be added
+    fn add_node(&self, node: &RegistryNode) -> Result<(), InternalError>;
+
+    /// Retrieves a node from the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `identity` - The id of the node to be retrieved
+    fn get_node(&self, identity: &str) -> Result<Option<RegistryNode>, InternalError>;
+
+    /// Lists the nodes in the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter` - Filter to apply to the list of nodes
+    fn list_nodes(&self, filter: Option<&str>) -> Result<RegistryNodeListSlice, InternalError>;
+
+    /// Update a node in the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The updated node replacing the current node in the registry
+    fn update_node(&self, node: &RegistryNode) -> Result<(), InternalError>;
+
+    /// Delete a node from the registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `identity` - The id of the node to be deleted
+    fn delete_node(&self, identity: &str) -> Result<(), InternalError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryNode {
+    pub identity: String,
+    pub endpoints: Vec<String>,
+    pub display_name: String,
+    pub keys: Vec<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl fmt::Display for RegistryNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut display_string = format!("identity: {}\nendpoints:", self.identity);
+        for endpoint in &self.endpoints {
+            display_string += &format!("\n  - {}", endpoint);
+        }
+        display_string += &format!("\ndisplay name: {}\nkeys:", self.display_name);
+        for key in &self.keys {
+            display_string += &format!("\n  - {}", key);
+        }
+        display_string += "\nmetadata:";
+        for (key, value) in &self.metadata {
+            display_string += &format!("\n  {}: {}", key, value);
+        }
+        write!(f, "{}", display_string)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryNodeListSlice {
+    pub data: Vec<RegistryNode>,
+    pub paging: Paging,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Paging {
+    pub current: String,
+    pub offset: usize,
+    pub limit: usize,
+    pub total: usize,
+    pub first: String,
+    pub prev: String,
+    pub next: String,
+    pub last: String,
+}

--- a/libsplinter/src/registry/client/reqwest.rs
+++ b/libsplinter/src/registry/client/reqwest.rs
@@ -1,0 +1,251 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A Reqwest-based implementation of RegistryClient
+
+use reqwest::{blocking::Client, StatusCode};
+
+use crate::error::InternalError;
+use crate::protocol::REGISTRY_PROTOCOL_VERSION;
+
+use super::{RegistryClient, RegistryNode, RegistryNodeListSlice};
+
+const PAGING_LIMIT: &str = "1000";
+
+#[derive(Deserialize)]
+struct ServerError {
+    pub message: String,
+}
+
+pub struct ReqwestRegistryClient {
+    pub url: String,
+    pub auth: String,
+}
+
+impl ReqwestRegistryClient {
+    pub fn new(url: String, auth: String) -> Self {
+        ReqwestRegistryClient { url, auth }
+    }
+}
+
+impl RegistryClient for ReqwestRegistryClient {
+    /// Add the given `node` to the registry.
+    fn add_node(&self, node: &RegistryNode) -> Result<(), InternalError> {
+        let request = Client::new()
+            .post(&format!("{}/registry/nodes", self.url))
+            .json(&node)
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| InternalError::from_source_with_message(Box::new(err), "Failed to add node to registry".to_string()))
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|err| {
+                            InternalError::from_source_with_message(
+                                err.into(),
+                                format!(
+                                    "Registry add node request failed with status code '{}', but error \
+                                 response was not valid",
+                                    status
+                                ),
+                            )
+                        })?
+                        .message;
+
+                        Err(InternalError::with_message(format!(
+                            "Failed to add node to registry: {}",
+                            message
+                        )))
+                }
+            })
+    }
+
+    /// Retrieve the node with the given `identity` from the registry.
+    fn get_node(&self, identity: &str) -> Result<Option<RegistryNode>, InternalError> {
+        let request = Client::new()
+            .get(&format!("{}/registry/nodes/{}", self.url, &identity))
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to fetch node".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<RegistryNode>().map(Some).map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else if status == StatusCode::NOT_FOUND {
+                    Ok(None)
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            InternalError::with_message(format!(
+                            "Registry get node request failed with status code '{}', but error \
+                             response was not valid",
+                            status
+                        ))
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to get node from registry: {}",
+                        message
+                    )))
+                }
+            })
+    }
+
+    /// List the nodes in the registry.
+    fn list_nodes(&self, filter: Option<&str>) -> Result<RegistryNodeListSlice, InternalError> {
+        let mut url = format!("{}/registry/nodes?limit={}", self.url, PAGING_LIMIT);
+        if let Some(filter) = filter {
+            url = format!("{}&filter={}", &url, &filter);
+        }
+
+        let request = Client::new()
+            .get(&url)
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request.send()
+            .map_err(|err| {
+                InternalError::from_source_with_message(
+                    Box::new(err),
+                    "Failed to list registry nodes".to_string(),
+                )
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    res.json::<RegistryNodeListSlice>().map_err(|_| {
+                        InternalError::with_message(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|err| {
+                            InternalError::from_source_with_message(
+                                err.into(),
+                                format!(
+                                    "Registry list nodes request failed with status code '{}', but error \
+                                 response was not valid",
+                                    status
+                                ),
+                            )
+                        })?
+                        .message;
+
+                    Err(InternalError::with_message(format!(
+                        "Failed to list nodes: {} {}",
+                        message,
+                        url
+                    )))
+                }
+            })
+    }
+
+    /// Update the node in the registry with the same id as the given `node`.
+    fn update_node(&self, node: &RegistryNode) -> Result<(), InternalError> {
+        let request = Client::new()
+            .put(&format!("{}/registry/nodes/{}", self.url, node.identity))
+            .json(&node)
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| InternalError::from_source_with_message(Box::new(err), "Failed to replace registry node".to_string()))
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|err| {
+                            InternalError::from_source_with_message(
+                                err.into(),
+                                format!(
+                                    "Registry replace node request failed with status code '{}', but error \
+                                 response was not valid",
+                                    status
+                                ),
+                            )
+                        })?
+                        .message;
+
+                        Err(InternalError::with_message(format!(
+                            "Failed to replace registry node: {}",
+                            message
+                        )))
+                }
+            })
+    }
+
+    /// Delete the node with the given `identity` from the registry.
+    fn delete_node(&self, identity: &str) -> Result<(), InternalError> {
+        let request = Client::new()
+            .delete(&format!("{}/registry/nodes/{}", self.url, identity))
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("Authorization", &self.auth);
+
+        request
+            .send()
+            .map_err(|err| InternalError::from_source_with_message(Box::new(err), "Failed to delete node from the registry".to_string()))
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|err| {
+                            InternalError::from_source_with_message(
+                                err.into(),
+                                format!(
+                                    "Registry delete node request failed with status code '{}', but error \
+                                 response was not valid",
+                                    status
+                                ),
+                            )
+                        })?
+                        .message;
+
+                        Err(InternalError::with_message(format!(
+                            "Failed to delete node from the registry: {}",
+                            message
+                        )))
+                }
+            })
+    }
+}

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -24,6 +24,8 @@
 //! [`RegistryWriter`]: trait.RegistryWriter.html
 //! [`RwRegistry`]: trait.RwRegistry.html
 
+#[cfg(feature = "registry-client")]
+pub mod client;
 #[cfg(feature = "diesel")]
 mod diesel;
 mod error;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -138,6 +138,8 @@ node = [
     "splinter/admin-service-client",
     "splinter/client-reqwest",
     "splinter/rest-api-actix-web-3",
+    "splinter/registry-client",
+    "splinter/registry-client-reqwest",
 ]
 oauth = [
     "splinter/oauth"

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -23,7 +23,10 @@ use cylinder::Signer;
 use scabbard::client::{ReqwestScabbardClientBuilder, ScabbardClient};
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::error::InternalError;
-use splinter::registry::RegistryWriter;
+use splinter::registry::{
+    client::{RegistryClient, ReqwestRegistryClient},
+    RegistryWriter,
+};
 use splinter::rest_api::actix_web_1::RestApiShutdownHandle;
 use splinter::rest_api::actix_web_3::RestApi;
 use splinter::threading::lifecycle::ShutdownHandle;
@@ -78,6 +81,13 @@ impl Node {
                 .with_auth("foo")
                 .build()
                 .map_err(|e| InternalError::from_source(Box::new(e)))?,
+        ))
+    }
+
+    pub fn registry_client(self: &Node) -> Box<dyn RegistryClient> {
+        Box::new(ReqwestRegistryClient::new(
+            format!("http://localhost:{}", self.rest_api_port),
+            "foo".to_string(),
         ))
     }
 }


### PR DESCRIPTION
- Add a `RegistryClient` trait and a reqwest based implementation of the trait, the client is behind an experimental feature `registry-client` and the reqwest based implementation is behind an experimental feature `registry-client-reqwest`
- Add `registry_client` to Node so that the registry client can be fetched from a node in registry integration testing.