### PR TITLE
Add metrics for the number of active circuits and proposals

### DIFF
--- a/docker/metrics/grafana/dashboards/splinter_metrics.json
+++ b/docker/metrics/grafana/dashboards/splinter_metrics.json
@@ -39,6 +39,256 @@
         "y": 0
       },
       "hiddenSeries": false,
+      "id": 46,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "splinter.admin.proposals",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pending Proposals",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 44,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "splinter.admin.circuits.active",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Active Circuits",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$DATASOURCE",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
       "id": 42,
       "legend": {
         "avg": false,
@@ -161,7 +411,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 8
       },
       "hiddenSeries": false,
       "id": 40,
@@ -283,10 +533,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 38,
@@ -411,7 +661,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 13,
@@ -632,7 +882,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 2,
@@ -853,7 +1103,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 34
       },
       "hiddenSeries": false,
       "id": 11,
@@ -1080,7 +1330,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 41
       },
       "hiddenSeries": false,
       "id": 14,
@@ -1261,7 +1511,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 48
       },
       "hiddenSeries": false,
       "id": 15,
@@ -1464,7 +1714,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 48
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1605,7 +1855,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 55
       },
       "hiddenSeries": false,
       "id": 17,
@@ -1740,7 +1990,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 46
+        "y": 55
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1879,7 +2129,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 62
       },
       "hiddenSeries": false,
       "id": 19,
@@ -2019,7 +2269,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 69
       },
       "hiddenSeries": false,
       "id": 20,
@@ -2165,7 +2415,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 69
       },
       "hiddenSeries": false,
       "id": 36,

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -221,6 +221,17 @@ impl AdminService {
     ///
     /// Also adds peer references for members of the circuits and proposals.
     fn re_initialize_circuits(&self) -> Result<(), ServiceStartError> {
+        #[cfg(feature = "admin-service-count")]
+        self.admin_service_shared
+            .lock()
+            .map_err(|_| {
+                ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
+            })?
+            .update_metrics()
+            .map_err(|err| {
+                ServiceStartError::Internal(format!("Unable to update metrics: {}", err))
+            })?;
+
         let mut active_circuits = vec![];
         let mut inactive_circuits = vec![];
         for circuit in self

--- a/libsplinter/src/metrics/influx.rs
+++ b/libsplinter/src/metrics/influx.rs
@@ -95,7 +95,7 @@ impl InfluxRecorder {
                     Some(MetricRequest::Counter { key, value, time }) => {
                         let counter = {
                             if let Some(mut counter) = counters.get_mut(&key) {
-                                counter.value += 1;
+                                counter.value += value;
                                 counter.time = time;
                                 counter.clone()
                             } else {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -132,7 +132,11 @@ database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]
 https-bind = ["splinter/https-bind"]
-metrics = ["splinter/metrics", "scabbard/metrics"]
+metrics = [
+  "splinter/admin-service-count",
+  "splinter/metrics",
+  "scabbard/metrics",
+]
 node = [
     "authorization",
     "https-bind",


### PR DESCRIPTION
The proposal metric includes all types of proposals, while the
circuit metric only tracks active circuits.

This commit also adds admin-service-count feature to splinterd
metrics feature so the circuit/proposal metrics are included.

The associated grafana panels are added the example dashboard. 

Also fixes a bug in the metric where the counter always increased by 1, instead of the value provided by the macro.

<img width="1352" alt="Screen Shot 2021-04-16 at 1 14 48 PM" src="https://user-images.githubusercontent.com/18215486/115082149-0a1aa480-9ecb-11eb-8010-ba31f922f218.png">
