### PR TITLE
Improve cli usability

### DIFF
--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -26,6 +26,7 @@ use crate::daemon::StartError;
 #[derive(Debug)]
 pub enum UserError {
     TransportError(GetTransportError),
+    #[cfg(feature = "metrics")]
     MissingArgument(String),
     InvalidArgument(String),
     ConfigError(ConfigError),
@@ -61,6 +62,7 @@ impl Error for UserError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             UserError::TransportError(err) => Some(err),
+            #[cfg(feature = "metrics")]
             UserError::MissingArgument(_) => None,
             UserError::InvalidArgument(_) => None,
             UserError::ConfigError(err) => Some(err),
@@ -88,6 +90,7 @@ impl fmt::Display for UserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             UserError::TransportError(err) => write!(f, "unable to get transport: {}", err),
+            #[cfg(feature = "metrics")]
             UserError::MissingArgument(msg) => write!(f, "missing required argument: {}", msg),
             UserError::InvalidArgument(msg) => write!(f, "required argument is invalid: {}", msg),
             UserError::ConfigError(msg) => {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -72,9 +72,7 @@ fn create_config(_toml_path: Option<&str>, _matches: ArgMatches) -> Result<Confi
     let default_config = DefaultPartialConfigBuilder::new().build()?;
     builder = builder.with_partial_config(default_config);
 
-    builder
-        .build()
-        .map_err(|e| UserError::MissingArgument(e.to_string()))
+    builder.build().map_err(UserError::ConfigError)
 }
 
 // Checks whether there is a saved node_id file. If there is, the config node_id must match

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -512,6 +512,14 @@ fn start_daemon(matches: ArgMatches) -> Result<(), UserError> {
 
     let config = create_config(config_file_path, matches.clone())?;
 
+    let state_dir = config.state_dir();
+    if !Path::new(&state_dir).is_dir() {
+        return Err(UserError::DaemonError {
+            context: format!("state directory {} does not exist", state_dir),
+            source: None,
+        });
+    }
+
     if config.no_tls() {
         for network_endpoint in config.network_endpoints() {
             if network_endpoint.starts_with("tcps://") {


### PR DESCRIPTION
This change makes two minor cli usability improvements.

First, I've corrected what looks like a bug in some of splinterd's error messages. The configuration build step prepends `missing required argument:` to all ConfigError results, despite the fact that many possible ConfigErrors have nothing to do with missing required arguments. When they do, the ConfigError already says this when formatted to a string, making for an oddly redundant error message. With this change, configuration errors during configuration object build will instead be preceded with: `error occurred building config object:`

Second, I've added an explicit check for the existence of the state directory. splinterd already requires a state directory. This was changed in favor of the current behavior of throwing an error at the first attempt to save state (for instance, while creating the node_id file).

Signed-off-by: Lee Bradley bradley@bitwise.io