### PR TITLE
Few stabilization fix-ups

### DIFF
--- a/libsplinter/src/admin/service/error.rs
+++ b/libsplinter/src/admin/service/error.rs
@@ -18,7 +18,11 @@ use std::fmt;
 use crate::admin::store::error::AdminServiceStoreError;
 use crate::consensus::error::ProposalManagerError;
 use crate::orchestrator::InitializeServiceError;
-#[cfg(any(feature = "circuit-disband", feature = "circuit-abandon"))]
+#[cfg(any(
+    feature = "circuit-disband",
+    feature = "circuit-abandon",
+    feature = "circuit-purge"
+))]
 use crate::orchestrator::ShutdownServiceError;
 use crate::service::error::{ServiceError, ServiceSendError};
 
@@ -163,7 +167,11 @@ pub enum AdminSharedError {
         context: String,
         source: Option<InitializeServiceError>,
     },
-    #[cfg(any(feature = "circuit-disband", feature = "circuit-abandon"))]
+    #[cfg(any(
+        feature = "circuit-disband",
+        feature = "circuit-abandon",
+        feature = "circuit-purge"
+    ))]
     ServiceShutdownFailed {
         context: String,
         source: Option<ShutdownServiceError>,
@@ -193,7 +201,11 @@ impl Error for AdminSharedError {
                     None
                 }
             }
-            #[cfg(any(feature = "circuit-disband", feature = "circuit-abandon"))]
+            #[cfg(any(
+                feature = "circuit-disband",
+                feature = "circuit-abandon",
+                feature = "circuit-purge"
+            ))]
             AdminSharedError::ServiceShutdownFailed { source, .. } => {
                 if let Some(ref err) = source {
                     Some(err)
@@ -228,7 +240,11 @@ impl fmt::Display for AdminSharedError {
                     f.write_str(&context)
                 }
             }
-            #[cfg(any(feature = "circuit-disband", feature = "circuit-abandon"))]
+            #[cfg(any(
+                feature = "circuit-disband",
+                feature = "circuit-abandon",
+                feature = "circuit-purge"
+            ))]
             AdminSharedError::ServiceShutdownFailed { context, source } => {
                 if let Some(ref err) = source {
                     write!(f, "{}: {}", context, err)

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1861,10 +1861,6 @@ impl AdminServiceShared {
             }
             Ok(())
         } else {
-            println!(
-                "Going to initialize the services for node {:?}",
-                self.node_id()
-            );
             self.initialize_services_if_members_ready(&circuit_id)
         }
     }


### PR DESCRIPTION
This PR: 
- removes a `println` from the shared admin service
- adds the `circuit-purge` feature guard to an error variant currently only guarded by `circuit-disband` and `circuit-abandon`, but is used by a `circuit-purge` guarded method