### PR TITLE
Add `splinter-circuit-remove-proposal` subcommand

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,6 +74,7 @@ experimental = [
     "health",
     "https-certs",
     "permissions",
+    "proposal-removal",
     "registry",
 ]
 
@@ -88,6 +89,7 @@ health = []
 
 https-certs = []
 permissions = []
+proposal-removal = ["splinter/proposal-removal"]
 
 database = ["diesel"]
 postgres = [

--- a/cli/man/splinter-circuit-remove-proposal.1.md
+++ b/cli/man/splinter-circuit-remove-proposal.1.md
@@ -1,0 +1,84 @@
+% SPLINTER-CIRCUIT-REMOVE-PROPOSAL(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-remove-proposal** — Remove a circuit proposal
+
+SYNOPSIS
+========
+| **splinter circuit remove-proposal** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT_ID
+
+DESCRIPTION
+===========
+Remove a circuit proposal from the node. This command only effects the
+requesting member. If any proposed member has removed a circuit proposal, the
+proposal may not be voted on to become a circuit. A circuit proposal may be
+removed at any point until it has been committed to state as a circuit.
+
+For information on how to remove a circuit, see the `splinter-circuit-disband`,
+`splinter-circuit-abandon`, and `splinter-circuit-purge` commands.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT_ID`
+: Specify the circuit ID of the circuit proposal to be removed.
+
+EXAMPLES
+========
+This command removes a circuit proposal from the requesting node, without
+affecting the other proposed members record of the proposal. The following
+shows how a circuit proposal with a circuit ID of `01234-ABCDE` is removed.
+
+```
+$ splinter circuit remove-proposal 01234-ABCDE \
+  --url URL-of-splinterd-REST-API \
+  -k path-to-private-key-file
+```
+
+You may verify the circuit proposal has been removed for the requesting node
+using the `splinter-circuit-proposals` or `splinter-circuit-show` command.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/src/action/circuit/payload.rs
+++ b/cli/src/action/circuit/payload.rs
@@ -17,6 +17,8 @@ use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
 use splinter::admin::messages::CreateCircuit;
 use splinter::protos::admin::CircuitAbandon;
+#[cfg(feature = "proposal-removal")]
+use splinter::protos::admin::ProposalRemoveRequest;
 use splinter::protos::admin::{
     CircuitCreateRequest, CircuitDisbandRequest, CircuitManagementPayload,
     CircuitManagementPayload_Action as Action, CircuitManagementPayload_Header as Header,
@@ -25,6 +27,8 @@ use splinter::protos::admin::{
 
 use crate::error::CliError;
 
+#[cfg(feature = "proposal-removal")]
+use super::RemoveProposal;
 use super::{AbandonedCircuit, CircuitDisband, CircuitPurge};
 use super::{CircuitVote, Vote};
 
@@ -189,5 +193,25 @@ impl CircuitAction<CircuitAbandon> for AbandonedCircuit {
 impl ApplyToEnvelope for CircuitAbandon {
     fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
         circuit_management_payload.set_circuit_abandon(self);
+    }
+}
+
+#[cfg(feature = "proposal-removal")]
+impl CircuitAction<ProposalRemoveRequest> for RemoveProposal {
+    fn action_type(&self) -> Action {
+        Action::PROPOSAL_REMOVE_REQUEST
+    }
+
+    fn into_proto(self) -> Result<ProposalRemoveRequest, CliError> {
+        let mut remove_proposal_req = ProposalRemoveRequest::new();
+        remove_proposal_req.set_circuit_id(self.circuit_id);
+        Ok(remove_proposal_req)
+    }
+}
+
+#[cfg(feature = "proposal-removal")]
+impl ApplyToEnvelope for ProposalRemoveRequest {
+    fn apply(self, circuit_management_payload: &mut CircuitManagementPayload) {
+        circuit_management_payload.set_proposal_remove_request(self);
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -556,6 +556,34 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             ),
     );
 
+    #[cfg(feature = "proposal-removal")]
+    let circuit_command = circuit_command.subcommand(
+        SubCommand::with_name("remove-proposal")
+            .about("Remove a circuit proposal")
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .takes_value(true)
+                    .help("URL of Splinter Daemon"),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Path to private key file"),
+            )
+            .arg(
+                Arg::with_name("circuit_id")
+                    .value_name("circuit-id")
+                    .takes_value(true)
+                    .required(true)
+                    .help("ID of the circuit proposal to remove"),
+            ),
+    );
+
     #[cfg(not(feature = "https-certs"))]
     let cert_generate_subcommand = SubCommand::with_name("generate")
         .long_about(
@@ -1547,6 +1575,10 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         .with_command("disband", circuit::CircuitDisbandAction)
         .with_command("abandon", circuit::CircuitAbandonAction)
         .with_command("purge", circuit::CircuitPurgeAction);
+
+    #[cfg(feature = "proposal-removal")]
+    let circuit_command =
+        circuit_command.with_command("remove-proposal", circuit::RemoveProposalAction);
 
     #[cfg(feature = "circuit-template")]
     let circuit_command = circuit_command.with_command(

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -101,6 +101,7 @@ experimental = [
     "https-bind",
     "metrics",
     "node",
+    "proposal-removal",
     "service-arg-validation",
     "service-endpoint",
     "ws-transport",
@@ -148,6 +149,7 @@ node = [
 oauth = [
     "splinter/oauth"
 ]
+proposal-removal = ["splinter/proposal-removal"]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-arg-validation = [
     "scabbard/service-arg-validation",


### PR DESCRIPTION
This PR adds the `splinter-circuit-remove-proposal` subcommand to the Splinter CLI. This enables users to submit a `ProposalRemoveRequest` to the admin service to delete a circuit proposal.