### PR TITLE
Append -experimental to packages with experimental features

### DIFF
--- a/bin/get_version
+++ b/bin/get_version
@@ -73,6 +73,9 @@ def version(default):
             version = os.environ['VERSION']
     else:
         version = default + "-dev1"
+    if 'CARGO_ARGS' in os.environ:
+        if "experimental" in os.environ['CARGO_ARGS']:
+            version = version + "-experimental"
     return version
 
 


### PR DESCRIPTION
Without this commit, it's impossible to differentiate packages built
with experimental features without installing the package and running
commands to test.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>