### PR TITLE
Download release versions of xo scar

### DIFF
--- a/examples/gameroom/daemon/Dockerfile-installed-focal
+++ b/examples/gameroom/daemon/Dockerfile-installed-focal
@@ -98,11 +98,11 @@ RUN apt-get update \
  && apt-get -f -y install
 
 # Fetch the XO smart contract
-RUN curl -OLsS https://build.sawtooth.me/job/Sawtooth-Hyperledger/job/sawtooth-sdk-rust/job/master/lastSuccessfulBuild/artifact/build/scar/*zip*/scar.zip
+RUN XO_LATEST=$(curl --silent https://files.splinter.dev/scar/index | grep ^xo_ | tail -1) \
+ && curl -OLsS https://files.splinter.dev/scar/$XO_LATEST
 
-RUN unzip -oj scar.zip \
- && tar -xvf xo_*.scar \
- && rm scar.zip xo_*.scar \
+RUN tar -xvf xo_*.scar \
+ && rm xo_*.scar \
  && mv xo-tp-rust.wasm /var/lib/gameroomd/xo-tp-rust.wasm
 
 CMD ["gameroomd"]


### PR DESCRIPTION
This provides a couple benefits:

  1) The Sawtooth build server sometimes is offline. This causes splinter
     builds to fail.
  2) Downloading release versions of the scar instead of main branch
     builds ensures consistent behavior over the long-term.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>