### PR TITLE
Provide a ScabbardClient from running Node

### DIFF
--- a/services/scabbard/libscabbard/src/client/mod.rs
+++ b/services/scabbard/libscabbard/src/client/mod.rs
@@ -176,6 +176,20 @@ pub trait ScabbardClient {
 mod tests {
     use super::*;
 
+    /// Verify that a `ServiceId` can be correctly parsed from a fully-qualified service ID string.
+    #[test]
+    fn service_id_from_string() {
+        assert!(ServiceId::from_string("").is_err());
+        assert!(ServiceId::from_string("01234-abcde").is_err());
+        assert!(ServiceId::from_string("::").is_err());
+        assert!(ServiceId::from_string("01234-abcde::").is_err());
+        assert!(ServiceId::from_string("::ABCD").is_err());
+
+        let service_id = ServiceId::from_string("01234-abcde::ABCD").expect("failed to parse");
+        assert_eq!(service_id.circuit(), "01234-abcde");
+        assert_eq!(service_id.service_id(), "ABCD");
+    }
+
     /// This test covers parsing ServiceId values from strings. It is tested via str::parse, which
     /// is provided by the FromStr implementation.
     ///

--- a/services/scabbard/libscabbard/src/client/reqwest/mod.rs
+++ b/services/scabbard/libscabbard/src/client/reqwest/mod.rs
@@ -490,20 +490,6 @@ mod tests {
         permission_description: "Allows the client to submit batches to scabbard services",
     };
 
-    /// Verify that a `ServiceId` can be correctly parsed from a fully-qualified service ID string.
-    #[test]
-    fn service_id_from_string() {
-        assert!(ServiceId::from_string("").is_err());
-        assert!(ServiceId::from_string("01234-abcde").is_err());
-        assert!(ServiceId::from_string("::").is_err());
-        assert!(ServiceId::from_string("01234-abcde::").is_err());
-        assert!(ServiceId::from_string("::ABCD").is_err());
-
-        let service_id = ServiceId::from_string("01234-abcde::ABCD").expect("failed to parse");
-        assert_eq!(service_id.circuit(), "01234-abcde");
-        assert_eq!(service_id.service_id(), "ABCD");
-    }
-
     /// Verify the `ScabbardClient::submit` method works properly.
     #[test]
     fn submit() {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -134,6 +134,7 @@ database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
 node = [
+    "scabbard/client",
     "scabbard/factory-builder",
     "splinter/admin-service-client",
     "splinter/client-reqwest",

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -20,6 +20,7 @@ pub mod network;
 use std::thread::JoinHandle;
 
 use cylinder::Signer;
+use scabbard::client::{ReqwestScabbardClientBuilder, ScabbardClient};
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::error::InternalError;
 use splinter::registry::RegistryWriter;
@@ -67,6 +68,16 @@ impl Node {
         Box::new(ReqwestAdminServiceClient::new(
             format!("http://localhost:{}", self.rest_api_port),
             "foo".to_string(),
+        ))
+    }
+
+    pub fn scabbard_client(&self) -> Result<Box<dyn ScabbardClient>, InternalError> {
+        Ok(Box::new(
+            ReqwestScabbardClientBuilder::new()
+                .with_url(&format!("http://localhost:{}", self.rest_api_port))
+                .with_auth("foo")
+                .build()
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
         ))
     }
 }


### PR DESCRIPTION
This change adds a scabbard client instance to the running `Node` instance.  It is configured in a similar manner to the Admin client, though it uses a builder.  The build error is mapped to an `InternalError` as a result.

It requires adding the scabbard/client feature to the node feature.

Additionally, 

- Implement `FromStr` on ServiceId, which will allow users to use `str::parse()` through the standard library.
- Moves a test that was not in the correct place.