### PR TITLE
Add `splinter user list` CLI command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,6 +75,7 @@ experimental = [
     "health",
     "upgrade",
     "https-certs",
+    "user-list",
     "permissions",
     "proposal-removal",
     "registry",
@@ -82,6 +83,7 @@ experimental = [
 
 authorization-handler-maintenance = []
 authorization-handler-rbac = []
+user-list = []
 challenge-authorization = ["splinter/challenge-authorization"]
 circuit-template = ["splinter/circuit-template"]
 

--- a/cli/man/splinter-user-list.1.md
+++ b/cli/man/splinter-user-list.1.md
@@ -1,0 +1,84 @@
+% SPLINTER-USER-LIST(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-user-list** — Displays the existing users for this Splinter node.
+
+SYNOPSIS
+========
+**splinter user list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command lists all of the users the local node has. This command
+displays abbreviated information pertaining to users in columns, with the
+headers `ID`, `USERNAME`, and `TYPE`. This makes it possible to view all the
+users registered with the local node, either through Biome or through one of
+the various Splinter-supported OAuth providers. The `USERNAME` is either a
+Biome user's `username` submitted at registration or the main `username` as
+determined by an OAuth provider. The `TYPE` column displays the method used by
+the user to register with Splinter, currently either `Biome` or `OAuth`. The
+`ID` column maps to the user's internal ID, which is used while assigning
+authorizations to a user.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the list. (default `human`). Possible values
+  for formatting are `human` and `csv`.
+
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+This command displays information about Splinter users with a default `human`
+formatting, meaning the information is displayed in a table.
+
+```
+$ splinter user list \
+  --url URL-of-splinterd-REST-API
+ID                                    USERNAME    TYPE
+f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4  oauth_user  OAuth
+3no4hz9g-628s-m20x-b9a3-4ijodc402973  biome_user  Biome
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-role(1)`
+| `splinter-role-create(1)`
+| `splinter-permissions(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -29,6 +29,8 @@ pub mod permissions;
 #[cfg(feature = "authorization-handler-rbac")]
 pub mod rbac;
 pub mod registry;
+#[cfg(feature = "user-list")]
+pub mod user;
 
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/cli/src/action/user/api.rs
+++ b/cli/src/action/user/api.rs
@@ -1,0 +1,65 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Deserialize;
+
+use crate::action::api::SplinterRestClient;
+use crate::error::CliError;
+
+pub(super) const PAGING_LIMIT: &str = "1000";
+// The Biome protocol version supported by the current CLI
+pub(super) const CLI_SPLINTER_USER_PROTOCOL_VERSION: &str = "1";
+
+impl SplinterRestClient {
+    pub fn list_biome_users(&self) -> Result<Vec<ClientBiomeUser>, CliError> {
+        unimplemented!();
+    }
+
+    /// Submits a request to list Biome's OAuth users
+    pub fn list_oauth_users(&self) -> Result<ClientOAuthUserListResponse, CliError> {
+        unimplemented!();
+    }
+}
+
+/// Biome OAuth user details.
+#[derive(Debug, Deserialize)]
+pub struct ClientOAuthUser {
+    pub subject: String,
+    pub user_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClientOAuthUserListResponse {
+    pub data: Vec<ClientOAuthUser>,
+    pub paging: Paging,
+}
+
+/// Biome user details, specific to the client to allow for deserializing the response data.
+#[derive(Debug, Deserialize)]
+pub struct ClientBiomeUser {
+    pub username: String,
+    pub user_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Paging {
+    pub current: String,
+    pub offset: usize,
+    pub limit: usize,
+    pub total: usize,
+    pub first: String,
+    pub prev: String,
+    pub next: String,
+    pub last: String,
+}

--- a/cli/src/action/user/mod.rs
+++ b/cli/src/action/user/mod.rs
@@ -13,3 +13,95 @@
 // limitations under the License.
 
 mod api;
+
+use clap::ArgMatches;
+use cylinder::Signer;
+
+use crate::error::CliError;
+use crate::signing::{create_cylinder_jwt_auth, load_signer};
+
+use super::api::SplinterRestClientBuilder;
+use super::{print_table, Action, DEFAULT_SPLINTER_REST_API_URL, SPLINTER_REST_API_URL_ENV};
+use api::{ClientBiomeUser, ClientOAuthUser};
+
+pub struct ListSplinterUsersAction;
+
+impl Action for ListSplinterUsersAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let format = args.value_of("format").unwrap_or("human");
+        let signer = load_signer(args.value_of("private_key_file"))?;
+        let url = args
+            .value_of("url")
+            .map(ToOwned::to_owned)
+            .or_else(|| std::env::var(SPLINTER_REST_API_URL_ENV).ok())
+            .unwrap_or_else(|| DEFAULT_SPLINTER_REST_API_URL.to_string());
+
+        display_splinter_users(&url, format, signer)
+    }
+}
+
+fn display_splinter_users(
+    url: &str,
+    format: &str,
+    signer: Box<dyn Signer>,
+) -> Result<(), CliError> {
+    let client = SplinterRestClientBuilder::new()
+        .with_url(url.to_string())
+        .with_auth(create_cylinder_jwt_auth(signer.clone())?)
+        .build()?;
+
+    let biome_users = client
+        .list_biome_users()?
+        .into_iter()
+        .map(ClientSplinterUser::from);
+
+    let biome_oauth_users = client
+        .list_oauth_users()?
+        .data
+        .into_iter()
+        .map(ClientSplinterUser::from);
+
+    let mut data = vec![
+        // headers
+        vec!["ID".to_string(), "USERNAME".to_string(), "TYPE".to_string()],
+    ];
+    let users = biome_users.into_iter().chain(biome_oauth_users.into_iter());
+    users.into_iter().for_each(|user| match user {
+        ClientSplinterUser::Biome(user) => {
+            data.push(vec![user.user_id, user.username, "Biome".to_string()])
+        }
+        ClientSplinterUser::OAuth(user) => {
+            data.push(vec![user.user_id, user.subject, "OAuth".to_string()])
+        }
+    });
+
+    if format == "csv" {
+        for row in data {
+            println!("{}", row.join(","));
+        }
+    } else {
+        print_table(data);
+    }
+
+    Ok(())
+}
+
+/// Representation of the users that may be returned by Splinter.
+enum ClientSplinterUser {
+    Biome(ClientBiomeUser),
+    OAuth(ClientOAuthUser),
+}
+
+impl From<ClientBiomeUser> for ClientSplinterUser {
+    fn from(client_user: ClientBiomeUser) -> Self {
+        ClientSplinterUser::Biome(client_user)
+    }
+}
+
+impl From<ClientOAuthUser> for ClientSplinterUser {
+    fn from(client_user: ClientOAuthUser) -> Self {
+        ClientSplinterUser::OAuth(client_user)
+    }
+}

--- a/cli/src/action/user/mod.rs
+++ b/cli/src/action/user/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod api;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1557,6 +1557,42 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         )
     }
 
+    #[cfg(feature = "user-list")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("user")
+                .about("Splinter user commands")
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List Splinter users, including Biome and OAuth users")
+                        .arg(
+                            Arg::with_name("format")
+                                .short("F")
+                                .long("format")
+                                .help("Output format")
+                                .possible_values(&["human", "csv"])
+                                .default_value("human")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("url")
+                                .short("U")
+                                .long("url")
+                                .help("URL of the Splinter daemon REST API")
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("private_key_file")
+                                .value_name("private-key-file")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Name or path of private key"),
+                        ),
+                ),
+        );
+    }
+
     let matches = app.get_matches_from_safe(args)?;
 
     // set default to info
@@ -1697,6 +1733,15 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
     {
         use action::permissions;
         subcommands = subcommands.with_command("permissions", permissions::ListAction)
+    }
+
+    #[cfg(feature = "user-list")]
+    {
+        use action::user;
+        subcommands = subcommands.with_command(
+            "user",
+            SubcommandActions::new().with_command("list", user::ListSplinterUsersAction),
+        )
     }
 
     subcommands.run(Some(&matches))

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -103,6 +103,7 @@ experimental = [
     "https-bind",
     "metrics",
     "node",
+    "oauth-user-list",
     "proposal-removal",
     "scabbard-back-pressure",
     "service-arg-validation",
@@ -160,6 +161,7 @@ node = [
 oauth = [
     "splinter/oauth"
 ]
+oauth-user-list = ["splinter/oauth-user-list"]
 proposal-removal = []
 rest-api-cors = ["splinter/rest-api-cors"]
 scabbard-back-pressure = ["scabbard/back-pressure"]


### PR DESCRIPTION
This adds a `splinter-user-list` subcommand to the CLI, which should return all users registered with Splinter, through Biome or OAuth. This command currently returns all Splinter users, regardless of how the user registered.