### PR TITLE
Add prerequisites to readme build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,33 @@ See [splinter.dev](https://www.splinter.dev/) to learn about Splinter.
 
 ## Building Splinter
 
-To build Splinter, run `cargo build` from the root directory. This command
-builds all of the Splinter components, including `libsplinter` (the main
-library), `splinterd` (the splinter daemon), the CLI, the client, and all
-examples in the `examples` directory.
+Splinter is built using latest stable [rust](https://www.rust-lang.org/), which
+you should install via [rustup](https://rustup.rs/).
+
+To install the remaining dependencies using a package manager, run one of the
+following commands.
+
+Homebrew (OS X):
+```bash
+brew install openssl zeromq pkg-config protobuf postgresql
+```
+
+APT (Ubuntu):
+```bash
+apt install libssl-dev libzmq3-dev pkg-config libprotobuf-dev postgresql
+```
+
+Once you have the prerequisites installed, build Splinter by running `cargo
+build` from the root directory. This command builds all of the Splinter
+components, including `libsplinter` (the main library), `splinterd` (the
+splinter daemon), the CLI, the client, and all examples in the `examples`
+directory.
 
 To build individual components, run `cargo build` in the component directories.
-For example, to build only the splinter library, navigate to
-`libsplinter`, then run `cargo build`.
+For example, to build only the splinter library, navigate to `libsplinter`,
+then run `cargo build`.
+
+### Building with Docker
 
 To build Splinter using Docker, run
 `docker-compose -f docker-compose-installed.yaml build` from the root


### PR DESCRIPTION
There are a number of libraries unlikely to be present on reader's
systems that must be installed before `cargo build` will successfully
build the project. These changes clarify prerequisites so that readers
following the README build instuctions can successfully build the
project without hitting roadblocks or guessing Splinter's dependencies.

Signed-off-by: Lee Bradley <bradley@bitwise.io>

Related PR: https://github.com/Cargill/splinter-docs/pull/222