### PR TITLE
Add external registries to testing framework

### DIFF
--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -39,6 +39,7 @@ pub struct AdminSubsystemBuilder {
     service_transport: Option<InprocTransport>,
     signing_context: Option<Box<dyn Context>>,
     scabbard_config: Option<ScabbardConfig>,
+    registries: Option<Vec<String>>,
 }
 
 impl AdminSubsystemBuilder {
@@ -94,6 +95,12 @@ impl AdminSubsystemBuilder {
         self
     }
 
+    /// Specifies any external registry files to be used in the unified registry.
+    pub fn with_external_registries(mut self, registries: Option<Vec<String>>) -> Self {
+        self.registries = registries;
+        self
+    }
+
     pub fn build(mut self) -> Result<RunnableAdminSubsystem, InternalError> {
         let node_id = self.node_id.take().ok_or_else(|| {
             InternalError::with_message("Cannot build AdminSubsystem without a node id".to_string())
@@ -146,6 +153,8 @@ impl AdminSubsystemBuilder {
             })
             .transpose()?;
 
+        let registries = self.registries;
+
         Ok(RunnableAdminSubsystem {
             node_id,
             admin_timeout,
@@ -155,6 +164,7 @@ impl AdminSubsystemBuilder {
             service_transport,
             admin_service_verifier,
             scabbard_service_factory,
+            registries,
         })
     }
 }

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -149,6 +149,14 @@ impl NodeBuilder {
         self
     }
 
+    /// Specifies any external registry files to be used in the unified registry.
+    pub fn with_external_registries(mut self, registries: Option<Vec<String>>) -> Self {
+        self.admin_subsystem_builder = self
+            .admin_subsystem_builder
+            .with_external_registries(registries);
+        self
+    }
+
     /// Builds the `RunnableNode` and consumes the `NodeBuilder`.
     pub fn build(mut self) -> Result<RunnableNode, InternalError> {
         let url = format!("127.0.0.1:{}", self.rest_api_port.take().unwrap_or(0),);

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -27,6 +27,7 @@ pub struct Network {
     default_rest_api_variant: RestApiVariant,
     nodes: Vec<Node>,
     temp_dirs: HashMap<String, TempDir>,
+    external_registries: Option<Vec<String>>,
 }
 
 impl Network {
@@ -35,6 +36,7 @@ impl Network {
             default_rest_api_variant: RestApiVariant::ActixWeb1,
             nodes: Vec::new(),
             temp_dirs: HashMap::new(),
+            external_registries: None,
         }
     }
 
@@ -57,6 +59,7 @@ impl Network {
                         .build()?,
                 )
                 .with_admin_signer(signer)
+                .with_external_registries(self.external_registries.clone())
                 .build()?
                 .run()?;
 
@@ -91,6 +94,11 @@ impl Network {
 
     pub fn with_default_rest_api_variant(mut self, variant: RestApiVariant) -> Self {
         self.default_rest_api_variant = variant;
+        self
+    }
+
+    pub fn with_external_registries(mut self, files: Vec<String>) -> Self {
+        self.external_registries = Some(files);
         self
     }
 


### PR DESCRIPTION
Add the ability to add a yaml file as an external registry to the testing framework. If any external registries are added a unified registry is created from the internal registry and external read-only registries.

A yaml registry file can be added by passing the registry file names in a vector to the `with_external_registries` method when creating a new Network.

Example:
```
let network = Network::new()
        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
        .with_external_registries(vec![<file names in the format "file://file-path">])
        .add_nodes_with_defaults(1)
```