### PR TITLE
Add a set of initial Splinter metrics and update the example grafana page

### DIFF
--- a/docker/metrics/grafana/dashboards/splinter_metrics.json
+++ b/docker/metrics/grafana/dashboards/splinter_metrics.json
@@ -33,10 +33,606 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 42,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "splinter.scabbard.pending_batches",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pending Batches",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 40,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "linear"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "splinter.scabbard.committed_batches",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Commited Batches",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "splinter.peer_manager.peers",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$DATASOURCE",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "paceLength": 10,
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "bytes recv [[tag_host]] [[tag_interface]]",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "host"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "interface"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "net",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "bytes_recv"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  "10s"
+                ],
+                "type": "non_negative_derivative"
+              },
+              {
+                "params": [
+                  "/10"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "bytes sent [[tag_host]] [[tag_interface]]",
+          "dsType": "influxdb",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "host"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "interface"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "net",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "bytes_sent"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  "10s"
+                ],
+                "type": "non_negative_derivative"
+              },
+              {
+                "params": [
+                  "/10"
+                ],
+                "type": "math"
+              },
+              {
+                "params": [
+                  "* -1"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bytes Per Second (+Recv/-Sent)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": "bytes per second",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$DATASOURCE",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 2,
@@ -254,231 +850,10 @@
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pluginVersion": "7.3.7",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "bytes recv [[tag_host]] [[tag_interface]]",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "host"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "interface"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "net",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "bytes_recv"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              },
-              {
-                "params": [
-                  "10s"
-                ],
-                "type": "non_negative_derivative"
-              },
-              {
-                "params": [
-                  "/10"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "alias": "bytes sent [[tag_host]] [[tag_interface]]",
-          "dsType": "influxdb",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "host"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "interface"
-              ],
-              "type": "tag"
-            },
-            {
-              "params": [
-                "none"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "net",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "bytes_sent"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              },
-              {
-                "params": [
-                  "10s"
-                ],
-                "type": "non_negative_derivative"
-              },
-              {
-                "params": [
-                  "/10"
-                ],
-                "type": "math"
-              },
-              {
-                "params": [
-                  "* -1"
-                ],
-                "type": "math"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Bytes Per Second (+Recv/-Sent)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decbytes",
-          "label": "bytes per second",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$DATASOURCE",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 11,
@@ -705,7 +1080,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 14,
@@ -886,7 +1261,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 15,
@@ -1089,7 +1464,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1230,7 +1605,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 17,
@@ -1365,7 +1740,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 46
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1504,7 +1879,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 19,
@@ -1644,7 +2019,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 20,
@@ -1790,7 +2165,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 36,

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -52,7 +52,7 @@ jsonwebtoken = { version = "6.0", optional = true }
 influxdb = { version = "0.4.0", features = ["derive"], optional = true }
 log = "0.3.0"
 # rename to not conflict with splinter::metrics
-metrics-lib = {package = "metrics", version = "0.12", features = ["std"]}
+metrics-lib = {package = "metrics", version = "0.12", features = ["std"], optional = true}
 mio = "0.6"
 mio-extras = "2"
 oauth2 = { version = "3.0", optional = true }
@@ -154,7 +154,7 @@ cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
-metrics = ["chrono", "futures-0-3", "influxdb", "tokio-0-2"]
+metrics = ["chrono", "futures-0-3", "influxdb", "metrics-lib", "tokio-0-2"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -28,6 +28,13 @@ extern crate diesel;
 #[macro_use]
 #[cfg(feature = "diesel")]
 extern crate diesel_migrations;
+#[cfg(feature = "metrics")]
+#[macro_use]
+extern crate metrics_lib;
+
+// macros_use must come before any modules that make use of the macro
+#[macro_use]
+pub mod metrics;
 
 #[macro_export]
 macro_rules! rwlock_read_unwrap {
@@ -74,8 +81,6 @@ pub mod events;
 mod hex;
 pub mod keys;
 pub mod mesh;
-#[cfg(feature = "metrics")]
-pub mod metrics;
 pub mod migrations;
 pub mod network;
 #[cfg(feature = "oauth")]

--- a/libsplinter/src/metrics/mod.rs
+++ b/libsplinter/src/metrics/mod.rs
@@ -11,4 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#[cfg(feature = "metrics")]
 pub mod influx;
+
+// no-op `counter` macro for when the `metrics` feature is not enabled
+#[cfg(not(feature = "metrics"))]
+#[macro_export]
+macro_rules! counter {
+    ($t:tt, $v:expr) => {};
+}
+
+// no-op `gauge` macro for when the `metrics` feature is not enabled
+#[cfg(not(feature = "metrics"))]
+#[macro_export]
+macro_rules! gauge {
+    ($t:tt, $v:expr) => {};
+}
+
+// no-op `histogram` macro for when the `metrics` feature is not enabled
+#[cfg(not(feature = "metrics"))]
+#[macro_export]
+macro_rules! histogram {
+    ($t:tt, $v:expr) => {};
+}

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -68,6 +68,9 @@ impl PeerMap {
     ///
     /// * `initial_retry_frequency` - The value to set as the retry frequency for a new peer
     pub fn new(initial_retry_frequency: u64) -> Self {
+        // initialize peers metric
+        gauge!("splinter.peer_manager.peers", 0);
+
         PeerMap {
             peers: HashMap::new(),
             endpoints: HashMap::new(),
@@ -125,6 +128,8 @@ impl PeerMap {
         for endpoint in endpoints {
             self.endpoints.insert(endpoint, peer_id.clone());
         }
+
+        gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
     }
 
     /// Removes a peer and its endpoints.
@@ -139,9 +144,10 @@ impl PeerMap {
             for endpoint in peer_metadata.endpoints.iter() {
                 self.endpoints.remove(endpoint);
             }
-
+            gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
             Some(peer_metadata)
         } else {
+            gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
             None
         }
     }

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -29,6 +29,7 @@ actix-web = { version = "1.0", optional = true, default-features = false, featur
 cylinder = "0.2"
 futures = { version = "0.1", optional = true }
 log = "0.3.0"
+metrics = { version = "0.12", optional = true}
 openssl = "0.10"
 protobuf = "2.19"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
@@ -67,6 +68,7 @@ experimental = [
   # The following features are experimental:
   "circuit-purge",
   "factory-builder",
+  "metrics",
 ]
 
 authorization = ["splinter/authorization"]

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -21,6 +21,15 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "metrics")]
+#[macro_use]
+extern crate metrics;
+
+// pull in `no-op` metric macros if `metrics` is not enabled
+#[cfg(not(feature = "metrics"))]
+#[macro_use]
+extern crate splinter;
+
 #[cfg(feature = "client")]
 pub mod client;
 mod hex;

--- a/services/scabbard/libscabbard/src/service/state.rs
+++ b/services/scabbard/libscabbard/src/service/state.rs
@@ -151,6 +151,9 @@ impl ScabbardState {
             .start()
             .map_err(|err| ScabbardStateError(format!("failed to start executor: {}", err)))?;
 
+        // initialize committed_batches metric
+        counter!("splinter.scabbard.committed_batches", 0);
+
         Ok(ScabbardState {
             db,
             context_manager,
@@ -341,7 +344,7 @@ impl ScabbardState {
                 }
 
                 self.batch_history.commit(&signature);
-
+                counter!("splinter.scabbard.committed_batches", 1);
                 Ok(())
             }
             None => Err(ScabbardStateError("no pending changes to commit".into())),

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -132,7 +132,7 @@ database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
-metrics = ["splinter/metrics"]
+metrics = ["splinter/metrics", "scabbard/metrics"]
 node = [
     "scabbard/client-reqwest",
     "scabbard/factory-builder",


### PR DESCRIPTION
This PR adds a set of no-op metric macros that can be used through out the code if metrics is not enabled without needing to pull in the metrics library. 

Also the following metrics:
- splinter.scabbard.committed_batches
- splinter.scabbard.pending_batches
- splinter.peer_manager.peers

Finally adds panels to the grafana dashboard to see these metrics:

<img width="1379" alt="Screen Shot 2021-04-13 at 2 19 39 PM" src="https://user-images.githubusercontent.com/18215486/114608446-506dca80-9c63-11eb-8e3d-2cb82b5a6a5b.png">
