### PR TITLE
Update protobuf dependency from 2.19 to 2.23

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ flexi_logger = "0.14"
 libc = "0.2"
 log = "0.4"
 openssl = "0.10"
-protobuf = "2.19"
+protobuf = "2.23"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -47,7 +47,7 @@ hyper = "0.12"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2.0"
-protobuf = "2.19"
+protobuf = "2.23"
 sabre-sdk = "0.7"
 scabbard = { path = "../../../services/scabbard/libscabbard", features = ["events"] }
 serde = "1.0"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -58,7 +58,7 @@ mio-extras = "2"
 oauth2 = { version = "3.0", optional = true }
 openssl = "0.10"
 percent-encoding = { version = "2.0", optional = true }
-protobuf = "2.19"
+protobuf = "2.23"
 rand = "0.7"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -31,7 +31,7 @@ futures = { version = "0.1", optional = true }
 log = "0.3.0"
 metrics = { version = "0.12", optional = true}
 openssl = "0.10"
-protobuf = "2.19"
+protobuf = "2.23"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth = { version = "0.6", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.7"

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -42,7 +42,7 @@ flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
 openssl = { version = "0.10", optional = true }
-protobuf = "2.19"
+protobuf = "2.23"
 rand = "0.7"
 serde = "1.0.80"
 serde_derive = "1.0.80"


### PR DESCRIPTION
This prevents a potential compilation error, since 2.19 no longer works
with the current version of rust without producing compiler
errors/warnings.
