### PR TITLE
Use Bionic builders for GHA CI

### DIFF
--- a/.github/workflows/lint-gameroom-client.yaml
+++ b/.github/workflows/lint-gameroom-client.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   lint_gameroom_client:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/lint-splinter.yaml
+++ b/.github/workflows/lint-splinter.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   lint_splinter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -9,7 +9,7 @@ env:
 jobs:
 
   lint_gameroom_client:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
@@ -20,7 +20,7 @@ jobs:
         run: just ci-lint-client
 
   lint_splinter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
@@ -31,7 +31,7 @@ jobs:
         run: just ci-lint-splinter
 
   unit_test_splinter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
@@ -42,7 +42,7 @@ jobs:
         run: just ci-test
 
   gameroom_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 
@@ -53,7 +53,7 @@ jobs:
         run: just ci-test-gameroom
 
   gameroom_ui_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish_to_crates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-docker-branch.yaml
+++ b/.github/workflows/publish-docker-branch.yaml
@@ -12,7 +12,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -36,7 +36,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == '0-4'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/test-gameroom-ui.yaml
+++ b/.github/workflows/test-gameroom-ui.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   gameroom_ui_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-gameroom.yaml
+++ b/.github/workflows/test-gameroom.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   gameroom_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/unit-test-splinter.yaml
+++ b/.github/workflows/unit-test-splinter.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   unit_test_splinter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
"ubuntu-latest" GHA runners are based on Ubuntu Focal, which includes the
option "trust-dns" in /etc/resolv.conf.

Docker containers inherit DNS settings from the host, including the contents
of /etc/resolv.conf.

Through a chain of dependencies, version 0.6.3 of resolv-conf is being
used which contains a bug in parsing resolv.conf files containing the option
"trust-dns". This was fixed in 0.7.0 but we're unable to update without
updating actix.

This commit can be reverted once actix is updated to a newer version which
pulls in resolv-conf >= 0.7.0.

https://github.com/tailhook/resolv-conf/issues/25

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>