### PR TITLE
Add v1 Trust Peer Authorization

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -134,6 +134,7 @@ experimental = [
     "rest-api-actix-web-3",
     "service-arg-validation",
     "service-network",
+    "trust-authorization",
     "ws-transport",
     "zmq-transport",
 ]
@@ -194,6 +195,7 @@ service-arg-validation = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]
 store-factory = []
+trust-authorization = []
 ws-transport = ["tungstenite"]
 zmq-transport = ["zmq"]
 

--- a/libsplinter/protos/authorization.proto
+++ b/libsplinter/protos/authorization.proto
@@ -126,8 +126,8 @@ message AuthorizationError {
 // This message will allow for the two connecting nodes to agree on what
 // authorization protocol version will be used
 message AuthProtocolRequest {
-    int32 auth_protocol_min = 1;
-    int32 auth_protocol_max = 2;
+    uint32 auth_protocol_min = 1;
+    uint32 auth_protocol_max = 2;
 }
 
 // Authorization protocol agreement response message
@@ -140,7 +140,7 @@ message AuthProtocolResponse {
         TRUST = 1;
         CHALLENGE = 2;
     }
-    int32 auth_protocol = 1;
+    uint32 auth_protocol = 1;
     repeated PeerAuthorizationType accepted_authorization_type = 2;
 }
 

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -1,0 +1,456 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Message handlers for v1 authorization messages
+
+use protobuf::Message;
+
+use crate::network::dispatch::{
+    ConnectionId, DispatchError, Handler, MessageContext, MessageSender,
+};
+use crate::protocol::authorization::{
+    AuthComplete, AuthProtocolRequest, AuthProtocolResponse, AuthTrustRequest, AuthTrustResponse,
+    AuthorizationError, PeerAuthorizationType,
+};
+use crate::protocol::{PEER_AUTHORIZATION_PROTOCOL_MIN, PEER_AUTHORIZATION_PROTOCOL_VERSION};
+use crate::protos::authorization;
+use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::protos::prelude::*;
+
+use crate::network::auth::{
+    state_machine::trust_v1::{TrustAuthorizationAction, TrustAuthorizationState},
+    AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessage,
+    AuthorizationState,
+};
+
+/// Handler for the Authorization Protocol Request Message Type
+pub struct AuthProtocolRequestHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+impl AuthProtocolRequestHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
+    }
+}
+
+impl Handler for AuthProtocolRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthProtocolRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_PROTOCOL_REQUEST
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization protocol request from {}",
+            context.source_connection_id()
+        );
+        let protocol_request = AuthProtocolRequest::from_proto(msg)?;
+
+        match self.auth_manager.next_remote_state(
+            context.source_connection_id(),
+            AuthorizationAction::ProtocolAgreeing,
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring authorization protocol request from {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+
+            Ok(AuthorizationState::ProtocolAgreeing) => {
+                let version = supported_protocol_version(
+                    protocol_request.auth_protocol_min,
+                    protocol_request.auth_protocol_max,
+                );
+
+                // Send error message if version is not agreed upon
+                if version == 0 {
+                    let response = AuthorizationMessage::AuthorizationError(
+                        AuthorizationError::AuthorizationRejected(
+                            "Unable to agree on protocol version".into(),
+                        ),
+                    );
+
+                    let mut msg = NetworkMessage::new();
+                    msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                    msg.set_payload(
+                        IntoBytes::<authorization::AuthorizationMessage>::into_bytes(response)?,
+                    );
+
+                    sender
+                        .send(context.source_id().clone(), msg.write_to_bytes()?)
+                        .map_err(|(recipient, payload)| {
+                            DispatchError::NetworkSendError((recipient.into(), payload))
+                        })?;
+
+                    if self
+                        .auth_manager
+                        .next_remote_state(
+                            context.source_connection_id(),
+                            AuthorizationAction::Unauthorizing,
+                        )
+                        .is_err()
+                    {
+                        warn!(
+                            "Unable to update state to Unauthorizing for {}",
+                            context.source_connection_id(),
+                        )
+                    };
+
+                    return Ok(());
+                };
+
+                debug!(
+                    "Sending agreed upon protocol version: {} and authorization types",
+                    version
+                );
+
+                let response = AuthorizationMessage::AuthProtocolResponse(AuthProtocolResponse {
+                    auth_protocol: version,
+                    accepted_authorization_type: vec![PeerAuthorizationType::Trust],
+                });
+
+                let mut msg = NetworkMessage::new();
+                msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                msg.set_payload(
+                    IntoBytes::<authorization::AuthorizationMessage>::into_bytes(response)?,
+                );
+
+                sender
+                    .send(context.source_id().clone(), msg.write_to_bytes()?)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+        Ok(())
+    }
+}
+
+/// Return the supported protocol version that matches the min/max provided. If there is no
+/// matching protocol version 0 is returned.
+fn supported_protocol_version(min: u32, max: u32) -> u32 {
+    if max < min {
+        info!("Received invalid peer auth protocol request: min cannot be greater than max");
+        return 0;
+    }
+
+    if min > PEER_AUTHORIZATION_PROTOCOL_VERSION {
+        info!(
+            "Request requires newer version than can be provided: {}",
+            min
+        );
+        return 0;
+    } else if max < PEER_AUTHORIZATION_PROTOCOL_MIN {
+        info!(
+            "Request requires older version than can be provided: {}",
+            max
+        );
+        return 0;
+    }
+
+    if max >= PEER_AUTHORIZATION_PROTOCOL_VERSION {
+        PEER_AUTHORIZATION_PROTOCOL_VERSION
+    } else if max > PEER_AUTHORIZATION_PROTOCOL_MIN {
+        max
+    } else if min > PEER_AUTHORIZATION_PROTOCOL_MIN {
+        min
+    } else {
+        PEER_AUTHORIZATION_PROTOCOL_MIN
+    }
+}
+
+/// Handler for the Authorization Protocol Response Message Type
+pub struct AuthProtocolResponseHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+    identity: String,
+}
+
+impl AuthProtocolResponseHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine, identity: String) -> Self {
+        Self {
+            auth_manager,
+            identity,
+        }
+    }
+}
+
+impl Handler for AuthProtocolResponseHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthProtocolResponse;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_PROTOCOL_RESPONSE
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization protocol response from {}",
+            context.source_connection_id()
+        );
+        let protocol_request = AuthProtocolResponse::from_proto(msg)?;
+
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::ProtocolAgreeing,
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring authorization protocol request from {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+
+            Ok(AuthorizationState::ProtocolAgreeing) => {
+                if protocol_request
+                    .accepted_authorization_type
+                    .iter()
+                    .any(|t| matches!(t, PeerAuthorizationType::Trust))
+                {
+                    let trust_request = AuthorizationMessage::AuthTrustRequest(AuthTrustRequest {
+                        identity: self.identity.clone(),
+                    });
+                    let mut msg = NetworkMessage::new();
+                    msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                    msg.set_payload(
+                        IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+                            trust_request,
+                        )?,
+                    );
+                    sender
+                        .send(context.source_id().clone(), msg.write_to_bytes()?)
+                        .map_err(|(recipient, payload)| {
+                            DispatchError::NetworkSendError((recipient.into(), payload))
+                        })?;
+                }
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Trust Request Message Type
+pub struct AuthTrustRequestHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+impl AuthTrustRequestHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
+    }
+}
+
+impl Handler for AuthTrustRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthTrustRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_TRUST_REQUEST
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization trust request from {}",
+            context.source_connection_id()
+        );
+        let trust_request = AuthTrustRequest::from_proto(msg)?;
+        match self.auth_manager.next_remote_state(
+            context.source_connection_id(),
+            AuthorizationAction::Trust(TrustAuthorizationAction::TrustIdentifying(
+                trust_request.identity,
+            )),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring trust request message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+                return Ok(());
+            }
+            Ok(AuthorizationState::Trust(TrustAuthorizationState::Identified(identity))) => {
+                debug!(
+                    "Sending trust response to connection {} after receiving identity {}",
+                    context.source_connection_id(),
+                    identity,
+                );
+                let auth_msg = AuthorizationMessage::AuthTrustResponse(AuthTrustResponse);
+                let mut msg = NetworkMessage::new();
+                msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+                msg.set_payload(
+                    IntoBytes::<authorization::AuthorizationMessage>::into_bytes(auth_msg)?,
+                );
+                sender
+                    .send(context.source_id().clone(), msg.write_to_bytes()?)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        if self
+            .auth_manager
+            .next_remote_state(
+                context.source_connection_id(),
+                AuthorizationAction::Trust(TrustAuthorizationAction::Authorizing),
+            )
+            .is_err()
+        {
+            error!("Unable to transition from TrustIdentified to Authorized")
+        };
+
+        let auth_msg = AuthorizationMessage::AuthComplete(AuthComplete);
+        let mut msg = NetworkMessage::new();
+        msg.set_message_type(NetworkMessageType::AUTHORIZATION);
+        msg.set_payload(IntoBytes::<authorization::AuthorizationMessage>::into_bytes(auth_msg)?);
+        sender
+            .send(context.source_id().clone(), msg.write_to_bytes()?)
+            .map_err(|(recipient, payload)| {
+                DispatchError::NetworkSendError((recipient.into(), payload))
+            })?;
+
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Trust Response Message Type
+pub struct AuthTrustResponseHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+    identity: String,
+}
+
+impl AuthTrustResponseHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine, identity: String) -> Self {
+        Self {
+            auth_manager,
+            identity,
+        }
+    }
+}
+
+impl Handler for AuthTrustResponseHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthTrustResponse;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_TRUST_RESPONSE
+    }
+
+    fn handle(
+        &self,
+        _msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization trust response from {}",
+            context.source_connection_id()
+        );
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::Trust(TrustAuthorizationAction::TrustIdentifying(
+                self.identity.clone(),
+            )),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring trust response message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationState::Trust(TrustAuthorizationState::Identified(_))) => (),
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Complete Message Type
+pub struct AuthCompleteHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+impl AuthCompleteHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
+    }
+}
+
+impl Handler for AuthCompleteHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthComplete;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_COMPLETE
+    }
+
+    fn handle(
+        &self,
+        _msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        _sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization complete from {}",
+            context.source_connection_id()
+        );
+        match self.auth_manager.next_state(
+            context.source_connection_id(),
+            AuthorizationAction::Trust(TrustAuthorizationAction::Authorizing),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring authorization complete message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationState::Trust(TrustAuthorizationState::Authorized(_)))
+            | Ok(AuthorizationState::AuthComplete(_)) => (),
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        Ok(())
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/mod.rs
@@ -1,0 +1,281 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub mod trust_v0;
+#[cfg(feature = "trust-authorization")]
+pub mod trust_v1;
+
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use self::trust_v0::{TrustV0AuthorizationAction, TrustV0AuthorizationState};
+#[cfg(feature = "trust-authorization")]
+use self::trust_v1::{TrustAuthorizationAction, TrustAuthorizationState};
+
+use super::{ManagedAuthorizationState, ManagedAuthorizations};
+
+type Identity = String;
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum AuthorizationState {
+    Unknown,
+    AuthComplete(Option<String>),
+    Unauthorized,
+
+    #[cfg(feature = "trust-authorization")]
+    ProtocolAgreeing,
+    TrustV0(TrustV0AuthorizationState),
+    #[cfg(feature = "trust-authorization")]
+    Trust(TrustAuthorizationState),
+}
+
+impl fmt::Display for AuthorizationState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationState::Unknown => f.write_str("Unknown"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationState::ProtocolAgreeing => f.write_str("ProtocolAgreeing"),
+            AuthorizationState::TrustV0(action) => write!(f, "TrustV0: {}", action),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationState::Trust(action) => write!(f, "Trust: {}", action),
+
+            AuthorizationState::AuthComplete(_) => f.write_str("Authorization Complete"),
+            AuthorizationState::Unauthorized => f.write_str("Unauthorized"),
+        }
+    }
+}
+
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum AuthorizationAction {
+    Connecting,
+    #[cfg(feature = "trust-authorization")]
+    ProtocolAgreeing,
+    TrustV0(TrustV0AuthorizationAction),
+    #[cfg(feature = "trust-authorization")]
+    Trust(TrustAuthorizationAction),
+
+    Unauthorizing,
+}
+
+impl fmt::Display for AuthorizationAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationAction::Connecting => f.write_str("Connecting"),
+            AuthorizationAction::Unauthorizing => f.write_str("Unauthorizing"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationAction::ProtocolAgreeing => f.write_str("ProtocolAgreeing"),
+            AuthorizationAction::TrustV0(_) => f.write_str("TrustV0"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationAction::Trust(_) => f.write_str("Trust"),
+        }
+    }
+}
+
+/// The errors that may occur for a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum AuthorizationActionError {
+    AlreadyConnecting,
+    InvalidMessageOrder(AuthorizationState, AuthorizationAction),
+    InternalError(String),
+}
+
+impl fmt::Display for AuthorizationActionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationActionError::AlreadyConnecting => {
+                f.write_str("Already attempting to connect")
+            }
+            AuthorizationActionError::InvalidMessageOrder(start, action) => {
+                write!(f, "Attempting to transition from {} via {}", start, action)
+            }
+            AuthorizationActionError::InternalError(msg) => f.write_str(&msg),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AuthorizationManagerStateMachine {
+    pub shared: Arc<Mutex<ManagedAuthorizations>>,
+}
+
+impl AuthorizationManagerStateMachine {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_state(
+        &self,
+        connection_id: &str,
+        action: AuthorizationAction,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        let mut shared = self.shared.lock().map_err(|_| {
+            AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
+        })?;
+
+        let mut cur_state =
+            shared
+                .states
+                .entry(connection_id.to_string())
+                .or_insert(ManagedAuthorizationState {
+                    local_state: AuthorizationState::Unknown,
+                    remote_state: AuthorizationState::Unknown,
+                });
+
+        if action == AuthorizationAction::Unauthorizing {
+            cur_state.local_state = AuthorizationState::Unauthorized;
+            cur_state.remote_state = AuthorizationState::Unauthorized;
+            return Ok(AuthorizationState::Unauthorized);
+        }
+
+        match cur_state.local_state.clone() {
+            AuthorizationState::Unknown => match action {
+                AuthorizationAction::Connecting => {
+                    if cur_state.local_state
+                        == AuthorizationState::TrustV0(TrustV0AuthorizationState::Connecting)
+                    {
+                        return Err(AuthorizationActionError::AlreadyConnecting);
+                    };
+                    cur_state.local_state =
+                        AuthorizationState::TrustV0(TrustV0AuthorizationState::Connecting);
+                    cur_state.remote_state = AuthorizationState::AuthComplete(None);
+                    Ok(AuthorizationState::TrustV0(
+                        TrustV0AuthorizationState::Connecting,
+                    ))
+                }
+                #[cfg(feature = "trust-authorization")]
+                AuthorizationAction::ProtocolAgreeing => {
+                    cur_state.local_state = AuthorizationState::ProtocolAgreeing;
+                    Ok(AuthorizationState::ProtocolAgreeing)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Unknown,
+                    action,
+                )),
+            },
+            AuthorizationState::TrustV0(state) => match action {
+                AuthorizationAction::TrustV0(action) => {
+                    let new_state = state.next_state(action)?;
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::TrustV0(state),
+                    action,
+                )),
+            },
+            // v1 state transitions
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationState::ProtocolAgreeing => match action {
+                AuthorizationAction::Trust(action) => {
+                    let new_state =
+                        TrustAuthorizationState::TrustConnecting.next_state(action, cur_state)?;
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::ProtocolAgreeing,
+                    action,
+                )),
+            },
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationState::Trust(state) => match action {
+                AuthorizationAction::Trust(action) => {
+                    let new_state = state.next_state(action, cur_state)?;
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(state),
+                    action,
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                cur_state.local_state.clone(),
+                action,
+            )),
+        }
+    }
+
+    /// Transitions from one authorization state to another. This is specific to the remote node
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    #[cfg(feature = "trust-authorization")]
+    pub(crate) fn next_remote_state(
+        &self,
+        connection_id: &str,
+        action: AuthorizationAction,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        let mut shared = self.shared.lock().map_err(|_| {
+            AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
+        })?;
+
+        let mut cur_state =
+            shared
+                .states
+                .entry(connection_id.to_string())
+                .or_insert(ManagedAuthorizationState {
+                    local_state: AuthorizationState::Unknown,
+                    remote_state: AuthorizationState::Unknown,
+                });
+
+        if action == AuthorizationAction::Unauthorizing {
+            cur_state.local_state = AuthorizationState::Unauthorized;
+            cur_state.remote_state = AuthorizationState::Unauthorized;
+            return Ok(AuthorizationState::Unauthorized);
+        }
+
+        match cur_state.remote_state.clone() {
+            AuthorizationState::Unknown => match action {
+                AuthorizationAction::ProtocolAgreeing => {
+                    cur_state.remote_state = AuthorizationState::ProtocolAgreeing;
+                    Ok(AuthorizationState::ProtocolAgreeing)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Unknown,
+                    action,
+                )),
+            },
+            // v1 state transitions
+            AuthorizationState::ProtocolAgreeing => match action {
+                AuthorizationAction::Trust(action) => {
+                    let new_state = TrustAuthorizationState::TrustConnecting
+                        .next_remote_state(action, cur_state)?;
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::ProtocolAgreeing,
+                    action,
+                )),
+            },
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationState::Trust(state) => match action {
+                AuthorizationAction::Trust(action) => {
+                    let new_state = state.next_remote_state(action, cur_state)?;
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(state),
+                    action,
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                cur_state.remote_state.clone(),
+                action,
+            )),
+        }
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/trust_v0.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v0.rs
@@ -1,0 +1,96 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use super::{AuthorizationAction, AuthorizationActionError, AuthorizationState, Identity};
+
+/// The states of a connection during v0 trust authorization.
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum TrustV0AuthorizationState {
+    Connecting,
+    RemoteIdentified(String),
+    RemoteAccepted,
+}
+
+impl fmt::Display for TrustV0AuthorizationState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            TrustV0AuthorizationState::Connecting => "Connecting",
+            TrustV0AuthorizationState::RemoteIdentified(_) => "Remote Identified",
+            TrustV0AuthorizationState::RemoteAccepted => "Remote Accepted",
+        })
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub(crate) enum TrustV0AuthorizationAction {
+    TrustIdentifyingV0(Identity),
+    RemoteAuthorizing,
+}
+
+impl fmt::Display for TrustV0AuthorizationAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TrustV0AuthorizationAction::TrustIdentifyingV0(_) => f.write_str("TrustIdentifyingV0"),
+            TrustV0AuthorizationAction::RemoteAuthorizing => f.write_str("RemoteAuthorizing"),
+        }
+    }
+}
+
+impl TrustV0AuthorizationState {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_state(
+        &self,
+        action: TrustV0AuthorizationAction,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        match &self {
+            // v0 state transitions
+            TrustV0AuthorizationState::Connecting => match action {
+                TrustV0AuthorizationAction::TrustIdentifyingV0(identity) => {
+                    Ok(AuthorizationState::TrustV0(
+                        TrustV0AuthorizationState::RemoteIdentified(identity),
+                    ))
+                }
+                TrustV0AuthorizationAction::RemoteAuthorizing => Ok(AuthorizationState::TrustV0(
+                    TrustV0AuthorizationState::RemoteAccepted,
+                )),
+            },
+            TrustV0AuthorizationState::RemoteIdentified(identity) => match action {
+                TrustV0AuthorizationAction::RemoteAuthorizing => {
+                    Ok(AuthorizationState::AuthComplete(Some(identity.clone())))
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::TrustV0(TrustV0AuthorizationState::RemoteIdentified(
+                        identity.clone(),
+                    )),
+                    AuthorizationAction::TrustV0(action),
+                )),
+            },
+            TrustV0AuthorizationState::RemoteAccepted => match action {
+                TrustV0AuthorizationAction::TrustIdentifyingV0(identity) => {
+                    Ok(AuthorizationState::AuthComplete(Some(identity)))
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::TrustV0(TrustV0AuthorizationState::RemoteAccepted),
+                    AuthorizationAction::TrustV0(action),
+                )),
+            },
+        }
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/trust_v1.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v1.rs
@@ -1,0 +1,164 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::network::auth::ManagedAuthorizationState;
+
+use super::{AuthorizationAction, AuthorizationActionError, AuthorizationState, Identity};
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum TrustAuthorizationState {
+    TrustConnecting,
+    Identified(String),
+    Authorized(String),
+}
+
+impl fmt::Display for TrustAuthorizationState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            TrustAuthorizationState::TrustConnecting => "Connecting",
+            TrustAuthorizationState::Identified(_) => "Trust Identified",
+            TrustAuthorizationState::Authorized(_) => "Authorized",
+        })
+    }
+}
+
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum TrustAuthorizationAction {
+    TrustIdentifying(Identity),
+    Authorizing,
+}
+
+impl fmt::Display for TrustAuthorizationAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TrustAuthorizationAction::TrustIdentifying(_) => f.write_str("TrustIdentifying"),
+            TrustAuthorizationAction::Authorizing => f.write_str("Authorizing"),
+        }
+    }
+}
+
+impl TrustAuthorizationState {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_state(
+        &self,
+        action: TrustAuthorizationAction,
+        cur_state: &mut ManagedAuthorizationState,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        match &self {
+            TrustAuthorizationState::TrustConnecting => match action {
+                TrustAuthorizationAction::TrustIdentifying(identity) => {
+                    let new_state =
+                        AuthorizationState::Trust(TrustAuthorizationState::Identified(identity));
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(self.clone()),
+                    AuthorizationAction::Trust(action),
+                )),
+            },
+            TrustAuthorizationState::Identified(identity) => match action {
+                TrustAuthorizationAction::Authorizing => {
+                    let new_state = {
+                        match &cur_state.remote_state {
+                            AuthorizationState::Trust(TrustAuthorizationState::Authorized(
+                                local_id,
+                            )) => {
+                                cur_state.remote_state =
+                                    AuthorizationState::AuthComplete(Some(local_id.to_string()));
+                                AuthorizationState::AuthComplete(Some(identity.to_string()))
+                            }
+                            _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
+                                identity.to_string(),
+                            )),
+                        }
+                    };
+
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(self.clone()),
+                    AuthorizationAction::Trust(action),
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                AuthorizationState::Trust(self.clone()),
+                AuthorizationAction::Trust(action),
+            )),
+        }
+    }
+
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_remote_state(
+        &self,
+        action: TrustAuthorizationAction,
+        cur_state: &mut ManagedAuthorizationState,
+    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        match &self {
+            TrustAuthorizationState::TrustConnecting => match action {
+                TrustAuthorizationAction::TrustIdentifying(identity) => {
+                    let new_state =
+                        AuthorizationState::Trust(TrustAuthorizationState::Identified(identity));
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(self.clone()),
+                    AuthorizationAction::Trust(action),
+                )),
+            },
+            TrustAuthorizationState::Identified(identity) => match action {
+                TrustAuthorizationAction::Authorizing => {
+                    let new_state = {
+                        match &cur_state.local_state {
+                            AuthorizationState::Trust(TrustAuthorizationState::Authorized(
+                                local_id,
+                            )) => {
+                                cur_state.local_state =
+                                    AuthorizationState::AuthComplete(Some(local_id.to_string()));
+                                AuthorizationState::AuthComplete(Some(identity.to_string()))
+                            }
+                            _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
+                                identity.to_string(),
+                            )),
+                        }
+                    };
+
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                    AuthorizationState::Trust(self.clone()),
+                    AuthorizationAction::Trust(action),
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+                AuthorizationState::Trust(self.clone()),
+                AuthorizationAction::Trust(action),
+            )),
+        }
+    }
+}

