### PR TITLE
Update keygen --system to check for env variable

### DIFF
--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -94,6 +94,19 @@ writing file: "/etc/splinter/keys/splinterd.priv"
 writing file: "/etc/splinter/keys/splinterd.pub"
 ```
 
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_CONFIG_DIR**
+: Specifies the directory containing configuration files, including system keys.
+  (See: `--config-dir`.)
+
+**SPLINTER_HOME**
+
+: Changes the base directory path for the Splinter directories, including the
+  config directory and system key location. (See the `splinterd(1)` man page for
+  more information.) This value is not used if `SPLINTER_CONFIG_DIR` is set.
+
 SEE ALSO
 ========
 

--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -33,6 +33,7 @@ use super::{chown, Action};
 const SYSTEM_KEY_PATH: &str = "/etc/splinter/keys";
 const SPLINTER_HOME_ENV: &str = "SPLINTER_HOME";
 const CONFIG_DIR_ENV: &str = "SPLINTER_CONFIG_DIR";
+const DEFAULT_SYSTEM_KEY_NAME: &str = "splinterd";
 
 pub struct KeyGenAction;
 
@@ -43,7 +44,13 @@ impl Action for KeyGenAction {
         let key_name = args
             .value_of("key-name")
             .map(String::from)
-            .unwrap_or_else(whoami::username);
+            .unwrap_or_else(|| {
+                if args.is_present("system") {
+                    DEFAULT_SYSTEM_KEY_NAME.to_string()
+                } else {
+                    whoami::username()
+                }
+            });
 
         let key_dir = if let Some(dir) = args.value_of("key_dir") {
             PathBuf::from(dir)


### PR DESCRIPTION
If --system is passed to keygen, the command will
check the SPLINTER_CONFIG_DIR and SPLINTER_HOME environment
variable to determine where the key should be generated.
The key will be added in one of the following locations:

SPLINTER_CONFIG_DIR/keys
SPLINTER_HOME/etc/keys
/etc/splinter/keys

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>