### PR TITLE
Fix issue with splinterd starting before networking

### DIFF
--- a/splinterd/packaging/systemd/splinterd.service
+++ b/splinterd/packaging/systemd/splinterd.service
@@ -14,7 +14,7 @@
 
 [Unit]
 Description=Splinter Daemon
-After=network.target
+After=network-online.target
 
 [Service]
 User=splinterd


### PR DESCRIPTION
Using "After: network-online.target" ensures that splinterd attempts
to bind after network interfaces have their IP Addresses.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>