### PR TITLE
Add dry-run flag to RBAC subcommands

### DIFF
--- a/cli/src/action/api/mod.rs
+++ b/cli/src/action/api/mod.rs
@@ -242,7 +242,7 @@ impl SplinterRestClient {
     }
 
     #[cfg(feature = "authorization-handler-rbac")]
-    pub fn get_role(&self, role_id: &str) -> Result<Role, CliError> {
+    pub fn get_role(&self, role_id: &str) -> Result<Option<Role>, CliError> {
         rbac::roles::get_role(&self.url, &self.auth, role_id)
     }
 

--- a/cli/src/action/api/mod.rs
+++ b/cli/src/action/api/mod.rs
@@ -271,7 +271,7 @@ impl SplinterRestClient {
     }
 
     #[cfg(feature = "authorization-handler-rbac")]
-    pub fn get_assignment(&self, identity: &Identity) -> Result<Assignment, CliError> {
+    pub fn get_assignment(&self, identity: &Identity) -> Result<Option<Assignment>, CliError> {
         rbac::assignments::get_assignment(&self.url, &self.auth, identity)
     }
 

--- a/cli/src/action/api/rbac/assignments.rs
+++ b/cli/src/action/api/rbac/assignments.rs
@@ -20,7 +20,7 @@ use crate::error::CliError;
 
 use super::{Pageable, RBAC_PROTOCOL_VERSION};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "identity_type", content = "identity")]
 #[serde(rename_all = "lowercase")]
 pub enum Identity {

--- a/cli/src/action/api/rbac/assignments.rs
+++ b/cli/src/action/api/rbac/assignments.rs
@@ -192,7 +192,7 @@ pub fn get_assignment(
     base_url: &str,
     auth: &str,
     identity: &Identity,
-) -> Result<Assignment, CliError> {
+) -> Result<Option<Assignment>, CliError> {
     let (id_value, id_type) = identity.parts();
 
     Client::new()
@@ -212,18 +212,17 @@ pub fn get_assignment(
         .and_then(|res| {
             let status = res.status();
             if status.is_success() {
-                res.json::<AssignmentGet>().map_err(|_| {
-                    CliError::ActionError(
-                        "Request was successful, but received an invalid response".into(),
-                    )
-                })
+                res.json::<AssignmentGet>()
+                    .map_err(|_| {
+                        CliError::ActionError(
+                            "Request was successful, but received an invalid response".into(),
+                        )
+                    })
+                    .map(|wrapper| Some(wrapper.assignment))
             } else if status.as_u16() == 401 {
                 Err(CliError::ActionError("Not Authorized".into()))
             } else if status.as_u16() == 404 {
-                Err(CliError::ActionError(format!(
-                    "Authorized identity {} {} does not exist",
-                    id_type, id_value,
-                )))
+                Ok(None)
             } else {
                 let message = res
                     .json::<ServerError>()
@@ -242,7 +241,6 @@ pub fn get_assignment(
                 )))
             }
         })
-        .map(|wrapper| wrapper.assignment)
 }
 
 pub fn update_assignment(

--- a/cli/src/action/rbac/roles.rs
+++ b/cli/src/action/rbac/roles.rs
@@ -68,7 +68,9 @@ impl Action for ShowRoleAction {
             .and_then(|args| args.value_of("role_id"))
             .ok_or_else(|| CliError::ActionError("A role ID must be specified".into()))?;
 
-        let role = new_client(&arg_matches)?.get_role(role_id)?;
+        let role = new_client(&arg_matches)?
+            .get_role(role_id)?
+            .ok_or_else(|| CliError::ActionError(format!("Role {} does not exist", role_id)))?;
 
         match format {
             "json" => println!(
@@ -181,7 +183,9 @@ fn update_role(
     permission_removal: PermissionRemoval,
     force: bool,
 ) -> Result<(), CliError> {
-    let role = client.get_role(role_id)?;
+    let role = client
+        .get_role(role_id)?
+        .ok_or_else(|| CliError::ActionError(format!("Role {} does not exist", role_id)))?;
 
     let permissions = match permission_removal {
         PermissionRemoval::RemoveAll => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1093,6 +1093,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .takes_value(true)
                                 .value_name("ROLE ID")
                                 .help("ID of role to be created"),
+                        )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without performing the role creation"),
                         ),
                 )
                 .subcommand(
@@ -1161,6 +1167,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .takes_value(true)
                                 .value_name("ROLE ID")
                                 .help("ID of role to be updated"),
+                        )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without performing the role update"),
                         ),
                 )
                 .subcommand(
@@ -1187,6 +1199,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .takes_value(true)
                                 .value_name("ROLE ID")
                                 .help("ID of role to be deleted"),
+                        )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without performing the role deletion"),
                         ),
                 ),
         ).subcommand(
@@ -1312,6 +1330,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .number_of_values(1)
                                 .required(true)
                                 .help("A role to be assigned to the provided identity"),
+                        )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without authorizing the identity"),
                         ),
                 )
                 .subcommand(
@@ -1386,6 +1410,13 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                     identity",
                                 ),
                         )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without updating the identity's \
+                                    authorizations"),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("delete")
@@ -1423,6 +1454,13 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .conflicts_with("id_key")
                                 .help("The user identity being deleted"),
                         )
+                        .arg(
+                            Arg::with_name("dry_run")
+                                .long("dry-run")
+                                .short("n")
+                                .help("Validate the command without deleting the identity's \
+                                    authorizations"),
+                        ),
                 )
         );
     }


### PR DESCRIPTION
This change adds a dry-run flag to the RBAC subcommnds:

- role create
- role update
- role delete
- authid create
- authid update
- authid delete

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>