### PR TITLE
Add authorization type and node public key to routing table

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -288,6 +288,8 @@ impl AdminService {
                         routing_members.push(routing::CircuitNode::new(
                             member.node_id().to_string(),
                             node.endpoints().to_vec(),
+                            #[cfg(feature = "challenge-authorization")]
+                            None,
                         ))
                     } else {
                         error!("Missing node information for {}", member.node_id());
@@ -332,6 +334,8 @@ impl AdminService {
                             .iter()
                             .map(|node| node.node_id().to_string())
                             .collect(),
+                        #[cfg(feature = "challenge-authorization")]
+                        routing::AuthorizationType::Trust,
                     ),
                     routing_members,
                 )

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -404,6 +404,8 @@ impl AdminServiceShared {
                                     .iter()
                                     .map(|node| node.node_id().to_string())
                                     .collect(),
+                                #[cfg(feature = "challenge-authorization")]
+                                routing::AuthorizationType::Trust,
                             );
 
                             let routing_members = circuit_proposal
@@ -414,6 +416,8 @@ impl AdminServiceShared {
                                     routing::CircuitNode::new(
                                         node.get_node_id().to_string(),
                                         node.get_endpoints().to_vec(),
+                                        #[cfg(feature = "challenge-authorization")]
+                                        None,
                                     )
                                 })
                                 .collect::<Vec<routing::CircuitNode>>();

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -148,6 +148,8 @@ impl ServiceInstances for RoutingTableServiceInstances {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "challenge-authorization")]
+    use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
     };
@@ -333,8 +335,18 @@ mod tests {
     }
 
     fn build_circuit() -> (Circuit, Vec<CircuitNode>) {
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -354,6 +366,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         (circuit, vec![node_123, node_345])

--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -187,6 +187,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
     };
