### PR TITLE
Update AuthChallengeSubmitRequest protobuf and protocol

### DIFF
--- a/libsplinter/protos/authorization.proto
+++ b/libsplinter/protos/authorization.proto
@@ -170,13 +170,17 @@ message AuthChallengeNonceResponse {
     bytes nonce = 1;
 }
 
+message SubmitRequest {
+    bytes public_key = 1;
+    bytes signature = 2;
+}
+
 // Challenge submit requests
 //
-// The connecting nodes public key and the signature created by signing the
+// The connecting nodes public keys and the signatures created by signing the
 // nonce received from the nonce response
 message AuthChallengeSubmitRequest {
-  bytes public_key = 1;
-  bytes signature = 2;
+    repeated SubmitRequest submit_requests = 1;
 }
 
 // v1 challenge response


### PR DESCRIPTION
The AuthChallengeSubmitRequest will return a list of public
key/signature pairs. This is required because a splinterd
can support multiple key pairs and it is not clear which
one is the expected public key without a proposal.

All public keys will be added as a separate connected peer.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>