### PR TITLE
Fix RoutingTable benchmark feature guards

### DIFF
--- a/libsplinter/src/base62.rs
+++ b/libsplinter/src/base62.rs
@@ -15,11 +15,11 @@
 #[cfg(feature = "circuit-template")]
 use std::str::FromStr as _;
 
-#[cfg(feature = "admin-service")]
+#[cfg(any(feature = "admin-service", feature = "benchmark"))]
 use rand::{distributions::Alphanumeric, Rng};
 
 /// Generate a random base62 string of the given length.
-#[cfg(feature = "admin-service")]
+#[cfg(any(feature = "admin-service", feature = "benchmark"))]
 pub fn generate_random_base62_string(len: usize) -> String {
     rand::thread_rng()
         .sample_iter(Alphanumeric)


### PR DESCRIPTION
The routing table benchmark tests also make use of
generate_random_base62_string which was previously guarded
only by the admin-service feature.

To run the routing table benchmark test run:

`cargo +nightly bench --features benchmark`