### PR TITLE
Add noninteractive to crates Dockerfile

### DIFF
--- a/ci/publish-splinter-crates
+++ b/ci/publish-splinter-crates
@@ -22,6 +22,8 @@
 
 FROM ubuntu:focal
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update \
  && apt-get install -y \
     curl \


### PR DESCRIPTION
Without this change, CI builds timeout when trying to publish
crates for tagged builds.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>