### PR TITLE
Stabilize authorization-handler-allow-keys

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -87,6 +87,7 @@ default = []
 stable = [
     "admin-service",
     "authorization",
+    "authorization-handler-allow-keys",
     "biome",
     "biome-credentials",
     "biome-key-management",
@@ -115,7 +116,6 @@ experimental = [
     "admin-service-event-client",
     "admin-service-event-client-actix-web-client",
     "admin-service-event-subscriber-glob",
-    "authorization-handler-allow-keys",
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-client",

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -85,6 +85,7 @@ default = [
 
 stable = [
     "authorization",
+    "authorization-handler-allow-keys",
     "default",
     "rest-api-cors",
 ]
@@ -93,7 +94,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "authorization-handler-allow-keys",
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-profile",


### PR DESCRIPTION
This change stabilizes the authorization-handler-allow-keys feature by moving it from experimental to stable.  It applies to both libsplinter and splinterd.
