### PR TITLE
`proposal-removal` stabilization updates

### DIFF
--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -29,6 +29,10 @@ command offers a partially completed circuit proposal, requiring less input than
 using `splinter circuit propose`. More information on how to use circuit templates
 can be found in the splinter-circuit-template(1) man page.
 
+A circuit proposal may be removed using `splinter circuit remove-proposal`.
+More information on this command is available in the
+splinter-circuit-remove-proposal(1) man page.
+
 FLAGS
 =====
 `-n`, `--dry-run`
@@ -197,5 +201,6 @@ SEE ALSO
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-template(1)`
 | `splinter-circuit-vote(1)`
+| `splinter-circuit-remove-proposal(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -2702,11 +2702,11 @@ impl AdminServiceShared {
     #[cfg(feature = "proposal-removal")]
     /// Validate a `ProposalRemoveRequest` payload by the following:
     ///
-    /// - Validate the protocol version used by the submitter node. Currently, abandoning is only
-    ///   available to nodes using `ADMIN_SERVICE_PROTOCOL_VERSION` 2.
+    /// - Validate the protocol version used by the submitter node. Currently, removing a proposal
+    ///   is only available to nodes using `ADMIN_SERVICE_PROTOCOL_VERSION` 2.
     /// - Validate the requester is authorized to propose a change for the requesting node
     /// - Validate the signer's public key is authorized for the requesting node
-    /// - Validate the proposal being abandoned exists
+    /// - Validate the proposal being removed exists
     fn validate_remove_proposal(
         &self,
         circuit_id: &str,


### PR DESCRIPTION
This adds a few updates requested for stabilizing the `proposal-removal` feature. This includes:
* updating the `splinter circuit propose` man page to refer to this new ability and adds a link to the `splinter-circuit-remove-proposal` man page to this doc.
* updates a doc comment for a function to remove a proposal defined in the admin service to correctly refer to the operation