### PR TITLE
Small clean up for circuit-disband 

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -499,7 +499,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                     .value_name("circuit-id")
                     .takes_value(true)
                     .required(true)
-                    .help("ID of the proposed circuit"),
+                    .help("ID of the circuit to be disbanded"),
             ),
     );
 

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1829,7 +1829,7 @@ impl AdminServiceShared {
     /// voted for. If the proposal type is `Create`, the vote submitted pertains to creating a
     /// circuit so the services must be initialized if all members are now ready. If the proposal
     /// type is disband, the vote submitted pertains to disbanding a circuit so the services
-    /// must be stopped if all members are now ready if the `circuit-disband` feature is enabled.
+    /// must be stopped if all members are now ready.
     pub fn add_ready_member(
         &mut self,
         circuit_id: &str,

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/mod.rs
@@ -36,7 +36,7 @@ pub struct Role {
 }
 
 impl Role {
-    /// Returns the role's id.
+    /// Returns the role's ID.
     pub fn id(&self) -> &str {
         &self.id
     }


### PR DESCRIPTION
Includes a commit to clarify circuit id being passed to `circuit disband` command, and remove mention of `circuit-disband` feature that had been removed.

Also includes a small PR to fix a typo that had id but should have ID based on our rust documentation guidelines. 