### PR TITLE
Add AdminServiceEventClient

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -129,7 +129,7 @@ experimental = [
 benchmark = []
 
 admin-service = []
-admin-service-client = []
+admin-service-client = ["admin-service"]
 authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
 authorization = ["rest-api"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -106,6 +106,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "admin-service-client",
+    "admin-service-event-client",
     "authorization-handler-allow-keys",
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
@@ -130,6 +131,7 @@ benchmark = []
 
 admin-service = []
 admin-service-client = ["admin-service"]
+admin-service-event-client = ["admin-service-client" ]
 authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
 authorization = ["rest-api"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -107,6 +107,7 @@ experimental = [
     # The following features are experimental:
     "admin-service-client",
     "admin-service-event-client",
+    "admin-service-event-client-actix-web-client",
     "authorization-handler-allow-keys",
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
@@ -132,6 +133,10 @@ benchmark = []
 admin-service = []
 admin-service-client = ["admin-service"]
 admin-service-event-client = ["admin-service-client" ]
+admin-service-event-client-actix-web-client = [
+    "admin-service-event-client",
+    "events"
+]
 authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
 authorization = ["rest-api"]

--- a/libsplinter/src/admin/client/event/error.rs
+++ b/libsplinter/src/admin/client/event/error.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::InternalError;
+
+#[derive(Debug)]
+pub enum NextEventError {
+    Disconnected,
+    InternalError(InternalError),
+}
+
+impl fmt::Display for NextEventError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NextEventError::Disconnected => f.write_str("Disconnected"),
+            NextEventError::InternalError(e) => f.write_str(&e.to_string()),
+        }
+    }
+}
+
+impl Error for NextEventError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            NextEventError::Disconnected => None,
+            NextEventError::InternalError(ref e) => Some(&*e),
+        }
+    }
+}

--- a/libsplinter/src/admin/client/event/mod.rs
+++ b/libsplinter/src/admin/client/event/mod.rs
@@ -1,0 +1,89 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Client traits to receive AdminServiceEvents.
+
+mod error;
+
+use super::ProposalSlice;
+
+pub use error::NextEventError;
+
+/// A public key for the private key that signed an admin proposal.
+#[derive(Clone, PartialEq)]
+#[repr(transparent)]
+pub struct PublicKey(pub Vec<u8>);
+
+impl std::fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&crate::hex::to_hex(&self.0))
+    }
+}
+
+#[derive(Clone, Debug)]
+/// An admin service event.
+///
+/// This event relays changes about circuits during the proposal phase through the circuit being
+/// ready.
+pub struct AdminServiceEvent {
+    event_id: u64,
+    event_type: EventType,
+    proposal: ProposalSlice,
+}
+
+/// The event type.
+///
+/// Some variants include a public key, that is associated with the particular event.
+#[derive(Clone, Debug, PartialEq)]
+pub enum EventType {
+    ProposalSubmitted,
+    ProposalVote { requester: PublicKey },
+    ProposalAccepted { requester: PublicKey },
+    ProposalRejected { requester: PublicKey },
+    CircuitReady,
+    CircuitDisbanded,
+}
+
+impl AdminServiceEvent {
+    /// The event's ID
+    pub fn event_id(&self) -> &u64 {
+        &self.event_id
+    }
+
+    /// The event type.
+    pub fn event_type(&self) -> &EventType {
+        &self.event_type
+    }
+
+    /// The complete proposal
+    pub fn proposal(&self) -> &ProposalSlice {
+        &self.proposal
+    }
+}
+
+/// An admin service event client will provide events as they are returned from an admin service.
+///
+/// It provides two methods, a blocking method and a non-blocking method, depending on the caller's
+/// tolerance for blocking a thread.
+pub trait AdminServiceEventClient {
+    /// Returns the next event, if one is available.
+    ///
+    /// This should be a non-blocking function.
+    fn try_next_event(&self) -> Result<Option<AdminServiceEvent>, NextEventError>;
+
+    /// Returns the next event.
+    ///
+    /// This should block until an event is available.
+    fn next_event(&self) -> Result<AdminServiceEvent, NextEventError>;
+}

--- a/libsplinter/src/admin/client/event/mod.rs
+++ b/libsplinter/src/admin/client/event/mod.rs
@@ -15,10 +15,17 @@
 //! Client traits to receive AdminServiceEvents.
 
 mod error;
+#[cfg(feature = "admin-service-event-client-actix-web-client")]
+mod ws;
 
 use super::ProposalSlice;
 
 pub use error::NextEventError;
+#[cfg(feature = "admin-service-event-client-actix-web-client")]
+pub use ws::actix_web_client::{
+    AwcAdminServiceEventClient, AwcAdminServiceEventClientBuilder,
+    RunnableAwcAdminServiceEventClient,
+};
 
 /// A public key for the private key that signed an admin proposal.
 #[derive(Clone, PartialEq)]