@@ -206,8 +208,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_1234 = CircuitNode::new("1234".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_5678 = CircuitNode::new("5678".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_1234 = CircuitNode::new(
+            "1234".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_5678 = CircuitNode::new(
+            "5678".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -227,6 +239,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -286,8 +300,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_1234 = CircuitNode::new("1234".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_5678 = CircuitNode::new("5678".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_1234 = CircuitNode::new(
+            "1234".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_5678 = CircuitNode::new(
+            "5678".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -307,6 +331,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -366,8 +392,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_1234 = CircuitNode::new("1234".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_5678 = CircuitNode::new("5678".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_1234 = CircuitNode::new(
+            "1234".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_5678 = CircuitNode::new(
+            "5678".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -387,6 +423,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -112,6 +112,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
     };
@@ -131,8 +133,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -152,6 +164,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -223,8 +237,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -244,6 +268,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -213,6 +213,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
     };
@@ -232,8 +234,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -256,6 +268,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -316,8 +330,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -340,6 +364,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -400,8 +426,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -416,6 +452,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer
@@ -477,8 +515,18 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let mut service_def = Service::new(
             "def".to_string(),
@@ -494,6 +542,8 @@ mod tests {
             "alpha".into(),
             vec![service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         writer

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -285,6 +285,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
     };
@@ -699,8 +701,18 @@ mod tests {
     }
 
     fn build_circuit() -> (Circuit, Vec<CircuitNode>) {
-        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()]);
-        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()]);
+        let node_123 = CircuitNode::new(
+            "123".to_string(),
+            vec!["123.0.0.1:0".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
+        let node_345 = CircuitNode::new(
+            "345".to_string(),
+            vec!["123.0.0.1:1".to_string()],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+        );
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -720,6 +732,8 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Trust,
         );
 
         (circuit, vec![node_123, node_345])

--- a/libsplinter/src/circuit/routing/memory/benchmarks.rs
+++ b/libsplinter/src/circuit/routing/memory/benchmarks.rs
@@ -18,6 +18,7 @@
 use super::{
     Circuit, CircuitNode, RoutingTable, RoutingTableReader, RoutingTableWriter, Service, ServiceId,
 };
+use crate::circuit::routing::AuthorizationType;
 
 extern crate test;
 
@@ -38,6 +39,7 @@ fn generate_circuits(num_circuits: i64, total_num_node: i64) -> (Vec<Circuit>, V
         let node = CircuitNode {
             node_id: format!("node_{}", i),
             endpoints: vec![format!("inproc://node_{}", i)],
+            public_key: None,
         };
         let service = Service {
             service_id: generate_random_base62_string(4),
@@ -76,6 +78,7 @@ fn generate_circuits(num_circuits: i64, total_num_node: i64) -> (Vec<Circuit>, V
             ),
             roster,
             members,
+            authorization_type: AuthorizationType::Trust,
         };
         circuits.push(circuit);
     }

--- a/libsplinter/src/circuit/routing/memory/mod.rs
+++ b/libsplinter/src/circuit/routing/memory/mod.rs
@@ -26,6 +26,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
 use super::error::RoutingTableReaderError;
+#[cfg(feature = "challenge-authorization")]
+use super::AuthorizationType;
 use super::{
     Circuit, CircuitIter, CircuitNode, CircuitNodeIter, RoutingTableReader, RoutingTableWriter,
     Service, ServiceId,
@@ -177,6 +179,8 @@ impl RoutingTableReader for RoutingTable {
                 ADMIN_CIRCUIT_ID.to_string(),
                 vec![],
                 vec![],
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Trust,
             )))
         } else {
             Ok(self
@@ -394,6 +398,8 @@ impl RoutingTableWriter for RoutingTable {
 mod test {
     use super::*;
 
+    use crate::circuit::routing::AuthorizationType;
+
     // Test the routing table read and write operations for circuits
     //
     // 1. Create circuits with corresponding nodes and services and write one circuit to the
@@ -419,6 +425,7 @@ mod test {
             let node = CircuitNode {
                 node_id: format!("node-{}", x),
                 endpoints: vec![format!("endpoint_{}", x)],
+                public_key: None,
             };
             let service = Service {
                 service_id: format!("service-{}", x),
@@ -442,11 +449,13 @@ mod test {
             circuit_id: "012-abc".to_string(),
             roster: circuit_roster0.clone(),
             members: circuit_members0.clone(),
+            authorization_type: AuthorizationType::Trust,
         };
         let circuit1 = Circuit {
             circuit_id: "345-def".to_string(),
             roster: circuit_roster1.clone(),
             members: circuit_members1.clone(),
+            authorization_type: AuthorizationType::Trust,
         };
 
         let mut expected_nodes = BTreeMap::new();
@@ -573,6 +582,7 @@ mod test {
         let node0 = CircuitNode {
             node_id: "node-0".to_string(),
             endpoints: vec!["endpoint_0".to_string()],
+            public_key: None,
         };
         let service0 = Service {
             service_id: "service-0".to_string(),
@@ -584,6 +594,7 @@ mod test {
         let node1 = CircuitNode {
             node_id: "node-1".to_string(),
             endpoints: vec!["endpoint_1".to_string()],
+            public_key: None,
         };
         let service1 = Service {
             service_id: "service-1".to_string(),
@@ -596,6 +607,7 @@ mod test {
             circuit_id: "012-abc".to_string(),
             roster: vec![service0.clone(), service1.clone()],
             members: vec![node0.node_id.clone(), node1.node_id.clone()],
+            authorization_type: AuthorizationType::Trust,
         };
         let service_id0 = ServiceId::new(
             "012-abc".to_string(),
@@ -679,10 +691,12 @@ mod test {
         let node0 = CircuitNode {
             node_id: "node-0".to_string(),
             endpoints: vec!["endpoint_0".to_string()],
+            public_key: None,
         };
         let node1 = CircuitNode {
             node_id: "node-1".to_string(),
             endpoints: vec!["endpoint_1".to_string()],
+            public_key: None,
         };
 
         let mut expected_nodes = BTreeMap::new();

--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -186,6 +186,7 @@ pub struct Circuit {
     circuit_id: String,
     roster: Vec<Service>,
     members: Vec<String>,
+    authorization_type: AuthorizationType,
 }
 
 impl Circuit {
@@ -196,11 +197,20 @@ impl Circuit {
     /// * `circuit_id` -  The unique ID for the circuit
     /// * `roster` - The list of services in the circuit
     /// * `members` - The list of node IDs for the members of a circuit
-    pub fn new(circuit_id: String, roster: Vec<Service>, members: Vec<String>) -> Self {
+    pub fn new(
+        circuit_id: String,
+        roster: Vec<Service>,
+        members: Vec<String>,
+        #[cfg(feature = "challenge-authorization")] authorization_type: AuthorizationType,
+    ) -> Self {
         Circuit {
             circuit_id,
             roster,
             members,
+            #[cfg(feature = "challenge-authorization")]
+            authorization_type,
+            #[cfg(not(feature = "challenge-authorization"))]
+            authorization_type: AuthorizationType::Trust,
         }
     }
 
@@ -218,6 +228,18 @@ impl Circuit {
     pub fn members(&self) -> &[String] {
         &self.members
     }
+
+    /// Returns the authorization type
+    pub fn authorization_type(&self) -> &AuthorizationType {
+        &self.authorization_type
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthorizationType {
+    Trust,
+    #[cfg(feature = "challenge-authorization")]
+    Challenge,
 }
 
 /// The routing table representation of a node
@@ -225,6 +247,7 @@ impl Circuit {
 pub struct CircuitNode {
     node_id: String,
     endpoints: Vec<String>,
+    public_key: Option<Vec<u8>>,
 }
 
 impl CircuitNode {
@@ -234,8 +257,19 @@ impl CircuitNode {
     ///
     /// * `node_id` -  The unique ID for the circuit
     /// * `endpoints` -  A list of endpoints the node can be reached at
-    pub fn new(node_id: String, endpoints: Vec<String>) -> Self {
-        CircuitNode { node_id, endpoints }
+    pub fn new(
+        node_id: String,
+        endpoints: Vec<String>,
+        #[cfg(feature = "challenge-authorization")] public_key: Option<Vec<u8>>,
+    ) -> Self {
+        CircuitNode {
+            node_id,
+            endpoints,
+            #[cfg(feature = "challenge-authorization")]
+            public_key,
+            #[cfg(not(feature = "challenge-authorization"))]
+            public_key: None,
+        }
     }
 }
 


### PR DESCRIPTION
This information will be used when Challenge Authorization
is implemented to know whether to route over the node id or
a public key.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>