### PR TITLE
Add `list_users` method to oauth user store

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -127,6 +127,7 @@ experimental = [
     "https-bind",
     "metrics",
     "oauth-profile",
+    "oauth-user-list",
     "proposal-removal",
     "registry-client",
     "registry-client-reqwest",
@@ -170,6 +171,7 @@ memory = ["sqlite"]
 metrics = ["chrono", "futures-0-3", "influxdb", "metrics-lib", "tokio-0-2"]
 oauth = ["biome", "oauth2", "reqwest", "rest-api"]
 oauth-profile = ["base64"]
+oauth-user-list = ["oauth"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 proposal-removal = []
 registry = []

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -20,6 +20,8 @@ pub(in crate::biome) mod schema;
 
 use diesel::r2d2::{ConnectionManager, Pool};
 
+#[cfg(feature = "oauth-user-list")]
+use super::OAuthUserIter;
 use super::{
     InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
     OAuthUserSessionStoreError,
@@ -82,6 +84,11 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::sqlite::Sqlit
         OAuthUserSessionStoreOperations::new(&*connection).get_user(subject)
     }
 
+    #[cfg(feature = "oauth-user-list")]
+    fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
+        unimplemented!()
+    }
+
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {
         Box::new(Self {
             connection_pool: self.connection_pool.clone(),
@@ -126,6 +133,11 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::pg::PgConnect
     fn get_user(&self, subject: &str) -> Result<Option<OAuthUser>, OAuthUserSessionStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserSessionStoreOperations::new(&*connection).get_user(subject)
+    }
+
+    #[cfg(feature = "oauth-user-list")]
+    fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
+        unimplemented!()
     }
 
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -27,6 +27,8 @@ use super::{
     OAuthUserSessionStoreError,
 };
 
+#[cfg(feature = "oauth-user-list")]
+use operations::list_users::OAuthUserSessionStoreListUsers as _;
 use operations::{
     add_session::OAuthUserSessionStoreAddSession as _,
     get_session::OAuthUserSessionStoreGetSession as _, get_user::OAuthUserSessionStoreGetUser as _,
@@ -86,7 +88,8 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::sqlite::Sqlit
 
     #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
-        unimplemented!()
+        let connection = self.connection_pool.get()?;
+        OAuthUserSessionStoreOperations::new(&*connection).list_users()
     }
 
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {
@@ -137,7 +140,8 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::pg::PgConnect
 
     #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
-        unimplemented!()
+        let connection = self.connection_pool.get()?;
+        OAuthUserSessionStoreOperations::new(&*connection).list_users()
     }
 
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {
@@ -469,6 +473,109 @@ pub mod tests {
         );
         assert_eq!(stored_session2.user().subject(), subject);
         assert_eq!(stored_session2.oauth_access_token(), oauth_access_token2);
+    }
+
+    #[cfg(feature = "oauth-user-list")]
+    /// Verify that a SQLite-backed `DieselOAuthUserSessionStore` correctly supports inserting and
+    /// and listing OAuth users.
+    ///
+    /// 1. Create a connection pool for an in-memory SQLite database and run migrations.
+    /// 2. Create a `DieselOAuthUserSessionStore`.
+    /// 3. Add an OAuth user session.
+    /// 4. Verify that the `list_users` method returns the OAuth user that matches the subject of
+    ///    the OAuth session.
+    /// 5. Add a new session for the same subject and verify that the `list_users` method returns
+    ///    the same user data as before.
+    /// 6. Add an OAuth user session for a different user subject
+    /// 7. Verify that the list_users method returns both OAuth users, matching the subject of both
+    ///    the OAuth sessions.
+    /// 8. Delete all sessions and verify that the `list_users` method still returns the users.
+    #[test]
+    fn sqlite_list_users() {
+        let pool = create_connection_pool_and_migrate();
+
+        let oauth_user_session_store = DieselOAuthUserSessionStore::new(pool);
+
+        // Create an initial session for the first user
+        let splinter_access_token1 = "splinter_access_token1";
+        let subject = "subject";
+        let session1 = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token1.into())
+            .with_subject(subject.into())
+            .with_oauth_access_token("oauth_access_token1".into())
+            .build()
+            .expect("Unable to build session1");
+        oauth_user_session_store
+            .add_session(session1)
+            .expect("Unable to add session1");
+
+        let users = oauth_user_session_store
+            .list_users()
+            .expect("Unable to list users")
+            .collect::<Vec<OAuthUser>>();
+        assert_eq!(users.len(), 1);
+        let user = users.get(0).expect("Unable to get user");
+        assert_eq!(user.subject(), subject);
+
+        // Create another session for the same user
+        let splinter_access_token2 = "splinter_access_token2";
+        let session2 = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token2.into())
+            .with_subject(subject.into())
+            .with_oauth_access_token("oauth_access_token2".into())
+            .build()
+            .expect("Unable to build session2");
+        oauth_user_session_store
+            .add_session(session2)
+            .expect("Unable to add session2");
+
+        let users = oauth_user_session_store
+            .list_users()
+            .expect("Unable to list users")
+            .collect::<Vec<OAuthUser>>();
+
+        assert_eq!(users.len(), 1);
+        let first_user = users.get(0).expect("Unable to get user");
+        assert_eq!(first_user.subject(), subject);
+
+        // Create a session for a second user
+        let splinter_access_token3 = "splinter_access_token3";
+        let second_subject = "second_subject";
+        let session3 = InsertableOAuthUserSessionBuilder::new()
+            .with_splinter_access_token(splinter_access_token3.into())
+            .with_subject(second_subject.into())
+            .with_oauth_access_token("oauth_access_token3".into())
+            .build()
+            .expect("Unable to build session3");
+        oauth_user_session_store
+            .add_session(session3)
+            .expect("Unable to add session3");
+
+        let users = oauth_user_session_store
+            .list_users()
+            .expect("Unable to list users")
+            .collect::<Vec<OAuthUser>>();
+        assert_eq!(users.len(), 2);
+        let user = users.get(0).expect("Unable to get user");
+        assert_eq!(user.subject(), subject);
+        let second_user = users.get(1).expect("Unable to get user");
+        assert_eq!(second_user.subject(), second_subject);
+
+        oauth_user_session_store
+            .remove_session(splinter_access_token1)
+            .expect("Unable to remove session1");
+        oauth_user_session_store
+            .remove_session(splinter_access_token2)
+            .expect("Unable to remove session2");
+        oauth_user_session_store
+            .remove_session(splinter_access_token3)
+            .expect("Unable to remove session3");
+
+        let users = oauth_user_session_store
+            .list_users()
+            .expect("Unable to list users")
+            .collect::<Vec<OAuthUser>>();
+        assert_eq!(users.len(), 2);
     }
 
     /// Creates a connection pool for an in-memory SQLite database with only a single connection

