### PR TITLE
Fix assignment error in commit_3_party_circuit

### DIFF
--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -190,7 +190,7 @@ pub(in crate::admin) fn commit_3_party_circuit(
     let node_b_event_client = node_b
         .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
-    let node_c_event_client = node_b
+    let node_c_event_client = node_c
         .admin_service_event_client(&format!("test_circuit_{}", &circuit_id))
         .expect("Unable to get event client");
 


### PR DESCRIPTION
The incorrect node was being used to create the
node_c_event client.

This would cause unexpected or false failures in the
circuit creation test.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>