### PR TITLE
Admin service start order bug

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1667,7 +1667,7 @@ impl AdminServiceShared {
                 })?;
         } else {
             return Err(AdminSharedError::ServiceProtocolError(format!(
-                "AdminService is not started, can't sent request to {}",
+                "AdminService is not started, can't send request to {}",
                 peer_id
             )));
         }


### PR DESCRIPTION
This change re-orders the service_registry connect call, as downstream threads require the network sender to be sent. Setting it after starting the threads creates a potential race condition.
