### PR TITLE
Seperate out v0 authorization handlers and state to make room for v1 TrustAuthorization

### DIFF
--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -335,7 +335,7 @@ impl Handler for TrustRequestHandler {
         let trust_request = TrustRequest::from_proto(msg)?;
         match self.auth_manager.next_state(
             context.source_connection_id(),
-            AuthorizationAction::TrustIdentifying(trust_request.identity),
+            AuthorizationAction::TrustIdentifyingV0(trust_request.identity),
         ) {
             Err(err) => {
                 warn!(

--- a/libsplinter/src/network/auth/handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/mod.rs
@@ -1,0 +1,167 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod v0_handlers;
+
+use crate::network::auth::{
+    AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessageSender,
+    AuthorizationState,
+};
+use crate::network::dispatch::{
+    ConnectionId, DispatchError, Dispatcher, Handler, MessageContext, MessageSender,
+};
+use crate::protocol::authorization::AuthorizationError;
+use crate::protos::authorization;
+use crate::protos::network::NetworkMessageType;
+use crate::protos::prelude::*;
+
+use self::v0_handlers::{
+    AuthorizedHandler, ConnectRequestHandler, ConnectResponseHandler, TrustRequestHandler,
+};
+
+/// Create a Dispatcher for Authorization messages
+///
+/// Creates and configures a Dispatcher to handle messages from an AuthorizationMessage envelope.
+/// The dispatcher is provided the given network sender for response messages, and the network
+/// itself to handle updating identities (or removing connections with authorization failures).
+///
+/// The identity provided is sent to connections for Trust authorizations.
+pub fn create_authorization_dispatcher(
+    identity: String,
+    auth_manager: AuthorizationManagerStateMachine,
+    auth_msg_sender: impl MessageSender<ConnectionId> + Clone + 'static,
+) -> Dispatcher<NetworkMessageType, ConnectionId> {
+    let mut auth_dispatcher = Dispatcher::new(Box::new(auth_msg_sender.clone()));
+
+    auth_dispatcher.set_handler(Box::new(ConnectRequestHandler::new(auth_manager.clone())));
+
+    auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(identity)));
+
+    auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
+
+    auth_dispatcher.set_handler(Box::new(AuthorizedHandler::new(auth_manager.clone())));
+
+    auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
+
+    let mut network_msg_dispatcher = Dispatcher::new(Box::new(auth_msg_sender));
+
+    network_msg_dispatcher.set_handler(Box::new(AuthorizationMessageHandler::new(auth_dispatcher)));
+
+    network_msg_dispatcher
+}
+
+/// The Handler for authorization network messages.
+///
+/// This Handler accepts authorization network messages, unwraps the envelope, and forwards the
+/// message contents to an authorization dispatcher.
+pub struct AuthorizationMessageHandler {
+    auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
+}
+
+impl AuthorizationMessageHandler {
+    /// Constructs a new AuthorizationMessageHandler
+    ///
+    /// This constructs an AuthorizationMessageHandler with a sender that will dispatch messages
+    /// to a authorization dispatcher.
+    pub fn new(
+        auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
+    ) -> Self {
+        AuthorizationMessageHandler { auth_dispatcher }
+    }
+}
+
+impl Handler for AuthorizationMessageHandler {
+    type Source = ConnectionId;
+    type MessageType = NetworkMessageType;
+    type Message = authorization::AuthorizationMessage;
+
+    fn match_type(&self) -> Self::MessageType {
+        NetworkMessageType::AUTHORIZATION
+    }
+
+    fn handle(
+        &self,
+        mut msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let msg_type = msg.get_message_type();
+        let payload = msg.take_payload();
+        self.auth_dispatcher
+            .dispatch(context.source_id().clone(), &msg_type, payload)
+    }
+}
+
+/// Handler for the Authorization Error Message Type
+pub struct AuthorizationErrorHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+impl AuthorizationErrorHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        AuthorizationErrorHandler { auth_manager }
+    }
+}
+
+impl Handler for AuthorizationErrorHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthorizationError;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTHORIZATION_ERROR
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        let auth_error = AuthorizationError::from_proto(msg)?;
+        match auth_error {
+            AuthorizationError::AuthorizationRejected(err_msg) => {
+                match self.auth_manager.next_state(
+                    context.source_connection_id(),
+                    AuthorizationAction::Unauthorizing,
+                ) {
+                    Ok(AuthorizationState::Unauthorized) => {
+                        info!(
+                            "Connection unauthorized by connection {}: {}",
+                            context.source_connection_id(),
+                            &err_msg
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Unable to handle unauthorizing by connection {}: {}",
+                            context.source_connection_id(),
+                            err
+                        );
+                    }
+                    Ok(next_state) => {
+                        panic!("Should not have been able to transition to {}", next_state)
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl MessageSender<ConnectionId> for AuthorizationMessageSender {
+    fn send(&self, id: ConnectionId, message: Vec<u8>) -> Result<(), (ConnectionId, Vec<u8>)> {
+        AuthorizationMessageSender::send(self, message).map_err(|msg| (id, msg))
+    }
+}

--- a/libsplinter/src/network/auth/handlers/v0_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v0_handlers.rs
@@ -15,100 +15,27 @@
 use protobuf::Message;
 
 use crate::network::dispatch::{
-    ConnectionId, DispatchError, Dispatcher, Handler, MessageContext, MessageSender,
+    ConnectionId, DispatchError, Handler, MessageContext, MessageSender,
 };
 use crate::protocol::authorization::{
-    AuthorizationError, AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest,
-    ConnectResponse, TrustRequest,
+    AuthorizationMessage, AuthorizationType, Authorized, ConnectRequest, ConnectResponse,
+    TrustRequest,
 };
 use crate::protos::authorization;
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::protos::prelude::*;
 
-use super::{
+use crate::network::auth::{
     AuthorizationAction, AuthorizationActionError, AuthorizationManagerStateMachine,
-    AuthorizationMessageSender, AuthorizationState,
+    AuthorizationState,
 };
-
-/// Create a Dispatcher for Authorization messages
-///
-/// Creates and configures a Dispatcher to handle messages from an AuthorizationMessage envelope.
-/// The dispatcher is provided the given network sender for response messages, and the network
-/// itself to handle updating identities (or removing connections with authorization failures).
-///
-/// The identity provided is sent to connections for Trust authorizations.
-pub fn create_authorization_dispatcher(
-    identity: String,
-    auth_manager: AuthorizationManagerStateMachine,
-    auth_msg_sender: impl MessageSender<ConnectionId> + Clone + 'static,
-) -> Dispatcher<NetworkMessageType, ConnectionId> {
-    let mut auth_dispatcher = Dispatcher::new(Box::new(auth_msg_sender.clone()));
-
-    auth_dispatcher.set_handler(Box::new(ConnectRequestHandler::new(auth_manager.clone())));
-
-    auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(identity)));
-
-    auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
-
-    auth_dispatcher.set_handler(Box::new(AuthorizedHandler::new(auth_manager.clone())));
-
-    auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
-
-    let mut network_msg_dispatcher = Dispatcher::new(Box::new(auth_msg_sender));
-
-    network_msg_dispatcher.set_handler(Box::new(AuthorizationMessageHandler::new(auth_dispatcher)));
-
-    network_msg_dispatcher
-}
-
-/// The Handler for authorization network messages.
-///
-/// This Handler accepts authorization network messages, unwraps the envelope, and forwards the
-/// message contents to an authorization dispatcher.
-pub struct AuthorizationMessageHandler {
-    auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
-}
-
-impl AuthorizationMessageHandler {
-    /// Constructs a new AuthorizationMessageHandler
-    ///
-    /// This constructs an AuthorizationMessageHandler with a sender that will dispatch messages
-    /// to a authorization dispatcher.
-    pub fn new(
-        auth_dispatcher: Dispatcher<authorization::AuthorizationMessageType, ConnectionId>,
-    ) -> Self {
-        AuthorizationMessageHandler { auth_dispatcher }
-    }
-}
-
-impl Handler for AuthorizationMessageHandler {
-    type Source = ConnectionId;
-    type MessageType = NetworkMessageType;
-    type Message = authorization::AuthorizationMessage;
-
-    fn match_type(&self) -> Self::MessageType {
-        NetworkMessageType::AUTHORIZATION
-    }
-
-    fn handle(
-        &self,
-        mut msg: Self::Message,
-        context: &MessageContext<Self::Source, Self::MessageType>,
-        _sender: &dyn MessageSender<Self::Source>,
-    ) -> Result<(), DispatchError> {
-        let msg_type = msg.get_message_type();
-        let payload = msg.take_payload();
-        self.auth_dispatcher
-            .dispatch(context.source_id().clone(), &msg_type, payload)
-    }
-}
 
 pub struct AuthorizedHandler {
     auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl AuthorizedHandler {
-    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         Self { auth_manager }
     }
 }
@@ -155,12 +82,12 @@ impl Handler for AuthorizedHandler {
 
 ///
 /// Handler for the Connect Request Authorization Message Type
-struct ConnectRequestHandler {
+pub struct ConnectRequestHandler {
     auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl ConnectRequestHandler {
-    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         ConnectRequestHandler { auth_manager }
     }
 }
@@ -251,12 +178,12 @@ impl Handler for ConnectRequestHandler {
 }
 
 /// Handler for the ConnectResponse Authorization Message Type
-struct ConnectResponseHandler {
+pub struct ConnectResponseHandler {
     identity: String,
 }
 
 impl ConnectResponseHandler {
-    fn new(identity: String) -> Self {
+    pub fn new(identity: String) -> Self {
         ConnectResponseHandler { identity }
     }
 }
@@ -307,12 +234,12 @@ impl Handler for ConnectResponseHandler {
 }
 
 /// Handler for the TrustRequest Authorization Message Type
-struct TrustRequestHandler {
+pub struct TrustRequestHandler {
     auth_manager: AuthorizationManagerStateMachine,
 }
 
 impl TrustRequestHandler {
-    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         TrustRequestHandler { auth_manager }
     }
 }
@@ -369,69 +296,6 @@ impl Handler for TrustRequestHandler {
     }
 }
 
-/// Handler for the Authorization Error Message Type
-struct AuthorizationErrorHandler {
-    auth_manager: AuthorizationManagerStateMachine,
-}
-
-impl AuthorizationErrorHandler {
-    fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
-        AuthorizationErrorHandler { auth_manager }
-    }
-}
-
-impl Handler for AuthorizationErrorHandler {
-    type Source = ConnectionId;
-    type MessageType = authorization::AuthorizationMessageType;
-    type Message = authorization::AuthorizationError;
-
-    fn match_type(&self) -> Self::MessageType {
-        authorization::AuthorizationMessageType::AUTHORIZATION_ERROR
-    }
-
-    fn handle(
-        &self,
-        msg: Self::Message,
-        context: &MessageContext<Self::Source, Self::MessageType>,
-        _: &dyn MessageSender<Self::Source>,
-    ) -> Result<(), DispatchError> {
-        let auth_error = AuthorizationError::from_proto(msg)?;
-        match auth_error {
-            AuthorizationError::AuthorizationRejected(err_msg) => {
-                match self.auth_manager.next_state(
-                    context.source_connection_id(),
-                    AuthorizationAction::Unauthorizing,
-                ) {
-                    Ok(AuthorizationState::Unauthorized) => {
-                        info!(
-                            "Connection unauthorized by connection {}: {}",
-                            context.source_connection_id(),
-                            &err_msg
-                        );
-                    }
-                    Err(err) => {
-                        warn!(
-                            "Unable to handle unauthorizing by connection {}: {}",
-                            context.source_connection_id(),
-                            err
-                        );
-                    }
-                    Ok(next_state) => {
-                        panic!("Should not have been able to transition to {}", next_state)
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl MessageSender<ConnectionId> for AuthorizationMessageSender {
-    fn send(&self, id: ConnectionId, message: Vec<u8>) -> Result<(), (ConnectionId, Vec<u8>)> {
-        AuthorizationMessageSender::send(self, message).map_err(|msg| (id, msg))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -441,6 +305,7 @@ mod tests {
 
     use protobuf::Message;
 
+    use crate::network::auth::create_authorization_dispatcher;
     use crate::protos::authorization;
     use crate::protos::network::{NetworkMessage, NetworkMessageType};
 

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -63,7 +63,7 @@ type Identity = String;
 #[derive(PartialEq, Debug)]
 pub(crate) enum AuthorizationAction {
     Connecting,
-    TrustIdentifying(Identity),
+    TrustIdentifyingV0(Identity),
     Unauthorizing,
     RemoteAuthorizing,
 }
@@ -72,7 +72,7 @@ impl fmt::Display for AuthorizationAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AuthorizationAction::Connecting => f.write_str("Connecting"),
-            AuthorizationAction::TrustIdentifying(_) => f.write_str("TrustIdentifying"),
+            AuthorizationAction::TrustIdentifyingV0(_) => f.write_str("TrustIdentifyingV0"),
             AuthorizationAction::Unauthorizing => f.write_str("Unauthorizing"),
             AuthorizationAction::RemoteAuthorizing => f.write_str("RemoteAuthorizing"),
         }
@@ -367,7 +367,7 @@ impl AuthorizationManagerStateMachine {
             },
             AuthorizationState::Connecting => match action {
                 AuthorizationAction::Connecting => Err(AuthorizationActionError::AlreadyConnecting),
-                AuthorizationAction::TrustIdentifying(identity) => {
+                AuthorizationAction::TrustIdentifyingV0(identity) => {
                     let new_state = AuthorizationState::RemoteIdentified(identity);
                     *cur_state = new_state.clone();
                     // Verify pub key allowed
@@ -394,7 +394,7 @@ impl AuthorizationManagerStateMachine {
                 )),
             },
             AuthorizationState::RemoteAccepted => match action {
-                AuthorizationAction::TrustIdentifying(identity) => {
+                AuthorizationAction::TrustIdentifyingV0(identity) => {
                     let new_state = AuthorizationState::Authorized(identity);
                     *cur_state = new_state.clone();
                     Ok(new_state)


### PR DESCRIPTION
Rename TrustIdentifying to TrustIdentifyingV0.This will be used to identify between v0 of trust authorization and v1.

Also moves handlers into its own module. The v0 handlers are moved to v0_handlers.rs to separate them from the future v1 message handlers.