### PR TITLE
Mesh improvements

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -53,7 +53,7 @@ influxdb = { version = "0.4.0", features = ["derive"], optional = true }
 log = "0.3.0"
 # rename to not conflict with splinter::metrics
 metrics-lib = {package = "metrics", version = "0.12", features = ["std"], optional = true}
-mio = "0.6"
+mio = { version = "0.6", default-features = false }
 mio-extras = "2"
 oauth2 = { version = "3.0", optional = true }
 openssl = "0.10"

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -115,6 +115,23 @@ impl Pool {
         }
     }
 
+    pub fn remove_all(&mut self) -> Result<(), io::Error> {
+        for (_, entry) in self.entries.drain() {
+            let connection_token = entry.connection_token();
+            let outgoing_token = entry.outgoing_token();
+
+            self.tokens.remove(&connection_token);
+            self.tokens.remove(&outgoing_token);
+
+            let (connection, outgoing) = entry.into_evented();
+
+            self.poll.deregister(connection.evented())?;
+            self.poll.deregister(&outgoing)?;
+        }
+
+        Ok(())
+    }
+
     pub fn register_external<E: Evented>(&mut self, evented: &E) -> Result<Token, io::Error> {
         let token = self.next_token();
         self.poll

--- a/libsplinter/src/mesh/pool.rs
+++ b/libsplinter/src/mesh/pool.rs
@@ -118,7 +118,7 @@ impl Pool {
     pub fn register_external<E: Evented>(&mut self, evented: &E) -> Result<Token, io::Error> {
         let token = self.next_token();
         self.poll
-            .register(evented, token, Ready::readable(), PollOpt::level())?;
+            .register(evented, token, Ready::readable(), PollOpt::edge())?;
         Ok(token)
     }
 

--- a/libsplinter/src/mesh/reactor.rs
+++ b/libsplinter/src/mesh/reactor.rs
@@ -129,33 +129,33 @@ impl Reactor {
     }
 
     fn handle_control_ready(&mut self) -> Turn {
-        match self.ctrl_rx.try_recv() {
-            Ok(ControlRequest::Add(AddRequest {
-                connection,
-                response_tx,
-                ..
-            })) => {
-                if let Err(err) = response_tx.send(self.add_connection(connection)) {
-                    error!("Failed to send back AddResponse: {:?}", err);
+        loop {
+            match self.ctrl_rx.try_recv() {
+                Ok(ControlRequest::Add(AddRequest {
+                    connection,
+                    response_tx,
+                    ..
+                })) => {
+                    if let Err(err) = response_tx.send(self.add_connection(connection)) {
+                        error!("Failed to send back AddResponse: {:?}", err);
+                    }
                 }
-                Turn::Continue
-            }
-            Ok(ControlRequest::Remove(RemoveRequest {
-                id, response_tx, ..
-            })) => {
-                if let Err(err) = response_tx.send(self.remove_connection(id)) {
-                    error!("Failed to send back RemoveResponse: {:?}", err);
+                Ok(ControlRequest::Remove(RemoveRequest {
+                    id, response_tx, ..
+                })) => {
+                    if let Err(err) = response_tx.send(self.remove_connection(id)) {
+                        error!("Failed to send back RemoveResponse: {:?}", err);
+                    }
                 }
-                Turn::Continue
-            }
-            Ok(ControlRequest::Shutdown) => {
-                if self.incoming_tx.send(InternalEnvelope::Shutdown).is_err() {
-                    error!("Unable to send shutdown envelope to Mesh")
+                Ok(ControlRequest::Shutdown) => {
+                    if self.incoming_tx.send(InternalEnvelope::Shutdown).is_err() {
+                        error!("Unable to send shutdown envelope to Mesh")
+                    }
+                    break Turn::Shutdown;
                 }
-                Turn::Shutdown
+                Err(TryRecvError::Empty) => break Turn::Continue,
+                Err(TryRecvError::Disconnected) => break Turn::Shutdown,
             }
-            Err(TryRecvError::Empty) => Turn::Continue,
-            Err(TryRecvError::Disconnected) => Turn::Shutdown,
         }
     }
 

--- a/libsplinter/src/mesh/reactor.rs
+++ b/libsplinter/src/mesh/reactor.rs
@@ -102,6 +102,9 @@ impl Reactor {
                 Turn::Continue => (),
             }
         }
+        if let Err(err) = self.pool.remove_all() {
+            error!("Failed to clean up mesh pool: {}", err);
+        }
     }
 
     fn turn(&mut self, events: &mut Events) -> Turn {


### PR DESCRIPTION
This PR includes a number of minor Mesh improvements.

* It changes the registration of the ctrl receiver (a mio channel) from level to edge, which triggers events once while the queue is full.  It will then drain the command queue until empty.  This is considered the more efficient way to register for events.
* It removes an avenue where a lock could be locked for a long period while a message is being sent on a sync channel if the channel is full.
* It cleans up the registrations on mesh shutdown - this ensures that any connections registered with the OS are removed.
* Removing default features from mio reduces the compilation surface of mio, as it removes a series of deprecated functions