### PR TITLE
Implement ShutdownHandle for RemoteYamlRegistry

### DIFF
--- a/libsplinter/src/registry/yaml/mod.rs
+++ b/libsplinter/src/registry/yaml/mod.rs
@@ -27,7 +27,7 @@ use super::Node;
 
 pub use local::LocalYamlRegistry;
 #[cfg(feature = "registry-remote")]
-pub use remote::{RemoteYamlRegistry, ShutdownHandle as RemoteYamlShutdownHandle};
+pub use remote::{RemoteYamlRegistry, RemoteYamlShutdownHandle};
 
 /// Yaml representation of a node in a registry.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]


### PR DESCRIPTION
Due to the registry needing to be passed to the UnifiedRegistry,
ShutdownHandle is implemented on RemoteYamlShutdownHandle that
can be taken from the registry.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>