### PR TITLE
Add experimental metrics support to libsplinter and splinterd

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -39,6 +39,7 @@ awc = { version = "0.2", optional = true }
 base64 = { version = "0.12", optional = true }
 bcrypt = {version = "0.6", optional = true}
 byteorder = "1"
+chrono = {version = "0.4", optional = true}
 crossbeam-channel = "0.3"
 cylinder = "0.2.1"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
@@ -48,7 +49,10 @@ futures-0-3 = { package = "futures", version = "0.3", optional = true }
 glob = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
 jsonwebtoken = { version = "6.0", optional = true }
+influxdb = { version = "0.4.0", features = ["derive"], optional = true }
 log = "0.3.0"
+# rename to not conflict with splinter::metrics
+metrics-lib = {package = "metrics", version = "0.12", features = ["std"]}
 mio = "0.6"
 mio-extras = "2"
 oauth2 = { version = "3.0", optional = true }
@@ -62,6 +66,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
+tokio-0-2 = { package = "tokio", version = "0.2", optional = true }
 tungstenite = { version = "0.10", optional = true }
 url = "1.7.1"
 uuid = { version = "0.8", features = ["v4", "v5"] }
@@ -113,6 +118,7 @@ experimental = [
     "biome-profile",
     "client-reqwest",
     "https-bind",
+    "metrics",
     "oauth-profile",
     "registry-client",
     "registry-client-reqwest",
@@ -144,6 +150,7 @@ cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
+metrics = ["chrono", "futures-0-3", "influxdb", "tokio-0-2"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -74,6 +74,8 @@ pub mod events;
 mod hex;
 pub mod keys;
 pub mod mesh;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod migrations;
 pub mod network;
 #[cfg(feature = "oauth")]

--- a/libsplinter/src/metrics/influx.rs
+++ b/libsplinter/src/metrics/influx.rs
@@ -1,0 +1,214 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains an influxdb specific implementation of the metrics::Recorder trait. InfluxRecorder
+//! enables using the metrics macros and sending the metrics data to a running Influx database.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use influxdb::Client;
+use influxdb::InfluxDbWriteable;
+use metrics_lib::{Key, Recorder};
+use tokio_0_2::runtime::Runtime;
+use tokio_0_2::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio_0_2::task::JoinHandle;
+
+use crate::error::InternalError;
+use crate::threading::lifecycle::ShutdownHandle;
+
+#[derive(InfluxDbWriteable, Clone)]
+struct Counter {
+    time: DateTime<Utc>,
+    key: String,
+    value: u64,
+}
+
+#[derive(InfluxDbWriteable, Clone)]
+struct Gauge {
+    time: DateTime<Utc>,
+    key: String,
+    value: i64,
+}
+
+#[derive(InfluxDbWriteable, Clone)]
+struct Histogram {
+    time: DateTime<Utc>,
+    key: String,
+    value: u64,
+}
+
+enum MetricRequest {
+    Counter {
+        key: String,
+        value: u64,
+        time: DateTime<Utc>,
+    },
+    Gauge {
+        key: String,
+        value: i64,
+        time: DateTime<Utc>,
+    },
+    Histogram {
+        key: String,
+        value: u64,
+        time: DateTime<Utc>,
+    },
+    Shutdown,
+}
+
+pub struct InfluxRecorder {
+    sender: UnboundedSender<MetricRequest>,
+    join_handle: JoinHandle<()>,
+    rt: Runtime,
+}
+
+impl InfluxRecorder {
+    pub fn new(
+        db_url: &str,
+        db_name: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<Self, InternalError> {
+        let (sender, mut recv) = unbounded_channel();
+        let rt = Runtime::new().map_err(|_| {
+            InternalError::with_message("Unable to start metrics runtime".to_string())
+        })?;
+
+        let client = Client::new(db_url, db_name).with_auth(username, password);
+
+        let join_handle = rt.spawn(async move {
+            let mut counters: HashMap<String, Counter> = HashMap::new();
+            loop {
+                match recv.recv().await {
+                    Some(MetricRequest::Counter { key, value, time }) => {
+                        let counter = {
+                            if let Some(mut counter) = counters.get_mut(&key) {
+                                counter.value += 1;
+                                counter.time = time;
+                                counter.clone()
+                            } else {
+                                let counter = Counter {
+                                    time,
+                                    key: key.to_string(),
+                                    value,
+                                };
+                                counters.insert(key.to_string(), counter.clone());
+                                counter
+                            }
+                        };
+
+                        let query = counter.into_query(key);
+                        if let Err(err) = client.query(&query).await {
+                            error!("Unable to submit influx query: {}", err)
+                        };
+                    }
+                    Some(MetricRequest::Gauge { key, value, time }) => {
+                        let gauge = Gauge {
+                            time,
+                            key: key.to_string(),
+                            value,
+                        };
+                        let query = gauge.into_query(key);
+                        if let Err(err) = client.query(&query).await {
+                            error!("Unable to submit influx query: {}", err)
+                        };
+                    }
+                    Some(MetricRequest::Histogram { key, value, time }) => {
+                        let histogram = Histogram {
+                            time,
+                            key: key.to_string(),
+                            value,
+                        };
+                        let query = histogram.into_query(key);
+                        if let Err(err) = client.query(&query).await {
+                            error!("Unable to submit influx query: {}", err)
+                        };
+                    }
+                    Some(MetricRequest::Shutdown) => {
+                        info!("Received MetricRequest::Shutdown");
+                        break;
+                    }
+                    _ => unimplemented!(),
+                }
+            }
+        });
+
+        Ok(Self {
+            sender,
+            join_handle,
+            rt,
+        })
+    }
+
+    pub fn init(
+        db_url: &str,
+        db_name: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<(), InternalError> {
+        let recorder = Self::new(db_url, db_name, username, password)?;
+        metrics_lib::set_boxed_recorder(Box::new(recorder))
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}
+
+impl ShutdownHandle for InfluxRecorder {
+    fn signal_shutdown(&mut self) {
+        if self.sender.send(MetricRequest::Shutdown).is_err() {
+            error!("Unable to send shutdown message to InfluxRecorder");
+        }
+    }
+
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
+        self.rt.block_on(self.join_handle).map_err(|err| {
+            InternalError::with_message(format!("Unable to join InfluxRecorder thread: {:?}", err))
+        })
+    }
+}
+
+impl Recorder for InfluxRecorder {
+    fn increment_counter(&self, key: Key, value: u64) {
+        let name = key.name().to_string();
+        if let Err(err) = self.sender.send(MetricRequest::Counter {
+            key: name,
+            value,
+            time: Utc::now(),
+        }) {
+            error!("Unable to to increment counter metric, {}", err);
+        };
+    }
+
+    fn update_gauge(&self, key: Key, value: i64) {
+        let name = key.name().to_string();
+        if let Err(err) = self.sender.send(MetricRequest::Gauge {
+            key: name,
+            value,
+            time: Utc::now(),
+        }) {
+            error!("Unable to update gauge metric, {}", err);
+        };
+    }
+
+    fn record_histogram(&self, key: Key, value: u64) {
+        let name = key.name().to_string();
+        if let Err(err) = self.sender.send(MetricRequest::Histogram {
+            key: name,
+            value,
+            time: Utc::now(),
+        }) {
+            error!("Unable to record histogram metric, {}", err);
+        };
+    }
+}

--- a/libsplinter/src/metrics/mod.rs
+++ b/libsplinter/src/metrics/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub mod influx;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -99,6 +99,7 @@ experimental = [
     "circuit-purge",
     "health-service",
     "https-bind",
+    "metrics",
     "node",
     "oauth",
     "service-arg-validation",
@@ -131,6 +132,7 @@ database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
+metrics = ["splinter/metrics"]
 node = [
     "scabbard/client-reqwest",
     "scabbard/factory-builder",

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -409,6 +409,36 @@ impl ConfigBuilder {
                     None => None,
                 })
                 .ok_or_else(|| ConfigError::MissingValue("strict_ref_counts".to_string()))?,
+            #[cfg(feature = "metrics")]
+            metrics_db: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.metrics_db() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }),
+            #[cfg(feature = "metrics")]
+            metrics_url: self
+                .partial_configs
+                .iter()
+                .find_map(|p| match p.metrics_url() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }),
+            #[cfg(feature = "metrics")]
+            metrics_username: self.partial_configs.iter().find_map(|p| {
+                match p.metrics_username() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }
+            }),
+            #[cfg(feature = "metrics")]
+            metrics_password: self.partial_configs.iter().find_map(|p| {
+                match p.metrics_password() {
+                    Some(v) => Some((v, p.source())),
+                    None => None,
+                }
+            }),
         })
     }
 }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -171,6 +171,15 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 )
         }
 
