### PR TITLE
Oauth-profile stabilization update

### DIFF
--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -28,7 +28,7 @@ use crate::biome::{
 };
 #[cfg(feature = "biome-profile")]
 use crate::error::InternalError;
-#[cfg(feature = "oauth-profile")]
+#[cfg(feature = "biome-profile")]
 use crate::oauth::Profile as OauthProfile;
 use crate::oauth::{
     rest_api::resources::callback::{generate_redirect_query, CallbackQuery},


### PR DESCRIPTION
Based on a comment on oauth-profile stabilization:

Fix cfg check that was originally "oauth-profile" but should be
"biome-profile".

Signed-off-by: Isabel Tomb <tomb@bitwise.io>