### PR TITLE
Add default for YamlCircuitStatus

### DIFF
--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1140,6 +1140,7 @@ struct YamlCircuit {
     display_name: Option<String>,
     #[serde(default = "default_circuit_value")]
     circuit_version: i32,
+    #[serde(default = "default_circuit_status")]
     circuit_status: YamlCircuitStatus,
 }
 
@@ -1483,6 +1484,7 @@ struct YamlProposedCircuit {
     display_name: Option<String>,
     #[serde(default = "default_circuit_value")]
     circuit_version: i32,
+    #[serde(default = "default_circuit_status")]
     circuit_status: YamlCircuitStatus,
 }
 
@@ -1811,6 +1813,10 @@ struct YamlState {
 
 fn default_circuit_value() -> i32 {
     1
+}
+
+fn default_circuit_status() -> YamlCircuitStatus {
+    YamlCircuitStatus::Active
 }
 
 /// YAML file specific CircuitStatus definition for serialization.


### PR DESCRIPTION
This is required for upgrading from 0.4 yaml state.
If circuit_status is not in the file yaml circuit, it
should default to Active.

This fixes this bug found when moving a 0.4 node to 0.5:

```
splinterd | [2021-06-09 15:25:33.486] T["main"] ERROR [splinterd] Failed to start daemon, unable to start the Splinter 
daemon: unable to set up storage: Unable to create YamlAdminServiceStore: Failed to read YAML circuit state file: 
circuits.XAi9e-PMiVt: missing field circuit_status at line 13 column 7
```