### PR TITLE
BACKPORT 0-4: Fix default CA typo in splinterd man page

### DIFF
--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -190,7 +190,7 @@ OPTIONS
 
 `--tls-ca-file CERT-FILE`
 : Specifies the path and file name for the trusted CA certificate.
-  (Default: `/etc/splinter/certs/ca_pem`.)
+  (Default: `/etc/splinter/certs/ca.pem`.)
 
   Do not use this option with the `--tls-insecure` flag.
 


### PR DESCRIPTION
Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>