### PR TITLE
Allow admin event subscribers on "*" 

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -114,6 +114,7 @@ experimental = [
     "admin-service-count",
     "admin-service-event-client",
     "admin-service-event-client-actix-web-client",
+    "admin-service-event-subscriber-glob",
     "authorization-handler-allow-keys",
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
@@ -146,6 +147,7 @@ admin-service-event-client-actix-web-client = [
     "admin-service-event-client",
     "events"
 ]
+admin-service-event-subscriber-glob = ["admin-service"]
 authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
 authorization = ["rest-api"]

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod error;
 pub(crate) mod messages;
 pub(super) mod proposal_store;
 mod shared;
+mod subscriber;
 
 use std::any::Any;
 #[cfg(feature = "service-arg-validation")]
@@ -60,13 +61,7 @@ pub use self::error::AdminKeyVerifierError;
 pub use self::error::AdminServiceError;
 pub use self::error::AdminSubscriberError;
 pub use self::shared::AdminServiceStatus;
-
-pub trait AdminServiceEventSubscriber: Send {
-    fn handle_event(
-        &self,
-        admin_service_event: &store::AdminServiceEvent,
-    ) -> Result<(), AdminSubscriberError>;
-}
+pub use self::subscriber::AdminServiceEventSubscriber;
 
 pub trait AdminCommands: Send + Sync {
     fn submit_circuit_change(

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 use std::iter::ExactSizeIterator;
@@ -23,10 +22,9 @@ use cylinder::{PublicKey, Signature, Verifier as SignatureVerifier};
 use protobuf::{Message, RepeatedField};
 
 use crate::admin::store::{
-    self, AdminServiceStore, Circuit as StoreCircuit, CircuitBuilder as StoreCircuitBuilder,
-    CircuitNode, CircuitPredicate, CircuitProposal as StoreProposal,
-    CircuitStatus as StoreCircuitStatus, ProposalType, ProposedNode, Service as StoreService, Vote,
-    VoteRecordBuilder,
+    AdminServiceStore, Circuit as StoreCircuit, CircuitBuilder as StoreCircuitBuilder, CircuitNode,
+    CircuitPredicate, CircuitProposal as StoreProposal, CircuitStatus as StoreCircuitStatus,
+    ProposalType, ProposedNode, Service as StoreService, Vote, VoteRecordBuilder,
 };
 use crate::circuit::routing::{self, RoutingTableWriter};
 use crate::consensus::{Proposal, ProposalId, ProposalUpdate};
@@ -55,10 +53,8 @@ use crate::service::ServiceNetworkSender;
 
 use super::error::{AdminSharedError, MarshallingError};
 use super::messages;
-use super::{
-    admin_service_id, sha256, AdminKeyVerifier, AdminServiceEventSubscriber, AdminSubscriberError,
-    Events,
-};
+use super::subscriber::SubscriberMap;
+use super::{admin_service_id, sha256, AdminKeyVerifier, AdminServiceEventSubscriber, Events};
 
 static VOTER_ROLE: &str = "voter";
 static PROPOSER_ROLE: &str = "proposer";
@@ -99,50 +95,6 @@ struct CircuitProposalContext {
 struct UninitializedCircuit {
     pub circuit: Option<CircuitProposal>,
     pub ready_members: HashSet<String>,
-}
-
-struct SubscriberMap {
-    subscribers_by_type: RefCell<HashMap<String, Vec<Box<dyn AdminServiceEventSubscriber>>>>,
-}
-
-impl SubscriberMap {
-    fn new() -> Self {
-        Self {
-            subscribers_by_type: RefCell::new(HashMap::new()),
-        }
-    }
-
-    fn broadcast_by_type(&self, event_type: &str, admin_service_event: &store::AdminServiceEvent) {
-        let mut subscribers_by_type = self.subscribers_by_type.borrow_mut();
-        if let Some(subscribers) = subscribers_by_type.get_mut(event_type) {
-            subscribers.retain(
-                |subscriber| match subscriber.handle_event(admin_service_event) {
-                    Ok(()) => true,
-                    Err(AdminSubscriberError::Unsubscribe) => false,
-                    Err(AdminSubscriberError::UnableToHandleEvent(msg)) => {
-                        error!("Unable to send event: {}", msg);
-                        true
-                    }
-                },
-            );
-        }
-    }
-
-    fn add_subscriber(
-        &mut self,
-        event_type: String,
-        listener: Box<dyn AdminServiceEventSubscriber>,
-    ) {
-        let mut subscribers_by_type = self.subscribers_by_type.borrow_mut();
-        let subscribers = subscribers_by_type
-            .entry(event_type)
-            .or_insert_with(Vec::new);
-        subscribers.push(listener);
-    }
-
-    fn clear(&mut self) {
-        self.subscribers_by_type.borrow_mut().clear()
-    }
 }
 
 pub struct AdminServiceShared {

--- a/libsplinter/src/admin/service/subscriber.rs
+++ b/libsplinter/src/admin/service/subscriber.rs
@@ -1,0 +1,73 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Event Subscriber Map
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::admin::store::AdminServiceEvent;
+
+use super::error::AdminSubscriberError;
+
+pub trait AdminServiceEventSubscriber: Send {
+    fn handle_event(
+        &self,
+        admin_service_event: &AdminServiceEvent,
+    ) -> Result<(), AdminSubscriberError>;
+}
+
+pub struct SubscriberMap {
+    subscribers_by_type: RefCell<HashMap<String, Vec<Box<dyn AdminServiceEventSubscriber>>>>,
+}
+
+impl SubscriberMap {
+    pub fn new() -> Self {
+        Self {
+            subscribers_by_type: RefCell::new(HashMap::new()),
+        }
+    }
+
+    pub fn broadcast_by_type(&self, event_type: &str, admin_service_event: &AdminServiceEvent) {
+        let mut subscribers_by_type = self.subscribers_by_type.borrow_mut();
+        if let Some(subscribers) = subscribers_by_type.get_mut(event_type) {
+            subscribers.retain(
+                |subscriber| match subscriber.handle_event(admin_service_event) {
+                    Ok(()) => true,
+                    Err(AdminSubscriberError::Unsubscribe) => false,
+                    Err(AdminSubscriberError::UnableToHandleEvent(msg)) => {
+                        error!("Unable to send event: {}", msg);
+                        true
+                    }
+                },
+            );
+        }
+    }
+
+    pub fn add_subscriber(
+        &mut self,
+        event_type: String,
+        listener: Box<dyn AdminServiceEventSubscriber>,
+    ) {
+        let mut subscribers_by_type = self.subscribers_by_type.borrow_mut();
+        let subscribers = subscribers_by_type
+            .entry(event_type)
+            .or_insert_with(Vec::new);
+        subscribers.push(listener);
+    }
+
+    pub fn clear(&mut self) {
+        self.subscribers_by_type.borrow_mut().clear()
+    }
+}


### PR DESCRIPTION
This change adds an experimental feature to allow for admin event subscribers for "*".  These subscribers will receive all admin events that occur, regardless of management type.

Additionally, 

- Adds unit tests for admin service subscriber map.
- moves the subscriber stuff to a submodule.