### PR TITLE
Stabilize `circuit-purge` feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,7 +71,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "circuit-auth-type",
-    "circuit-purge",
     "health",
     "https-certs",
     "permissions",
@@ -81,7 +80,6 @@ experimental = [
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
 circuit-auth-type = []
-circuit-purge = []
 circuit-template = ["splinter/circuit-template"]
 
 registry = []

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -678,15 +678,12 @@ fn propose_circuit_disband(
     }
 }
 
-#[cfg(feature = "circuit-purge")]
 struct CircuitPurge {
     circuit_id: String,
 }
 
-#[cfg(feature = "circuit-purge")]
 pub struct CircuitPurgeAction;
 
-#[cfg(feature = "circuit-purge")]
 impl Action for CircuitPurgeAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
@@ -706,7 +703,6 @@ impl Action for CircuitPurgeAction {
     }
 }
 
-#[cfg(feature = "circuit-purge")]
 fn request_purge_circuit(
     url: &str,
     signer: Box<dyn Signer>,

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -17,19 +17,15 @@ use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
 use splinter::protos::admin::CircuitAbandon;
-use splinter::protos::admin::CircuitDisbandRequest;
-#[cfg(feature = "circuit-purge")]
-use splinter::protos::admin::CircuitPurgeRequest;
 use splinter::protos::admin::{
-    CircuitCreateRequest, CircuitManagementPayload, CircuitManagementPayload_Action as Action,
-    CircuitManagementPayload_Header as Header, CircuitProposalVote, CircuitProposalVote_Vote,
+    CircuitCreateRequest, CircuitDisbandRequest, CircuitManagementPayload,
+    CircuitManagementPayload_Action as Action, CircuitManagementPayload_Header as Header,
+    CircuitProposalVote, CircuitProposalVote_Vote, CircuitPurgeRequest,
 };
 
 use crate::error::CliError;
 
-#[cfg(feature = "circuit-purge")]
-use super::CircuitPurge;
-use super::{AbandonedCircuit, CircuitDisband};
+use super::{AbandonedCircuit, CircuitDisband, CircuitPurge};
 use super::{CircuitVote, Vote};
 
 /// A circuit action that has a type and can be converted into a protobuf-serializable struct.
@@ -160,7 +156,6 @@ impl ApplyToEnvelope for CircuitDisbandRequest {
     }
 }
 
-#[cfg(feature = "circuit-purge")]
 impl CircuitAction<CircuitPurgeRequest> for CircuitPurge {
     fn action_type(&self) -> Action {
         Action::CIRCUIT_PURGE_REQUEST
@@ -173,7 +168,6 @@ impl CircuitAction<CircuitPurgeRequest> for CircuitPurge {
     }
 }
 
-#[cfg(feature = "circuit-purge")]
 impl ApplyToEnvelope for CircuitPurgeRequest {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_purge_request(self);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -502,7 +502,6 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             ),
     );
 
-    #[cfg(feature = "circuit-purge")]
     let circuit_command = circuit_command.subcommand(
         SubCommand::with_name("purge")
             .about("Purge an existing inactive circuit")
@@ -1546,10 +1545,8 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         .with_command("show", circuit::CircuitShowAction)
         .with_command("proposals", circuit::CircuitProposalsAction)
         .with_command("disband", circuit::CircuitDisbandAction)
-        .with_command("abandon", circuit::CircuitAbandonAction);
-
-    #[cfg(feature = "circuit-purge")]
-    let circuit_command = circuit_command.with_command("purge", circuit::CircuitPurgeAction);
+        .with_command("abandon", circuit::CircuitAbandonAction)
+        .with_command("purge", circuit::CircuitPurgeAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(

--- a/services/health/Cargo.toml
+++ b/services/health/Cargo.toml
@@ -40,8 +40,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "circuit-purge",
 ]
 
 authorization = ["splinter/authorization"]
-circuit-purge = []

--- a/services/health/src/lib.rs
+++ b/services/health/src/lib.rs
@@ -77,15 +77,8 @@ impl Service for HealthService {
         Ok(())
     }
 
-    #[cfg(feature = "circuit-purge")]
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
         info!("Purging health service");
-        Ok(())
-    }
-
-    #[cfg(not(feature = "circuit-purge"))]
-    fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
-        info!("`circuit-purge` feature is not enabled for Health service");
         Ok(())
     }
 

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -66,13 +66,11 @@ experimental = [
   # The experimental feature extends stable:
   "stable",
   # The following features are experimental:
-  "circuit-purge",
   "factory-builder",
   "metrics",
 ]
 
 authorization = ["splinter/authorization"]
