### PR TITLE
Implement Node stop in integration test framework

### DIFF
--- a/splinterd/src/node/runnable/admin.rs
+++ b/splinterd/src/node/runnable/admin.rs
@@ -165,6 +165,7 @@ impl RunnableAdminSubsystem {
             registry_writer: registry.clone_box_as_writer(),
             admin_service_shutdown,
             actix1_resources,
+            store_factory,
         })
     }
 }

--- a/splinterd/src/node/running/admin.rs
+++ b/splinterd/src/node/running/admin.rs
@@ -18,6 +18,7 @@ use splinter::error::InternalError;
 use splinter::registry::RegistryWriter;
 use splinter::rest_api::actix_web_1::Resource as Actix1Resource;
 use splinter::service::ServiceProcessorShutdownHandle;
+use splinter::store::StoreFactory;
 use splinter::threading::lifecycle::ShutdownHandle;
 
 /// A running admin subsystem.
@@ -25,6 +26,7 @@ pub struct AdminSubsystem {
     pub(crate) registry_writer: Box<dyn RegistryWriter>,
     pub(crate) admin_service_shutdown: ServiceProcessorShutdownHandle,
     pub(crate) actix1_resources: Vec<Actix1Resource>,
+    pub(crate) store_factory: Box<dyn StoreFactory>,
 }
 
 impl AdminSubsystem {

--- a/splinterd/tests/admin/mod.rs
+++ b/splinterd/tests/admin/mod.rs
@@ -18,5 +18,6 @@ mod circuit_commit;
 mod circuit_create;
 mod circuit_disband;
 mod circuit_list;
+mod node_lifecycle;
 mod payload;
 mod registry;

--- a/splinterd/tests/admin/node_lifecycle.rs
+++ b/splinterd/tests/admin/node_lifecycle.rs
@@ -1,0 +1,161 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use splinterd::node::RestApiVariant;
+
+use crate::framework::network::Network;
+
+/// Test that nodes can be stopped and restarted successfully.
+///
+/// 1. Create a three node network
+/// 2. Stop the first node and check that it has been stopped and can no longer be
+///    retrieved from the network
+/// 3. Check that the second and third nodes are running by getting the registry clients
+///    from them and using them
+/// 4. Stop the second node and check that it has been stopped and can no longer be
+///    retrieved from the network
+/// 5. Check that the third node is still running by getting the registry client
+///    from it and using it
+/// 6. Stop the third node and check that it has been stopped and can no longer be
+///    retrieved from the network
+/// 7. Check that none of the nodes are running by ensuring none of them can be
+///    retrieved from the network
+/// 8. Start the first node and check that it can now be retrieved from the network
+/// 9. Check that the first node is running by getting its registry client and using it
+/// 10. Check that the second and thrid nodes are still stopped
+/// 11. Start the second node and check that it can now be retrieved from the network
+/// 12. Check that the second node is running by getting its registry client and using it
+/// 13. Check that the third node is still stopped
+/// 14. Start the third node and check that it can now be retrieved from the network
+/// 15. Check that the third node is running by getting its registry client and using it
+/// 16. Shutdown
+#[test]
+pub fn test_stop_start_nodes_multiple() {
+    // create network with three nodes
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(3)
+        .expect("Unable to start three node ActixWeb1 network");
+
+    // Stop the first node
+    network = network.stop(0).expect("Unable to stop first node");
+
+    // Check that the first node is stopped and can not be retrieved from the network
+    assert!(network.node(0).is_err());
+    // Check that the second and third nodes are still running and can be retrieved from
+    // the network
+    let node_1 = network.node(1).expect("Unable to retrieve second node");
+    let node_2 = network.node(2).expect("Unable to retrieve third node");
+    // Test that the second and third nodes are running by using the registry client
+    let registry_response = node_1
+        .registry_client()
+        .get_node(node_1.node_id())
+        .expect("Unable to get node from the registry");
+    assert_eq!(node_1.node_id(), registry_response.unwrap().identity);
+    let registry_response = node_2
+        .registry_client()
+        .list_nodes(None)
+        .expect("Unable to list nodes from registry");
+    assert_eq!(3, registry_response.data.len());
+
+    // Stop the second node
+    network = network.stop(1).expect("Unable to stop the second node");
+
+    // Check that the second node is stopped and can not be retrieved from the network
+    assert!(network.node(1).is_err());
+    // Check that the first node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(0).is_err());
+    // Check that the third nodes is still running and can be retrieved from the network
+    let node_2 = network.node(2).expect("Unable to retrieve third node");
+    // Test that the third node is running by using the registry client
+    let registry_response = node_2
+        .registry_client()
+        .get_node(node_2.node_id())
+        .expect("Unable to get node from the registry");
+    assert_eq!(
+        node_2.network_endpoints(),
+        registry_response.unwrap().endpoints
+    );
+
+    // Stop the third node
+    network = network.stop(2).expect("Unable to stop the third node");
+
+    // Check that the third node is stopped and can not be retrieved from the network
+    assert!(network.node(2).is_err());
+    // Check that the second node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(1).is_err());
+    // Check that the first node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(0).is_err());
+
+    // Start the first node
+    network = network.start(0).expect("Unable to start the first node");
+
+    // Check that the first node has been started and can be retrieved from the network
+    let node_0 = network.node(0).expect("Unable to retieve first node");
+    // Check that the first node is running by using the registry client
+    let registry_response = node_0
+        .registry_client()
+        .get_node(node_0.node_id())
+        .expect("Unable to get node from the registry");
+    assert_eq!(
+        node_0.network_endpoints(),
+        registry_response.unwrap().endpoints
+    );
+
+    // Check that the second node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(1).is_err());
+    // Check that the third node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(2).is_err());
+
+    // Start the second node
+    network = network.start(1).expect("Unable to start the first node");
+
+    // Check that the second node has been started and can be retrieved from the network
+    let node_1 = network.node(1).expect("Unable to retieve second node");
+    // Check that the second node is running by using the registry client
+    let registry_response = node_1
+        .registry_client()
+        .get_node(node_1.node_id())
+        .expect("Unable to get node from the registry");
+    assert_eq!(
+        node_1.network_endpoints(),
+        registry_response.unwrap().endpoints
+    );
+
+    // Check that the third node is still stopped and can not be retrieved from
+    // the network
+    assert!(network.node(2).is_err());
+
+    // Start the third node
+    network = network.start(2).expect("Unable to start the third node");
+
+    // Check that the third node has been started and can be retrieved from the network
+    let node_2 = network.node(2).expect("Unable to retieve third node");
+    // Check that the third node's is active by using the registry client
+    let registry_response = node_2
+        .registry_client()
+        .get_node(node_2.node_id())
+        .expect("Unable to get node from the registry");
+    assert_eq!(
+        node_2.network_endpoints(),
+        registry_response.unwrap().endpoints
+    );
+
+    shutdown!(network).expect("Unable to shutdown network");
+}

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -20,14 +20,19 @@ use cylinder::{secp256k1::Secp256k1Context, Context};
 use splinter::error::{InternalError, InvalidArgumentError};
 use splinter::registry::Node as RegistryNode;
 use splinter::threading::lifecycle::ShutdownHandle;
-use splinterd::node::{Node, NodeBuilder, RestApiVariant, ScabbardConfigBuilder};
+use splinterd::node::{Node, NodeBuilder, RestApiVariant, RunnableNode, ScabbardConfigBuilder};
 use tempdir::TempDir;
 
 pub struct Network {
     default_rest_api_variant: RestApiVariant,
-    nodes: Vec<Node>,
+    nodes: Vec<NetworkNode>,
     temp_dirs: HashMap<String, TempDir>,
     external_registries: Option<Vec<String>>,
+}
+
+pub enum NetworkNode {
+    Node(Node),
+    RunnableNode(RunnableNode),
 }
 
 impl Network {
@@ -70,22 +75,27 @@ impl Network {
             ));
 
             self.temp_dirs.insert(node.node_id().to_string(), temp_dir);
-            self.nodes.push(node);
+            self.nodes.push(NetworkNode::Node(node));
         }
 
         for node in &self.nodes {
-            let registry_writer = node.registry_writer();
-            for (node_id, pub_key, endpoints) in &registry_info {
-                registry_writer
-                    .add_node(
-                        RegistryNode::builder(node_id)
-                            .with_display_name(node_id)
-                            .with_endpoints(endpoints.to_vec())
-                            .with_key(pub_key.as_hex())
-                            .build()
-                            .map_err(|e| InternalError::from_source(Box::new(e)))?,
-                    )
-                    .map_err(|e| InternalError::from_source(Box::new(e)))?;
+            match node {
+                NetworkNode::Node(node) => {
+                    let registry_writer = node.registry_writer();
+                    for (node_id, pub_key, endpoints) in &registry_info {
+                        registry_writer
+                            .add_node(
+                                RegistryNode::builder(node_id)
+                                    .with_display_name(node_id)
+                                    .with_endpoints(endpoints.to_vec())
+                                    .with_key(pub_key.as_hex())
+                                    .build()
+                                    .map_err(|e| InternalError::from_source(Box::new(e)))?,
+                            )
+                            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+                    }
+                }
+                _ => unreachable!(), // a new network will only contain running nodes
             }
         }
 
@@ -104,7 +114,13 @@ impl Network {
 
     pub fn node(&self, n: usize) -> Result<&Node, InvalidArgumentError> {
         match self.nodes.get(n) {
-            Some(node) => Ok(node),
+            Some(network_node) => match network_node {
+                NetworkNode::Node(node) => Ok(node),
+                NetworkNode::RunnableNode(_) => Err(InvalidArgumentError::new(
+                    "n".to_string(),
+                    "node is stopped".to_string(),
+                )),
+            },
             None => Err(InvalidArgumentError::new(
                 "n".to_string(),
                 "out of range".to_string(),
@@ -116,13 +132,19 @@ impl Network {
 impl ShutdownHandle for Network {
     fn signal_shutdown(&mut self) {
         for node in &mut self.nodes {
-            node.signal_shutdown()
+            match node {
+                NetworkNode::Node(node) => node.signal_shutdown(),
+                NetworkNode::RunnableNode(_) => (),
+            }
         }
     }
 
     fn wait_for_shutdown(self) -> Result<(), InternalError> {
         for node in self.nodes.into_iter() {
-            node.wait_for_shutdown()?;
+            match node {
+                NetworkNode::Node(node) => node.wait_for_shutdown()?,
+                NetworkNode::RunnableNode(_) => (),
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Implement Node::stop() in the integration test framework

- Add a `clone_box` method to the `StoreFactory` trait and implement `Clone` for `StoreFactory`
- Add a `store_factory` field to `AdminSubsystem` in the integration test framework so that a store factory can be retrieved from a node and used in the creation of a `RunnableNode` when a node is stopped, this allows the same store factory remain with a node throughout the node lifecycle 
- Add a `stop` method to node that will shut down a node and create a `RunnableNode` from the node data
- Create a `NetworkNode` enum in `Network` to allow for the node list in `Network` to hold both stopped and running nodes and maintain the original order the nodes were created in
- Add methods to `Network` for starting and stopping nodes
- Add a test that starts a network of three nodes and runs through stopping and then starting each node

### **Testing:**
Run the `test_stop_start_nodes_multiple` test in splinterd/tests/admin/node_lifecycle.rs