### PR TITLE
Update splinterd to load signing keys from config directory

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -944,8 +944,12 @@ mod tests {
             ),
         ]);
 
-        let authorization_manager = AuthorizationManager::new("test-node".into())
-            .expect("Unable to create authorization pool");
+        let authorization_manager = AuthorizationManager::new(
+            "test-node".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
         let mut authorizers = Authorizers::new();
         authorizers.add_authorizer("inproc", inproc_authorizer);
         authorizers.add_authorizer("", authorization_manager.authorization_connector());

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -7179,8 +7179,12 @@ mod tests {
             ),
         ]);
 
-        let authorization_manager = AuthorizationManager::new("test-node".into())
-            .expect("Unable to create authorization pool");
+        let authorization_manager = AuthorizationManager::new(
+            "test-node".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
         let mut authorizers = Authorizers::new();
         authorizers.add_authorizer("inproc", inproc_authorizer);
         authorizers.add_authorizer("", authorization_manager.authorization_connector());

--- a/libsplinter/src/network/auth/handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/mod.rs
@@ -14,6 +14,9 @@
 
 mod v0_handlers;
 
+#[cfg(feature = "challenge-authorization")]
+use cylinder::Signer;
+
 use crate::network::auth::{
     AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessageSender,
     AuthorizationState,
@@ -39,6 +42,7 @@ use self::v0_handlers::{
 /// The identity provided is sent to connections for Trust authorizations.
 pub fn create_authorization_dispatcher(
     identity: String,
+    #[cfg(feature = "challenge-authorization")] _signers: Vec<Box<dyn Signer>>,
     auth_manager: AuthorizationManagerStateMachine,
     auth_msg_sender: impl MessageSender<ConnectionId> + Clone + 'static,
 ) -> Dispatcher<NetworkMessageType, ConnectionId> {

--- a/libsplinter/src/network/auth/handlers/v0_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v0_handlers.rs
@@ -321,8 +321,13 @@ mod tests {
         let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
-        let dispatcher =
-            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+        let dispatcher = create_authorization_dispatcher(
+            "mock_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            auth_mgr,
+            dispatch_sender,
+        );
 
         let connection_id = "test_connection".to_string();
         let mut msg = authorization::ConnectRequest::new();
@@ -380,8 +385,13 @@ mod tests {
         let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
-        let dispatcher =
-            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+        let dispatcher = create_authorization_dispatcher(
+            "mock_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            auth_mgr,
+            dispatch_sender,
+        );
         let connection_id = "test_connection".to_string();
         let mut msg = authorization::ConnectResponse::new();
         msg.set_accepted_authorization_types(
@@ -424,8 +434,13 @@ mod tests {
         let auth_mgr = AuthorizationManagerStateMachine::default();
         let mock_sender = MockSender::new();
         let dispatch_sender = mock_sender.clone();
-        let dispatcher =
-            create_authorization_dispatcher("mock_identity".into(), auth_mgr, dispatch_sender);
+        let dispatcher = create_authorization_dispatcher(
+            "mock_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            auth_mgr,
+            dispatch_sender,
+        );
         let connection_id = "test_connection".to_string();
         // Begin the connection process, otherwise, the response will fail
         let mut msg = authorization::ConnectRequest::new();

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -1044,8 +1044,12 @@ mod tests {
             mesh.wait_for_shutdown().expect("Unable to shutdown mesh");
         });
 
-        let auth_mgr = AuthorizationManager::new("test_identity".into())
-            .expect("Unable to create authorization pool");
+        let auth_mgr = AuthorizationManager::new(
+            "test_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::builder()
             .with_authorizer(Box::new(auth_mgr.authorization_connector()))
             .with_matrix_life_cycle(mesh.get_life_cycle())
@@ -1106,8 +1110,12 @@ mod tests {
             mesh.wait_for_shutdown().expect("Unable to shutdown mesh");
         });
 
-        let auth_mgr = AuthorizationManager::new("test_identity".into())
-            .expect("Unable to create authorization pool");
+        let auth_mgr = AuthorizationManager::new(
+            "test_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::builder()
             .with_authorizer(Box::new(auth_mgr.authorization_connector()))
             .with_matrix_life_cycle(mesh.get_life_cycle())
@@ -1245,8 +1253,12 @@ mod tests {
             mesh2.wait_for_shutdown().expect("Unable to shutdown mesh");
         });
 
-        let auth_mgr = AuthorizationManager::new("test_identity".into())
-            .expect("Unable to create authorization pool");
+        let auth_mgr = AuthorizationManager::new(
+            "test_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
         let mut cm = ConnectionManager::builder()
             .with_authorizer(Box::new(auth_mgr.authorization_connector()))
             .with_matrix_life_cycle(mesh1.get_life_cycle())
@@ -1401,8 +1413,12 @@ mod tests {
         let endpoint = listener.endpoint();
 
         let mesh = Mesh::new(512, 128);
-        let auth_mgr = AuthorizationManager::new("test_identity".into())
-            .expect("Unable to create authorization pool");
+        let auth_mgr = AuthorizationManager::new(
+            "test_identity".into(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .expect("Unable to create authorization pool");
 
         let (conn_tx, conn_rx) = mpsc::channel();
         let server_endpoint = endpoint.clone();

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -194,7 +194,11 @@ impl ServiceConnectionManager {
     /// # use splinter::transport::inproc::InprocTransport;
     /// # let transport = InprocTransport::default();
     /// # let mesh = Mesh::new(1, 1);
-    /// # let auth_mgr = AuthorizationManager::new("test_identity".into()).unwrap();
+    /// # let auth_mgr = AuthorizationManager::new(
+    /// #   "test_identity".into(),
+    /// #    #[cfg(feature = "challenge-authorization")]
+    /// #    vec![],
+    /// # ).unwrap();
     /// # let authorizer: Box<dyn Authorizer + Send> = Box::new(auth_mgr.authorization_connector());
     /// let mut cm = ConnectionManager::builder()
     ///     .with_authorizer(authorizer)

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -37,7 +37,7 @@ bytes = "0.4"
 clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"
-cylinder = "0.2"
+cylinder = "0.2.2"
 flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
@@ -124,7 +124,10 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile", "splinter/oauth-profile"]
-challenge-authorization = ["splinter/challenge-authorization"]
+challenge-authorization = [
+  "cylinder/key-load",
+  "splinter/challenge-authorization"
+]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health"]

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -16,6 +16,8 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
+#[cfg(feature = "challenge-authorization")]
+use cylinder::KeyLoadError;
 #[cfg(feature = "metrics")]
 use splinter::error::InternalError;
 use splinter::transport::socket::TlsInitError;
@@ -40,6 +42,8 @@ pub enum UserError {
     },
     #[cfg(feature = "metrics")]
     MetricsError(InternalError),
+    #[cfg(feature = "challenge-authorization")]
+    KeyLoadError(KeyLoadError),
 }
 
 impl UserError {
@@ -70,6 +74,8 @@ impl Error for UserError {
             UserError::DaemonError { source, .. } => source.as_ref().map(|err| &**err),
             #[cfg(feature = "metrics")]
             UserError::MetricsError(err) => Some(err),
+            #[cfg(feature = "challenge-authorization")]
+            UserError::KeyLoadError(err) => Some(err),
         }
     }
 }
@@ -100,6 +106,8 @@ impl fmt::Display for UserError {
             }
             #[cfg(feature = "metrics")]
             UserError::MetricsError(msg) => write!(f, "{}", msg),
+            #[cfg(feature = "challenge-authorization")]
+            UserError::KeyLoadError(err) => write!(f, "{}", err),
         }
     }
 }

--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -209,8 +209,12 @@ impl RunnableNetworkSubsystem {
         // Set up Authorization
         let inproc_authorizer = InprocAuthorizer::new(inproc_ids);
 
-        let authorization_manager = AuthorizationManager::new(node_id.to_string())
-            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+        let authorization_manager = AuthorizationManager::new(
+            node_id.to_string(),
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        )
+        .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
         let mut authorizers = Authorizers::new();
         authorizers.add_authorizer("inproc", inproc_authorizer);


### PR DESCRIPTION
The splinterd will use these keys to execute challenge authorization.
The splinterd will load every private key stored in the config_dir/keys.
This is behind the experimental feature "challenge-authorization"