### PR TITLE
Fix integration test assignment typo

### DIFF
--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -390,7 +390,7 @@ pub fn test_3_party_circuit_lifecycle() {
     // Wait for the proposal event from each node.
     let proposal_a_event = node_a_events.next().expect("Unable to get next event");
     let proposal_b_event = node_b_events.next().expect("Unable to get next event");
-    let proposal_c_event = node_b_events.next().expect("Unable to get next event");
+    let proposal_c_event = node_c_events.next().expect("Unable to get next event");
 
     assert_eq!(&EventType::ProposalSubmitted, proposal_a_event.event_type());
     assert_eq!(&EventType::ProposalSubmitted, proposal_b_event.event_type());


### PR DESCRIPTION
This change fixes a typo in an assignment in an integration test,
`node_a` -> `node_c`. This is a typo as the node being assigned should
match the node event client referred to.

Signed-off-by: Shannyn Telander <telander@bitwise.io>