### PR TITLE
Update scabbard to handle both json lists and csv for arguments

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -293,7 +293,11 @@ impl fmt::Display for CircuitSlice {
                                 Err(_) => display_string += &format!("              {}\n", value),
                             };
                         } else {
-                            display_string += &format!("              {}\n", value);
+                            let values =
+                                value.split(',').map(String::from).collect::<Vec<String>>();
+                            for value in values {
+                                display_string += &format!("              {}\n", value);
+                            }
                         }
                     }
                 }
@@ -392,7 +396,11 @@ impl fmt::Display for ProposalSlice {
                                 Err(_) => display_string += &format!("                {}\n", value),
                             };
                         } else {
-                            display_string += &format!("                {}\n", value);
+                            let values =
+                                value.split(',').map(String::from).collect::<Vec<String>>();
+                            for value in values {
+                                display_string += &format!("              {}\n", value);
+                            }
                         }
                     }
                 }

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -463,12 +463,15 @@ fn parse_service_argument(service_argument: &str) -> Result<(String, (String, St
         )));
     }
 
-    let value = argument_iter.next().ok_or_else(|| {
-        CliError::ActionError(format!(
-            "Missing value in service argument '{}::{}'",
-            service_id, key,
-        ))
-    })?;
+    let value = argument_iter
+        .next()
+        .ok_or_else(|| {
+            CliError::ActionError(format!(
+                "Missing value in service argument '{}::{}'",
+                service_id, key,
+            ))
+        })?
+        .to_string();
     if value.is_empty() {
         return Err(CliError::ActionError(format!(
             "Empty value detected in service argument '{}::{}'",
@@ -476,7 +479,7 @@ fn parse_service_argument(service_argument: &str) -> Result<(String, (String, St
         )));
     }
 
-    Ok((service_id, (key, format!("{:?}", vec![value]))))
+    Ok((service_id, (key, value)))
 }
 
 fn parse_service_type_argument(service_type: &str) -> Result<(String, String), CliError> {


### PR DESCRIPTION
This PR also updates the `splinter circuit propose   --service-arg` to take the value as provided, before it was wrapped in a Vec but this caused issues with setting the version service arg because that should be in a vec. 

The Scabbard factory can now handle peer_services and admin_keys in either json fmt or csv:

`--service-arg "*::admin_keys=admin_keys=key1,key2"`
or 
`--service-arg "*::admin_keys=[\"key1\", \"key2\"]"`


