### PR TITLE
Splinterd database bug fix

### DIFF
--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -95,6 +95,12 @@ pub fn create_store_factory(
         }
         #[cfg(feature = "sqlite")]
         ConnectionUri::Sqlite(conn_str) => {
+            if (conn_str != ":memory:") && !std::path::Path::new(&conn_str).exists() {
+                return Err(InternalError::with_message(format!(
+                    "Database file '{}' does not exist",
+                    conn_str
+                )));
+            }
             let connection_manager =
                 ConnectionManager::<diesel::sqlite::SqliteConnection>::new(&conn_str);
             let mut pool_builder =


### PR DESCRIPTION
Currently splinterd creates a database if one doesn't exist, allowing splinterd to start successfully and later log an error because the necessary tables aren't in the database.

This PR adds the following to keep this from happening:
- When using a file for the database source, check that the file exists and that it is not empty. Return an error and shut down splinterd if either case is true.

### **Testing:**

Start splinter locally without a database:
If the file `/tmp/splinter/data/splinter_state.db` exists delete it then run the following commands
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features stable -- cert generate --skip`
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features stable -- --tls-insecure --enable-biome -vv --rest-api-endpoint http://127.0.0.1:8080`

Check that splinterd reports the daemon failed to start because it was unable to set up storage

Then run successfully with a database:

SQLite:
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml --features stable -- database migrate`
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features stable -- --tls-insecure --enable-biome -vv --rest-api-endpoint http://127.0.0.1:8080`

Postgres:
`$ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=splinter -d postgres`
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path cli/Cargo.toml -- database migrate -C postgres://postgres:mypassword@localhost:5432/splinter`
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features stable -- --tls-insecure --enable-biome -vv --rest-api-endpoint http://127.0.0.1:8080 --database postgres://postgres:mypassword@localhost:5432/splinter`

Memory:
`$ SPLINTER_HOME=/tmp/splinter cargo run --manifest-path splinterd/Cargo.toml --features stable -- --tls-insecure --enable-biome -vv --rest-api-endpoint http://127.0.0.1:8080 --database memory`