### PR TITLE
Replace string peer id with PeerAuthorizationToken 

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3460,6 +3460,7 @@ mod tests {
         circuit.set_comments("test circuit".into());
         circuit.set_display_name("test_display".into());
         circuit.set_circuit_status(admin::Circuit_CircuitStatus::ACTIVE);
+        circuit.set_durability(admin::Circuit_DurabilityType::NO_DURABILITY);
 
         circuit.set_members(protobuf::RepeatedField::from_vec(vec![
             splinter_node("test-node", &["inproc://someplace:8000".to_string()]),
@@ -6769,6 +6770,7 @@ mod tests {
         let mut service = admin::SplinterService::new();
         service.set_service_id(service_id.into());
         service.set_service_type(service_type.into());
+        service.set_allowed_nodes(RepeatedField::from_vec(vec!["node_id".into()]));
         service
     }
 

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -17,6 +17,7 @@
 use std::convert::TryFrom;
 
 use crate::admin::messages::{self, is_valid_circuit_id};
+use crate::circuit::routing;
 use crate::error::InvalidStateError;
 use crate::protos::admin;
 
@@ -637,6 +638,16 @@ impl From<ProposedCircuit> for Circuit {
             display_name: circuit.display_name().clone(),
             circuit_version: circuit.circuit_version(),
             circuit_status: circuit.circuit_status().clone(),
+        }
+    }
+}
+
+impl From<&AuthorizationType> for routing::AuthorizationType {
+    fn from(auth_type: &AuthorizationType) -> Self {
+        match auth_type {
+            AuthorizationType::Trust => routing::AuthorizationType::Trust,
+            #[cfg(feature = "challenge-authorization")]
+            AuthorizationType::Challenge => routing::AuthorizationType::Challenge,
         }
     }
 }

--- a/libsplinter/src/admin/token/mod.rs
+++ b/libsplinter/src/admin/token/mod.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "admin-service-client")]
-pub mod client;
-pub mod error;
-pub mod messages;
-#[cfg(feature = "rest-api")]
-pub mod rest_api;
-pub mod service;
-pub mod store;
-mod token;
+//! A trait to make it easier to get a list of PeerAuthorizationToken from Circuits and Proposals
+//!
+//! This module includes implementations for store and protobuf structs
+
+pub mod token_protobuf;
+pub mod token_protocol;
+
+use crate::error::InvalidStateError;
+use crate::peer::PeerAuthorizationToken;
+
+pub trait ListPeerAuthorizationTokens {
+    fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError>;
+}

--- a/libsplinter/src/admin/token/token_protobuf.rs
+++ b/libsplinter/src/admin/token/token_protobuf.rs
@@ -1,0 +1,50 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::InvalidStateError;
+use crate::peer::PeerAuthorizationToken;
+use crate::protos::admin::{Circuit, Circuit_AuthorizationType};
+
+use super::ListPeerAuthorizationTokens;
+
+impl ListPeerAuthorizationTokens for Circuit {
+    fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
+        self.get_members()
+            .iter()
+            .map(|member| match self.get_authorization_type() {
+                Circuit_AuthorizationType::TRUST_AUTHORIZATION => {
+                    Ok(PeerAuthorizationToken::from_peer_id(member.get_node_id()))
+                }
+                #[cfg(feature = "challenge-authorization")]
+                Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
+                    if !member.get_public_key().is_empty() {
+                        Ok(PeerAuthorizationToken::from_public_key(
+                            member.get_public_key(),
+                        ))
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                             authorization: {}",
+                            self.get_circuit_id()
+                        )))
+                    }
+                }
+                _ => Err(InvalidStateError::with_message(format!(
+                    "Circuit is missing authorization type: {}",
+                    self.get_circuit_id()
+                ))),
+            })
+            .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
+    }
+}

