### PR TITLE
Add count methods for proposal and circuits to AdminServiceStore

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -111,6 +111,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "admin-service-client",
+    "admin-service-count",
     "admin-service-event-client",
     "admin-service-event-client-actix-web-client",
     "authorization-handler-allow-keys",
@@ -138,6 +139,7 @@ benchmark = []
 
 admin-service = []
 admin-service-client = ["admin-service"]
+admin-service-count = []
 admin-service-event-client = ["admin-service-client" ]
 admin-service-event-client-actix-web-client = [
     "admin-service-event-client",

--- a/libsplinter/src/admin/store/diesel/operations/count_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/count_circuits.rs
@@ -1,0 +1,118 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "count circuits" operation for the `DieselAdminServiceStore`.
+
+use std::convert::TryFrom;
+
+use diesel::{
+    dsl::{count_star, exists},
+    prelude::*,
+};
+
+use crate::admin::store::{
+    diesel::{
+        models::CircuitStatusModel,
+        schema::{circuit, circuit_member},
+    },
+    error::AdminServiceStoreError,
+    CircuitPredicate,
+};
+use crate::error::InternalError;
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreCountCircuitsOperation {
+    fn count_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreCountCircuitsOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+    i16: diesel::deserialize::FromSql<diesel::sql_types::SmallInt, C::Backend>,
+{
+    fn count_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError> {
+        // Collect the management types included in the list of `CircuitPredicates`
+        let management_types: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::ManagementTypeEq(man_type) => Some(man_type.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<String>>();
+        // Collects the members included in the list of `CircuitPredicates`
+        let members: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::MembersInclude(members) => Some(members.to_vec()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        let statuses: Vec<CircuitStatusModel> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::CircuitStatus(status) => Some(CircuitStatusModel::from(status)),
+                _ => None,
+            })
+            .collect();
+        self.conn.transaction::<u32, _, _>(|| {
+            // Collects circuits which match the circuit predicates
+            let mut query = circuit::table.into_boxed().select(circuit::all_columns);
+
+            if !management_types.is_empty() {
+                query = query.filter(circuit::circuit_management_type.eq_any(management_types));
+            }
+
+            if !members.is_empty() {
+                query = query.filter(exists(
+                    // Selects all `circuit_member` entries where the `node_id` is equal
+                    // to any of the members in the circuit predicates
+                    circuit_member::table.filter(
+                        circuit_member::circuit_id
+                            .eq(circuit::circuit_id)
+                            .and(circuit_member::node_id.eq_any(members)),
+                    ),
+                ));
+            }
+
+            if statuses.is_empty() {
+                // By default, only display active circuits
+                query = query.filter(circuit::circuit_status.eq(CircuitStatusModel::Active));
+            } else {
+                query = query.filter(
+                    // Select only circuits that have the `CircuitStatus` in the predicates
+                    circuit::circuit_status.eq_any(statuses),
+                );
+            }
+
+            let count = query.select(count_star()).first::<i64>(self.conn)?;
+
+            u32::try_from(count).map_err(|_| {
+                AdminServiceStoreError::InternalError(InternalError::with_message(
+                    "The number of circuits is larger than the max u32".to_string(),
+                ))
+            })
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/count_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/count_proposals.rs
@@ -1,0 +1,122 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the " count proposals" operation for the `DieselAdminServiceStore`.
+
+use std::convert::TryFrom;
+
+use diesel::{
+    dsl::{count_star, exists},
+    prelude::*,
+    sql_types::{Binary, Integer, Nullable, SmallInt, Text},
+};
+
+use crate::admin::store::{
+    diesel::{
+        models::{CircuitProposalModel, ProposedCircuitModel},
+        schema::{proposed_circuit, proposed_node},
+    },
+    error::AdminServiceStoreError,
+    CircuitPredicate,
+};
+use crate::error::InternalError;
+
+use super::AdminServiceStoreOperations;
+
+pub(in crate::admin::store::diesel) trait AdminServiceStoreCountProposalsOperation {
+    fn count_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError>;
+}
+
+impl<'a, C> AdminServiceStoreCountProposalsOperation for AdminServiceStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+    CircuitProposalModel: diesel::Queryable<(Text, Text, Text, Binary, Text), C::Backend>,
+    ProposedCircuitModel: diesel::Queryable<
+        (
+            Text,
+            Text,
+            Text,
+            Text,
+            Text,
+            Text,
+            Nullable<Binary>,
+            Nullable<Text>,
+            Nullable<Text>,
+            Integer,
+            SmallInt,
+        ),
+        C::Backend,
+    >,
+{
+    fn count_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError> {
+        // Collect the management types included in the list of `CircuitPredicates`
+        let management_types: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::ManagementTypeEq(man_type) => Some(man_type.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<String>>();
+        // Collects the members included in the list of `CircuitPredicates`
+        let members: Vec<String> = predicates
+            .iter()
+            .filter_map(|pred| match pred {
+                CircuitPredicate::MembersInclude(members) => Some(members.to_vec()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        self.conn.transaction::<u32, _, _>(|| {
+            let mut query = proposed_circuit::table
+                .into_boxed()
+                .select(proposed_circuit::all_columns);
+
+            if !members.is_empty() {
+                query = query.filter(exists(
+                    // Selects all `proposed_node` entries where the `node_id` is not equal
+                    // to any of the members in the circuit predicates
+                    proposed_node::table.filter(
+                        proposed_node::circuit_id
+                            .eq(proposed_circuit::circuit_id)
+                            .and(proposed_node::node_id.eq_any(members)),
+                    ),
+                ))
+            }
+
+            // Selects proposed circuits that match the management types
+            if !management_types.is_empty() {
+                query = query
+                    .filter(proposed_circuit::circuit_management_type.eq_any(management_types));
+            }
+
+            let count = query.select(count_star()).first::<i64>(self.conn)?;
+
+            u32::try_from(count).map_err(|_| {
+                AdminServiceStoreError::InternalError(InternalError::with_message(
+                    "The number of proposals is larger than the max u32".to_string(),
+                ))
+            })
+        })
+    }
+}

--- a/libsplinter/src/admin/store/diesel/operations/mod.rs
+++ b/libsplinter/src/admin/store/diesel/operations/mod.rs
@@ -17,6 +17,10 @@
 pub(super) mod add_circuit;
 pub(super) mod add_event;
 pub(super) mod add_proposal;
+#[cfg(feature = "admin-service-count")]
+pub(super) mod count_circuits;
+#[cfg(feature = "admin-service-count")]
+pub(super) mod count_proposals;
 pub(super) mod get_circuit;
 pub(super) mod get_node;
 pub(super) mod get_proposal;

--- a/libsplinter/src/admin/store/mod.rs
+++ b/libsplinter/src/admin/store/mod.rs
@@ -229,6 +229,18 @@ pub trait AdminServiceStore: Send + Sync {
         predicates: &[CircuitPredicate],
     ) -> Result<Box<dyn ExactSizeIterator<Item = CircuitProposal>>, AdminServiceStoreError>;
 
+    /// Returns the count of proposals in the store
+    ///
+    /// # Arguments
+    ///
+    /// * `predicates` - A list of predicates to be applied before counting the proposals.
+    ///    This enables getting the count of proposals with specific management types and members.
+    #[cfg(feature = "admin-service-count")]
+    fn count_proposals(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError>;
+
     /// Adds a circuit to the store along with the associated services and nodes
     ///
     /// # Arguments
@@ -275,6 +287,18 @@ pub trait AdminServiceStore: Send + Sync {
         &self,
         predicates: &[CircuitPredicate],
     ) -> Result<Box<dyn ExactSizeIterator<Item = Circuit>>, AdminServiceStoreError>;
+
+    /// Returns the count of circuits in the store
+    ///
+    /// # Arguments
+    ///
+    /// * `predicates` - A list of predicates to be applied before counting the circuits.
+    ///    This enables getting the count of circuits with specific management types and members.
+    #[cfg(feature = "admin-service-count")]
+    fn count_circuits(
+        &self,
+        predicates: &[CircuitPredicate],
+    ) -> Result<u32, AdminServiceStoreError>;
 
     /// Adds a circuit, along with the associated services and nodes, to the store based on the
     /// proposal that is already in state. The associated circuit proposal for the circuit ID is


### PR DESCRIPTION
This commit adds two new methods, count_circuits and count_proposals,
to the AdminServiceStore to return the number of circuits and proposals.
These methods both take the same circuit CircuitPredicates based to the
associated list methods.

These implementations are currently behind an experimental feature
"admin-service-count"

These methods will be used to make adding metrics that keep track
of the number circuits and proposals easier to implement.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>