### PR TITLE
Stabilize circuit-disband in CLI and splinterd

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,7 +72,6 @@ experimental = [
     "authorization-handler-rbac",
     "circuit-auth-type",
     "circuit-abandon",
-    "circuit-disband",
     "circuit-purge",
     "health",
     "https-certs",
@@ -84,7 +83,6 @@ authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
 circuit-abandon = []
-circuit-disband = []
 circuit-purge = []
 circuit-template = ["splinter/circuit-template"]
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -626,15 +626,12 @@ fn vote_on_circuit_proposal(
     }
 }
 
-#[cfg(feature = "circuit-disband")]
 struct CircuitDisband {
     circuit_id: String,
 }
 
-#[cfg(feature = "circuit-disband")]
 pub struct CircuitDisbandAction;
 
-#[cfg(feature = "circuit-disband")]
 impl Action for CircuitDisbandAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
@@ -654,7 +651,6 @@ impl Action for CircuitDisbandAction {
     }
 }
 
-#[cfg(feature = "circuit-disband")]
 fn propose_circuit_disband(
     url: &str,
     signer: Box<dyn Signer>,

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -18,7 +18,6 @@ use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
 #[cfg(feature = "circuit-abandon")]
 use splinter::protos::admin::CircuitAbandon;
-#[cfg(feature = "circuit-disband")]
 use splinter::protos::admin::CircuitDisbandRequest;
 #[cfg(feature = "circuit-purge")]
 use splinter::protos::admin::CircuitPurgeRequest;
@@ -31,7 +30,6 @@ use crate::error::CliError;
 
 #[cfg(feature = "circuit-abandon")]
 use super::AbandonedCircuit;
-#[cfg(feature = "circuit-disband")]
 use super::CircuitDisband;
 #[cfg(feature = "circuit-purge")]
 use super::CircuitPurge;
@@ -147,7 +145,6 @@ impl ApplyToEnvelope for CircuitProposalVote {
     }
 }
 
-#[cfg(feature = "circuit-disband")]
 impl CircuitAction<CircuitDisbandRequest> for CircuitDisband {
     fn action_type(&self) -> Action {
         Action::CIRCUIT_DISBAND_REQUEST
@@ -160,7 +157,6 @@ impl CircuitAction<CircuitDisbandRequest> for CircuitDisband {
     }
 }
 
-#[cfg(feature = "circuit-disband")]
 impl ApplyToEnvelope for CircuitDisbandRequest {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_disband_request(self);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -475,7 +475,6 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 ),
         );
 
-    #[cfg(feature = "circuit-disband")]
     let circuit_command = circuit_command.subcommand(
         SubCommand::with_name("disband")
             .about("Propose to disband an existing circuit")
@@ -1508,10 +1507,8 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         .with_command("vote", circuit::CircuitVoteAction)
         .with_command("list", circuit::CircuitListAction)
         .with_command("show", circuit::CircuitShowAction)
-        .with_command("proposals", circuit::CircuitProposalsAction);
-
-    #[cfg(feature = "circuit-disband")]
-    let circuit_command = circuit_command.with_command("disband", circuit::CircuitDisbandAction);
+        .with_command("proposals", circuit::CircuitProposalsAction)
+        .with_command("disband", circuit::CircuitDisbandAction);
 
     #[cfg(feature = "circuit-purge")]
     let circuit_command = circuit_command.with_command("purge", circuit::CircuitPurgeAction);

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -95,7 +95,6 @@ experimental = [
     "authorization-handler-rbac",
     "biome-profile",
     "circuit-abandon",
-    "circuit-disband",
     "circuit-purge",
     "health-service",
     "https-bind",
@@ -123,7 +122,6 @@ biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
 circuit-abandon = []
-circuit-disband = []
 circuit-purge = [
   "health/circuit-purge",
   "scabbard/circuit-purge",


### PR DESCRIPTION
This change stabilizes the circuit-disband feature in both the CLI and splinterd by removing the feature.

In splinterd's case, this has no effect, as the feature was not guarding any code blocks, nor was it enabling any dependency's features.
