### PR TITLE
Add `Biome` endpoints to `RunningNode`

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -145,6 +145,8 @@ node = [
     "splinter/rest-api-actix-web-3",
     "splinter/registry-client",
     "splinter/registry-client-reqwest",
+    "splinter/biome-client",
+    "splinter/biome-client-reqwest",
 ]
 oauth = [
     "splinter/oauth"

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -55,6 +55,7 @@ pub struct NodeBuilder {
     rest_api_variant: RestApiVariant,
     network_subsystem_builder: NetworkSubsystemBuilder,
     node_id: Option<String>,
+    enable_biome: bool,
 }
 
 impl Default for NodeBuilder {
@@ -73,6 +74,7 @@ impl NodeBuilder {
             rest_api_variant: RestApiVariant::ActixWeb1,
             network_subsystem_builder: NetworkSubsystemBuilder::new(),
             node_id: None,
+            enable_biome: false,
         }
     }
 
@@ -167,6 +169,12 @@ impl NodeBuilder {
         self
     }
 
+    /// Make Biome resources available on the network
+    pub fn with_biome_enabled(mut self) -> Self {
+        self.enable_biome = true;
+        self
+    }
+
     /// Builds the `RunnableNode` and consumes the `NodeBuilder`.
     pub fn build(mut self) -> Result<RunnableNode, InternalError> {
         let url = format!("127.0.0.1:{}", self.rest_api_port.take().unwrap_or(0),);
@@ -206,12 +214,15 @@ impl NodeBuilder {
             ),
         };
 
+        let enable_biome = self.enable_biome;
+
         Ok(RunnableNode {
             admin_signer,
             admin_subsystem_builder,
             runnable_network_subsystem,
             rest_api_variant,
             node_id,
+            enable_biome,
         })
     }
 }

--- a/splinterd/src/node/mod.rs
+++ b/splinterd/src/node/mod.rs
@@ -20,6 +20,7 @@ mod running;
 
 pub use builder::scabbard::{ScabbardConfig, ScabbardConfigBuilder};
 pub use builder::{NodeBuilder, RestApiVariant};
+pub use runnable::biome::BiomeResourceProvider;
 pub use runnable::RunnableNode;
 use runnable::RunnableNodeRestApiVariant;
 pub use running::Node;

--- a/splinterd/src/node/runnable/biome.rs
+++ b/splinterd/src/node/runnable/biome.rs
@@ -1,0 +1,83 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for configuring Biome REST API resources
+
+use std::sync::Arc;
+
+use splinter::biome::{
+    credentials::rest_api::BiomeCredentialsRestResourceProviderBuilder,
+    key_management::rest_api::BiomeKeyManagementRestResourceProvider,
+    profile::rest_api::BiomeProfileRestResourceProvider,
+};
+use splinter::error::InternalError;
+use splinter::rest_api::{
+    actix_web_1::Resource as Actix1Resource, AuthConfig, RestResourceProvider,
+};
+use splinter::store::StoreFactory;
+
+/// Biome resource provider
+pub struct BiomeResourceProvider {
+    /// Biome's ActixWeb1 resources
+    pub(crate) actix1_resources: Vec<Actix1Resource>,
+    /// Biome-specific authorization configurations
+    pub(crate) auth_configs: Vec<AuthConfig>,
+}
+
+impl BiomeResourceProvider {
+    /// Build a `BiomeResourceProvider`
+    pub fn new(store_factory: &dyn StoreFactory) -> Result<BiomeResourceProvider, InternalError> {
+        // Used to collect the Biome-specific Actix 1 resources
+        let mut actix1_resources = vec![];
+
+        // Create the `BiomeCredentialsRestResourceProvider` to create the credentials resources
+        let mut credentials_resource_builder: BiomeCredentialsRestResourceProviderBuilder =
+            Default::default();
+        credentials_resource_builder = credentials_resource_builder
+            .with_credentials_store(store_factory.get_biome_credentials_store())
+            .with_refresh_token_store(store_factory.get_biome_refresh_token_store())
+            .with_key_store(store_factory.get_biome_key_store());
+        let credentials_resource_provider = credentials_resource_builder
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        // Create the `BiomeKeyManagementRestResourceProvider` to create the key-related resources
+        let key_management_resource_provider = BiomeKeyManagementRestResourceProvider::new(
+            Arc::new(store_factory.get_biome_key_store()),
+        );
+
+        // Create the `BiomeProfileRestResourceProvider` to create profile-related resources
+        let profile_resource_provider = BiomeProfileRestResourceProvider::new(Arc::new(
+            store_factory.get_biome_user_profile_store(),
+        ));
+
+        actix1_resources.extend(profile_resource_provider.resources());
+        actix1_resources.extend(credentials_resource_provider.resources());
+        actix1_resources.extend(key_management_resource_provider.resources());
+
+        Ok(BiomeResourceProvider {
+            actix1_resources,
+            auth_configs: vec![AuthConfig::Biome {
+                biome_credentials_resource_provider: credentials_resource_provider,
+            }],
+        })
+    }
+
+    /// Take the available REST Resources from the Biome resource provider.
+    pub fn take_actix1_resources(&mut self) -> Vec<Actix1Resource> {
+        let mut replaced = vec![];
+        std::mem::swap(&mut self.actix1_resources, &mut replaced);
+        replaced
+    }
+}

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -15,6 +15,7 @@
 //! Contains the implementation of `RunnableNode`.
 
 pub(super) mod admin;
+pub(super) mod biome;
 pub(super) mod network;
 
 use std::net::{Ipv4Addr, SocketAddr};

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -23,6 +23,7 @@ use cylinder::Signer;
 use scabbard::client::{ReqwestScabbardClientBuilder, ScabbardClient};
 use splinter::admin::client::event::AdminServiceEventClient;
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
+use splinter::biome::client::{BiomeClient, ReqwestBiomeClient};
 use splinter::error::InternalError;
 use splinter::registry::{
     client::{RegistryClient, ReqwestRegistryClient},
@@ -155,6 +156,16 @@ impl Node {
             .with_rest_api_port(rest_api_port.into())
             .with_store_factory(store_factory)
             .build()
+    }
+
+    pub fn biome_client(self: &Node, auth: Option<&str>) -> Box<dyn BiomeClient> {
+        let mut biome_client =
+            ReqwestBiomeClient::new(format!("http://localhost:{}", self.rest_api_port));
+        if let Some(auth) = auth {
+            biome_client.add_auth(auth.to_string());
+        }
+
+        Box::new(biome_client)
     }
 }
 

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -65,6 +65,7 @@ impl Network {
                 )
                 .with_admin_signer(signer)
                 .with_external_registries(self.external_registries.clone())
+                .with_biome_enabled()
                 .build()?
                 .run()?;
 


### PR DESCRIPTION
This PR adds the set-up within the RunningNode to allow for test nodes to access a `BiomeClient`. This is in support of the Biome integration tests. 