--- a/libsplinter/src/admin/token/token_protocol.rs
+++ b/libsplinter/src/admin/token/token_protocol.rs
@@ -1,0 +1,69 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::admin::store::{AuthorizationType, Circuit, ProposedCircuit};
+use crate::error::InvalidStateError;
+use crate::peer::PeerAuthorizationToken;
+
+use super::ListPeerAuthorizationTokens;
+
+impl ListPeerAuthorizationTokens for ProposedCircuit {
+    fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
+        self.members()
+            .iter()
+            .map(|member| match self.authorization_type() {
+                AuthorizationType::Trust => {
+                    Ok(PeerAuthorizationToken::from_peer_id(member.node_id()))
+                }
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(PeerAuthorizationToken::from_public_key(public_key))
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                             authorization: {}",
+                            self.circuit_id()
+                        )))
+                    }
+                }
+            })
+            .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
+    }
+}
+
+impl ListPeerAuthorizationTokens for Circuit {
+    fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
+        self.members()
+            .iter()
+            .map(|member| match self.authorization_type() {
+                AuthorizationType::Trust => {
+                    Ok(PeerAuthorizationToken::from_peer_id(member.node_id()))
+                }
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(PeerAuthorizationToken::from_public_key(public_key))
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                             authorization: {}",
+                            self.circuit_id()
+                        )))
+                    }
+                }
+            })
+            .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
+    }
+}

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -15,6 +15,7 @@
 //! trait implementations to support service components.
 
 use crate::circuit::routing::{RoutingTableReader, RoutingTableWriter, Service, ServiceId};
+use crate::peer::PeerAuthorizationToken;
 use crate::service::network::handlers::{
     ServiceAddInstanceError, ServiceInstances, ServiceRemoveInstanceError,
 };
@@ -102,7 +103,7 @@ impl ServiceInstances for RoutingTableServiceInstances {
             return Err(ServiceAddInstanceError::AlreadyRegistered);
         }
 
