### PR TITLE
Fix `UserProfileStoreError` doc comment

### DIFF
--- a/libsplinter/src/biome/profile/store/error.rs
+++ b/libsplinter/src/biome/profile/store/error.rs
@@ -21,7 +21,7 @@ use crate::error::{
     ConstraintViolationError, InternalError, InvalidArgumentError, InvalidStateError,
 };
 
-/// Errors that may occur during [UserProfileStoreError] operations.
+/// Errors that may occur during [UserProfileStore] operations.
 #[derive(Debug)]
 pub enum UserProfileStoreError {
     ConstraintViolation(ConstraintViolationError),


### PR DESCRIPTION
This PR addresses stabilization comments on the `biome-profile` feature
- Fix a typo in the `UserProfileStoreError` doc comment.