### PR TITLE
Add protocols for proto::network messages 

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3362,7 +3362,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
-    use protobuf::{Message, RepeatedField};
+    use protobuf::RepeatedField;
 
     use diesel::{
         r2d2::{ConnectionManager as DieselConnectionManager, Pool},
@@ -3385,12 +3385,12 @@ mod tests {
         AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest, ConnectResponse,
         TrustRequest,
     };
+    use crate::protocol::network::NetworkMessage;
     use crate::protos::admin;
     use crate::protos::admin::{
         CircuitProposalVote_Vote, CircuitProposal_VoteRecord, SplinterNode, SplinterService,
     };
-    use crate::protos::authorization;
-    use crate::protos::network::{NetworkMessage, NetworkMessageType};
+    use crate::protos::network;
     use crate::protos::prelude::*;
     use crate::service::{ServiceMessageContext, ServiceSendError};
     use crate::threading::lifecycle::ShutdownHandle;
@@ -7308,16 +7308,12 @@ mod tests {
     }
 
     fn write_auth_message(connection_id: &str, auth_msg: AuthorizationMessage) -> Envelope {
-        let mut msg = NetworkMessage::new();
-        msg.set_message_type(NetworkMessageType::AUTHORIZATION);
-        msg.set_payload(
-            IntoBytes::<authorization::AuthorizationMessage>::into_bytes(auth_msg)
-                .expect("Unable to convert into bytes"),
-        );
+        let msg = NetworkMessage::from(auth_msg);
 
         Envelope::new(
             connection_id.to_string(),
-            msg.write_to_bytes().expect("Unable to write to bytes"),
+            IntoBytes::<network::NetworkMessage>::into_bytes(msg)
+                .expect("Unable to write to bytes"),
         )
     }
 }

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod authorization;
 pub mod component;
+pub mod network;
 pub mod service;
 
 // Admin REST API protocol versions

--- a/libsplinter/src/protocol/network.rs
+++ b/libsplinter/src/protocol/network.rs
@@ -1,0 +1,120 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::protos::network;
+use crate::protos::prelude::*;
+
+/// The network message envelope
+#[derive(Debug)]
+pub enum NetworkMessage {
+    NetworkEcho(NetworkEcho),
+    NetworkHeartbeat(NetworkHeartbeat),
+    Circuit(Vec<u8>),
+    Authorization(Vec<u8>),
+}
+
+/// This message is used for debugging
+#[derive(Debug)]
+pub struct NetworkEcho {
+    payload: Vec<u8>,
+    recipient: String,
+    time_to_live: i32,
+}
+
+/// This message is used to keep connections alive
+#[derive(Debug)]
+pub struct NetworkHeartbeat;
+
+impl FromProto<network::NetworkEcho> for NetworkEcho {
+    fn from_proto(mut source: network::NetworkEcho) -> Result<Self, ProtoConversionError> {
+        Ok(Self {
+            payload: source.take_payload(),
+            recipient: source.take_recipient(),
+            time_to_live: source.get_time_to_live(),
+        })
+    }
+}
+
+impl FromNative<NetworkEcho> for network::NetworkEcho {
+    fn from_native(source: NetworkEcho) -> Result<Self, ProtoConversionError> {
+        let mut proto_request = network::NetworkEcho::new();
+        proto_request.set_payload(source.payload);
+        proto_request.set_recipient(source.recipient);
+        proto_request.set_time_to_live(source.time_to_live);
+
+        Ok(proto_request)
+    }
+}
+
+impl FromProto<network::NetworkHeartbeat> for NetworkHeartbeat {
+    fn from_proto(_: network::NetworkHeartbeat) -> Result<Self, ProtoConversionError> {
+        Ok(NetworkHeartbeat)
+    }
+}
+
+impl FromNative<NetworkHeartbeat> for network::NetworkHeartbeat {
+    fn from_native(_: NetworkHeartbeat) -> Result<Self, ProtoConversionError> {
+        Ok(network::NetworkHeartbeat::new())
+    }
+}
+
+impl FromProto<network::NetworkMessage> for NetworkMessage {
+    fn from_proto(mut source: network::NetworkMessage) -> Result<Self, ProtoConversionError> {
+        use network::NetworkMessageType::*;
+        match source.message_type {
+            NETWORK_ECHO => Ok(NetworkMessage::NetworkEcho(FromBytes::<
+                network::NetworkEcho,
+            >::from_bytes(
+                source.get_payload()
+            )?)),
+            NETWORK_HEARTBEAT => Ok(NetworkMessage::NetworkHeartbeat(FromBytes::<
+                network::NetworkHeartbeat,
+            >::from_bytes(
+                source.get_payload()
+            )?)),
+            CIRCUIT => Ok(NetworkMessage::Circuit(source.take_payload())),
+            AUTHORIZATION => Ok(NetworkMessage::Authorization(source.take_payload())),
+            UNSET_NETWORK_MESSAGE_TYPE => Err(ProtoConversionError::InvalidTypeError(
+                "no message type was set".into(),
+            )),
+        }
+    }
+}
+
+impl FromNative<NetworkMessage> for network::NetworkMessage {
+    fn from_native(source: NetworkMessage) -> Result<Self, ProtoConversionError> {
+        use network::NetworkMessageType::*;
+
+        let mut message = network::NetworkMessage::new();
+        match source {
+            NetworkMessage::NetworkEcho(payload) => {
+                message.set_message_type(NETWORK_ECHO);
+                message.set_payload(IntoBytes::<network::NetworkEcho>::into_bytes(payload)?);
+            }
+            NetworkMessage::NetworkHeartbeat(payload) => {
+                message.set_message_type(NETWORK_HEARTBEAT);
+                message.set_payload(IntoBytes::<network::NetworkHeartbeat>::into_bytes(payload)?);
+            }
+            NetworkMessage::Circuit(payload) => {
+                message.set_message_type(CIRCUIT);
+                message.set_payload(payload);
+            }
+            NetworkMessage::Authorization(payload) => {
+                message.set_message_type(AUTHORIZATION);
+                message.set_payload(payload);
+            }
+        }
+        Ok(message)
+    }
+}


### PR DESCRIPTION
There are some instance around the dispatchers that still require
the protobuf. Also some instance of the protos are left
until the circuit protocols are implemented. They will be
updated in a future commit.