-circuit-purge = []
 client = []
 client-reqwest = ["client", "reqwest"]
 events = ["splinter/events"]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -374,7 +374,6 @@ impl Service for Scabbard {
         }
     }
 
-    #[cfg(feature = "circuit-purge")]
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
         self.state
             .lock()
@@ -383,12 +382,6 @@ impl Service for Scabbard {
             })?
             .remove_db_files()
             .map_err(|err| splinter::error::InternalError::from_source(Box::new(err)))
-    }
-
-    #[cfg(not(feature = "circuit-purge"))]
-    fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
-        info!("`circuit-purge` feature is not enabled for Scabbard service");
-        Ok(())
     }
 
     fn handle_message(

--- a/services/scabbard/libscabbard/src/service/state.rs
+++ b/services/scabbard/libscabbard/src/service/state.rs
@@ -15,11 +15,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fmt;
-#[cfg(feature = "circuit-purge")]
 use std::fs;
-use std::path::Path;
-#[cfg(feature = "circuit-purge")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{
     mpsc::{channel, Receiver, RecvTimeoutError, Sender},
     Arc, RwLock,
@@ -77,9 +74,7 @@ pub struct ScabbardState {
     pending_changes: Option<(String, Vec<TransactionReceipt>)>,
     event_subscribers: Vec<Box<dyn StateSubscriber>>,
     batch_history: BatchHistory,
-    #[cfg(feature = "circuit-purge")]
     state_db_file: PathBuf,
-    #[cfg(feature = "circuit-purge")]
     receipt_db_file: PathBuf,
 }
 
@@ -94,9 +89,7 @@ impl ScabbardState {
         // Initialize the database
         let mut indexes = INDEXES.to_vec();
         indexes.push(CURRENT_STATE_ROOT_INDEX);
-        #[cfg(feature = "circuit-purge")]
         let state_db_file = state_db_path.to_path_buf();
-        #[cfg(feature = "circuit-purge")]
         let receipt_db_file = receipt_db_path.to_path_buf();
         let state_db_path = state_db_path.with_extension("lmdb");
         let receipt_db_path = receipt_db_path.with_extension("lmdb");
@@ -168,9 +161,7 @@ impl ScabbardState {
             pending_changes: None,
             event_subscribers: vec![],
             batch_history: BatchHistory::new(),
-            #[cfg(feature = "circuit-purge")]
             state_db_file,
-            #[cfg(feature = "circuit-purge")]
             receipt_db_file,
         })
     }
@@ -379,7 +370,6 @@ impl ScabbardState {
         self.event_subscribers.clear();
     }
 
-    #[cfg(feature = "circuit-purge")]
     /// Computes the files associated with the LMDB state, including lock files.
     pub fn remove_db_files(&self) -> Result<(), ScabbardStateError> {
         let state_db_path = self.state_db_file.with_extension("lmdb");

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -95,7 +95,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-profile",
-    "circuit-purge",
     "health-service",
     "https-bind",
     "metrics",
@@ -120,7 +119,6 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
-circuit-purge = []
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -120,10 +120,7 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
-circuit-purge = [
-  "health/circuit-purge",
-  "scabbard/circuit-purge",
-]
+circuit-purge = []
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]


### PR DESCRIPTION
This PR stabilizes the `circuit-purge` feature by removing it from the CLI, splinter services, and splinterd.