### PR TITLE
Stabilize `circuit-abandon` feature in CLI and splinterd

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,7 +71,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "circuit-auth-type",
-    "circuit-abandon",
     "circuit-purge",
     "health",
     "https-certs",
@@ -82,7 +81,6 @@ experimental = [
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
-circuit-abandon = []
 circuit-purge = []
 circuit-template = ["splinter/circuit-template"]
 

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -743,15 +743,12 @@ fn request_purge_circuit(
     }
 }
 
-#[cfg(feature = "circuit-abandon")]
 struct AbandonedCircuit {
     circuit_id: String,
 }
 
-#[cfg(feature = "circuit-abandon")]
 pub struct CircuitAbandonAction;
 
-#[cfg(feature = "circuit-abandon")]
 impl Action for CircuitAbandonAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
@@ -771,7 +768,6 @@ impl Action for CircuitAbandonAction {
     }
 }
 
-#[cfg(feature = "circuit-abandon")]
 fn request_abandon_circuit(
     url: &str,
     signer: Box<dyn Signer>,

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -16,7 +16,6 @@ use cylinder::Signer;
 use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
-#[cfg(feature = "circuit-abandon")]
 use splinter::protos::admin::CircuitAbandon;
 use splinter::protos::admin::CircuitDisbandRequest;
 #[cfg(feature = "circuit-purge")]
@@ -28,11 +27,9 @@ use splinter::protos::admin::{
 
 use crate::error::CliError;
 
-#[cfg(feature = "circuit-abandon")]
-use super::AbandonedCircuit;
-use super::CircuitDisband;
 #[cfg(feature = "circuit-purge")]
 use super::CircuitPurge;
+use super::{AbandonedCircuit, CircuitDisband};
 use super::{CircuitVote, Vote};
 
 /// A circuit action that has a type and can be converted into a protobuf-serializable struct.
@@ -183,7 +180,6 @@ impl ApplyToEnvelope for CircuitPurgeRequest {
     }
 }
 
-#[cfg(feature = "circuit-abandon")]
 impl CircuitAction<CircuitAbandon> for AbandonedCircuit {
     fn action_type(&self) -> Action {
         Action::CIRCUIT_ABANDON
@@ -196,7 +192,6 @@ impl CircuitAction<CircuitAbandon> for AbandonedCircuit {
     }
 }
 
-#[cfg(feature = "circuit-abandon")]
 impl ApplyToEnvelope for CircuitAbandon {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_abandon(self);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -530,7 +530,6 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             ),
     );
 
-    #[cfg(feature = "circuit-abandon")]
     let circuit_command = circuit_command.subcommand(
         SubCommand::with_name("abandon")
             .about("Abandon an existing circuit")
@@ -1546,13 +1545,11 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         .with_command("list", circuit::CircuitListAction)
         .with_command("show", circuit::CircuitShowAction)
         .with_command("proposals", circuit::CircuitProposalsAction)
-        .with_command("disband", circuit::CircuitDisbandAction);
+        .with_command("disband", circuit::CircuitDisbandAction)
+        .with_command("abandon", circuit::CircuitAbandonAction);
 
     #[cfg(feature = "circuit-purge")]
     let circuit_command = circuit_command.with_command("purge", circuit::CircuitPurgeAction);
-
-    #[cfg(feature = "circuit-abandon")]
-    let circuit_command = circuit_command.with_command("abandon", circuit::CircuitAbandonAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -94,7 +94,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-profile",
-    "circuit-abandon",
     "circuit-purge",
     "health-service",
     "https-bind",
@@ -121,7 +120,6 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
-circuit-abandon = []
 circuit-purge = [
   "health/circuit-purge",
   "scabbard/circuit-purge",


### PR DESCRIPTION
This PR stabilizes the `circuit-abandon` feature in the CLI and splinterd by removing the feature. 