--- a/libsplinter/src/admin/client/event/ws/actix_web_client.rs
+++ b/libsplinter/src/admin/client/event/ws/actix_web_client.rs
@@ -1,0 +1,439 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Websocket-backed implementation of the AdminServiceEventClient.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{sync_channel, Receiver, TryRecvError, TrySendError};
+use std::sync::Arc;
+
+use crate::admin::client::event::{
+    AdminServiceEvent, AdminServiceEventClient, EventType, NextEventError, PublicKey,
+};
+use crate::admin::client::{
+    CircuitMembers, CircuitService, ProposalCircuitSlice, ProposalSlice, VoteRecord,
+};
+use crate::admin::messages;
+use crate::error::{InternalError, InvalidStateError};
+use crate::events::{
+    Igniter, ParseBytes, ParseError, Reactor, WebSocketClient, WebSocketError, WsResponse,
+};
+use crate::hex;
+use crate::threading::lifecycle::ShutdownHandle;
+
+enum WsRuntime {
+    Reactor(Option<Reactor>),
+    Igniter(Igniter),
+}
+
+/// Constructs a new AwcAdminServiceEventClient.
+#[derive(Default)]
+pub struct AwcAdminServiceEventClientBuilder {
+    ws_runtime: Option<WsRuntime>,
+    root_url: Option<String>,
+    event_type: Option<String>,
+    authorization: Option<String>,
+    last_event_id: Option<u64>,
+}
+
+impl AwcAdminServiceEventClientBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the event reactor to use with this client instance.
+    ///
+    /// This enables multiple clients to be created on the same reactor.
+    pub fn with_reactor(mut self, reactor: &Reactor) -> Self {
+        self.ws_runtime = Some(WsRuntime::Igniter(reactor.igniter()));
+        self
+    }
+
+    /// Sets the base Splinter REST API URL.
+    ///
+    /// This field is required by the final AwcAdminServiceEventClient.
+    pub fn with_splinter_url(mut self, splinter_url: String) -> Self {
+        self.root_url = Some(splinter_url);
+        self
+    }
+
+    /// Sets the event type to receive.
+    ///
+    /// This field is required by the final AwcAdminServiceEventClient.
+    pub fn with_event_type(mut self, event_type: String) -> Self {
+        self.event_type = Some(event_type);
+        self
+    }
+
+    /// Sets the authorization value that will be sent with any REST API requests.
+    ///
+    /// This field is required by the final AwcAdminServiceEventClient.
+    pub fn with_authorization(mut self, authorization: String) -> Self {
+        self.authorization = Some(authorization);
+        self
+    }
+
+    /// Sets the last event id.  This allows the client to start at a given event id, vs starting
+    /// from the beginning of time.
+    pub fn with_last_event_id(mut self, last_event_id: Option<u64>) -> Self {
+        self.last_event_id = last_event_id;
+        self
+    }
+
+    /// Build the runnable (but not started) AwcAdminServiceEventClient.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InvalidStateError if any required fields are missing.
+    pub fn build(self) -> Result<RunnableAwcAdminServiceEventClient, InvalidStateError> {
+        let root_url = self
+            .root_url
+            .ok_or_else(|| InvalidStateError::with_message("A splinter url is required.".into()))?;
+        let event_type = self
+            .event_type
+            .ok_or_else(|| InvalidStateError::with_message("An event type is required.".into()))?;
+        let authorization = self.authorization.ok_or_else(|| {
+            InvalidStateError::with_message("An authorization field is required.".into())
+        })?;
+
+        let ws_runtime = self
+            .ws_runtime
+            .unwrap_or_else(|| WsRuntime::Reactor(Some(Reactor::new())));
+        let last_event_id = self.last_event_id;
+
+        Ok(RunnableAwcAdminServiceEventClient {
+            ws_runtime,
+            root_url,
+            event_type,
+            authorization,
+            last_event_id,
+        })
+    }
+}
+
+/// A configured, but not yet started AwcAdminServiceEventClient.
+pub struct RunnableAwcAdminServiceEventClient {
+    ws_runtime: WsRuntime,
+    root_url: String,
+    event_type: String,
+    authorization: String,
+    last_event_id: Option<u64>,
+}
+
+impl RunnableAwcAdminServiceEventClient {
+    /// Starts the AwcAdminServiceEventClient.
+    ///
+    /// # Errors
+    ///
+    /// Returns an InternalError if the client is unable to start.
+    pub fn run(self) -> Result<AwcAdminServiceEventClient, InternalError> {
+        let Self {
+            ws_runtime,
+            root_url,
+            event_type,
+            authorization,
+            last_event_id,
+        } = self;
+
+        let full_url = if let Some(id) = last_event_id.as_ref() {
+            format!(
+                "{}/ws/admin/register/{}?last={}",
+                &root_url, &event_type, id
+            )
+        } else {
+            format!("{}/ws/admin/register/{}", &root_url, &event_type,)
+        };
+
+        let (event_sender, event_receiver) = sync_channel(256);
+        let last_event_id = Arc::new(AtomicU64::new(last_event_id.unwrap_or(0)));
+        let received_id = last_event_id.clone();
+        let received_sender = event_sender.clone();
+        let mut ws_client = WebSocketClient::new(
+            &full_url,
+            &authorization,
+            move |_, event: AdminServiceEvent| {
+                let event_id = *event.event_id();
+                match received_sender.try_send(Ok(event)) {
+                    // This will block.  An async sleep would be better here, but we don't have a
+                    // way of doing that, as this closure is hiding the fact that this closure is
+                    // executed in a future.
+                    Err(TrySendError::Full(evt)) => {
+                        if received_sender.send(evt).is_err() {
+                            error!("Receiver was dropped without shutting down the reactor.");
+                            return WsResponse::Close;
+                        }
+                    }
+                    Err(TrySendError::Disconnected(_evt_res)) => {
+                        error!("Receiver was dropped without shutting down the reactor.");
+                        return WsResponse::Close;
+                    }
+                    Ok(()) => (),
+                }
+                received_id.store(event_id, Ordering::SeqCst);
+                WsResponse::Empty
+            },
+        );
+
+        ws_client.header(
+            "SplinterProtocolVersion",
+            crate::protocol::ADMIN_SERVICE_PROTOCOL_VERSION.to_string(),
+        );
+
+        ws_client.set_reconnect(true);
+        ws_client.set_reconnect_limit(10);
+        ws_client.set_timeout(60);
+
+        ws_client.on_error(move |err, _| {
+            match event_sender.try_send(Err(err)) {
+                // This will block.  An async sleep would be better here, but we don't have a
+                // way of doing that, as this closure is hiding the fact that this closure is
+                // executed in a future.
+                Err(TrySendError::Full(e)) => {
+                    if event_sender.send(e).is_err() {
+                        error!("Receiver was dropped without shutting down the reactor.");
+                    }
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    error!("Receiver was dropped without shutting down the reactor.");
+                }
+                Ok(()) => (),
+            }
+            Ok(())
+        });
+
+        ws_client.on_reconnect(move |ws| {
+            let last_seen_id = last_event_id.load(Ordering::SeqCst);
+            let full_url = format!(
+                "{}/ws/admin/register/{}?last={}",
+                root_url, event_type, last_seen_id
+            );
+            ws.set_url(&full_url);
+        });
+
+        let igniter = match &ws_runtime {
+            WsRuntime::Reactor(Some(reactor)) => reactor.igniter(),
+            // This state cannot be reached at this point, as nothing can replace the value of this
+            // option with None until the running client is shutdown.
+            WsRuntime::Reactor(None) => unreachable!(),
+            WsRuntime::Igniter(igniter) => igniter.clone(),
+        };
+        igniter
+            .start_ws(&ws_client)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        Ok(AwcAdminServiceEventClient {
+            ws_runtime,
+            event_receiver,
+        })
+    }
+}
+
+pub struct AwcAdminServiceEventClient {
+    ws_runtime: WsRuntime,
+    event_receiver: Receiver<Result<AdminServiceEvent, WebSocketError>>,
+}
+
+impl ShutdownHandle for AwcAdminServiceEventClient {
+    fn signal_shutdown(&mut self) {
+        if let WsRuntime::Reactor(Some(reactor)) = &self.ws_runtime {
+            if let Err(err) = reactor.shutdown_signaler().signal_shutdown() {
+                error!(
+                    "unable to signal event reactor to cleanly shutdown: {}",
+                    err
+                );
+            }
+        }
+    }
+
+    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
+        match &mut self.ws_runtime {
+            WsRuntime::Reactor(reactor) => {
+                if let Some(reactor) = reactor.take() {
+                    reactor
+                        .wait_for_shutdown()
+                        .map_err(|e| InternalError::from_source(Box::new(e)))
+                } else {
+                    // Calling this function will have consumed this object, so we don't have any
+                    // alternative branches
+                    unreachable!()
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Drop for AwcAdminServiceEventClient {
+    fn drop(&mut self) {
+        self.signal_shutdown();
+    }
+}
+
+impl AdminServiceEventClient for AwcAdminServiceEventClient {
+    /// Non-blocking
+    fn try_next_event(&self) -> Result<Option<AdminServiceEvent>, NextEventError> {
+        let evt_result = match self.event_receiver.try_recv() {
+            Ok(res) => res,
+            Err(TryRecvError::Empty) => return Ok(None),
+            Err(TryRecvError::Disconnected) => return Err(NextEventError::Disconnected),
+        };
+
+        evt_result
+            .map(Some)
+            .map_err(|e| NextEventError::InternalError(InternalError::from_source(Box::new(e))))
+    }
+
+    /// Blocking
+    fn next_event(&self) -> Result<AdminServiceEvent, NextEventError> {
+        let evt_result = self
+            .event_receiver
+            .recv()
+            .map_err(|_| NextEventError::Disconnected)?;
+        evt_result
+            .map_err(|e| NextEventError::InternalError(InternalError::from_source(Box::new(e))))
+    }
+}
+
+impl ParseBytes<AdminServiceEvent> for AdminServiceEvent {
+    fn from_bytes(bytes: &[u8]) -> Result<AdminServiceEvent, ParseError> {
+        let json_event: Event = serde_json::from_slice(bytes)
+            .map_err(|err| ParseError::MalformedMessage(Box::new(err)))?;
+
+        use messages::AdminServiceEvent::*;
+        let (proposal, event_type) = match json_event.admin_event {
+            ProposalSubmitted(proposal) => (proposal, EventType::ProposalSubmitted),
+            ProposalVote((proposal, pub_key_bytes)) => (
+                proposal,
+                EventType::ProposalVote {
+                    requester: PublicKey(pub_key_bytes),
+                },
+            ),
+            ProposalAccepted((proposal, pub_key_bytes)) => (
+                proposal,
+                EventType::ProposalAccepted {
+                    requester: PublicKey(pub_key_bytes),
+                },
+            ),
+            ProposalRejected((proposal, pub_key_bytes)) => (
+                proposal,
+                EventType::ProposalRejected {
+                    requester: PublicKey(pub_key_bytes),
+                },
+            ),
+            CircuitReady(proposal) => (proposal, EventType::CircuitReady),
+            CircuitDisbanded(proposal) => (proposal, EventType::CircuitDisbanded),
+        };
+
+        Ok(AdminServiceEvent {
+            event_id: json_event.event_id,
+            event_type,
+            proposal: proposal.into(),
+        })
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct Event {
+    event_id: u64,
+
+    #[serde(flatten)]
+    admin_event: messages::AdminServiceEvent,
+}
+
+impl From<messages::CircuitProposal> for ProposalSlice {
+    fn from(proposal: messages::CircuitProposal) -> Self {
+        use messages::ProposalType::*;
+        let proposal_type = match proposal.proposal_type {
+            Create => "Create",
+            UpdateRoster => "UpdateRoster",
+            AddNode => "AddNode",
+            RemoveNode => "RemoveNode",
+            Disband => "Disband",
+        }
+        .to_owned();
+
+        Self {
+            proposal_type,
+            circuit_id: proposal.circuit_id,
+            circuit_hash: proposal.circuit_hash,
+            circuit: proposal.circuit.into(),
+            votes: proposal.votes.into_iter().map(VoteRecord::from).collect(),
+            requester: hex::to_hex(&proposal.requester),
+            requester_node_id: proposal.requester_node_id,
+        }
+    }
+}
+
+impl From<messages::CreateCircuit> for ProposalCircuitSlice {
+    fn from(create_circuit: messages::CreateCircuit) -> Self {
+        Self {
+            circuit_id: create_circuit.circuit_id,
+            members: create_circuit
+                .members
+                .into_iter()
+                .map(CircuitMembers::from)
+                .collect(),
+            roster: create_circuit
+                .roster
+                .into_iter()
+                .map(CircuitService::from)
+                .collect(),
+            management_type: create_circuit.circuit_management_type,
+            comments: create_circuit.comments,
+            display_name: create_circuit.display_name,
+        }
+    }
+}
+
+impl From<messages::VoteRecord> for VoteRecord {
+    fn from(vote_record: messages::VoteRecord) -> Self {
+        Self {
+            public_key: hex::to_hex(&vote_record.public_key),
+            vote: match vote_record.vote {
+                messages::Vote::Accept => "Accept",
+                messages::Vote::Reject => "Reject",
+            }
+            .into(),
+            voter_node_id: vote_record.voter_node_id,
+        }
+    }
+}
+
+impl From<messages::SplinterNode> for CircuitMembers {
+    fn from(splinter_node: messages::SplinterNode) -> Self {
+        Self {
+            node_id: splinter_node.node_id,
+            endpoints: splinter_node.endpoints,
+        }
+    }
+}
+
+impl From<messages::SplinterService> for CircuitService {
+    fn from(splinter_service: messages::SplinterService) -> Self {
+        Self {
+            service_id: splinter_service.service_id,
+            service_type: splinter_service.service_type,
+            node_id: splinter_service
+                .allowed_nodes
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| String::from("<NONE>")),
+            arguments: splinter_service
+                .arguments
+                .into_iter()
+                .map(|(k, v)| vec![k, v])
+                .collect(),
+        }
+    }
+}

--- a/libsplinter/src/admin/client/event/ws/mod.rs
+++ b/libsplinter/src/admin/client/event/ws/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Websocket-backed implementations of the AdminServiceEventClient.
+
+#[cfg(feature = "admin-service-event-client-actix-web-client")]
+pub mod actix_web_client;

--- a/libsplinter/src/admin/client/mod.rs
+++ b/libsplinter/src/admin/client/mod.rs
@@ -15,6 +15,8 @@
 //! Traits and implementations useful for communicating with the Splinter admin service as
 //! a client.
 
+#[cfg(feature = "admin-service-event-client")]
+pub mod event;
 #[cfg(feature = "client-reqwest")]
 mod reqwest;
 

--- a/libsplinter/src/admin/client/mod.rs
+++ b/libsplinter/src/admin/client/mod.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::InternalError;
 
+#[cfg(feature = "client-reqwest")]
 pub use self::reqwest::ReqwestAdminServiceClient;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/libsplinter/src/events/error.rs
+++ b/libsplinter/src/events/error.rs
@@ -20,12 +20,15 @@ use tokio::io;
 #[derive(Debug)]
 pub enum ParseError {
     MalformedMessage(Box<dyn error::Error + Send + Sync + 'static>),
+    /// This type provides a sendable alternative to source errors that may not be Sync and Send.
+    MalformedReducedToString(String),
 }
 
 impl error::Error for ParseError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             ParseError::MalformedMessage(_) => None,
+            ParseError::MalformedReducedToString(_) => None,
         }
     }
 }
@@ -34,6 +37,7 @@ impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ParseError::MalformedMessage(err) => write!(f, "Malformed message {}", err),
+            ParseError::MalformedReducedToString(msg) => f.write_str(&msg),
         }
     }
 }

