### PR TITLE
Add Scabbard transactions to circuit integration tests

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -51,6 +51,8 @@ toml = "0.5"
 
 [dev-dependencies]
 openssl = { version = "0.10" }
+sabre-sdk = "0.7"
+transact = { version = "0.3" }
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -44,6 +44,18 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![
+            node_a
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get first node's public key")
+                .as_hex(),
+            node_b
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get second node's public key")
+                .as_hex(),
+        ],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a
@@ -175,6 +187,23 @@ pub(in crate::admin) fn commit_3_party_circuit(
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![
+            node_a
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get first node's public key")
+                .as_hex(),
+            node_b
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get second node's public key")
+                .as_hex(),
+            node_c
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get third node's public key")
+                .as_hex(),
+        ],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -129,6 +129,11 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![node_a
+            .admin_signer()
+            .public_key()
+            .expect("Unable to get first node's public key")
+            .as_hex()],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a
@@ -258,6 +263,11 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![node_a
+            .admin_signer()
+            .public_key()
+            .expect("Unable to get first node's public key")
+            .as_hex()],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -420,7 +420,6 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
 /// 15. Submit a `Scabbard` transaction from one of the nodes to validate the batch is unable to be
 ///    committed on the disbanded circuit as the services set-up for this circuit have been stopped
 #[test]
-#[ignore]
 pub fn test_3_party_circuit_lifecycle() {
     // Start a 3-node network
     let mut network = Network::new()
@@ -539,7 +538,7 @@ pub fn test_3_party_circuit_lifecycle() {
             .fetch_proposal(&circuit_id)
             .expect("Unable to fetch proposal from third node")
             .unwrap();
-        if proposal_a.votes.is_empty() && proposal_b.votes.is_empty() && proposal_c.votes.is_empty()
+        if proposal_a.votes.is_empty() || proposal_b.votes.is_empty() || proposal_c.votes.is_empty()
         {
             continue;
         } else {

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -20,25 +20,40 @@ use std::time::{Duration, Instant};
 use splinterd::node::RestApiVariant;
 
 use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
-use crate::admin::payload::{make_circuit_disband_payload, make_circuit_proposal_vote_payload};
+use crate::admin::{
+    get_node_service_id,
+    payload::{
+        make_circuit_disband_payload, make_circuit_proposal_vote_payload,
+        make_create_contract_registry_batch,
+    },
+};
 use crate::framework::network::Network;
 
 /// Test that a 2-party circuit may be created on a 2-node network. This test then validates the
-/// circuit is able to be disbanded. Furthermore, this test validates the disbanded circuit is
-/// still accessible to each node and the circuit definition is as expected, after disbanding.
+/// circuit is able to be disbanded. This test also validates the Splinter services running on the
+/// on the circuit behave as expected throughout the disband process. The service transactions
+/// are expected to submit successfully while the services are still running, up until all circuit
+/// members have agreed to disband the circuit. Once the circuit has been disbanded, the services
+/// for the circuit are expected to have been stopped and service transaction submissions will
+/// return an error. Furthermore, this test validates the disbanded circuit is still accessible to
+/// each node and the circuit definition is as expected, after disbanding.
 ///
-/// 1. Create a circuit between 2 nodes
-/// 2. Create and submit a `CircuitDisbandRequest` from the first node
-/// 3. Wait until the disband proposal is available to the second node, using `list_proposals`
-/// 4. Verify the same disband proposal is available on each node
-/// 5. Submit the same `CircuitDisbandRequest` from the second step to the second node
-/// 6. Validate this duplicate disband proposal is rejected
-/// 7. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
-/// 8. Wait until the circuit is no longer available as an active circuit on the first node,
+/// 1. Create and commit a circuit between 2 nodes
+/// 2. Submit a Scabbard transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 3. Create and submit a `CircuitDisbandRequest` from the first node
+/// 4. Wait until the disband proposal is available to the second node, using `list_proposals`
+/// 5. Verify the same disband proposal is available on each node
+/// 6. Submit the same `CircuitDisbandRequest` from the second step to the second node
+/// 7. Validate this duplicate disband proposal is rejected
+/// 8. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
+/// 9. Wait until the circuit is no longer available as an active circuit on the first node,
 ///    using `list_circuits`
-/// 9. Validate the circuit is no longer active on every node
-/// 10. Validate the disbanded circuit is still available to each node, though disbanded, and that
+/// 10. Validate the circuit is no longer active on every node
+/// 11. Validate the disbanded circuit is still available to each node, though disbanded, and that
 ///    the disbanded circuit is the same for each node
+/// 12. Submit a `Scabbard` transaction from one of the nodes to validate the batch is unable to be
+///    committed on the disbanded circuit as the services set-up for this circuit have been stopped
 #[test]
 pub fn test_2_party_circuit_lifecycle() {
     // Start a 2-node network
@@ -50,9 +65,27 @@ pub fn test_2_party_circuit_lifecycle() {
     let node_a = network.node(0).expect("Unable to get first node");
     // Get the second node in the network
     let node_b = network.node(1).expect("Unable to get second node");
+
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
     commit_2_party_circuit(&circuit_id, node_a, node_b);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
 
     // Create disband request to be sent from the first node
     let disband_payload = make_circuit_disband_payload(
@@ -105,6 +138,23 @@ pub fn test_2_party_circuit_lifecycle() {
         .submit_admin_payload(disband_payload);
     assert!(duplicate_res.is_err());
 
+    // Create the `ServiceId` struct based on the second node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_b = get_node_service_id(&circuit_id, node_b);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_b.admin_signer());
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get second node's ScabbardClient")
+        .submit(
+            &service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
     // Create `CircuitProposalVote` to accept the disband proposal
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
     let vote_payload_bytes = make_circuit_proposal_vote_payload(
@@ -156,6 +206,21 @@ pub fn test_2_party_circuit_lifecycle() {
         .unwrap();
     assert_eq!(disbanded_circuit_a, disbanded_circuit_b);
 
+    // Submit a `CreateContractRegistryAction` to validate the service transaction returns an
+    // error as the circuit has been disbanded, meaning both nodes' services running on that
+    // circuit have been stopped
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_b.admin_signer());
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get second node's ScabbardClient")
+        .submit(
+            &service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
     shutdown!(network).expect("Unable to shutdown network");
 }
 
@@ -163,16 +228,20 @@ pub fn test_2_party_circuit_lifecycle() {
 /// circuit member is able to propose to disband the circuit. This test then validates the disband
 /// request is able to be rejected by another circuit member, removing the disband proposal.
 ///
-/// 1. Create a circuit between 2 nodes
-/// 2. Create and submit a `CircuitDisbandRequest` from the first node
-/// 3. Wait until the disband proposal is available to the second node, using `list_proposals`
-/// 4. Verify the same disband proposal is available on each node
-/// 5. Create and submit a `CircuitProposalVote` from the second node to reject the disband proposal
-/// 6. Wait until the disband proposal is no longer available to the second node,
+/// 1. Create and commit a circuit between 2 nodes
+/// 2. Submit a `Scabbard` transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 3. Create and submit a `CircuitDisbandRequest` from the first node
+/// 4. Wait until the disband proposal is available to the second node, using `list_proposals`
+/// 5. Verify the same disband proposal is available on each node
+/// 6. Create and submit a `CircuitProposalVote` from the second node to reject the disband proposal
+/// 7. Wait until the disband proposal is no longer available to the second node,
 ///    using `list_proposals`
-/// 7. Validate the proposal is no longer available on the nodes
-/// 8. Validate the active circuit is still available to each node, using `list_circuits` which
+/// 8. Validate the proposal is no longer available on the nodes
+/// 9. Validate the active circuit is still available to each node, using `list_circuits` which
 ///    only returns active circuits
+/// 10. Submit a `Scabbard` transaction from one of the nodes to validate the service is still able
+///    to commit the batch on the circuit that has remained active
 #[test]
 #[ignore]
 pub fn test_2_party_circuit_disband_proposal_rejected() {
@@ -188,6 +257,23 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
     commit_2_party_circuit(&circuit_id, node_a, node_b);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
 
     // Create disband request to be sent from the first node
     let disband_payload = make_circuit_disband_payload(
@@ -285,13 +371,32 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
         .data;
     assert!(active_circuits_b.len() == 1);
 
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
     shutdown!(network).expect("Unable to shutdown network");
 }
 
 /// Test that a 3-party circuit may be created on a 3-node network. This test then validates the
-/// circuit is able to be disbanded.
+/// circuit is able to be disbanded. This test also validates that the Splinter services running
+/// on the circuit behave as expected throughout the disband process. The service transactions
+/// are expected to submit successfully while the services are still running, up until all circuit
+/// members have agreed to disband the circuit. Once the circuit has been disbanded, the services
+/// for the circuit are expected to have been stopped and service transaction submissions will
+/// return an error.
 ///
-/// 1. Create a circuit between 3 nodes
+/// 1. Create and commit a circuit between 3 nodes
 /// 2. Create and submit a `CircuitDisbandRequest` from the first node
 /// 3. Wait until the disband proposal is available to each node, using `list_proposals`
 /// 4. Verify the same disband proposal is present on each node
@@ -304,12 +409,16 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
 ///    remote node
 /// 9. Validate the proposal has been updated and includes the `Vote` submitted in the previous
 ///    steps for every node
-/// 10. Create and submit a `CircuitProposalVote` from the third node to accept the disband proposal
-/// 11. Wait until the active circuit is no longer available to the remote nodes, using
+/// 10. Create and submit a `Scabbard` transaction from a node, validate this submission returns
+///    successfully
+/// 11. Create and submit a `CircuitProposalVote` from the third node to accept the disband proposal
+/// 12. Wait until the active circuit is no longer available to the remote nodes, using
 ///    `list_circuits`
-/// 12. Validate the circuit is no longer active on the nodes
-/// 13. Validate the disbanded circuit is still available to each node, though disbanded, and that
+/// 13. Validate the circuit is no longer active on the nodes
+/// 14. Validate the disbanded circuit is still available to each node, though disbanded, and that
 ///    the disbanded circuit is the same for each node
+/// 15. Submit a `Scabbard` transaction from one of the nodes to validate the batch is unable to be
+///    committed on the disbanded circuit as the services set-up for this circuit have been stopped
 #[test]
 #[ignore]
 pub fn test_3_party_circuit_lifecycle() {
@@ -440,6 +549,23 @@ pub fn test_3_party_circuit_lifecycle() {
         }
     }
 
+    // Create the `ServiceId` struct based on the second node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_c = get_node_service_id(&circuit_id, node_c);
+    // Submit another `Scabbard` transaction from the other node to validate the transaction
+    // is successfully committed on the circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_c.admin_signer());
+    assert!(node_c
+        .scabbard_client()
+        .expect("Unable to get third node's ScabbardClient")
+        .submit(
+            &service_id_c,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
     let vote_payload_bytes = make_circuit_proposal_vote_payload(
@@ -498,28 +624,50 @@ pub fn test_3_party_circuit_lifecycle() {
     assert_eq!(disbanded_circuit_a, disbanded_circuit_b);
     assert_eq!(disbanded_circuit_b, disbanded_circuit_c);
 
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction returns an
+    // error as the circuit has been disbanded, meaning both nodes' services running on that
+    // circuit have been stopped
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_3", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
     shutdown!(network).expect("Unable to shutdown network");
 }
 
 /// Test that a 3-party circuit may be created on a 3-node network. This test then validates the
 /// circuit is able to be disbanded.
 ///
-/// 1. Create a circuit between 3 nodes
-/// 2. Create and submit a `CircuitDisbandRequest` from the first node
-/// 3. Wait until the disband proposal is available to each node, using `list_proposals`
-/// 4. Verify the same disband proposal is present on each node
-/// 5. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
-/// 6. Wait until this vote is recorded on the proposal, using `fetch_proposal` and validating
+/// 1. Create and commit a circuit between 3 nodes
+/// 2. Submit a `Scabbard` transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 3. Create and submit a `CircuitDisbandRequest` from the first node
+/// 4. Wait until the disband proposal is available to each node, using `list_proposals`
+/// 5. Verify the same disband proposal is present on each node
+/// 6. Create and submit a `CircuitProposalVote` from the second node to accept the disband proposal
+/// 7. Wait until this vote is recorded on the proposal, using `fetch_proposal` and validating
 ///    the `Vote` from the node that voted in the previous step appears on the proposal for each
 ///    remote node
-/// 7. Validate the proposal has been updated and includes the `Vote` submitted in the previous
+/// 8. Validate the proposal has been updated and includes the `Vote` submitted in the previous
 ///    steps for every node
-/// 8. Create and submit a `CircuitProposalVote` from the third node to reject the disband proposal
-/// 9. Wait until the disband proposal is no longer available to the remote nodes, using
+/// 9. Create and submit a `CircuitProposalVote` from the third node to reject the disband proposal
+/// 10. Wait until the disband proposal is no longer available to the remote nodes, using
 ///    `list_proposals`
-/// 10. Validate the disband proposal is no longer available for every node
-/// 11. Validate the circuit is still active for each node, using `list_circuits` which only returns
-///     active circuits
+/// 11. Validate the disband proposal is no longer available for every node
+/// 12. Validate the circuit is still active for each node, using `list_circuits` which only
+///     returns active circuits
+/// 13. Submit a `Scabbard` transaction from one of the nodes to validate the service is still able
+///    to commit the batch on the circuit that has remained active
 #[test]
 #[ignore]
 pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
@@ -537,6 +685,23 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
 
     let circuit_id = "ABCDE-01234";
     commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
 
     // Create disband request to be sent from the first node
     let disband_payload = make_circuit_disband_payload(
@@ -700,6 +865,20 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
         .expect("Unable to list circuits from third node")
         .data;
     assert!(active_circuits_c.len() == 1);
+
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_a.admin_signer());
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
 
     shutdown!(network).expect("Unable to shutdown network");
 }

--- a/splinterd/tests/admin/mod.rs
+++ b/splinterd/tests/admin/mod.rs
@@ -20,3 +20,29 @@ mod circuit_disband;
 mod circuit_list;
 mod payload;
 mod registry;
+
+use scabbard::client::ServiceId;
+use splinterd::node::Node;
+
+// Helper function to generate the `ServiceId` for the provided Node on the circuit specified by
+// the `circuit_id` argument. The generic definition of this function allows for this function to
+// be used for any Node that is apart of the circuit specified.
+pub(super) fn get_node_service_id(circuit_id: &str, node: &Node) -> ServiceId {
+    // Retrieve the node's associated `service_id` from the circuit just committed
+    let circuit = node
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit")
+        .unwrap();
+    // Create the `ServiceId` struct based on the node's associated `service_id` and the
+    // committed `circuit_id`
+    let node_service = &circuit
+        .roster
+        .iter()
+        .find(|service_slice| &service_slice.node_id == node.node_id())
+        .expect("Circuit committed without service for node")
+        .service_id;
+    format!("{}::{}", &circuit_id, node_service)
+        .parse::<ServiceId>()
+        .expect("Unable to parse `ServiceId`")
+}

--- a/splinterd/tests/admin/payload.rs
+++ b/splinterd/tests/admin/payload.rs
@@ -40,13 +40,14 @@ pub(in crate::admin) fn make_create_circuit_payload(
     requester: &str,
     node_info: HashMap<String, Vec<String>>,
     signer: &dyn Signer,
+    admin_keys: &[String],
 ) -> Vec<u8> {
-    // Get the public key to create the `CircuitCreateRequest` and to also set the `requester`
-    // field of the `CircuitManagementPayload` header
+    // Get the public key to set the `requester` field of the `CircuitManagementPayload` header
     let public_key = signer
         .public_key()
-        .expect("Unable to get signer's public key");
-    let circuit_request = setup_circuit(circuit_id, node_info, &public_key.as_hex());
+        .expect("Unable to get signer's public key")
+        .into_bytes();
+    let circuit_request = setup_circuit(circuit_id, node_info, admin_keys);
     let serialized_action = circuit_request
         .write_to_bytes()
         .expect("Unable to serialize `CircuitCreateRequest`");
@@ -55,7 +56,7 @@ pub(in crate::admin) fn make_create_circuit_payload(
 
     let mut header = CircuitManagementPayload_Header::new();
     header.set_action(CircuitManagementPayload_Action::CIRCUIT_CREATE_REQUEST);
-    header.set_requester(public_key.into_bytes());
+    header.set_requester(public_key);
     header.set_payload_sha512(hashed_bytes.to_vec());
     header.set_requester_node_id(requester.to_string());
 
@@ -170,7 +171,7 @@ pub(in crate::admin) fn make_circuit_disband_payload(
 fn setup_circuit(
     circuit_id: &str,
     node_info: HashMap<String, Vec<String>>,
-    public_key: &str,
+    admin_keys: &[String],
 ) -> CircuitCreateRequest {
     // The services require the service IDs from its peer services, which will be generated
     // after the node information is iterated over and the `SplinterServiceBuilder` is created
@@ -199,7 +200,10 @@ fn setup_circuit(
                 .with_arguments(
                     vec![
                         ("peer_services".to_string(), format!("{:?}", peer_services)),
-                        ("admin_keys".to_string(), format!("{:?}", vec![public_key])),
+                        (
+                            "admin_keys".to_string(),
+                            format!("{:?}", admin_keys.to_vec()),
+                        ),
                     ]
                     .as_ref(),
                 )


### PR DESCRIPTION
This PR adds the necessary plumbing to create and submit a batch to the Scabbard client's `submit` endpoint, and also adds validation in the currently implemented tests for the submission of scabbard transactions. 

This PR also makes an update to the `test_3_party_circuit_lifecycle` test, which allows this test to pass so this PR also removes the `#[ignore]` from this test so that it is able to run in CI.