+        #[cfg(feature = "metrics")]
+        {
+            partial_config = partial_config
+                .with_metrics_db(self.matches.value_of("metrics_db").map(String::from))
+                .with_metrics_url(self.matches.value_of("metrics_url").map(String::from))
+                .with_metrics_username(self.matches.value_of("metrics_username").map(String::from))
+                .with_metrics_password(self.matches.value_of("metrics_password").map(String::from))
+        }
+
         Ok(partial_config)
     }
 }

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -35,6 +35,14 @@ const OAUTH_CLIENT_SECRET_ENV: &str = "OAUTH_CLIENT_SECRET";
 const OAUTH_REDIRECT_URL_ENV: &str = "OAUTH_REDIRECT_URL";
 #[cfg(feature = "oauth")]
 const OAUTH_OPENID_URL_ENV: &str = "OAUTH_OPENID_URL";
+#[cfg(feature = "metrics")]
+const METRICS_DB_ENV: &str = "SPLINTER_METRICS_DB";
+#[cfg(feature = "metrics")]
+const METRICS_URL_ENV: &str = "SPLINTER_METRICS_URL";
+#[cfg(feature = "metrics")]
+const METRICS_USERNAME_ENV: &str = "SPLINTER_METRICS_USERNAME";
+#[cfg(feature = "metrics")]
+const METRICS_PASSWORD_ENV: &str = "SPLINTER_METRICS_PASSWORD";
 
 pub struct EnvPartialConfigBuilder;
 