--- a/libsplinter/src/events/mod.rs
+++ b/libsplinter/src/events/mod.rs
@@ -17,5 +17,5 @@ mod reactor;
 mod ws;
 
 pub use error::{ParseError, ReactorError, WebSocketError};
-pub use reactor::{Igniter, Reactor};
+pub use reactor::{Igniter, Reactor, ReactorShutdownSignaler};
 pub use ws::{ParseBytes, WebSocketClient, WsResponse};

--- a/libsplinter/src/events/ws.rs
+++ b/libsplinter/src/events/ws.rs
@@ -74,7 +74,7 @@ use tokio::prelude::*;
 use crate::events::{Igniter, ParseError, WebSocketError};
 
 type OnErrorHandle<T> =
-    dyn Fn(&WebSocketError, Context<T>) -> Result<(), WebSocketError> + Send + Sync + 'static;
+    dyn Fn(WebSocketError, Context<T>) -> Result<(), WebSocketError> + Send + Sync + 'static;
 
 const MAX_FRAME_SIZE: usize = 10_000_000;
 const DEFAULT_RECONNECT: bool = false;
@@ -241,7 +241,7 @@ impl<T: ParseBytes<T> + 'static> WebSocketClient<T> {
     /// Websocket or to reestablish the connection if appropriate.
     pub fn on_error<F>(&mut self, on_error: F)
     where
