### PR TITLE
Properly version tagged releases

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -45,7 +45,9 @@ jobs:
           fetch-depth: 0
 
       - name: Publish release to dockerhub
-        run: ./ci/publish-docker
+        run: |
+          git fetch --tags --force
+          ./ci/publish-docker
         env:
           NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
           VERSION: AUTO_STRICT
@@ -66,4 +68,6 @@ jobs:
         run: env
 
       - name: Publish release to crates
-        run: CARGO_TOKEN=${{ secrets.CARGO_TOKEN }} ./ci/publish-crates
+        run: |
+          git fetch --tags --force
+          CARGO_TOKEN=${{ secrets.CARGO_TOKEN }} ./ci/publish-crates


### PR DESCRIPTION
actions/checkout@v2 doesn't preserve annotations on tags which causes
bin/get_version to incorrectly report a -dev version.

Bug report: https://github.com/actions/checkout/issues/290

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>