### PR TITLE
Remove agreed upon admin protocol version if dropping connection

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -319,6 +319,10 @@ impl AdminServiceShared {
             peer_ref_vec.pop();
             if !peer_ref_vec.is_empty() {
                 self.peer_refs.insert(peer_id.to_string(), peer_ref_vec);
+            } else {
+                // If we have no other peer refs for this peer, the connection will be closed.
+                // On reconnection, the peer must go through protocol agreement again
+                self.service_protocols.remove(&admin_service_id(&peer_id));
             }
         }
     }


### PR DESCRIPTION
If the other admin service wishes to reconnect, it will need to
go through protocol agreement again.

Note the protocol version is already dropped if we receive a
disconnection notification.

This fixes a bug I saw while testing disband.