-        service.set_peer_id(component_id);
+        service.set_peer_id(PeerAuthorizationToken::from_peer_id(&component_id));
 
         let mut writer = self.routing_table_writer.clone();
         writer.add_service(unique_id, service).map_err(|err| {
@@ -219,7 +220,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .expect("Missing service");
-        service.set_peer_id("abc_network".into());
+        service.set_peer_id(PeerAuthorizationToken::from_peer_id("abc_network".into()));
         writer
             .add_service(id, service)
             .expect("Unable to add service");
@@ -265,7 +266,7 @@ mod tests {
                 .expect("cannot check if it has the service")
                 .expect("no service returned")
                 .peer_id(),
-            &Some("my_component".to_string())
+            &Some(PeerAuthorizationToken::from_peer_id("my_component"))
         );
     }
 
@@ -314,7 +315,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .expect("Missing service");
-        service.set_peer_id("abc_network".into());
+        service.set_peer_id(PeerAuthorizationToken::from_peer_id("abc_network"));
         writer
             .add_service(id.clone(), service)
             .expect("Unable to add service");

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -75,6 +75,7 @@ mod tests {
 
     use super::*;
     use crate::network::dispatch::{DispatchLoopBuilder, Dispatcher};
+    use crate::peer::PeerAuthorizationToken;
     use crate::protos::circuit::ServiceConnectRequest;
     use crate::protos::network::NetworkMessageType;
 
@@ -113,7 +114,7 @@ mod tests {
         // Dispatch network message
         network_dispatcher
             .dispatch(
-                "PEER".into(),
+                PeerAuthorizationToken::from_peer_id("PEER").into(),
                 &NetworkMessageType::CIRCUIT,
                 circuit_bytes.clone(),
             )

--- a/libsplinter/src/network/auth/connection_manager.rs
+++ b/libsplinter/src/network/auth/connection_manager.rs
@@ -14,6 +14,7 @@
 
 use crate::network::connection_manager::{
     AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
+    ConnectionAuthorizationType,
 };
 use crate::transport::Connection;
 
@@ -45,7 +46,7 @@ impl From<ConnectionAuthorizationState> for AuthorizationResult {
             } => AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity,
+                identity: ConnectionAuthorizationType::Trust { identity },
             },
 
             ConnectionAuthorizationState::Unauthorized {

--- a/libsplinter/src/network/connection_manager/authorizers.rs
+++ b/libsplinter/src/network/connection_manager/authorizers.rs
@@ -23,7 +23,10 @@ use std::collections::HashMap;
 
 use crate::transport::Connection;
 
-use super::{AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError};
+use super::{
+    AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
+    ConnectionAuthorizationType,
+};
 
 /// Authorize Inproc Connections with predefined identities.
 ///
@@ -62,7 +65,7 @@ impl Authorizer for InprocAuthorizer {
         {
             (*on_complete)(AuthorizationResult::Authorized {
                 connection_id,
-                identity,
+                identity: ConnectionAuthorizationType::Trust { identity },
                 connection,
             })
             .map_err(|err| AuthorizerError(err.to_string()))
@@ -157,7 +160,12 @@ mod tests {
 
         match result {
             AuthorizationResult::Authorized { identity, .. } => {
-                assert_eq!("test-ident1", &identity)
+                assert_eq!(
+                    ConnectionAuthorizationType::Trust {
+                        identity: "test-ident1".into()
+                    },
+                    identity
+                )
             }
             AuthorizationResult::Unauthorized { .. } => panic!("should have been authorized"),
         }
@@ -230,7 +238,12 @@ mod tests {
 
         match result {
             AuthorizationResult::Authorized { identity, .. } => {
-                assert_eq!("test-ident1", &identity)
+                assert_eq!(
+                    ConnectionAuthorizationType::Trust {
+                        identity: "test-ident1".into()
+                    },
+                    identity
+                )
             }
             AuthorizationResult::Unauthorized { .. } => panic!("should have been authorized"),
         }
@@ -248,7 +261,12 @@ mod tests {
 
         match result {
             AuthorizationResult::Authorized { identity, .. } => {
-                assert_eq!("test-ident2", &identity)
+                assert_eq!(
+                    ConnectionAuthorizationType::Trust {
+                        identity: "test-ident2".into()
+                    },
+                    identity
+                )
             }
             AuthorizationResult::Unauthorized { .. } => panic!("should have been authorized"),
         }
@@ -266,7 +284,12 @@ mod tests {
 
         match result {
             AuthorizationResult::Authorized { identity, .. } => {
-                assert_eq!("test-ident3", &identity)
+                assert_eq!(
+                    ConnectionAuthorizationType::Trust {
+                        identity: "test-ident3".into()
+                    },
+                    identity
+                )
             }
             AuthorizationResult::Unauthorized { .. } => panic!("should have been authorized"),
         }
@@ -348,7 +371,9 @@ mod tests {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity: self.authorized_id.clone(),
+                identity: ConnectionAuthorizationType::Trust {
+                    identity: self.authorized_id.clone(),
+                },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/network/connection_manager/builder.rs
+++ b/libsplinter/src/network/connection_manager/builder.rs
@@ -337,7 +337,7 @@ fn send_heartbeats<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
 
                         subscribers.broadcast(ConnectionManagerNotification::Disconnected {
                             endpoint: endpoint.clone(),
-                            identity: metadata.identity.to_string(),
+                            identity: metadata.identity.clone(),
                         });
                         reconnections.push(endpoint.to_string());
                     }
@@ -359,7 +359,7 @@ fn send_heartbeats<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
                         *disconnected = true;
                         subscribers.broadcast(ConnectionManagerNotification::Disconnected {
                             endpoint: endpoint.clone(),
-                            identity: metadata.identity.to_string(),
+                            identity: metadata.identity.clone(),
                         });
                     }
                 } else {

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -30,8 +30,6 @@ pub use error::{AuthorizerError, ConnectionManagerError};
 pub use notification::ConnectionManagerNotification;
 
 use crate::error::InternalError;
-#[cfg(feature = "challenge-authorization")]
-use crate::hex::to_hex;
 use crate::threading::lifecycle::ShutdownHandle;
 use crate::threading::pacemaker;
 use crate::transport::matrix::{ConnectionMatrixLifeCycle, ConnectionMatrixSender};
@@ -414,16 +412,6 @@ pub enum ConnectionAuthorizationType {
     Challenge {
         public_key: Vec<u8>,
     },
-}
-
-impl From<ConnectionAuthorizationType> for String {
-    fn from(auth_type: ConnectionAuthorizationType) -> Self {
-        match auth_type {
-            ConnectionAuthorizationType::Trust { identity } => identity.to_string(),
-            #[cfg(feature = "challenge-authorization")]
-            ConnectionAuthorizationType::Challenge { public_key } => to_hex(&public_key),
-        }
-    }
 }
 
 /// Metadata describing a connection managed by the connection manager.

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::error::ConnectionManagerError;
+use super::ConnectionAuthorizationType;
 
 /// Messages that will be dispatched to all subscription handlers
 #[derive(Debug, PartialEq, Clone)]
@@ -20,7 +21,7 @@ pub enum ConnectionManagerNotification {
     Connected {
         endpoint: String,
         connection_id: String,
-        identity: String,
+        identity: ConnectionAuthorizationType,
     },
     FatalConnectionError {
         endpoint: String,
@@ -29,15 +30,15 @@ pub enum ConnectionManagerNotification {
     InboundConnection {
         endpoint: String,
         connection_id: String,
-        identity: String,
+        identity: ConnectionAuthorizationType,
     },
     Disconnected {
         endpoint: String,
-        identity: String,
+        identity: ConnectionAuthorizationType,
     },
     NonFatalConnectionError {
         endpoint: String,
         attempts: u64,
-        identity: String,
+        identity: ConnectionAuthorizationType,
     },
 }

--- a/libsplinter/src/network/dispatch/context.rs
+++ b/libsplinter/src/network/dispatch/context.rs
@@ -72,7 +72,7 @@ impl<MT> MessageContext<PeerId, MT> {
     /// The Source Peer ID.
     ///
     /// This is the peer id of the original sender of the message
-    pub fn source_peer_id(&self) -> &str {
+    pub fn source_peer_id(&self) -> &PeerId {
         &self.source_id
     }
 }

--- a/libsplinter/src/network/dispatch/mod.rs
+++ b/libsplinter/src/network/dispatch/mod.rs
@@ -31,41 +31,43 @@ pub use r#loop::{
     DispatchMessageReceiver, DispatchMessageSender,
 };
 
+use crate::peer::PeerAuthorizationToken;
+
 /// A wrapper for a PeerId.
 ///
 /// This type constrains a dispatcher to peer-specific messages
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct PeerId(String);
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeerId(PeerAuthorizationToken);
 
 impl std::ops::Deref for PeerId {
-    type Target = str;
+    type Target = PeerAuthorizationToken;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<String> for PeerId {
-    fn from(s: String) -> PeerId {
-        PeerId(s)
+impl From<PeerAuthorizationToken> for PeerId {
+    fn from(p: PeerAuthorizationToken) -> PeerId {
+        PeerId(p)
     }
 }
 
-impl From<&str> for PeerId {
-    fn from(s: &str) -> PeerId {
-        PeerId(s.into())
+impl From<PeerId> for PeerAuthorizationToken {
+    fn from(p: PeerId) -> PeerAuthorizationToken {
+        p.0
     }
 }
 
 impl From<PeerId> for String {
     fn from(peer_id: PeerId) -> String {
-        peer_id.0
+        peer_id.0.id_as_string()
     }
 }
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(&format!("{}", self.0))
     }
 }
 
@@ -422,7 +424,7 @@ mod tests {
         assert_eq!(
             Ok(()),
             dispatcher.dispatch(
-                "TestPeer".into(),
+                PeerAuthorizationToken::from_peer_id("TestPeer").into(),
                 &NetworkMessageType::NETWORK_ECHO,
                 outgoing_message_bytes
             )
@@ -460,7 +462,7 @@ mod tests {
             assert_eq!(
                 Ok(()),
                 dispatcher.dispatch(
-                    "TestPeer".into(),
+                    PeerAuthorizationToken::from_peer_id("TestPeer").into(),
                     &NetworkMessageType::NETWORK_ECHO,
                     outgoing_message_bytes
                 )

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -631,7 +631,8 @@ pub mod tests {
 
     use crate::mesh::{Envelope, Mesh};
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
+        ConnectionManager,
     };
     use crate::network::dispatch::{
         dispatch_channel, DispatchError, DispatchLoopBuilder, Dispatcher, Handler, MessageContext,
@@ -963,7 +964,9 @@ pub mod tests {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity: self.authorized_id.clone(),
+                identity: ConnectionAuthorizationType::Trust {
+                    identity: self.authorized_id.clone(),
+                },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -858,7 +858,7 @@ fn handle_notifications(
         // If a connection has disconnected, forward notification to subscribers
         ConnectionManagerNotification::Disconnected { endpoint, identity } => handle_disconnection(
             endpoint,
-            identity,
+            identity.into(),
             unreferenced_peers,
             peers,
             connector,
@@ -871,6 +871,7 @@ fn handle_notifications(
         } => {
             // Check if the disconnected peer has reached the retry limit, if so try to find a
             // different endpoint that can be connected to
+            let identity: String = identity.into();
             if let Some(mut peer_metadata) = peers.get_by_peer_id(&identity).cloned() {
                 info!(
                     "{} reconnection attempts have been made to peer {}",
@@ -916,7 +917,7 @@ fn handle_notifications(
             identity,
         } => handle_inbound_connection(
             endpoint,
-            identity,
+            identity.into(),
             connection_id,
             unreferenced_peers,
             peers,
@@ -931,7 +932,7 @@ fn handle_notifications(
             connection_id,
         } => handle_connected(
             endpoint,
-            identity,
+            identity.into(),
             connection_id,
             unreferenced_peers,
             peers,
@@ -1431,7 +1432,8 @@ pub mod tests {
 
     use crate::mesh::Mesh;
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
+        ConnectionManager,
     };
     use crate::protos::network::{NetworkMessage, NetworkMessageType};
     use crate::threading::lifecycle::ShutdownHandle;
@@ -2545,7 +2547,7 @@ pub mod tests {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity,
+                identity: ConnectionAuthorizationType::Trust { identity },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -29,6 +29,7 @@ pub mod interconnect;
 mod notification;
 mod peer_map;
 mod peer_ref;
+mod token;
 
 use std::cmp::min;
 use std::collections::HashMap;

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 use crate::collections::BiHashMap;
 
 use super::error::PeerUpdateError;
+use super::PeerAuthorizationToken;
 
 /// Enum for the current status of a peer
 #[derive(Clone, PartialEq, Debug)]
@@ -35,8 +36,8 @@ pub enum PeerStatus {
 /// The representation of a peer in the `PeerMap`
 #[derive(Clone, PartialEq, Debug)]
 pub struct PeerMetadata {
-    /// The unique ID for the peer
-    pub id: String,
+    /// The unique PeerAuthorizationToken ID for the peer
+    pub id: PeerAuthorizationToken,
     /// The connection ID for the peer's connection
     pub connection_id: String,
     /// A list of endpoints the peer is reachable at
@@ -55,9 +56,9 @@ pub struct PeerMetadata {
 ///
 /// Peer metadata includes the peer ID, the list of endpoints, and the current active endpoint.
 pub struct PeerMap {
-    peers: HashMap<String, PeerMetadata>,
+    peers: HashMap<PeerAuthorizationToken, PeerMetadata>,
     // Endpoint to peer id
-    endpoints: HashMap<String, String>,
+    endpoints: HashMap<String, PeerAuthorizationToken>,
     initial_retry_frequency: u64,
 }
 
@@ -79,18 +80,18 @@ impl PeerMap {
     }
 
     /// Returns the current list of peer IDs
-    pub fn peer_ids(&self) -> Vec<String> {
+    pub fn peer_ids(&self) -> Vec<PeerAuthorizationToken> {
         self.peers
             .iter()
-            .map(|(_, metadata)| metadata.id.to_string())
+            .map(|(_, metadata)| metadata.id.clone())
             .collect()
     }
 
     /// Returns the current map of peer IDs to connection IDs
-    pub fn connection_ids(&self) -> BiHashMap<String, String> {
+    pub fn connection_ids(&self) -> BiHashMap<PeerAuthorizationToken, String> {
         let mut peer_to_connection_id = BiHashMap::new();
         for (peer, metadata) in self.peers.iter() {
-            peer_to_connection_id.insert(peer.to_string(), metadata.connection_id.to_string());
+            peer_to_connection_id.insert(peer.clone(), metadata.connection_id.to_string());
         }
 
         peer_to_connection_id
@@ -107,7 +108,7 @@ impl PeerMap {
     /// * `status` - The peer's current status
     pub fn insert(
         &mut self,
-        peer_id: String,
+        peer_id: PeerAuthorizationToken,
         connection_id: String,
         endpoints: Vec<String>,
         active_endpoint: String,
@@ -139,8 +140,8 @@ impl PeerMap {
     /// * `peer_id` - The unique ID for the peer
     ///
     /// Returns the metadata for the peer if it exists.
-    pub fn remove(&mut self, peer_id: &str) -> Option<PeerMetadata> {
-        if let Some(peer_metadata) = self.peers.remove(&peer_id.to_string()) {
+    pub fn remove(&mut self, peer_id: &PeerAuthorizationToken) -> Option<PeerMetadata> {
+        if let Some(peer_metadata) = self.peers.remove(&peer_id) {
             for endpoint in peer_metadata.endpoints.iter() {
                 self.endpoints.remove(endpoint);
             }
@@ -165,8 +166,7 @@ impl PeerMap {
                     .insert(endpoint.to_string(), peer_metadata.id.clone());
             }
 
-            self.peers
-                .insert(peer_metadata.id.to_string(), peer_metadata);
+            self.peers.insert(peer_metadata.id.clone(), peer_metadata);
 
             Ok(())
         } else {
@@ -187,7 +187,7 @@ impl PeerMap {
     }
 
     /// Returns the metadata for a peer from the provided peer ID
-    pub fn get_by_peer_id(&self, peer_id: &str) -> Option<&PeerMetadata> {
+    pub fn get_by_peer_id(&self, peer_id: &PeerAuthorizationToken) -> Option<&PeerMetadata> {
         self.peers.get(peer_id)
     }
 
@@ -199,7 +199,7 @@ impl PeerMap {
     }
 
     /// Returns the list of peers whose peer status is pending
-    pub fn get_pending(&self) -> impl Iterator<Item = (&String, &PeerMetadata)> {
+    pub fn get_pending(&self) -> impl Iterator<Item = (&PeerAuthorizationToken, &PeerMetadata)> {
         self.peers
             .iter()
             .filter(|(_id, peer_meta)| peer_meta.status == PeerStatus::Pending)
@@ -224,10 +224,12 @@ pub mod tests {
         let mut peer_map = PeerMap::new(10);
 
         let peers = peer_map.peer_ids();
-        assert_eq!(peers, Vec::<String>::new());
+        assert_eq!(peers, Vec::<PeerAuthorizationToken>::new());
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id_1".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
@@ -235,7 +237,9 @@ pub mod tests {
         );
 
         peer_map.insert(
-            "next_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "next_peer".to_string(),
+            },
             "connection_id_2".to_string(),
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
@@ -246,7 +250,14 @@ pub mod tests {
         peers.sort();
         assert_eq!(
             peers,
-            vec!["next_peer".to_string(), "test_peer".to_string()]
+            vec![
+                PeerAuthorizationToken::Trust {
+                    peer_id: "next_peer".to_string()
+                },
+                PeerAuthorizationToken::Trust {
+                    peer_id: "test_peer".to_string()
+                }
+            ]
         );
     }
 
@@ -258,10 +269,12 @@ pub mod tests {
         let mut peer_map = PeerMap::new(10);
 
         let peers = peer_map.peer_ids();
-        assert_eq!(peers, Vec::<String>::new());
+        assert_eq!(peers, Vec::<PeerAuthorizationToken>::new());
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id_1".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
@@ -269,7 +282,9 @@ pub mod tests {
         );
 
         peer_map.insert(
-            "next_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "next_peer".to_string(),
+            },
             "connection_id_2".to_string(),
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
@@ -278,11 +293,15 @@ pub mod tests {
 
         let peers = peer_map.connection_ids();
         assert_eq!(
-            peers.get_by_key("test_peer"),
+            peers.get_by_key(&PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string()
+            }),
             Some(&"connection_id_1".to_string())
         );
         assert_eq!(
-            peers.get_by_key("next_peer"),
+            peers.get_by_key(&PeerAuthorizationToken::Trust {
+                peer_id: "next_peer".to_string()
+            }),
             Some(&"connection_id_2".to_string())
         );
     }
@@ -301,7 +320,9 @@ pub mod tests {
         assert_eq!(peer_metadata, None);
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
@@ -312,7 +333,12 @@ pub mod tests {
             .get_peer_from_endpoint("test_endpoint1")
             .expect("missing expected peer_metadata");
 
-        assert_eq!(peer_metadata.id, "test_peer".to_string());
+        assert_eq!(
+            peer_metadata.id,
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string()
+            }
+        );
         assert_eq!(
             peer_metadata.endpoints,
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()]
@@ -335,19 +361,30 @@ pub mod tests {
         let mut peer_map = PeerMap::new(10);
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
         );
-        assert!(peer_map.peers.contains_key("test_peer"));
+        assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
+            peer_id: "test_peer".to_string(),
+        }));
 
         let peer_metadata = peer_map
             .peers
-            .get("test_peer")
+            .get(&PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            })
             .expect("Missing peer_metadata");
-        assert_eq!(peer_metadata.id, "test_peer".to_string());
+        assert_eq!(
+            peer_metadata.id,
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string()
+            }
+        );
         assert_eq!(
             peer_metadata.endpoints,
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()]
@@ -364,24 +401,43 @@ pub mod tests {
     fn test_remove_peer() {
         let mut peer_map = PeerMap::new(10);
 
-        let peer_metdata = peer_map.remove("test_peer");
+        let peer_metdata = peer_map.remove(&PeerAuthorizationToken::Trust {
+            peer_id: "test_peer".to_string(),
+        });
 
         assert_eq!(peer_metdata, None);
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
         );
-        assert!(peer_map.peers.contains_key("test_peer"));
+        assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
+            peer_id: "test_peer".to_string()
+        }));
 
-        let peer_metadata = peer_map.remove("test_peer").expect("Missing peer_metadata");
-        assert!(!peer_map.peers.contains_key("test_peer"));
+        let peer_metadata = peer_map
+            .remove(&PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            })
+            .expect("Missing peer_metadata");
+        assert!(
+            !peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string()
+            })
+        );
 
         assert_eq!(peer_metadata.active_endpoint, "test_endpoint2".to_string());
-        assert_eq!(peer_metadata.id, "test_peer".to_string());
+        assert_eq!(
+            peer_metadata.id,
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string()
+            },
+        );
     }
 
     // Test that a peer can be updated
@@ -394,7 +450,9 @@ pub mod tests {
     fn test_get_update_active_endpoint() {
         let mut peer_map = PeerMap::new(10);
         let no_peer_metadata = PeerMetadata {
-            id: "test_peer".to_string(),
+            id: PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             connection_id: "connection_id".to_string(),
             endpoints: vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             active_endpoint: "test_endpoint1".to_string(),
@@ -408,13 +466,17 @@ pub mod tests {
         }
 
         peer_map.insert(
-            "test_peer".to_string(),
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            },
             "connection_id".to_string(),
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
         );
-        assert!(peer_map.peers.contains_key("test_peer"));
+        assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
+            peer_id: "test_peer".to_string(),
+        }));
 
         let mut peer_metadata = peer_map
             .get_peer_from_endpoint("test_endpoint2")
@@ -431,10 +493,17 @@ pub mod tests {
 
         let peer_metadata = peer_map
             .peers
-            .get("test_peer")
+            .get(&PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            })
             .expect("Missing peer_metadata");
 
-        assert_eq!(peer_metadata.id, "test_peer".to_string());
+        assert_eq!(
+            peer_metadata.id,
+            PeerAuthorizationToken::Trust {
+                peer_id: "test_peer".to_string(),
+            }
+        );
         assert_eq!(
             peer_metadata.endpoints,
             vec![

--- a/libsplinter/src/peer/peer_ref.rs
+++ b/libsplinter/src/peer/peer_ref.rs
@@ -16,6 +16,7 @@
 //!
 //! The public interface includes the structs [`PeerRef`] and [`EndpointPeerRef`]
 
+use super::PeerAuthorizationToken;
 use crate::peer::connector::PeerRemover;
 
 /// Used to keep track of peer references. When dropped, the `PeerRef` will send a request to the
@@ -23,13 +24,13 @@ use crate::peer::connector::PeerRemover;
 /// exist.
 #[derive(Debug, PartialEq)]
 pub struct PeerRef {
-    peer_id: String,
+    peer_id: PeerAuthorizationToken,
     peer_remover: PeerRemover,
 }
 
 impl PeerRef {
     /// Creates a new `PeerRef`
-    pub(super) fn new(peer_id: String, peer_remover: PeerRemover) -> Self {
+    pub(super) fn new(peer_id: PeerAuthorizationToken, peer_remover: PeerRemover) -> Self {
         PeerRef {
             peer_id,
             peer_remover,
@@ -37,7 +38,7 @@ impl PeerRef {
     }
 
     /// Returns the peer ID this reference is for
-    pub fn peer_id(&self) -> &str {
+    pub fn peer_id(&self) -> &PeerAuthorizationToken {
         &self.peer_id
     }
 }

--- a/libsplinter/src/peer/token.rs
+++ b/libsplinter/src/peer/token.rs
@@ -1,0 +1,140 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! With the addition of challenge authorization, the idenity of a peer can either be a node ID
+//! when using Trust authorization or a public key when using Challenge authorization. The
+//! PeerAuthorizationToken will be used to idenitfy the peer on the networking level.
+
+use std::cmp::Ordering;
+use std::fmt;
+
+#[cfg(feature = "challenge-authorization")]
+use crate::hex::to_hex;
+use crate::network::connection_manager::ConnectionAuthorizationType;
+
+/// The authorization type specific peer ID
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PeerAuthorizationToken {
+    Trust {
+        peer_id: String,
+    },
+    #[cfg(feature = "challenge-authorization")]
+    Challenge {
+        public_key: Vec<u8>,
+    },
+}
+
+impl PeerAuthorizationToken {
+    /// Get a trust token from a provided ID
+    pub fn from_peer_id(peer_id: &str) -> Self {
+        PeerAuthorizationToken::Trust {
+            peer_id: peer_id.to_string(),
+        }
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    /// Get a challenge token from a provided public_key
+    pub fn from_public_key(public_key: &[u8]) -> Self {
+        PeerAuthorizationToken::Challenge {
+            public_key: public_key.to_vec(),
+        }
+    }
+
+    /// Check if the token is trust and has the provided ID
+    pub fn has_peer_id(&self, peer_id: &str) -> bool {
+        match self {
+            PeerAuthorizationToken::Trust { peer_id: id } => peer_id == id,
+            #[cfg(feature = "challenge-authorization")]
+            PeerAuthorizationToken::Challenge { .. } => false,
+        }
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    /// Check if the token is challenge and has the provided public key
+    pub fn has_public_key(&self, public_keys: &[Vec<u8>]) -> bool {
+        match self {
+            PeerAuthorizationToken::Trust { .. } => false,
+            PeerAuthorizationToken::Challenge { public_key } => public_keys.contains(&public_key),
+        }
+    }
+
+    /// Get the ID if the token is trust, else None
+    pub fn peer_id(&self) -> Option<&str> {
+        match self {
+            PeerAuthorizationToken::Trust { peer_id } => Some(&peer_id),
+            #[cfg(feature = "challenge-authorization")]
+            PeerAuthorizationToken::Challenge { .. } => None,
+        }
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    /// Get the public key if the token is challenge, else None
+    pub fn public_key(&self) -> Option<&[u8]> {
+        match self {
+            PeerAuthorizationToken::Trust { .. } => None,
+            PeerAuthorizationToken::Challenge { public_key } => Some(public_key),
+        }
+    }
+
+    /// Convert the token to a string represention
+    pub fn id_as_string(&self) -> String {
+        match self {
+            PeerAuthorizationToken::Trust { peer_id } => peer_id.to_string(),
+            #[cfg(feature = "challenge-authorization")]
+            PeerAuthorizationToken::Challenge { public_key } => {
+                format!("public_key::{}", to_hex(public_key))
+            }
+        }
+    }
+}
+
+impl fmt::Display for PeerAuthorizationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PeerAuthorizationToken::Trust { peer_id } => {
+                write!(f, "Trust ( peer_id: {} )", peer_id)
+            }
+            #[cfg(feature = "challenge-authorization")]
+            PeerAuthorizationToken::Challenge { public_key } => {
+                write!(f, "Challenge ( public_key: {} )", to_hex(public_key))
+            }
+        }
+    }
+}
+
+impl From<ConnectionAuthorizationType> for PeerAuthorizationToken {
+    fn from(connection_type: ConnectionAuthorizationType) -> Self {
+        match connection_type {
+            ConnectionAuthorizationType::Trust { identity } => {
+                PeerAuthorizationToken::Trust { peer_id: identity }
+            }
+            #[cfg(feature = "challenge-authorization")]
+            ConnectionAuthorizationType::Challenge { public_key } => {
+                PeerAuthorizationToken::Challenge { public_key }
+            }
+        }
+    }
+}
+
+impl Ord for PeerAuthorizationToken {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id_as_string().cmp(&other.id_as_string())
+    }
+}
+
+impl PartialOrd for PeerAuthorizationToken {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -430,7 +430,8 @@ pub mod tests {
 
     use crate::mesh::{Envelope, Mesh};
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
+        ConnectionManager,
     };
     use crate::network::dispatch::{
         dispatch_channel, ConnectionId, DispatchError, DispatchLoopBuilder, Dispatcher, Handler,
@@ -741,7 +742,9 @@ pub mod tests {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity: self.authorized_id.clone(),
+                identity: ConnectionAuthorizationType::Trust {
+                    identity: self.authorized_id.clone(),
+                },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -271,8 +271,12 @@ impl RunnableNetworkSubsystem {
         dispatcher.set_handler(Box::new(circuit_error_handler));
 
         // Circuit Admin handlers
-        let admin_direct_message_handler =
-            AdminDirectMessageHandler::new(node_id.to_string(), routing_reader);
+        let admin_direct_message_handler = AdminDirectMessageHandler::new(
+            node_id.to_string(),
+            routing_reader,
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+        );
         dispatcher.set_handler(Box::new(admin_direct_message_handler));
 
         dispatcher


### PR DESCRIPTION
This enables routing over the correct identity based on how the
connection was authorized. The layer that knows what authorization
type is required is the admin service, as such much of the public
API of the PeerManager, PeerManagerConnector, PeerInterconnect, and
network dispatchers had to be updated to use PeerAuthorizationToken
instead of a string.

The PeerID used by network dispatcher before wrapped a string but now
wraps a PeerAuthorizationToken. To make it easier to know which
PeerAuthorizationToken should be used in circuit handlers, a method
has been added to the routing table return the correct token based
on the authorization type used by the circuit.

This currently raises issues for two handler types. NetworkEcho knows
nothing about circuits and therefore cannot get the authorization type
required to send the message, so it is currently restricted to Trust.

Admin services that are using challenge authorization will have an
admin service id in the form admin::public_key::<public key as hex>
and it will be parsed by the AdminDirectMessageHandler. This will
work for the short term but before challenge authorization is stabilized
a better solution should be implemented.

This PR does not update the ConnectionManager to enforce an authorization 
type based on what is requested yet, this will be added with the Challenge
Authorization is implementation.