### PR TITLE
Prefix RBAC table names with rbac_

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-04-13-045000_rename_rbac_tables/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-04-13-045000_rename_rbac_tables/down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE rbac_roles RENAME TO roles;
+ALTER TABLE rbac_role_permissions RENAME TO role_permissions;
+ALTER TABLE rbac_identities RENAME TO identities;
+ALTER TABLE rbac_assignments RENAME TO assignments;
+

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-04-13-045000_rename_rbac_tables/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-04-13-045000_rename_rbac_tables/up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE roles RENAME TO rbac_roles;
+ALTER TABLE role_permissions RENAME TO rbac_role_permissions;
+ALTER TABLE identities RENAME TO rbac_identities;
+ALTER TABLE assignments RENAME TO rbac_assignments;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-04-13-045000_rename_rbac_tables/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-04-13-045000_rename_rbac_tables/down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE rbac_roles RENAME TO roles;
+ALTER TABLE rbac_role_permissions RENAME TO role_permissions;
+ALTER TABLE rbac_identities RENAME TO identities;
+ALTER TABLE rbac_assignments RENAME TO assignments;
+

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-04-13-045000_rename_rbac_tables/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-04-13-045000_rename_rbac_tables/up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE roles RENAME TO rbac_roles;
+ALTER TABLE role_permissions RENAME TO rbac_role_permissions;
+ALTER TABLE identities RENAME TO rbac_identities;
+ALTER TABLE assignments RENAME TO rbac_assignments;

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/mod.rs
@@ -695,8 +695,8 @@ mod tests {
         // verify that the permissions have been removed (in a block, so the connection is dropped)
         {
             let connection = pool.get().expect("Unable to get connection");
-            let perms = schema::role_permissions::table
-                .filter(schema::role_permissions::role_id.eq("test-role"))
+            let perms = schema::rbac_role_permissions::table
+                .filter(schema::rbac_role_permissions::role_id.eq("test-role"))
                 .load::<models::RolePermissionModel>(&*connection)
                 .expect("Unable to load permissions");
             assert!(perms.is_empty());
@@ -1086,8 +1086,8 @@ mod tests {
         // verify that the assignments have been removed (in a block, so the connection is dropped)
         {
             let connection = pool.get().expect("Unable to get connection");
-            let perms = schema::assignments::table
-                .filter(schema::assignments::identity.eq("some-user-id"))
+            let perms = schema::rbac_assignments::table
+                .filter(schema::rbac_assignments::identity.eq("some-user-id"))
                 .load::<models::RolePermissionModel>(&*connection)
                 .expect("Unable to load permissions");
             assert!(perms.is_empty());

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/models.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/models.rs
@@ -35,10 +35,10 @@ use diesel::pg::Pg;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::Sqlite;
 
-use super::schema::{assignments, identities, role_permissions, roles};
+use super::schema::{rbac_assignments, rbac_identities, rbac_role_permissions, rbac_roles};
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
-#[table_name = "roles"]
+#[table_name = "rbac_roles"]
 #[primary_key(id)]
 pub(super) struct RoleModel {
     pub id: String,
@@ -46,7 +46,7 @@ pub(super) struct RoleModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
-#[table_name = "role_permissions"]
+#[table_name = "rbac_role_permissions"]
 #[belongs_to(RoleModel, foreign_key = "role_id")]
 #[primary_key(role_id, permission)]
 pub(super) struct RolePermissionModel {
@@ -207,7 +207,7 @@ impl HasSqlType<IdentityModelTypeMapping> for Sqlite {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
-#[table_name = "identities"]
+#[table_name = "rbac_identities"]
 #[primary_key(identity)]
 pub(super) struct IdentityModel {
     pub identity: String,
@@ -215,7 +215,7 @@ pub(super) struct IdentityModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable)]
-#[table_name = "assignments"]
+#[table_name = "rbac_assignments"]
 #[belongs_to(IdentityModel, foreign_key = "identity")]
 #[primary_key(identity, role_id)]
 pub(super) struct AssignmentModel {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_assignment.rs
@@ -17,7 +17,7 @@ use diesel::{dsl::insert_into, prelude::*};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{AssignmentModel, IdentityModel},
-        schema::{assignments, identities},
+        schema::{rbac_assignments, rbac_identities},
     },
     Assignment, RoleBasedAuthorizationStoreError,
 };
@@ -41,11 +41,11 @@ impl<'a> RoleBasedAuthorizationStoreAddAssignment
     ) -> Result<(), RoleBasedAuthorizationStoreError> {
         let (identity, assignments): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
         self.conn.transaction::<_, _, _>(|| {
-            insert_into(identities::table)
+            insert_into(rbac_identities::table)
                 .values(identity)
                 .execute(self.conn)?;
 
-            insert_into(assignments::table)
+            insert_into(rbac_assignments::table)
                 .values(assignments)
                 .execute(self.conn)?;
 
@@ -64,11 +64,11 @@ impl<'a> RoleBasedAuthorizationStoreAddAssignment
     ) -> Result<(), RoleBasedAuthorizationStoreError> {
         let (identity, assignments): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
         self.conn.transaction::<_, _, _>(|| {
-            insert_into(identities::table)
+            insert_into(rbac_identities::table)
                 .values(identity)
                 .execute(self.conn)?;
 
-            insert_into(assignments::table)
+            insert_into(rbac_assignments::table)
                 .values(assignments)
                 .execute(self.conn)?;
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/add_role.rs
@@ -17,7 +17,7 @@ use diesel::{dsl::insert_into, prelude::*};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{RoleModel, RolePermissionModel},
-        schema::{role_permissions, roles},
+        schema::{rbac_role_permissions, rbac_roles},
     },
     Role, RoleBasedAuthorizationStoreError,
 };
@@ -36,9 +36,11 @@ impl<'a> RoleBasedAuthorizationStoreAddRole
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
 
         self.conn.transaction::<_, _, _>(|| {
-            insert_into(roles::table).values(role).execute(self.conn)?;
+            insert_into(rbac_roles::table)
+                .values(role)
+                .execute(self.conn)?;
 
-            insert_into(role_permissions::table)
+            insert_into(rbac_role_permissions::table)
                 .values(permissions)
                 .execute(self.conn)?;
 
@@ -54,9 +56,11 @@ impl<'a> RoleBasedAuthorizationStoreAddRole
     fn add_role(&self, role: Role) -> Result<(), RoleBasedAuthorizationStoreError> {
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
         self.conn.transaction::<_, _, _>(|| {
-            insert_into(roles::table).values(role).execute(self.conn)?;
+            insert_into(rbac_roles::table)
+                .values(role)
+                .execute(self.conn)?;
 
-            insert_into(role_permissions::table)
+            insert_into(rbac_role_permissions::table)
                 .values(permissions)
                 .execute(self.conn)?;
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assigned_roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assigned_roles.rs
@@ -22,7 +22,7 @@ use crate::rest_api::auth::authorization::rbac::store::{
             AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping, RoleModel,
             RolePermissionModel,
         },
-        schema::{identities, roles},
+        schema::{rbac_identities, rbac_roles},
     },
     Identity, Role, RoleBasedAuthorizationStoreError,
 };
@@ -55,8 +55,8 @@ where
         };
         self.conn
             .transaction::<Box<dyn ExactSizeIterator<Item = Role>>, _, _>(|| {
-                let identities = identities::table
-                    .filter(identities::identity.eq(search_identity))
+                let identities = rbac_identities::table
+                    .filter(rbac_identities::identity.eq(search_identity))
                     .load::<IdentityModel>(self.conn)?;
 
                 let role_ids = AssignmentModel::belonging_to(&identities)
@@ -65,8 +65,8 @@ where
                     .map(|assignment| assignment.role_id)
                     .collect::<Vec<_>>();
 
-                let roles = roles::table
-                    .filter(roles::id.eq_any(role_ids))
+                let roles = rbac_roles::table
+                    .filter(rbac_roles::id.eq_any(role_ids))
                     .load::<RoleModel>(self.conn)?;
 
                 let perms = RolePermissionModel::belonging_to(&roles)

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_assignment.rs
@@ -19,7 +19,7 @@ use diesel::prelude::*;
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping},
-        schema::identities,
+        schema::rbac_identities,
     },
     Assignment, Identity, RoleBasedAuthorizationStoreError,
 };
@@ -51,8 +51,8 @@ where
             Identity::User(ref user_id) => user_id,
         };
         self.conn.transaction(|| {
-            let identities = identities::table
-                .filter(identities::identity.eq(search_identity))
+            let identities = rbac_identities::table
+                .filter(rbac_identities::identity.eq(search_identity))
                 .load::<IdentityModel>(self.conn)?;
 
             let assignments = AssignmentModel::belonging_to(&identities)

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/get_role.rs
@@ -19,7 +19,7 @@ use diesel::prelude::*;
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{RoleModel, RolePermissionModel},
-        schema::roles,
+        schema::rbac_roles,
     },
     Role, RoleBasedAuthorizationStoreError,
 };
@@ -37,8 +37,8 @@ where
 {
     fn get_role(&self, search_id: &str) -> Result<Option<Role>, RoleBasedAuthorizationStoreError> {
         self.conn.transaction(|| {
-            let roles = roles::table
-                .filter(roles::id.eq(search_id))
+            let roles = rbac_roles::table
+                .filter(rbac_roles::id.eq(search_id))
                 .load::<RoleModel>(self.conn)?;
 
             let perms = RolePermissionModel::belonging_to(&roles)

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_assignments.rs
@@ -19,7 +19,7 @@ use diesel::prelude::*;
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{AssignmentModel, IdentityModel, IdentityModelType, IdentityModelTypeMapping},
-        schema::identities,
+        schema::rbac_identities,
     },
     Assignment, RoleBasedAuthorizationStoreError,
 };
@@ -47,7 +47,7 @@ where
     {
         self.conn
             .transaction::<Box<dyn ExactSizeIterator<Item = Assignment>>, _, _>(|| {
-                let identities = identities::table.load::<IdentityModel>(self.conn)?;
+                let identities = rbac_identities::table.load::<IdentityModel>(self.conn)?;
 
                 let assignments = AssignmentModel::belonging_to(&identities)
                     .load::<AssignmentModel>(self.conn)?

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/list_roles.rs
@@ -19,7 +19,7 @@ use diesel::prelude::*;
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{RoleModel, RolePermissionModel},
-        schema::roles,
+        schema::rbac_roles,
     },
     Role, RoleBasedAuthorizationStoreError,
 };
@@ -42,7 +42,7 @@ where
     ) -> Result<Box<dyn ExactSizeIterator<Item = Role>>, RoleBasedAuthorizationStoreError> {
         self.conn
             .transaction::<Box<dyn ExactSizeIterator<Item = Role>>, _, _>(|| {
-                let roles = roles::table.load::<RoleModel>(self.conn)?;
+                let roles = rbac_roles::table.load::<RoleModel>(self.conn)?;
 
                 let perms = RolePermissionModel::belonging_to(&roles)
                     .load::<RolePermissionModel>(self.conn)?

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_assignment.rs
@@ -17,7 +17,7 @@ use diesel::{dsl::delete, prelude::*};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::IdentityModelTypeMapping,
-        schema::{assignments, identities},
+        schema::{rbac_assignments, rbac_identities},
     },
     Identity, RoleBasedAuthorizationStoreError,
 };
@@ -47,9 +47,9 @@ where
             Identity::User(ref user_id) => user_id,
         };
         self.conn.transaction::<_, _, _>(|| {
-            delete(assignments::table.filter(assignments::identity.eq(search_identity)))
+            delete(rbac_assignments::table.filter(rbac_assignments::identity.eq(search_identity)))
                 .execute(self.conn)?;
-            delete(identities::table.filter(identities::identity.eq(search_identity)))
+            delete(rbac_identities::table.filter(rbac_identities::identity.eq(search_identity)))
                 .execute(self.conn)?;
 
             Ok(())

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/remove_role.rs
@@ -15,7 +15,7 @@
 use diesel::{dsl::delete, prelude::*};
 
 use crate::rest_api::auth::authorization::rbac::store::{
-    diesel::schema::{role_permissions, roles},
+    diesel::schema::{rbac_role_permissions, rbac_roles},
     RoleBasedAuthorizationStoreError,
 };
 
@@ -32,10 +32,10 @@ where
 {
     fn remove_role(&self, role_id: &str) -> Result<(), RoleBasedAuthorizationStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            delete(role_permissions::table.filter(role_permissions::role_id.eq(role_id)))
+            delete(rbac_role_permissions::table.filter(rbac_role_permissions::role_id.eq(role_id)))
                 .execute(self.conn)?;
 
-            delete(roles::table.filter(roles::id.eq(role_id))).execute(self.conn)?;
+            delete(rbac_roles::table.filter(rbac_roles::id.eq(role_id))).execute(self.conn)?;
 
             Ok(())
         })

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_assignment.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_assignment.rs
@@ -21,7 +21,7 @@ use crate::error::{ConstraintViolationError, ConstraintViolationType};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{AssignmentModel, IdentityModel},
-        schema::{assignments, identities},
+        schema::{rbac_assignments, rbac_identities},
     },
     Assignment, RoleBasedAuthorizationStoreError,
 };
@@ -45,11 +45,11 @@ impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
     ) -> Result<(), RoleBasedAuthorizationStoreError> {
         let (identity, roles): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
         self.conn.transaction::<_, _, _>(|| {
-            let count = identities::table
+            let count = rbac_identities::table
                 .filter(
-                    identities::identity
+                    rbac_identities::identity
                         .eq(&identity.identity)
-                        .and(identities::identity_type.eq(identity.identity_type)),
+                        .and(rbac_identities::identity_type.eq(identity.identity_type)),
                 )
                 .count()
                 .get_result::<i64>(self.conn)?;
@@ -62,10 +62,12 @@ impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
                 ));
             }
 
-            delete(assignments::table.filter(assignments::identity.eq(&identity.identity)))
-                .execute(self.conn)?;
+            delete(
+                rbac_assignments::table.filter(rbac_assignments::identity.eq(&identity.identity)),
+            )
+            .execute(self.conn)?;
 
-            insert_into(assignments::table)
+            insert_into(rbac_assignments::table)
                 .values(roles)
                 .execute(self.conn)?;
 
@@ -84,11 +86,11 @@ impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
     ) -> Result<(), RoleBasedAuthorizationStoreError> {
         let (identity, roles): (IdentityModel, Vec<AssignmentModel>) = assignment.into();
         self.conn.transaction::<_, _, _>(|| {
-            let count = identities::table
+            let count = rbac_identities::table
                 .filter(
-                    identities::identity
+                    rbac_identities::identity
                         .eq(&identity.identity)
-                        .and(identities::identity_type.eq(identity.identity_type)),
+                        .and(rbac_identities::identity_type.eq(identity.identity_type)),
                 )
                 .count()
                 .get_result::<i64>(self.conn)?;
@@ -101,10 +103,12 @@ impl<'a> RoleBasedAuthorizationStoreUpdateAssignment
                 ));
             }
 
-            delete(assignments::table.filter(assignments::identity.eq(&identity.identity)))
-                .execute(self.conn)?;
+            delete(
+                rbac_assignments::table.filter(rbac_assignments::identity.eq(&identity.identity)),
+            )
+            .execute(self.conn)?;
 
-            insert_into(assignments::table)
+            insert_into(rbac_assignments::table)
                 .values(roles)
                 .execute(self.conn)?;
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/operations/update_role.rs
@@ -21,7 +21,7 @@ use crate::error::{ConstraintViolationError, ConstraintViolationType};
 use crate::rest_api::auth::authorization::rbac::store::{
     diesel::{
         models::{RoleModel, RolePermissionModel},
-        schema::{role_permissions, roles},
+        schema::{rbac_role_permissions, rbac_roles},
     },
     Role, RoleBasedAuthorizationStoreError,
 };
@@ -40,8 +40,8 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
 
         self.conn.transaction::<_, _, _>(|| {
-            let updated = update(roles::table.find(&role.id))
-                .set(roles::display_name.eq(&role.display_name))
+            let updated = update(rbac_roles::table.find(&role.id))
+                .set(rbac_roles::display_name.eq(&role.display_name))
                 .execute(self.conn)?;
 
             if updated == 0 {
@@ -52,10 +52,12 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
                 ));
             }
 
-            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
-                .execute(self.conn)?;
+            delete(
+                rbac_role_permissions::table.filter(rbac_role_permissions::role_id.eq(&role.id)),
+            )
+            .execute(self.conn)?;
 
-            insert_into(role_permissions::table)
+            insert_into(rbac_role_permissions::table)
                 .values(permissions)
                 .execute(self.conn)?;
 
@@ -72,8 +74,8 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
         let (role, permissions): (RoleModel, Vec<RolePermissionModel>) = role.into();
 
         self.conn.transaction::<_, _, _>(|| {
-            let updated = update(roles::table.find(&role.id))
-                .set(roles::display_name.eq(&role.display_name))
+            let updated = update(rbac_roles::table.find(&role.id))
+                .set(rbac_roles::display_name.eq(&role.display_name))
                 .execute(self.conn)?;
 
             if updated == 0 {
@@ -84,10 +86,12 @@ impl<'a> RoleBasedAuthorizationStoreUpdateRole
                 ));
             }
 
-            delete(role_permissions::table.filter(role_permissions::role_id.eq(&role.id)))
-                .execute(self.conn)?;
+            delete(
+                rbac_role_permissions::table.filter(rbac_role_permissions::role_id.eq(&role.id)),
+            )
+            .execute(self.conn)?;
 
-            insert_into(role_permissions::table)
+            insert_into(rbac_role_permissions::table)
                 .values(permissions)
                 .execute(self.conn)?;
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/schema.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/store/diesel/schema.rs
@@ -13,24 +13,24 @@
 // limitations under the License.
 
 table! {
-   roles (id) {
+   rbac_roles (id) {
         id -> Text,
         display_name -> Text,
     }
 }
 
 table! {
-    role_permissions (role_id, permission) {
+    rbac_role_permissions (role_id, permission) {
         role_id -> Text,
         permission -> Text,
     }
 }
 
-joinable!(role_permissions -> roles (role_id));
-allow_tables_to_appear_in_same_query!(roles, role_permissions);
+joinable!(rbac_role_permissions -> rbac_roles (role_id));
+allow_tables_to_appear_in_same_query!(rbac_roles, rbac_role_permissions);
 
 table! {
-    identities (identity) {
+    rbac_identities (identity) {
         identity -> Text,
         identity_type ->
             // the macro output can't find this type if it isn't fully qualified.
@@ -39,7 +39,7 @@ table! {
 }
 
 table! {
-    assignments (identity, role_id) {
+    rbac_assignments (identity, role_id) {
         identity -> Text,
         role_id -> Text,
     }


### PR DESCRIPTION
This change adds the prefix `rbac_` to the RBAC table names.  It creates a logical grouping of the tables under the RBAC umbrella, making them easily identifiable to a database administrator.

This does require renaming the diesel table schema definitions and updating their resulting usages.