### PR TITLE
Modify OpenIdProfileProvider + OAuthClient doc comment

### DIFF
--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -77,6 +77,8 @@ impl OAuthClient {
     ///   identifiers
     /// * `inflight_request_store` - The store for information about in-flight request to a
     /// provider.
+    /// * `profile_provider` - The OAuth profile provider used to retrieve the profile
+    ///   information of the authenticated user from the OAuth provider.
     fn new(
         client: BasicClient,
         extra_auth_params: Vec<(String, String)>,

--- a/libsplinter/src/oauth/profile/openid.rs
+++ b/libsplinter/src/oauth/profile/openid.rs
@@ -71,13 +71,20 @@ impl ProfileProvider for OpenIdProfileProvider {
                 .header("Authorization", format!("Bearer {}", access_token))
                 .send()
             {
-                Ok(image) => match image.bytes() {
-                    Ok(image_data) => Some(encode(image_data.to_vec())),
-                    Err(_) => {
-                        warn!("Failed to get bytes from microsoft graph HTTP response");
+                Ok(res) => {
+                    if res.status().is_success() {
+                        match res.bytes() {
+                            Ok(image_data) => Some(encode(image_data.to_vec())),
+                            Err(_) => {
+                                warn!("Failed to get bytes from microsoft graph HTTP response");
+                                Some("".into())
+                            }
+                        }
+                    } else {
+                        warn!("Microsoft graph API request failed");
                         Some("".into())
                     }
-                },
+                }
                 Err(_) => {
                     warn!("Failed to get user profile picture from microsoft graph API");
                     Some("".into())


### PR DESCRIPTION
This PR addresses stabilization comments on the `oauth-profile` feature
- Modifies the `OpenIdProfileProvider` to check the status of the microsoft graph api request response to ensure a returned error response isn't encoded and set for the `picture` field of the profile struct.
- Updates the `OAuthClient` constructor doc comment to include a description of the `profile_provider` argument