### PR TITLE
Stabilize splinterd oauth

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -78,6 +78,7 @@ default = [
     "biome-key-management",
     "database-postgres",
     "database-sqlite",
+    "oauth",
 ]
 
 stable = [
@@ -101,7 +102,6 @@ experimental = [
     "https-bind",
     "metrics",
     "node",
-    "oauth",
     "service-arg-validation",
     "service-endpoint",
     "ws-transport",


### PR DESCRIPTION
This feature stabilizes the splinterd `oauth` feature by moving it to the default set of features, making it a peer of `biome-credentials`.

The position in default features maintains this feature in all stable builds, but doesn't not make the feature an optional add on, but still removable in custom, no-default-features builds.