### PR TITLE
Split scabbard client feature

### DIFF
--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -36,7 +36,7 @@ flexi_logger = "0.14"
 log = "0.4"
 sabre-sdk = "0.7"
 transact = { version = "0.3", features = ["contract-archive"] }
-scabbard = { path = "../libscabbard", features = ["client"] }
+scabbard = { path = "../libscabbard", features = ["client-reqwest"] }
 
 [dev-dependencies]
 serial_test = "0.3"

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -54,6 +54,7 @@ default = []
 stable = [
   "authorization",
   "client",
+  "client-reqwest",
   "default",
   "events",
   "rest-api",
@@ -70,7 +71,8 @@ experimental = [
 
 authorization = ["splinter/authorization"]
 circuit-purge = ["splinter/circuit-purge"]
-client = ["reqwest"]
+client = []
+client-reqwest = ["client", "reqwest"]
 events = ["splinter/events"]
 factory-builder = []
 rest-api = ["futures", "splinter/rest-api"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -133,7 +133,7 @@ database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
 node = [
-    "scabbard/client",
+    "scabbard/client-reqwest",
     "scabbard/factory-builder",
     "splinter/admin-service-client",
     "splinter/client-reqwest",


### PR DESCRIPTION
This change splits the scabbard "client" feature into "client" and "client-reqwest".  This follows the more commonly used pattern in the repo for trait features and specific implementations.
