### PR TITLE
Update Rest API and splinter CLI for node public key additions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,6 +70,7 @@ experimental = [
     # The following features are experimental:
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
+    "challenge-authorization",
     "circuit-auth-type",
     "health",
     "https-certs",
@@ -80,6 +81,7 @@ experimental = [
 
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
+challenge-authorization = ["circuit-auth-type", "splinter/challenge-authorization"]
 circuit-auth-type = []
 circuit-template = ["splinter/circuit-template"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,7 +71,6 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "challenge-authorization",
-    "circuit-auth-type",
     "health",
     "https-certs",
     "permissions",
@@ -81,8 +80,7 @@ experimental = [
 
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
-challenge-authorization = ["circuit-auth-type", "splinter/challenge-authorization"]
-circuit-auth-type = []
+challenge-authorization = ["splinter/challenge-authorization"]
 circuit-template = ["splinter/circuit-template"]
 
 registry = []

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -86,6 +86,13 @@ OPTIONS
   to be be included on the circuit proposal. Repeat this option to specify
   multiple nodes.
 
+`--node-public-key NODE-PUBLIC-KEY-STRING` ...
+: Specifies the public key for node, using the format `NODE-ID::PUBLIC-KEY`.
+  The proposer must also specify its own node's public key, if it is
+  to be be included on the circuit proposal. Repeat this option to specify keys
+  for multiple nodes. Public keys are required if using `challenge`
+  authorization.
+
 `--service SERVICE-STRING` ...
 : Specifies the service ID and allowed nodes, using the format
   `SERVICE-ID::ALLOWED-NODES`. Service IDs are comprised of 4 ASCII alphanumeric

--- a/cli/man/splinter-circuit-propose.1.md
+++ b/cli/man/splinter-circuit-propose.1.md
@@ -54,6 +54,10 @@ FLAGS
 
 OPTIONS
 =======
+`--auth-type AUTHORIZATION_TYPE`
+: Authorization type for the circuit. Possible values `trust` or `challenge`.
+  Defaults to `trust`. If using `challenge`, node public keys are required.
+
 `--comments COMMENTS`
 : Adds human-readable comments to the circuit proposal.
 

--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -241,7 +241,7 @@ impl SplinterRestClient {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CircuitSlice {
     pub id: String,
-    pub members: Vec<String>,
+    pub members: Vec<CircuitMembers>,
     pub roster: Vec<CircuitServiceSlice>,
     pub management_type: String,
     pub display_name: Option<String>,
@@ -271,9 +271,13 @@ impl fmt::Display for CircuitSlice {
         );
 
         for member in self.members.iter() {
-            display_string += &format!("\n    {}\n", member);
+            display_string += &format!("\n    {}\n", member.node_id);
+            #[cfg(feature = "challenge-authorization")]
+            if let Some(public_key) = &member.public_key {
+                display_string += &format!("        Public Key: {}\n", public_key);
+            }
             for service in self.roster.iter() {
-                if member == &service.node_id {
+                if member.node_id == service.node_id {
                     display_string += &format!(
                         "        Service ({}): {}\n",
                         service.service_type, service.service_id
@@ -361,6 +365,10 @@ impl fmt::Display for ProposalSlice {
 
         for member in self.circuit.members.iter() {
             display_string += &format!("\n    {} ({:?})\n", member.node_id, member.endpoints);
+            #[cfg(feature = "challenge-authorization")]
+            if let Some(public_key) = &member.public_key {
+                display_string += &format!("        Public Key: {}\n", public_key);
+            }
             if member.node_id == self.requester_node_id {
                 display_string += &"        Vote: ACCEPT (implied as requester):\n".to_string();
                 display_string += &format!("            {}\n", self.requester);
@@ -427,6 +435,8 @@ pub struct ProposalCircuitSlice {
 pub struct CircuitMembers {
     pub node_id: String,
     pub endpoints: Vec<String>,
+    #[cfg(feature = "challenge-authorization")]
+    pub public_key: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "circuit-auth-type")]
+#[cfg(feature = "challenge-authorization")]
 use splinter::admin::messages::AuthorizationType;
 use splinter::admin::messages::{
     BuilderError, CircuitStatus, CreateCircuit, CreateCircuitBuilder, SplinterNode,
@@ -30,7 +30,7 @@ pub struct CreateCircuitMessageBuilder {
     services: Vec<SplinterServiceBuilder>,
     nodes: Vec<SplinterNode>,
     management_type: Option<String>,
-    #[cfg(feature = "circuit-auth-type")]
+    #[cfg(feature = "challenge-authorization")]
     authorization_type: Option<AuthorizationType>,
     application_metadata: Vec<u8>,
     comments: Option<String>,
@@ -46,7 +46,7 @@ impl CreateCircuitMessageBuilder {
             services: vec![],
             nodes: vec![],
             management_type: None,
-            #[cfg(feature = "circuit-auth-type")]
+            #[cfg(feature = "challenge-authorization")]
             authorization_type: None,
             application_metadata: vec![],
             comments: None,
@@ -229,7 +229,7 @@ impl CreateCircuitMessageBuilder {
         self.management_type = Some(management_type.into());
     }
 
-    #[cfg(feature = "circuit-auth-type")]
+    #[cfg(feature = "challenge-authorization")]
     pub fn set_authorization_type(&mut self, authorization_type: &str) -> Result<(), CliError> {
         let auth_type = match authorization_type {
             "trust" => AuthorizationType::Trust,
@@ -340,7 +340,7 @@ impl CreateCircuitMessageBuilder {
             create_circuit_builder = create_circuit_builder.with_circuit_status(&circuit_status);
         }
 
-        #[cfg(feature = "circuit-auth-type")]
+        #[cfg(feature = "challenge-authorization")]
         let create_circuit_builder = match self.authorization_type {
             Some(authorization_type) => {
                 create_circuit_builder.with_authorization_type(&authorization_type)

--- a/cli/src/action/circuit/builder.rs
+++ b/cli/src/action/circuit/builder.rs
@@ -233,6 +233,7 @@ impl CreateCircuitMessageBuilder {
     pub fn set_authorization_type(&mut self, authorization_type: &str) -> Result<(), CliError> {
         let auth_type = match authorization_type {
             "trust" => AuthorizationType::Trust,
+            "challenge" => AuthorizationType::Challenge,
             _ => {
                 return Err(CliError::ActionError(format!(
                     "Invalid authorization type {}",

--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -131,7 +131,7 @@ impl Action for CircuitProposeAction {
             }
         }
 
-        #[cfg(feature = "circuit-auth-type")]
+        #[cfg(feature = "challenge-authorization")]
         #[allow(clippy::single_match)]
         match args.value_of("authorization_type") {
             Some(auth_type) => builder.set_authorization_type(auth_type)?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -263,6 +263,18 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             .help("Authorization type for the circuit"),
     );
 
+    #[cfg(feature = "challenge-authorization")]
+    let propose_circuit = propose_circuit.arg(
+        Arg::with_name("node_public_key")
+            .long("node-public-key")
+            .takes_value(true)
+            .multiple(true)
+            .help(
+                "Public key for a node that will be used in challenge authorization \
+                 (<node_id>::<public_key>)",
+            ),
+    );
+
     #[cfg(feature = "circuit-template")]
     let propose_circuit = propose_circuit
         .arg(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -257,7 +257,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
     let propose_circuit = propose_circuit.arg(
         Arg::with_name("authorization_type")
             .long("auth-type")
-            .possible_values(&["trust"])
+            .possible_values(&["trust", "challenge"])
             .default_value("trust")
             .takes_value(true)
             .help("Authorization type for the circuit"),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -253,7 +253,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         )
         .after_help(CIRCUIT_PROPOSE_AFTER_HELP);
 
-    #[cfg(feature = "circuit-auth-type")]
+    #[cfg(feature = "challenge-authorization")]
     let propose_circuit = propose_circuit.arg(
         Arg::with_name("authorization_type")
             .long("auth-type")

--- a/libsplinter/src/admin/client/event/ws/actix_web_client.rs
+++ b/libsplinter/src/admin/client/event/ws/actix_web_client.rs
@@ -415,6 +415,11 @@ impl From<messages::SplinterNode> for CircuitMembers {
         Self {
             node_id: splinter_node.node_id,
             endpoints: splinter_node.endpoints,
+            #[cfg(feature = "challenge-authorization")]
+            public_key: splinter_node
+                .public_key
+                .as_ref()
+                .map(|public_key| hex::to_hex(&public_key)),
         }
     }
 }

--- a/libsplinter/src/admin/client/mod.rs
+++ b/libsplinter/src/admin/client/mod.rs
@@ -52,7 +52,7 @@ pub struct CircuitServiceSlice {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CircuitSlice {
     pub id: String,
-    pub members: Vec<String>,
+    pub members: Vec<CircuitMembers>,
     pub roster: Vec<CircuitServiceSlice>,
     pub management_type: String,
     pub display_name: Option<String>,
@@ -68,6 +68,8 @@ pub struct CircuitListSlice {
 pub struct CircuitMembers {
     pub node_id: String,
     pub endpoints: Vec<String>,
+    #[cfg(feature = "challenge-authorization")]
+    pub public_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -14,10 +14,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::admin::store::{Circuit, CircuitStatus, Service, CircuitNode };
-use crate::rest_api::paging::Paging;
+use crate::admin::store::{Circuit, CircuitNode, CircuitStatus, Service};
 #[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
+use crate::rest_api::paging::Paging;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct ListCircuitsResponse<'a> {
@@ -91,25 +91,20 @@ impl From<String> for CircuitStatus {
 pub(crate) struct CircuitNodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
+    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
 impl<'a> From<&'a CircuitNode> for CircuitNodeResponse<'a> {
     fn from(node_def: &'a CircuitNode) -> Self {
-        // need to mutable if challenge-authorization is enabled
-        #[allow(unused_mut)]
-        let mut public_key = None;
-
-        #[cfg(feature = "challenge-authorization")]
-        if let Some(node_public_key) = node_def.public_key() {
-            public_key = Some(to_hex(node_public_key));
-        }
-
         Self {
             node_id: node_def.node_id(),
             endpoints: node_def.endpoints(),
-            public_key: public_key,
-
+            #[cfg(feature = "challenge-authorization")]
+            public_key: node_def
+                .public_key()
+                .as_ref()
+                .map(|public_key| to_hex(&public_key)),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -14,8 +14,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::admin::store::{Circuit, CircuitStatus, Service};
+use crate::admin::store::{Circuit, CircuitStatus, Service, CircuitNode };
 use crate::rest_api::paging::Paging;
+#[cfg(feature = "challenge-authorization")]
+use crate::hex::to_hex;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct ListCircuitsResponse<'a> {
@@ -26,7 +28,7 @@ pub(crate) struct ListCircuitsResponse<'a> {
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct CircuitResponse<'a> {
     pub id: &'a str,
-    pub members: Vec<String>,
+    pub members: Vec<CircuitNodeResponse<'a>>,
     pub roster: Vec<ServiceResponse<'a>>,
     pub management_type: &'a str,
     pub display_name: &'a Option<String>,
@@ -41,7 +43,7 @@ impl<'a> From<&'a Circuit> for CircuitResponse<'a> {
             members: circuit
                 .members()
                 .iter()
-                .map(|node| node.node_id().to_string())
+                .map(CircuitNodeResponse::from)
                 .collect(),
             roster: circuit.roster().iter().map(ServiceResponse::from).collect(),
             management_type: circuit.circuit_management_type(),
@@ -81,6 +83,33 @@ impl From<String> for CircuitStatus {
             "disbanded" => CircuitStatus::Disbanded,
             "abandoned" => CircuitStatus::Abandoned,
             _ => CircuitStatus::Active,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub(crate) struct CircuitNodeResponse<'a> {
+    pub node_id: &'a str,
+    pub endpoints: &'a [String],
+    pub public_key: Option<String>,
+}
+
+impl<'a> From<&'a CircuitNode> for CircuitNodeResponse<'a> {
+    fn from(node_def: &'a CircuitNode) -> Self {
+        // need to mutable if challenge-authorization is enabled
+        #[allow(unused_mut)]
+        let mut public_key = None;
+
+        #[cfg(feature = "challenge-authorization")]
+        if let Some(node_public_key) = node_def.public_key() {
+            public_key = Some(to_hex(node_public_key));
+        }
+
+        Self {
+            node_id: node_def.node_id(),
+            endpoints: node_def.endpoints(),
+            public_key: public_key,
+
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::admin::store::{Circuit, CircuitStatus, Service, CircuitNode};
+use crate::admin::store::{Circuit, CircuitNode, CircuitStatus, Service};
 #[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 
@@ -74,25 +74,20 @@ impl<'a> From<&'a Service> for ServiceResponse<'a> {
 pub(crate) struct CircuitNodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
+    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
 impl<'a> From<&'a CircuitNode> for CircuitNodeResponse<'a> {
     fn from(node_def: &'a CircuitNode) -> Self {
-        // need to mutable if challenge-authorization is enabled
-        #[allow(unused_mut)]
-        let mut public_key = None;
-
-        #[cfg(feature = "challenge-authorization")]
-        if let Some(node_public_key) = node_def.public_key() {
-            public_key = Some(to_hex(node_public_key));
-        }
-
         Self {
             node_id: node_def.node_id(),
             endpoints: node_def.endpoints(),
-            public_key: public_key,
-
+            #[cfg(feature = "challenge-authorization")]
+            public_key: node_def
+                .public_key()
+                .as_ref()
+                .map(|public_key| to_hex(&public_key)),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
@@ -18,6 +18,8 @@ use crate::admin::messages::{
     Vote, VoteRecord,
 };
 use crate::hex::as_hex;
+#[cfg(feature = "challenge-authorization")]
+use crate::hex::to_hex;
 use crate::rest_api::paging::Paging;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -124,6 +126,8 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
+    #[cfg(feature = "challenge-authorization")]
+    pub public_key: Option<String>,
 }
 
 impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
@@ -131,6 +135,11 @@ impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
         Self {
             node_id: &node.node_id,
             endpoints: &node.endpoints,
+            #[cfg(feature = "challenge-authorization")]
+            public_key: node
+                .public_key
+                .as_ref()
+                .map(|public_key| to_hex(&public_key)),
         }
     }
 }

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
@@ -19,6 +19,8 @@ use crate::admin::messages::{
     Vote, VoteRecord,
 };
 use crate::hex::as_hex;
+#[cfg(feature = "challenge-authorization")]
+use crate::hex::to_hex;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub(crate) struct ProposalResponse<'a> {
@@ -119,6 +121,8 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
+    #[cfg(feature = "challenge-authorization")]
+    pub public_key: Option<String>,
 }
 
 impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
@@ -126,6 +130,11 @@ impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
         Self {
             node_id: &node.node_id,
             endpoints: &node.endpoints,
+            #[cfg(feature = "challenge-authorization")]
+            public_key: node
+                .public_key
+                .as_ref()
+                .map(|public_key| to_hex(&public_key)),
         }
     }
 }

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -375,6 +375,12 @@ impl SplinterNodeBuilder {
         self
     }
 
+    #[cfg(feature = "challenge-authorization")]
+    pub fn with_public_key(mut self, public_key: &[u8]) -> SplinterNodeBuilder {
+        self.public_key = Some(public_key.into());
+        self
+    }
+
     pub fn build(self) -> Result<SplinterNode, BuilderError> {
         let node_id = self
             .node_id

--- a/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
@@ -141,6 +141,12 @@ where
                             .collect::<Vec<String>>();
                         builder = builder.with_endpoints(&endpoints);
                     }
+
+                    #[cfg(feature = "challenge-authorization")]
+                    if let Some(public_key) = &node.public_key {
+                        builder = builder.with_public_key(&public_key)
+                    }
+
                     builder
                         .build()
                         .map_err(AdminServiceStoreError::InvalidStateError)

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -307,7 +307,14 @@ where
                     {
                         proposed_node.endpoints.push(endpoint);
                     } else {
-                        let proposed_node = ProposedNodeBuilder::new().with_node_id(&node.node_id);
+                        #[allow(unused_mut)]
+                        let mut proposed_node =
+                            ProposedNodeBuilder::new().with_node_id(&node.node_id);
+
+                        #[cfg(feature = "challenge-authorization")]
+                        if let Some(public_key) = &node.public_key {
+                            proposed_node = proposed_node.with_public_key(&public_key)
+                        }
 
                         proposed_nodes.insert(
                             (node.circuit_id, node.node_id),

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -97,6 +97,7 @@ experimental = [
     "authorization-handler-maintenance",
     "authorization-handler-rbac",
     "biome-profile",
+    "challenge-authorization",
     "health-service",
     "https-bind",
     "metrics",
@@ -123,6 +124,7 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
+challenge-authorization = ["splinter/challenge-authorization"]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -137,6 +137,7 @@ metrics = [
 node = [
     "authorization",
     "https-bind",
+    "challenge-authorization",
     "scabbard/client-reqwest",
     "scabbard/factory-builder",
     "splinter/admin-service-client",

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -2216,11 +2216,10 @@ components:
           type: string
           example: 01234-ABCDE
         members:
-          description: Node IDs of the circuit's members
+          description: Circuit members in the circuit
           type: array
           items:
-            type: string
-            example: alpha-node-000
+              $ref: '#/components/schemas/CircuitMember'
         roster:
           description: All services defined for the circuit
           type: array
@@ -2255,6 +2254,21 @@ components:
           description: The node ID that is allowed to run this service
           type: string
           example: alpha-node-000
+
+    CircuitMember:
+      type: object
+      properties:
+        node_id:
+          type: string
+          example: alpha-node-000
+        endpoints:
+          type: array
+          items:
+            type: string
+            example: tcps://12.0.0.123:8431
+        public_key:
+          type: string
+          example: 026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118
 
     Proposal:
       type: object
@@ -2332,6 +2346,9 @@ components:
           items:
             type: string
             example: tcps://12.0.0.123:8431
+        public_key:
+          type: string
+          example: 026c889058c2d22558ead2c61b321634b74e705c42f890e6b7bc2c80abb4713118
 
     ProposedCircuitService:
       type: object


### PR DESCRIPTION
Updates the Rest API to return public keys with proposals and the full circuit node in the member list of circuits. If challenge authorization is not enabled, the public key is not included. 
```
"members": [
                {
                    "node_id": "n20959",
                    "endpoints": [
                        "tcp://127.0.0.1:18044"
                    ],
                    "public_key": "03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03"
                },
                {
                    "node_id": "n8198",
                    "endpoints": [
                        "tcp://127.0.0.1:28044"
                    ],
                    "public_key": "02e1634dc54bc6ac5675eb3ecafc0c5a833f8e5169d021afcbb9545c122b22d00a"
                }
            ],
```

This requires that the CLI is updated as well, if the public key is not none, it will be shown in the circuit definition
```
Circuit: cXCyT-phOYD
    Display Name: circuit01
    Circuit Status: Active
    Schema Version: 2
    Management Type: manual

    n20959
        Public Key: 03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
        Service (scabbard): a000
          admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
          peer_services:
              b000
          version:
              2

    n8198
        Public Key: 02e1634dc54bc6ac5675eb3ecafc0c5a833f8e5169d021afcbb9545c122b22d00a
        Service (scabbard): b000
          admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
          peer_services:
              a000
          version:
              2
```

This PR also updates the `splinter circuit propose` CLI command to take challenge authorization type and adding a option to provide public keys for nodes. These changes are also behind an experimental feature challenge-authorization.

```
splinter circuit propose -h
   --auth-type <authorization_type>
            Authorization type for the circuit [default: trust]  [possible values: trust, challenge]
   --node-public-key <node_public_key>...
            Public key for a node that will be used in challenge authorization (<node_id>::<public_key>)
```