### PR TITLE
Change to_string_pretty to to_string in websocket.rs

### DIFF
--- a/libsplinter/src/rest_api/actix_web_1/websocket.rs
+++ b/libsplinter/src/rest_api/actix_web_1/websocket.rs
@@ -151,7 +151,7 @@ impl<T: Serialize + Debug + 'static> StreamHandler<MessageWrapper<T>, ()>
         match msg {
             MessageWrapper::Message(msg) => {
                 debug!("Received a message: {:?}", msg);
-                match serde_json::to_string_pretty(&msg) {
+                match serde_json::to_string(&msg) {
                     Ok(text) => ctx.text(text),
                     Err(err) => {
                         debug!("Failed to serialize payload: {:?}", err);


### PR DESCRIPTION
to_string_pretty makes the message larger then to_string.
This was causing uploading smart contract state changes in
scabbard to be too large for the maximum size of the websocket
frame and caused the gameroom example to break.

to_string was used before but was accidently replaced in a
previous commit.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>