--- a/libsplinter/src/biome/oauth/store/diesel/operations/list_users.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/list_users.rs
@@ -1,0 +1,42 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+
+use crate::biome::oauth::store::{
+    diesel::{models::OAuthUserModel, schema::oauth_users},
+    OAuthUser, OAuthUserIter, OAuthUserSessionStoreError,
+};
+
+use super::OAuthUserSessionStoreOperations;
+
+pub trait OAuthUserSessionStoreListUsers {
+    fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError>;
+}
+
+impl<'a, C> OAuthUserSessionStoreListUsers for OAuthUserSessionStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
+        Ok(OAuthUserIter::new(
+            oauth_users::table
+                .load::<OAuthUserModel>(self.conn)?
+                .into_iter()
+                .map(OAuthUser::from)
+                .collect::<Vec<OAuthUser>>(),
+        ))
+    }
+}

--- a/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
@@ -17,6 +17,8 @@
 pub(super) mod add_session;
 pub(super) mod get_session;
 pub(super) mod get_user;
+#[cfg(feature = "oauth-user-list")]
+pub(super) mod list_users;
 pub(super) mod remove_session;
 pub(super) mod update_session;
 

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -190,7 +190,15 @@ impl OAuthUserSessionStore for MemoryOAuthUserSessionStore {
 
     #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
-        unimplemented!()
+        let internal = self.internal.lock().map_err(|_| {
+            OAuthUserSessionStoreError::Internal(InternalError::with_message(
+                "Cannot access OAuth user session store: mutex lock poisoned".to_string(),
+            ))
+        })?;
+
+        let users = internal.users.values().cloned().collect::<Vec<OAuthUser>>();
+
+        Ok(OAuthUserIter::new(users))
     }
 
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -23,6 +23,8 @@ use crate::error::{
     InvalidStateError,
 };
 
+#[cfg(feature = "oauth-user-list")]
+use super::OAuthUserIter;
 use super::{
     InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
     OAuthUserSessionStoreError,
@@ -184,6 +186,11 @@ impl OAuthUserSessionStore for MemoryOAuthUserSessionStore {
             .users
             .get(subject)
             .cloned())
+    }
+
+    #[cfg(feature = "oauth-user-list")]
+    fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
+        unimplemented!()
     }
 
     fn clone_box(&self) -> Box<dyn OAuthUserSessionStore> {


### PR DESCRIPTION
This adds a `list_users` method to the `OAuthUserSessionStore` trait and adds implementations for both the memory and diesel-backed implementations of this trait. It also adds a sqlite test for the `list_users` method. 

This operation will support a new rest endpoint for the `OAuthUserSessionStore` which will be used to list users.

For testing, run `cargo test --features experimental sqlite_list_users`