### PR TITLE
Change logging library to log4rs

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -38,9 +38,9 @@ clap = "2.32"
 crossbeam-channel = "0.3"
 ctrlc = "3.0"
 cylinder = "0.2.2"
-flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
+log4rs = "1"
 openssl = { version = "0.10", optional = true }
 protobuf = "2.23"
 rand = "0.7"


### PR DESCRIPTION
No change to functionality from flexilogger just a new facade for
logging. This is the first step to allowing user configuration of
logging levels and targets.

Signed-off-by: Caleb Hill <hill@bitwise.io>