-        F: Fn(&WebSocketError, Context<T>) -> Result<(), WebSocketError> + Send + Sync + 'static,
+        F: Fn(WebSocketError, Context<T>) -> Result<(), WebSocketError> + Send + Sync + 'static,
     {
         self.on_error = Some(Arc::new(on_error));
     }
@@ -307,7 +307,7 @@ impl<T: ParseBytes<T> + 'static> WebSocketClient<T> {
                     if res.status() != StatusCode::SWITCHING_PROTOCOLS {
                         error!("The server didn't upgrade: {}", res.status());
                         if let Err(err) = on_error(
-                            &WebSocketError::ConnectError(format!(
+                            WebSocketError::ConnectError(format!(
                             "Received status code {:?} while attempting to establish a connection"
                         , res.status())),
                             connection_failed_context,
@@ -610,7 +610,7 @@ impl<T: ParseBytes<T> + 'static> Context<T> {
 
             self.reset_wait();
             self.reset_reconnect_count();
-            on_error(&error_message, self.clone())
+            on_error(error_message, self.clone())
         }
     }
 

--- a/libsplinter/src/rest_api/actix_web_1/websocket.rs
+++ b/libsplinter/src/rest_api/actix_web_1/websocket.rs
@@ -151,7 +151,7 @@ impl<T: Serialize + Debug + 'static> StreamHandler<MessageWrapper<T>, ()>
         match msg {
             MessageWrapper::Message(msg) => {
                 debug!("Received a message: {:?}", msg);
-                match serde_json::to_string(&msg) {
+                match serde_json::to_string_pretty(&msg) {
                     Ok(text) => ctx.text(text),
                     Err(err) => {
                         debug!("Failed to serialize payload: {:?}", err);

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -132,6 +132,8 @@ database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
 node = [
+    "authorization",
+    "https-bind",
     "scabbard/client-reqwest",
     "scabbard/factory-builder",
     "splinter/admin-service-client",

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -137,6 +137,8 @@ node = [
     "scabbard/client-reqwest",
     "scabbard/factory-builder",
     "splinter/admin-service-client",
+    "splinter/admin-service-event-client",
+    "splinter/admin-service-event-client-actix-web-client",
     "splinter/client-reqwest",
     "splinter/rest-api-actix-web-3",
     "splinter/registry-client",

--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -29,7 +29,12 @@ use crate::node::runnable::admin::RunnableAdminSubsystem;
 
 const DEFAULT_ADMIN_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Default)]
+/// An enumeration of the AdminServiceEventClient backend variants.
+#[derive(Clone, Copy, Debug)]
+pub enum AdminServiceEventClientVariant {
+    ActixWebClient,
+}
+
 pub struct AdminSubsystemBuilder {
     node_id: Option<String>,
     admin_timeout: Option<Duration>,
@@ -40,11 +45,23 @@ pub struct AdminSubsystemBuilder {
     signing_context: Option<Box<dyn Context>>,
     scabbard_config: Option<ScabbardConfig>,
     registries: Option<Vec<String>>,
+    admin_service_event_client_variant: AdminServiceEventClientVariant,
 }
 
 impl AdminSubsystemBuilder {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            node_id: None,
+            admin_timeout: None,
+            store_factory: None,
+            peer_connector: None,
+            routing_writer: None,
+            service_transport: None,
+            signing_context: None,
+            scabbard_config: None,
+            registries: None,
+            admin_service_event_client_variant: AdminServiceEventClientVariant::ActixWebClient,
+        }
     }
 
     /// Specifies the id for the node. Defaults to a random node id.
@@ -101,6 +118,15 @@ impl AdminSubsystemBuilder {
         self
     }
 
+    /// Specifies the admin_service_event_client_variant.
+    pub fn with_admin_service_event_client_variant(
+        mut self,
+        admin_service_event_client_variant: AdminServiceEventClientVariant,
+    ) -> Self {
+        self.admin_service_event_client_variant = admin_service_event_client_variant;
+        self
+    }
+
     pub fn build(mut self) -> Result<RunnableAdminSubsystem, InternalError> {
         let node_id = self.node_id.take().ok_or_else(|| {
             InternalError::with_message("Cannot build AdminSubsystem without a node id".to_string())
@@ -154,6 +180,7 @@ impl AdminSubsystemBuilder {
             .transpose()?;
 
         let registries = self.registries;
+        let admin_service_event_client_variant = self.admin_service_event_client_variant;
 
         Ok(RunnableAdminSubsystem {
             node_id,
@@ -165,6 +192,7 @@ impl AdminSubsystemBuilder {
             admin_service_verifier,
             scabbard_service_factory,
             registries,
+            admin_service_event_client_variant,
         })
     }
 }

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -35,7 +35,7 @@ use splinter::store::StoreFactory;
 
 use super::{RunnableNode, RunnableNodeRestApiVariant, ScabbardConfig};
 
-use self::admin::AdminSubsystemBuilder;
+use self::admin::{AdminServiceEventClientVariant, AdminSubsystemBuilder};
 use self::network::NetworkSubsystemBuilder;
 
 /// An enumeration of the REST API backend variants.
@@ -120,6 +120,17 @@ impl NodeBuilder {
         self.admin_subsystem_builder = self
             .admin_subsystem_builder
             .with_store_factory(store_factory);
+        self
+    }
+
+    pub fn with_admin_service_event_client_variant(
+        mut self,
+        admin_service_event_client_variant: AdminServiceEventClientVariant,
+    ) -> Self {
+        self.admin_subsystem_builder = self
+            .admin_subsystem_builder
+            .with_admin_service_event_client_variant(admin_service_event_client_variant);
+
         self
     }
 

--- a/splinterd/src/node/running/admin.rs
+++ b/splinterd/src/node/running/admin.rs
@@ -14,12 +14,19 @@
 
 //! This module defines the running admin subsystem.
 
+use splinter::admin::client::event::{AdminServiceEventClient, AwcAdminServiceEventClientBuilder};
 use splinter::error::InternalError;
+use splinter::events::Reactor;
 use splinter::registry::RegistryWriter;
 use splinter::rest_api::actix_web_1::Resource as Actix1Resource;
 use splinter::service::ServiceProcessorShutdownHandle;
 use splinter::store::StoreFactory;
 use splinter::threading::lifecycle::ShutdownHandle;
+
+/// The configured, running Admin Service Event client variants.
+pub enum AdminServiceEventClientVariant {
+    ActixWebClient(Reactor),
+}
 
 /// A running admin subsystem.
 pub struct AdminSubsystem {
@@ -27,6 +34,7 @@ pub struct AdminSubsystem {
     pub(crate) admin_service_shutdown: ServiceProcessorShutdownHandle,
     pub(crate) actix1_resources: Vec<Actix1Resource>,
     pub(crate) store_factory: Box<dyn StoreFactory>,
+    pub(crate) admin_service_event_client_variant: AdminServiceEventClientVariant,
 }
 
 impl AdminSubsystem {
@@ -40,15 +48,51 @@ impl AdminSubsystem {
     pub fn registry_writer(&self) -> &dyn RegistryWriter {
         &*self.registry_writer
     }
+
+    pub fn admin_service_event_client(
+        &self,
+        splinter_url: String,
+        authorization: String,
+        event_type: String,
+    ) -> Result<Box<dyn AdminServiceEventClient>, InternalError> {
+        match &self.admin_service_event_client_variant {
+            AdminServiceEventClientVariant::ActixWebClient(reactor) => {
+                AwcAdminServiceEventClientBuilder::new()
+                    .with_reactor(reactor)
+                    .with_splinter_url(splinter_url)
+                    .with_event_type(event_type)
+                    .with_authorization(authorization)
+                    .build()
+                    .map_err(|e| InternalError::from_source(Box::new(e)))?
+                    .run()
+                    .map(|client| Box::new(client) as Box<dyn AdminServiceEventClient>)
+            }
+        }
+    }
 }
 
 impl ShutdownHandle for AdminSubsystem {
     fn signal_shutdown(&mut self) {
+        let AdminServiceEventClientVariant::ActixWebClient(reactor) =
+            &self.admin_service_event_client_variant;
+
+        if let Err(err) = reactor.shutdown_signaler().signal_shutdown() {
+            error!("Unable to cleanly signal reactor shutdown: {}", err);
+        }
+
         self.admin_service_shutdown.signal_shutdown();
     }
 
     fn wait_for_shutdown(self) -> Result<(), InternalError> {
         let mut errors = vec![];
+
+        let AdminServiceEventClientVariant::ActixWebClient(reactor) =
+            self.admin_service_event_client_variant;
+
+        if let Err(e) = reactor.wait_for_shutdown() {
+            errors.push(InternalError::from_source(Box::new(e)));
+        }
+
         if let Err(err) = self.admin_service_shutdown.wait_for_shutdown() {
             errors.push(err)
         }

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -21,6 +21,7 @@ use std::thread::JoinHandle;
 
 use cylinder::Signer;
 use scabbard::client::{ReqwestScabbardClientBuilder, ScabbardClient};
+use splinter::admin::client::event::AdminServiceEventClient;
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::error::InternalError;
 use splinter::registry::{
@@ -74,6 +75,17 @@ impl Node {
             format!("http://localhost:{}", self.rest_api_port),
             "foo".to_string(),
         ))
+    }
+
+    pub fn admin_service_event_client(
+        &self,
+        event_type: &str,
+    ) -> Result<Box<dyn AdminServiceEventClient>, InternalError> {
+        self.admin_subsystem.admin_service_event_client(
+            format!("http://localhost:{}", self.rest_api_port),
+            "foo".to_string(),
+            event_type.to_string(),
+        )
     }
 
     pub fn scabbard_client(&self) -> Result<Box<dyn ScabbardClient>, InternalError> {
@@ -149,6 +161,7 @@ impl Node {
 impl ShutdownHandle for Node {
     fn signal_shutdown(&mut self) {
         self.admin_subsystem.signal_shutdown();
+
         if let NodeRestApiVariant::ActixWeb3(ref mut rest_api) = self.rest_api_variant {
             rest_api.signal_shutdown();
         }

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -15,8 +15,8 @@
 //! Provides the functionality of committing a 2- to 3-party circuit on a running network.
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
 
+use splinter::admin::client::event::{EventType, PublicKey};
 use splinterd::node::Node;
 
 use crate::admin::payload::{make_circuit_proposal_vote_payload, make_create_circuit_payload};
@@ -39,6 +39,15 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
     .into_iter()
     .collect::<HashMap<String, Vec<String>>>();
 
+    let node_b_admin_pubkey = admin_pubkey(node_b);
+
+    let node_a_event_client = node_a
+        .admin_service_event_client("test_circuit")
+        .expect("Unable to get event client");
+    let node_b_event_client = node_b
+        .admin_service_event_client("test_circuit")
+        .expect("Unable to get event client");
+
     let circuit_payload_bytes = make_create_circuit_payload(
         &circuit_id,
         node_a.node_id(),
@@ -51,52 +60,33 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
         .submit_admin_payload(circuit_payload_bytes.clone());
     assert!(res.is_ok());
 
-    // Wait for the proposal to be committed for the second node
-    let mut proposal_b;
-    let start = Instant::now();
-    let proposal_a = loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(60) {
-            panic!("Failed to detect proposal in time");
-        }
-        let proposals = node_b
-            .admin_service_client()
-            .list_proposals(None, None)
-            .expect("Unable to list proposals from node_b")
-            .data;
+    // Wait for the proposal event from each node.
+    let proposal_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let proposal_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
 
-        if !proposals.is_empty() {
-            // Unwrap the first element in this list as we've already validated that the list
-            // is not empty
-            proposal_b = proposals.get(0).unwrap().clone();
-        } else {
-            continue;
-        }
-
-        // Validate the same proposal is available to the first node
-        let proposal_a = match node_a
-            .admin_service_client()
-            .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from node_a")
-        {
-            Some(proposal_a) => proposal_a,
-            None => continue,
-        };
-
-        assert_eq!(proposal_a, proposal_b);
-        break proposal_a;
-    };
+    assert_eq!(&EventType::ProposalSubmitted, proposal_a_event.event_type());
+    assert_eq!(&EventType::ProposalSubmitted, proposal_b_event.event_type());
+    assert_eq!(proposal_a_event.proposal(), proposal_b_event.proposal());
 
     // Submit the same `CircuitManagmentPayload` to create the circuit to the second node
     // to validate this duplicate proposal is rejected
     let duplicate_res = node_b
         .admin_service_client()
         .submit_admin_payload(circuit_payload_bytes);
-    assert!(duplicate_res.is_err());
+    assert!(
+        duplicate_res.is_err(),
+        "node {} erroneously accepted a duplicate proposal",
+        node_b.node_id()
+    );
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
     let vote_payload_bytes = make_circuit_proposal_vote_payload(
-        proposal_a,
+        proposal_a_event.proposal().clone(),
         node_b.node_id(),
         &*node_b.admin_signer().clone_box(),
         true,
@@ -106,40 +96,50 @@ pub(in crate::admin) fn commit_2_party_circuit(circuit_id: &str, node_a: &Node, 
         .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
-    // Wait for the circuit to be committed for the second node
-    let mut circuit_b;
-    let start = Instant::now();
-    loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(60) {
-            panic!("Failed to detect circuit in time");
-        }
-        let circuits = node_b
-            .admin_service_client()
-            .list_circuits(None)
-            .expect("Unable to list circuits from node_b")
-            .data;
+    // Wait for proposal accepted
+    let accepted_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let accepted_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_b_admin_pubkey.clone()
+        },
+        accepted_a_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_b_admin_pubkey.clone()
+        },
+        accepted_b_event.event_type(),
+    );
+    assert_eq!(accepted_a_event.proposal(), accepted_b_event.proposal());
 
-        if !circuits.is_empty() {
-            // Unwrap the first element in this list as we've already validated that the list
-            // is not empty
-            circuit_b = circuits.get(0).unwrap().clone();
-        } else {
-            continue;
-        }
+    // Wait for circuit ready.
+    let ready_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let ready_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(ready_a_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_b_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_a_event.proposal(), ready_b_event.proposal());
 
-        // Validate the circuit is available to the first node
-        let circuit_a = match node_a
-            .admin_service_client()
-            .fetch_circuit(&circuit_id)
-            .expect("Unable to list circuits from node_b")
-        {
-            Some(circuit) => circuit,
-            None => continue,
-        };
+    let circuit_a = node_a
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to get circuit from node_b")
+        .expect("Circuit was not found");
+    let circuit_b = node_b
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to get circuit from node_b")
+        .expect("Circuit was not found");
 
-        assert_eq!(circuit_a, circuit_b);
-        break;
-    }
+    assert_eq!(circuit_a, circuit_b);
 }
 
 /// Commit a 3-party circuit on a network that is already running
@@ -169,6 +169,19 @@ pub(in crate::admin) fn commit_3_party_circuit(
     .into_iter()
     .collect::<HashMap<String, Vec<String>>>();
 
+    let node_b_admin_pubkey = admin_pubkey(node_b);
+    let node_c_admin_pubkey = admin_pubkey(node_c);
+
+    let node_a_event_client = node_a
+        .admin_service_event_client("test_circuit")
+        .expect("Unable to get event client");
+    let node_b_event_client = node_b
+        .admin_service_event_client("test_circuit")
+        .expect("Unable to get event client");
+    let node_c_event_client = node_b
+        .admin_service_event_client("test_circuit")
+        .expect("Unable to get event client");
+
     // Create the `CircuitManagementPayload` to be sent to a node
     let circuit_payload_bytes = make_create_circuit_payload(
         &circuit_id,
@@ -182,47 +195,22 @@ pub(in crate::admin) fn commit_3_party_circuit(
         .submit_admin_payload(circuit_payload_bytes.clone());
     assert!(res.is_ok());
 
-    // Wait for the proposal to be committed for the remote nodes
-    let mut proposal_b;
-    let mut proposal_c;
-    let start = Instant::now();
-    let proposal_a = loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(60) {
-            panic!("Failed to detect proposal in time");
-        }
-        let proposals_b = node_b
-            .admin_service_client()
-            .list_proposals(None, None)
-            .expect("Unable to list proposals from second node")
-            .data;
-        let proposals_c = node_c
-            .admin_service_client()
-            .list_proposals(None, None)
-            .expect("Unable to list proposals from third node")
-            .data;
-        if !proposals_b.is_empty() && !proposals_c.is_empty() {
-            // Unwrap the first elements in each list as we've already validated that both of
-            // the lists are not empty
-            proposal_b = proposals_b.get(0).unwrap().clone();
-            proposal_c = proposals_c.get(0).unwrap().clone();
-        } else {
-            continue;
-        }
+    // Wait for the proposal event from each node
+    let proposal_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let proposal_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let proposal_c_event = node_c_event_client
+        .next_event()
+        .expect("Unable to get next event");
 
-        // Validate the same proposal is available to the first node
-        let proposal_a = match node_a
-            .admin_service_client()
-            .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from first node")
-        {
-            Some(proposal_a) => proposal_a,
-            None => continue,
-        };
-
-        assert_eq!(proposal_a, proposal_b);
-        assert_eq!(proposal_b, proposal_c);
-        break proposal_a;
-    };
+    assert_eq!(&EventType::ProposalSubmitted, proposal_a_event.event_type());
+    assert_eq!(&EventType::ProposalSubmitted, proposal_b_event.event_type());
+    assert_eq!(&EventType::ProposalSubmitted, proposal_c_event.event_type());
+    assert_eq!(proposal_a_event.proposal(), proposal_b_event.proposal());
+    assert_eq!(proposal_a_event.proposal(), proposal_c_event.proposal());
 
     // Submit the same `CircuitManagmentPayload` to create the circuit to the second node
     // to validate this duplicate proposal is rejected
@@ -240,7 +228,7 @@ pub(in crate::admin) fn commit_3_party_circuit(
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
     let vote_payload_bytes = make_circuit_proposal_vote_payload(
-        proposal_a,
+        proposal_a_event.proposal().clone(),
         node_b.node_id(),
         &*node_b.admin_signer().clone_box(),
         true,
@@ -250,45 +238,42 @@ pub(in crate::admin) fn commit_3_party_circuit(
         .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
-    // Wait for the vote from this node to appear on the proposal for the remote nodes
-    let mut proposal_a;
-    let start = Instant::now();
-    loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(60) {
-            panic!("Failed to detect proposal vote in time");
-        }
-        // The proposal should already be available to each of these nodes, so we are able to
-        // unwrap the result of the `fetch_proposal` call
-        proposal_a = node_a
-            .admin_service_client()
-            .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from first node")
-            .unwrap();
-        let proposal_b = node_b
-            .admin_service_client()
-            .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from second node")
-            .unwrap();
-        let proposal_c = node_c
-            .admin_service_client()
-            .fetch_proposal(&circuit_id)
-            .expect("Unable to fetch proposal from third node")
-            .unwrap();
+    // wait for vote event
+    let vote_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let vote_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let vote_c_event = node_c_event_client
+        .next_event()
+        .expect("Unable to get next event");
 
-        if proposal_a.votes.len() == 1 && proposal_b.votes.len() == 1 && proposal_c.votes.len() == 1
-        {
-            assert_eq!(proposal_a, proposal_b);
-            assert_eq!(proposal_b, proposal_c);
-            break;
-        } else {
-            continue;
-        }
-    }
+    assert_eq!(
+        &EventType::ProposalVote {
+            requester: node_b_admin_pubkey.clone()
+        },
+        vote_a_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalVote {
+            requester: node_b_admin_pubkey.clone()
+        },
+        vote_b_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalVote {
+            requester: node_b_admin_pubkey.clone()
+        },
+        vote_c_event.event_type(),
+    );
+    assert_eq!(vote_a_event.proposal(), vote_b_event.proposal());
+    assert_eq!(vote_a_event.proposal(), vote_c_event.proposal());
 
     // Create the `CircuitProposalVote` to be sent to a node
     // Uses `true` for the `accept` argument to create a vote to accept the proposal
     let vote_payload_bytes = make_circuit_proposal_vote_payload(
-        proposal_a,
+        proposal_a_event.proposal().clone(),
         node_c.node_id(),
         &*node_c.admin_signer().clone_box(),
         true,
@@ -298,45 +283,80 @@ pub(in crate::admin) fn commit_3_party_circuit(
         .submit_admin_payload(vote_payload_bytes);
     assert!(res.is_ok());
 
-    // Wait for the circuit to be committed for the other nodes
-    let mut circuit_a;
-    let mut circuit_b;
-    let start = Instant::now();
-    loop {
-        if Instant::now().duration_since(start) > Duration::from_secs(60) {
-            panic!("Failed to detect circuit in time");
-        }
-        let circuits_a = node_a
-            .admin_service_client()
-            .list_circuits(None)
-            .expect("Unable to list circuits from first node")
-            .data;
-        let circuits_b = node_b
-            .admin_service_client()
-            .list_circuits(None)
-            .expect("Unable to list circuits from third node")
-            .data;
-        if !circuits_a.is_empty() && !circuits_b.is_empty() {
-            // Unwrap the first element in each list as we've already validated each of the
-            // lists are not empty
-            circuit_a = circuits_a.get(0).unwrap().clone();
-            circuit_b = circuits_b.get(0).unwrap().clone();
-        } else {
-            continue;
-        }
+    // Wait for proposal accepted
+    let accepted_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let accepted_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let accepted_c_event = node_c_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_c_admin_pubkey.clone()
+        },
+        accepted_a_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_c_admin_pubkey.clone()
+        },
+        accepted_b_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_c_admin_pubkey.clone()
+        },
+        accepted_c_event.event_type(),
+    );
+    assert_eq!(accepted_a_event.proposal(), accepted_b_event.proposal());
+    assert_eq!(accepted_a_event.proposal(), accepted_c_event.proposal());
 
-        // Validate the circuit is available to the first node
-        let circuit_c = match node_c
-            .admin_service_client()
-            .fetch_circuit(&circuit_id)
-            .expect("Unable to fetch circuit from third node")
-        {
-            Some(circuit) => circuit,
-            None => continue,
-        };
+    // Wait for circuit ready.
+    let ready_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let ready_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let ready_c_event = node_c_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(ready_a_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_b_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_c_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_a_event.proposal(), ready_b_event.proposal());
+    assert_eq!(ready_a_event.proposal(), ready_c_event.proposal());
 
-        assert_eq!(circuit_a, circuit_b);
-        assert_eq!(circuit_b, circuit_c);
-        break;
-    }
+    // Validate the circuit is available to the first node
+    let circuit_a = node_a
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from first node")
+        .expect("Circuit was not found");
+    let circuit_b = node_b
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from second node")
+        .expect("Circuit was not found");
+    let circuit_c = node_c
+        .admin_service_client()
+        .fetch_circuit(&circuit_id)
+        .expect("Unable to fetch circuit from third node")
+        .expect("Circuit was not found");
+
+    assert_eq!(circuit_a, circuit_b);
+    assert_eq!(circuit_b, circuit_c);
+}
+
+fn admin_pubkey(node: &Node) -> PublicKey {
+    PublicKey(
+        node.admin_signer()
+            .public_key()
+            .unwrap()
+            .as_slice()
+            .to_vec(),
+    )
 }


### PR DESCRIPTION
This PR adds the AdminServiceEventClient trait and an implementation backed by client websockets.  It updates the circuit tests to make use of these clients to verify that the correct events have occurred.