### PR TITLE
Fix two_phase::v1::tests::test_shutdown test

### DIFF
--- a/libsplinter/src/consensus/two_phase/v1/mod.rs
+++ b/libsplinter/src/consensus/two_phase/v1/mod.rs
@@ -725,7 +725,7 @@ pub mod tests {
     #[test]
     fn test_shutdown() {
         let (update_tx, update_rx) = channel();
-        let (_, consensus_msg_rx) = channel();
+        let (_consensus_msg_tx, consensus_msg_rx) = channel();
 
         let manager = MockProposalManager::new(update_tx.clone());
         let network = MockConsensusNetworkSender::new();


### PR DESCRIPTION
The use of just an _ for the unused part of a channel was causing the
engine to shutdown before the Shutdown message could be sent because
the engines consensus_msg channel had disconnected. Using
_ in a let statement causes the item to be dropped immediately. But using
_VARIABLE moves the drop to the end of the test as intended.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>