--- a/libsplinter/src/protocol/authorization.rs
+++ b/libsplinter/src/protocol/authorization.rs
@@ -229,8 +229,8 @@ pub struct AuthComplete;
 /// returned.
 #[derive(Debug)]
 pub struct AuthProtocolRequest {
-    auth_protocol_min: i32,
-    auth_protocol_max: i32,
+    auth_protocol_min: u32,
+    auth_protocol_max: u32,
 }
 
 #[derive(Debug)]
@@ -245,7 +245,7 @@ pub enum PeerAuthorizationType {
 /// authorization types.
 #[derive(Debug)]
 pub struct AuthProtocolResponse {
-    auth_protocol: i32,
+    auth_protocol: u32,
     accepted_authorization_type: Vec<PeerAuthorizationType>,
 }
 

--- a/libsplinter/src/protocol/authorization.rs
+++ b/libsplinter/src/protocol/authorization.rs
@@ -229,8 +229,8 @@ pub struct AuthComplete;
 /// returned.
 #[derive(Debug)]
 pub struct AuthProtocolRequest {
-    auth_protocol_min: u32,
-    auth_protocol_max: u32,
+    pub auth_protocol_min: u32,
+    pub auth_protocol_max: u32,
 }
 
 #[derive(Debug)]
@@ -245,8 +245,8 @@ pub enum PeerAuthorizationType {
 /// authorization types.
 #[derive(Debug)]
 pub struct AuthProtocolResponse {
-    auth_protocol: u32,
-    accepted_authorization_type: Vec<PeerAuthorizationType>,
+    pub auth_protocol: u32,
+    pub accepted_authorization_type: Vec<PeerAuthorizationType>,
 }
 
 /// A trust request.
@@ -255,7 +255,7 @@ pub struct AuthProtocolResponse {
 /// response will be returned.
 #[derive(Debug)]
 pub struct AuthTrustRequest {
-    identity: String,
+    pub identity: String,
 }
 
 /// A successful trust authorization.
@@ -277,7 +277,7 @@ pub struct AuthChallengeNonceRequest;
 /// AuthChallengeSubmitRequest message
 #[derive(Debug)]
 pub struct AuthChallengeNonceResponse {
-    nonce: Vec<u8>,
+    pub nonce: Vec<u8>,
 }
 
 /// A challenge submit request
@@ -286,8 +286,8 @@ pub struct AuthChallengeNonceResponse {
 /// and the public key for the signature.
 #[derive(Debug)]
 pub struct AuthChallengeSubmitRequest {
-    public_key: Vec<u8>,
-    signature: Vec<u8>,
+    pub public_key: Vec<u8>,
+    pub signature: Vec<u8>,
 }
 
 /// A successful challenge authorization.

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -110,3 +110,10 @@ pub(crate) const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;
 pub(crate) const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
 #[cfg(all(feature = "biome-profile", feature = "rest-api",))]
 pub(crate) const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
+
+// Peer authorization protocol versions
+#[cfg(feature = "trust-authorization")]
+pub const PEER_AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
+
+#[cfg(feature = "trust-authorization")]
+pub(crate) const PEER_AUTHORIZATION_PROTOCOL_MIN: u32 = 1;

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -106,6 +106,7 @@ experimental = [
     "scabbard-back-pressure",
     "service-arg-validation",
     "service-endpoint",
+    "trust-authorization",
     "ws-transport",
 ]
 
@@ -165,6 +166,7 @@ service-arg-validation = [
     "splinter/service-arg-validation",
 ]
 service-endpoint = []
+trust-authorization = ["splinter/trust-authorization"]
 ws-transport = ["splinter/ws-transport"]
 
 [package.metadata.deb]


### PR DESCRIPTION
This PR  includes the message handlers for the new authorization
message, as well as separating out the authorization state machine into
several state machines to make room for new actions/states in the new
trust procedure. This will make it easier in the future to add a
new state machine for challenge authorization.

The v0 Trust is still supported along with v1. If a ConnectRequest
is the first message received v0 trust will be used. If
AuthProtocolRequest is the first message v1 Trust will be used.
This is required to stay backwards compatible with 0.4.

It is also now required to track both our local authorization state
and the state of the remote as separate state machines. This is
because authorization will be happening in parallel.

The new implementation is behind a new experimental features
`trust-authorization`. The `challenge-authorization` features
now depends on this new feature.