### PR TITLE
Add wait_for method and node event client

### DIFF
--- a/libsplinter/src/admin/client/event/error.rs
+++ b/libsplinter/src/admin/client/event/error.rs
@@ -40,3 +40,27 @@ impl Error for NextEventError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum WaitForError {
+    TimeoutError,
+    NextEventError(NextEventError),
+}
+
+impl fmt::Display for WaitForError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WaitForError::TimeoutError => f.write_str("Timeout"),
+            WaitForError::NextEventError(e) => f.write_str(&e.to_string()),
+        }
+    }
+}
+
+impl Error for WaitForError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            WaitForError::TimeoutError => None,
+            WaitForError::NextEventError(ref e) => Some(&*e),
+        }
+    }
+}

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -140,6 +140,7 @@ node = [
     "splinter/admin-service-client",
     "splinter/admin-service-event-client",
     "splinter/admin-service-event-client-actix-web-client",
+    "splinter/admin-service-event-subscriber-glob",
     "splinter/client-reqwest",
     "splinter/rest-api-actix-web-3",
     "splinter/registry-client",

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -153,6 +153,16 @@ impl RunnableNode {
             }
         };
 
+        let admin_service_event_client = Box::new(
+            admin_subsystem
+                .admin_service_event_client(
+                    format!("http://localhost:{}", rest_api_port),
+                    "foo".to_string(),
+                    "*".to_string(),
+                )
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
+        );
+
         Ok(Node {
             admin_signer: self.admin_signer,
             admin_subsystem,
@@ -160,6 +170,7 @@ impl RunnableNode {
             rest_api_variant,
             rest_api_port,
             node_id,
+            admin_service_event_client,
         })
     }
 }


### PR DESCRIPTION
Add wait_for convenience method, which allows a node to wait for a
particular admin event type rather than manually looping through every
event.

Add persistent node event client for nodes that will listen for all
event types and track the current event state. This event client is
currently only used by the wait_for convenience method.

Signed-off-by: Lee Bradley <bradley@bitwise.io>