### PR TITLE
Add circuit-abandon integration tests

### DIFF
--- a/libsplinter/src/admin/client/reqwest.rs
+++ b/libsplinter/src/admin/client/reqwest.rs
@@ -84,7 +84,11 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
     fn list_circuits(&self, filter: Option<&str>) -> Result<CircuitListSlice, InternalError> {
         let mut url = format!("{}/admin/circuits?limit={}", self.url, PAGING_LIMIT);
         if let Some(filter) = filter {
-            url = format!("{}&filter={}", &url, &filter);
+            if filter.starts_with("status") {
+                url = format!("{}&{}", &url, &filter);
+            } else {
+                url = format!("{}&filter={}", &url, &filter);
+            }
         }
 
         let request = Client::new()

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -51,6 +51,8 @@ toml = "0.5"
 
 [dev-dependencies]
 openssl = { version = "0.10" }
+sabre-sdk = "0.7"
+transact = { version = "0.3" }
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"

--- a/splinterd/tests/admin/circuit_abandon.rs
+++ b/splinterd/tests/admin/circuit_abandon.rs
@@ -1,0 +1,485 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the process of creating and committing a circuit, then abandoning the
+//! circuit between multiple nodes.
+
+use std::time::Duration;
+
+use splinterd::node::RestApiVariant;
+
+use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
+use crate::admin::{
+    get_node_service_id,
+    payload::{make_circuit_abandon_payload, make_create_contract_registry_batch},
+};
+use crate::framework::network::Network;
+
+/// This test validates the process of committing a circuit between 2 nodes and the process of both
+/// nodes abandoning the committed circuit. The test also validates that Splinter service
+/// transactions succeed on an active, committed circuit and do not succeed once any member has
+/// abandoned the circuit.
+///
+/// 1. Create and commit a circuit between 2 nodes
+/// 2. Submit a Scabbard transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 3. Create and commit another circuit (that will remain active throughout the test) between the
+///    2 nodes
+/// 4. Submit a Scabbard transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 5. Create and submit a `CircuitAbandon` payload to abandon the circuit from one node
+/// 6. Verify the circuit is returned as `Abandoned` by the abandoning node from the previous step,
+///    using `list_circuits` filtered on the circuit's status (`status=abandoned`, in this case)
+/// 7. Create and submit a `Scabbard` transaction from the non-abandoning node to the abandoned
+///    circuit, validate this transaction does not return successfully
+/// 8. Create and submit a `Scabbard` transaction from a node to the circuit that remained active,
+///    validate this transaction returns successfully
+/// 9. Create and submit a `CircuitAbandon` payload to completely abandon the circuit for all
+///    members
+/// 10. Verify the circuit is returned as `Abandoned` by the abandoning node from the previous step,
+///    using `list_circuits` filtered on the circuit's status (`status=abandoned`, in this case)
+/// 11. Create and submit a `Scabbard` transaction to the `Abandoned` circuit, validate this
+///    transaction does not complete successfully
+/// 12. Create and submit a `Scabbard` transaction to the circuit that has remained active, validate
+///    this transaction completes successfully.
+#[test]
+pub fn test_2_party_circuit_abandon() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(2)
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    let circuit_id = "ABCDE-01234";
+    // Commit the circuit to state
+    commit_2_party_circuit(&circuit_id, node_a, node_b);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Commit a circuit between the 2 nodes that will remain active while the other circuit is
+    // abandoned
+    let active_circuit_id = "FGHIJ-56789";
+    // Commit the circuit to state
+    commit_2_party_circuit(&active_circuit_id, node_a, node_b);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let active_service_id_a = get_node_service_id(&active_circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Create the abandon request to be sent from the first node
+    let abandon_payload = make_circuit_abandon_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    if let Ok(()) = node_a
+        .admin_service_client()
+        .submit_admin_payload(abandon_payload)
+    {
+        let abandoned_circuits = node_a
+            .admin_service_client()
+            .list_circuits(Some("status=abandoned"))
+            .expect("Failed to list circuits")
+            .data;
+        assert_eq!(abandoned_circuits.len(), 1);
+    } else {
+        panic!("Failed to submit `CircuitAbandon` payload to node");
+    }
+
+    // Create the `ServiceId` struct based on the second node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_b = get_node_service_id(&circuit_id, node_b);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction, though valid,
+    // is not able to be committed as a node has abandoned the specified circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get second node's ScabbardClient")
+        .submit(
+            &service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let active_service_id_b = get_node_service_id(&active_circuit_id, node_b);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Create the abandon request to be sent from the first node
+    let abandon_payload = make_circuit_abandon_payload(
+        &circuit_id,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    if let Ok(()) = node_b
+        .admin_service_client()
+        .submit_admin_payload(abandon_payload)
+    {
+        let abandoned_circuits = node_b
+            .admin_service_client()
+            .list_circuits(Some("status=abandoned"))
+            .expect("Failed to list circuits")
+            .data;
+        assert_eq!(abandoned_circuits.len(), 1);
+    } else {
+        panic!("Failed to submit `CircuitAbandon` payload to node");
+    }
+
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // not able to be committed as the first node has abandoned the specified circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get second node's ScabbardClient")
+        .submit(
+            &service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// This test validates the process of committing a circuit between 3 nodes and the process of all
+/// nodes abandoning the committed circuit. The test also validates that Splinter service
+/// transactions succeed on an active, committed circuit and do not succeed once any member has
+/// abandoned the circuit.
+///
+/// 1. Create and commit a circuit between 3 nodes
+/// 2. Submit a Scabbard transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 3. Create and commit another circuit (that will remain active throughout the test) between the
+///    3 nodes
+/// 4. Submit a Scabbard transaction from one of the nodes to validate the service is able to
+///    commit a batch on the circuit committed in the previous step
+/// 5. Create and submit a `CircuitAbandon` payload to abandon the circuit from one node
+/// 6. Verify the circuit is returned as `Abandoned` by the abandoning node from the previous step,
+///    using `list_circuits` filtered on the circuit's status (`status=abandoned`, in this case)
+/// 7. Create and submit a `Scabbard` transaction from a non-abandoning node to the abandoned
+///    circuit, validate this transaction does not return successfully
+/// 8. Create and submit a `Scabbard` transaction from a node to the circuit that remained active,
+///    validate this transaction returns successfully
+/// 9. Create and submit a `CircuitAbandon` payload to abandon the circuit from another node
+/// 10. Verify the circuit is returned as `Abandoned` by the abandoning node from the previous
+///    step, using `list_circuits` filtered on the circuit's status (`status=abandoned`)
+/// 11. Create and submit a `Scabbard` transaction from the last non-abandoning node to the
+///    abandoned circuit, validate this transaction does not return successfully
+/// 12. Create and submit a `Scabbard` transaction from a node to the circuit that remained active,
+///    validate this transaction returns successfully
+/// 13. Create and submit a `CircuitAbandon` payload to completely abandon the circuit for all
+///    members
+/// 14. Verify the circuit is returned as `Abandoned` by the abandoning node from the previous
+///    step, using `list_circuits` filtered on the circuit's status (`status=abandoned`)
+/// 15. Create and submit a `Scabbard` transaction to the `Abandoned` circuit, validate this
+///    transaction does not complete successfully
+/// 16. Create and submit a `Scabbard` transaction to the circuit that has remained active,
+///    validate this transaction completes successfully.
+#[test]
+#[ignore]
+pub fn test_3_party_circuit_abandon() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(3)
+        .expect("Unable to start 3-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+    // Get the third node from the network
+    let node_c = network.node(2).expect("Unable to get third node");
+
+    let circuit_id = "ABCDE-01234";
+    // Commit a circuit to state
+    commit_3_party_circuit(&circuit_id, node_a, node_b, node_c);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_a = get_node_service_id(&circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Commit a circuit between the nodes that will remain active while the other circuit is
+    // abandoned
+    let active_circuit_id = "FGHIJ-56789";
+    // Commit the circuit to state
+    commit_3_party_circuit(&active_circuit_id, node_a, node_b, node_c);
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let active_service_id_a = get_node_service_id(&active_circuit_id, node_a);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_0", &*node_a.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_a
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_a,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Create the abandon request to be sent from the first node
+    let abandon_payload = make_circuit_abandon_payload(
+        &circuit_id,
+        node_a.node_id(),
+        &*node_a.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the first node
+    if let Ok(()) = node_a
+        .admin_service_client()
+        .submit_admin_payload(abandon_payload)
+    {
+        let abandoned_circuits = node_a
+            .admin_service_client()
+            .list_circuits(Some("status=abandoned"))
+            .expect("Failed to list circuits")
+            .data;
+        assert_eq!(abandoned_circuits.len(), 1);
+    } else {
+        panic!("Failed to submit `CircuitAbandon` payload to node");
+    }
+
+    // Create the `ServiceId` struct based on the second node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_b = get_node_service_id(&circuit_id, node_b);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction, though valid,
+    // is not able to be committed as a node has abandoned the specified circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get second node's ScabbardClient")
+        .submit(
+            &service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
+    // Create the `ServiceId` struct based on the first node's associated `service_id` and the
+    // committed `circuit_id`
+    let active_service_id_b = get_node_service_id(&active_circuit_id, node_b);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_1", &*node_b.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_b
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_b,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Create the abandon request to be sent from the second node
+    let abandon_payload = make_circuit_abandon_payload(
+        &circuit_id,
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the second node
+    if let Ok(()) = node_b
+        .admin_service_client()
+        .submit_admin_payload(abandon_payload)
+    {
+        let circuits = node_b
+            .admin_service_client()
+            .list_circuits(Some("status=abandoned"))
+            .expect("Unable to list abandoned circuits")
+            .data;
+        assert_eq!(circuits.len(), 1);
+    } else {
+        panic!("Failed to abandon circuit from node");
+    }
+
+    // Create the `ServiceId` struct based on the third node's associated `service_id` and the
+    // committed `circuit_id`
+    let service_id_c = get_node_service_id(&circuit_id, node_c);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction, though valid,
+    // is not able to be committed as a node has abandoned the specified circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_c.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_c
+        .scabbard_client()
+        .expect("Unable to get third node's ScabbardClient")
+        .submit(
+            &service_id_c,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
+    // Create the `ServiceId` struct based on the third node's associated `service_id` and the
+    // committed `circuit_id` for the circuit that is still active
+    let active_service_id_c = get_node_service_id(&active_circuit_id, node_c);
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_2", &*node_c.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_c
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_c,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    // Create the abandon request to be sent from the third node
+    let abandon_payload = make_circuit_abandon_payload(
+        &circuit_id,
+        node_c.node_id(),
+        &*node_c.admin_signer().clone_box(),
+    );
+    // Submit the `CircuitManagementPayload` to the third node
+    if let Ok(()) = node_c
+        .admin_service_client()
+        .submit_admin_payload(abandon_payload)
+    {
+        let circuits = node_c
+            .admin_service_client()
+            .list_circuits(Some("status=abandoned"))
+            .expect("Unable to list abandoned circuits")
+            .data;
+        assert_eq!(circuits.len(), 1);
+    } else {
+        panic!("Failed to abandon circuit from node");
+    }
+
+    // Submit a `CreateContractRegistryAction` to validate the service transaction, though valid,
+    // is not able to be committed as nodes have abandoned the specified circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_3", &*node_c.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_c
+        .scabbard_client()
+        .expect("Unable to get third node's ScabbardClient")
+        .submit(
+            &service_id_c,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_err());
+
+    // Submit a `CreateContractRegistryAction` to validate the service transaction is
+    // valid on the active circuit.
+    let scabbard_batch =
+        make_create_contract_registry_batch("contract_registry_3", &*node_c.admin_signer())
+            .expect("Unable to build `CreateContractRegistryAction`");
+    assert!(node_c
+        .scabbard_client()
+        .expect("Unable to get first node's ScabbardClient")
+        .submit(
+            &active_service_id_c,
+            vec![scabbard_batch],
+            Some(Duration::from_secs(5)),
+        )
+        .is_ok());
+
+    shutdown!(network).expect("Unable to shutdown network");
+}

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -53,6 +53,18 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![
+            node_a
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get first node's public key")
+                .as_hex(),
+            node_b
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get second node's public key")
+                .as_hex(),
+        ],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a
@@ -188,6 +200,23 @@ pub(in crate::admin) fn commit_3_party_circuit(
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![
+            node_a
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get first node's public key")
+                .as_hex(),
+            node_b
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get second node's public key")
+                .as_hex(),
+            node_c
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get third node's public key")
+                .as_hex(),
+        ],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -42,10 +42,10 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
     let node_b_admin_pubkey = admin_pubkey(node_b);
 
     let node_a_event_client = node_a
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_b_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
 
     let circuit_payload_bytes = make_create_circuit_payload(
@@ -185,13 +185,13 @@ pub(in crate::admin) fn commit_3_party_circuit(
     let node_c_admin_pubkey = admin_pubkey(node_c);
 
     let node_a_event_client = node_a
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_b_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_c_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
 
     // Create the `CircuitManagementPayload` to be sent to a node

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -123,15 +123,14 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
     ]
     .into_iter()
     .collect::<HashMap<String, Vec<String>>>();
+    let circuit_id = "ABCDE-01234";
 
     let node_a_event_client = node_a
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_b_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
-
-    let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(
         &circuit_id,
@@ -259,18 +258,18 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
     ]
     .into_iter()
     .collect::<HashMap<String, Vec<String>>>();
+    let circuit_id = "ABCDE-01234";
 
     let node_a_event_client = node_a
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_b_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
     let node_c_event_client = node_b
-        .admin_service_event_client("test_circuit")
+        .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
 
-    let circuit_id = "ABCDE-01234";
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(
         &circuit_id,

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -138,6 +138,11 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![node_a
+            .admin_signer()
+            .public_key()
+            .expect("Unable to get first node's public key")
+            .as_hex()],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a
@@ -272,6 +277,11 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
         node_a.node_id(),
         node_info,
         &*node_a.admin_signer().clone_box(),
+        &vec![node_a
+            .admin_signer()
+            .public_key()
+            .expect("Unable to get first node's public key")
+            .as_hex()],
     );
     // Submit the `CircuitManagementPayload` to the first node
     let res = node_a

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -57,14 +57,14 @@ pub fn test_2_party_circuit_lifecycle() {
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
         node_a
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_b_events = BlockingAdminServiceEventIterator::new(
         node_b
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
@@ -201,14 +201,14 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
         node_a
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_b_events = BlockingAdminServiceEventIterator::new(
         node_b
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
@@ -343,21 +343,21 @@ pub fn test_3_party_circuit_lifecycle() {
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
         node_a
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_b_events = BlockingAdminServiceEventIterator::new(
         node_b
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_c_events = BlockingAdminServiceEventIterator::new(
         node_c
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
@@ -548,21 +548,21 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
         node_a
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_b_events = BlockingAdminServiceEventIterator::new(
         node_b
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)
     .skip(1); // skip the ready event itself.
     let mut node_c_events = BlockingAdminServiceEventIterator::new(
         node_c
-            .admin_service_event_client("test_circuit")
+            .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
             .expect("Unable to get event client"),
     )
     .skip_while(|evt| evt.event_type() != &EventType::CircuitReady)

--- a/splinterd/tests/admin/mod.rs
+++ b/splinterd/tests/admin/mod.rs
@@ -22,3 +22,29 @@ mod circuit_list;
 mod node_lifecycle;
 mod payload;
 mod registry;
+
+use scabbard::client::ServiceId;
+use splinterd::node::Node;
+
+// Helper function to generate the `ServiceId` for the provided Node on the circuit specified by
+// the `circuit_id` argument. The generic definition of this function allows for this function to
+// be used for any Node that is apart of the circuit specified.
+pub(super) fn get_node_service_id(circuit_id: &str, node: &Node) -> ServiceId {
+    // Retrieve the node's associated `service_id` from the circuit just committed
+    let circuit = node
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit")
+        .unwrap();
+    // Create the `ServiceId` struct based on the node's associated `service_id` and the
+    // committed `circuit_id`
+    let node_service = &circuit
+        .roster
+        .iter()
+        .find(|service_slice| &service_slice.node_id == node.node_id())
+        .expect("Circuit committed without service for node")
+        .service_id;
+    format!("{}::{}", &circuit_id, node_service)
+        .parse::<ServiceId>()
+        .expect("Unable to parse `ServiceId`")
+}

--- a/splinterd/tests/admin/mod.rs
+++ b/splinterd/tests/admin/mod.rs
@@ -15,6 +15,7 @@
 //! Admin service integration tests.
 
 mod biome;
+mod circuit_abandon;
 mod circuit_commit;
 mod circuit_create;
 mod circuit_disband;

--- a/splinterd/tests/admin/payload.rs
+++ b/splinterd/tests/admin/payload.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides functionality for building `CircuitManagmentPayload`s, used in the admin service
+//! Provides functionality for building `CircuitManagementPayload`s, used in the admin service
 //! integration tests.
 
 use std::collections::HashMap;
@@ -71,9 +71,8 @@ pub(in crate::admin) fn make_create_circuit_payload(
     payload.set_circuit_create_request(circuit_request);
     payload
         .set_header(Message::write_to_bytes(&header).expect("Unable to serialize payload header"));
-
     // Return the bytes of the payload
-    Message::write_to_bytes(&payload).expect("Unable to serialize `CircuitManagmentPayload`")
+    Message::write_to_bytes(&payload).expect("Unable to serialize `CircuitManagementPayload`")
 }
 
 /// Makes the `CircuitProposalVote` payload to either accept or reject the proposal (based on
@@ -156,7 +155,7 @@ pub(in crate::admin) fn make_circuit_disband_payload(
     payload.set_signature(
         signer
             .sign(&payload.header)
-            .expect("Unable to sign `CircuitManagmentPayload` header")
+            .expect("Unable to sign `CircuitManagementPayload` header")
             .take_bytes(),
     );
     payload.set_circuit_disband_request(disband_request);
@@ -200,7 +199,7 @@ pub(in crate::admin) fn make_circuit_abandon_payload(
     payload.set_signature(
         signer
             .sign(&payload.header)
-            .expect("Unable to sign `CircuitManagmentPayload` header")
+            .expect("Unable to sign `CircuitManagementPayload` header")
             .take_bytes(),
     );
     payload.set_circuit_abandon(circuit_abandon);

--- a/splinterd/tests/admin/payload.rs
+++ b/splinterd/tests/admin/payload.rs
@@ -276,7 +276,7 @@ fn setup_circuit(
         .with_persistence(&PersistenceType::Any)
         .with_durability(&DurabilityType::NoDurability)
         .with_routes(&RouteType::Any)
-        .with_circuit_management_type("test_circuit")
+        .with_circuit_management_type(&format!("test_circuit_{}", &circuit_id))
         .with_application_metadata(b"test_data")
         .with_comments("test circuit")
         .with_display_name("test_circuit")


### PR DESCRIPTION
This PR adds the following to the circuit-integration tests: 
- Updates the `commit_*_circuit` functions to handle multiple circuits, this enables multiple circuits to be committed in the circuit integration tests
- Updates the helper function that creates the `CircuitCreateRequest` to take a list of public keys to be used as the `admin_keys` service arg for each node's service to allow service transactions from any of the nodes on the circuit.
- Adds plumbing to submit scabbard transactions from the circuit integration tests
- Updates the `ReqwestAdminServiceClient` to handle `circuit_status` filters. Initially, the client would add filters to the url with `filter={}`, but the `circuit_status` filter is expected as `status={}` in the url thus requiring the update. 
-  Adds initial circuit-abandon integration tests, which validate the process of abandoning a circuit between 2- and 3-nodes.


Additionally, this PR contains the Scabbard plumbing introduced in #1268 but does not contain the service transaction updates to the existing circuit-integration tests. 