@@ -115,6 +123,15 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
                 .with_oauth_client_secret(env::var(OAUTH_CLIENT_SECRET_ENV).ok())
                 .with_oauth_redirect_url(env::var(OAUTH_REDIRECT_URL_ENV).ok())
                 .with_oauth_openid_url(env::var(OAUTH_OPENID_URL_ENV).ok());
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            config = config
+                .with_metrics_db(env::var(METRICS_DB_ENV).ok())
+                .with_metrics_url(env::var(METRICS_URL_ENV).ok())
+                .with_metrics_username(env::var(METRICS_USERNAME_ENV).ok())
+                .with_metrics_password(env::var(METRICS_PASSWORD_ENV).ok())
         }
 
         Ok(config)

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -88,6 +88,14 @@ pub struct Config {
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<(Vec<String>, ConfigSource)>,
     strict_ref_counts: (bool, ConfigSource),
+    #[cfg(feature = "metrics")]
+    metrics_db: Option<(String, ConfigSource)>,
+    #[cfg(feature = "metrics")]
+    metrics_url: Option<(String, ConfigSource)>,
+    #[cfg(feature = "metrics")]
+    metrics_username: Option<(String, ConfigSource)>,
+    #[cfg(feature = "metrics")]
+    metrics_password: Option<(String, ConfigSource)>,
 }
 
 impl Config {
@@ -291,6 +299,42 @@ impl Config {
         self.strict_ref_counts.0
     }
 
+    #[cfg(feature = "metrics")]
+    pub fn metrics_db(&self) -> Option<&str> {
+        if let Some((db, _)) = &self.metrics_db {
+            Some(db)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_url(&self) -> Option<&str> {
+        if let Some((url, _)) = &self.metrics_url {
+            Some(url)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_username(&self) -> Option<&str> {
+        if let Some((username, _)) = &self.metrics_username {
+            Some(username)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_password(&self) -> Option<&str> {
+        if let Some((password, _)) = &self.metrics_password {
+            Some(password)
+        } else {
+            None
+        }
+    }
+
     pub fn config_dir_source(&self) -> &ConfigSource {
         &self.config_dir.1
     }
@@ -489,6 +533,42 @@ impl Config {
 
     fn strict_ref_counts_source(&self) -> &ConfigSource {
         &self.strict_ref_counts.1
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_db_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.metrics_db {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_url_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.metrics_url {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_username_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.metrics_username {
+            Some(source)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_password_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.metrics_password {
+            Some(source)
+        } else {
+            None
+        }
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -694,6 +774,31 @@ impl Config {
             self.strict_ref_counts(),
             self.strict_ref_counts_source()
         );
+        #[cfg(feature = "metrics")]
+        {
+            if let (Some(db), Some(source)) = (self.metrics_db(), self.metrics_db_source()) {
+                debug!("Config: metrics_db: {:?} (source: {:?})", db, source,);
+            }
+
+            if let (Some(url), Some(source)) = (self.metrics_url(), self.metrics_url_source()) {
+                debug!("Config: metrics_url: {:?} (source: {:?})", url, source,);
+            }
+
+            if let (Some(username), Some(source)) =
+                (self.metrics_username(), self.metrics_username_source())
+            {
+                debug!(
+                    "Config: metrics_username: {:?} (source: {:?})",
+                    username, source,
+                );
+            }
+
+            if let (Some(_), Some(source)) =
+                (self.metrics_password(), self.metrics_password_source())
+            {
+                debug!("Config: metrics_password: <HIDDEN> (source: {:?})", source,);
+            }
+        }
     }
 
     #[cfg(feature = "rest-api-cors")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -81,6 +81,14 @@ pub struct PartialConfig {
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<Vec<String>>,
     strict_ref_counts: Option<bool>,
+    #[cfg(feature = "metrics")]
+    metrics_db: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_url: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_username: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_password: Option<String>,
 }
 
 impl PartialConfig {
@@ -136,6 +144,14 @@ impl PartialConfig {
             #[cfg(feature = "oauth")]
             oauth_openid_scopes: None,
             strict_ref_counts: None,
+            #[cfg(feature = "metrics")]
+            metrics_db: None,
+            #[cfg(feature = "metrics")]
+            metrics_url: None,
+            #[cfg(feature = "metrics")]
+            metrics_username: None,
+            #[cfg(feature = "metrics")]
+            metrics_password: None,
         }
     }
 
@@ -297,6 +313,26 @@ impl PartialConfig {
 
     pub fn strict_ref_counts(&self) -> Option<bool> {
         self.strict_ref_counts
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_db(&self) -> Option<String> {
+        self.metrics_db.clone()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_url(&self) -> Option<String> {
+        self.metrics_url.clone()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_username(&self) -> Option<String> {
+        self.metrics_username.clone()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn metrics_password(&self) -> Option<String> {
+        self.metrics_password.clone()
     }
 
     /// Adds a `config_dir` value to the `PartialConfig` object.
@@ -718,6 +754,56 @@ impl PartialConfig {
     ///
     pub fn with_strict_ref_counts(mut self, strict_ref_counts: Option<bool>) -> Self {
         self.strict_ref_counts = strict_ref_counts;
+        self
+    }
+
+    #[cfg(feature = "metrics")]
+    /// Adds an `metrics_db` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `metrics_db` - Add the name of the InfluxDB database used for metrics
+    ///
+    pub fn with_metrics_db(mut self, metrics_db: Option<String>) -> Self {
+        self.metrics_db = metrics_db;
+        self
+    }
+
+    #[cfg(feature = "metrics")]
+    /// Adds an `metrics_url` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `metrics_url` - Add the URL of the InfluxDB database used for metrics
+    ///
+    pub fn with_metrics_url(mut self, metrics_url: Option<String>) -> Self {
+        self.metrics_url = metrics_url;
+        self
+    }
+
+    #[cfg(feature = "metrics")]
+    /// Adds an `metrics_username` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `metrics_username` - Add the username for authorization with the InfluxDB database used
+    ///    for metrics
+    ///
+    pub fn with_metrics_username(mut self, metrics_username: Option<String>) -> Self {
+        self.metrics_username = metrics_username;
+        self
+    }
+
+    #[cfg(feature = "metrics")]
+    /// Adds an `metrics_password` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `metrics_password` - Add the password for authorization with the InfluxDB database used
+    ///    for metrics
+    ///
+    pub fn with_metrics_password(mut self, metrics_password: Option<String>) -> Self {
+        self.metrics_password = metrics_password;
         self
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -70,6 +70,14 @@ struct TomlConfig {
     oauth_openid_auth_params: Option<Vec<(String, String)>>,
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<Vec<String>>,
+    #[cfg(feature = "metrics")]
+    metrics_db: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_url: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_username: Option<String>,
+    #[cfg(feature = "metrics")]
+    metrics_password: Option<String>,
 
     // Deprecated values
     cert_dir: Option<String>,
@@ -179,6 +187,15 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_oauth_openid_url(self.toml_config.oauth_openid_url)
                 .with_oauth_openid_auth_params(self.toml_config.oauth_openid_auth_params)
                 .with_oauth_openid_scopes(self.toml_config.oauth_openid_scopes);
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            partial_config = partial_config
+                .with_metrics_db(self.toml_config.metrics_db)
+                .with_metrics_url(self.toml_config.metrics_url)
+                .with_metrics_username(self.toml_config.metrics_username)
+                .with_metrics_password(self.toml_config.metrics_password)
         }
 
         // deprecated values, only set if the current value was not set

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -16,6 +16,8 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
+#[cfg(feature = "metrics")]
+use splinter::error::InternalError;
 use splinter::transport::socket::TlsInitError;
 
 use crate::config::ConfigError;
@@ -35,6 +37,8 @@ pub enum UserError {
         context: String,
         source: Option<Box<dyn Error>>,
     },
+    #[cfg(feature = "metrics")]
+    MetricsError(InternalError),
 }
 
 impl UserError {
@@ -74,6 +78,8 @@ impl Error for UserError {
                     None
                 }
             }
+            #[cfg(feature = "metrics")]
+            UserError::MetricsError(err) => Some(err),
         }
     }
 }
@@ -101,6 +107,8 @@ impl fmt::Display for UserError {
                     f.write_str(&context)
                 }
             }
+            #[cfg(feature = "metrics")]
+            UserError::MetricsError(msg) => write!(f, "{}", msg),
         }
     }
 }


### PR DESCRIPTION
running splinterd with "metrics" features, splinterd now has the following options:

```
--metrics-db <metrics_db>                                   The name of the InfluxDB database for metrics collection
--metrics-password <metrics_password>                       The password used for authorization with the InfluxDB
--metrics-url <metrics_url>                                 The URL to connect the InfluxDB database for metrics collection
--metrics-username <metrics_username>                       The username used for authorization with the InfluxDB

```

The following values would allow the daemon to connect the database in https://github.com/Cargill/splinter/pull/1173

```
--metrics-url http://localhost:8086 \
--metrics-db metrics \
--metrics-username admin \
--metrics-password foobar\
```

Note : I renamed metrics crate to metrics-lib in the dependency because it conflict with the local metrics mod I had added. I am open to renaming the local mod if anyone has better naming ideas. 