### PR TITLE
Add module and struct doc to the RBAC actions

### DIFF
--- a/cli/src/action/rbac/assignments.rs
+++ b/cli/src/action/rbac/assignments.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Actions to support the RBAC subcommands related to authorizing identities.
+
 use std::collections::BTreeSet;
 
 use clap::ArgMatches;
@@ -24,6 +26,11 @@ use crate::error::CliError;
 
 use super::new_client;
 
+/// The action responsible for listing authorized identities.
+///
+/// The specific args for this action:
+///
+/// * format: specifies the output format; one of "human" or "csv"
 pub struct ListAssignmentsAction;
 
 impl Action for ListAssignmentsAction {
@@ -68,6 +75,13 @@ impl Action for ListAssignmentsAction {
     }
 }
 
+/// The action responsible for creating authorized identities.
+///
+/// The specific args for this action:
+///
+/// * id_key: an identifier of type key; a public key
+/// * id_user: an identifier of type user; a user ID
+/// * role: a role to add to the assignment; repeated
 pub struct CreateAssignmentAction;
 
 impl Action for CreateAssignmentAction {
@@ -99,6 +113,13 @@ impl Action for CreateAssignmentAction {
     }
 }
 
+/// The action responsible for showing a specific authorized identity.
+///
+/// The specific args for this action:
+///
+/// * id_key: an identifier of type key; a public key
+/// * id_user: an identifier of type user; a user ID
+/// * format: specifies the output format; one of "human", "json", or "yaml"
 pub struct ShowAssignmentAction;
 
 impl Action for ShowAssignmentAction {
@@ -139,6 +160,17 @@ impl Action for ShowAssignmentAction {
     }
 }
 
+/// The action responsible for updating a specific authorized identity.
+///
+/// The specific args for this action:
+///
+/// * id_key: an identifier of type key; a public key
+/// * id_user: an identifier of type user; a user ID
+/// * add_role: a role to add to the assignment; repeated
+/// * rm_role: a role to remove from the assignment; repeated
+/// * rm_all: remove all the currently assigned roles
+/// * dry_run: validate the inputs but do not submit the changes
+/// * force: applies the changes, even if a role is added and removed
 pub struct UpdateAssignmentAction;
 
 impl Action for UpdateAssignmentAction {
@@ -259,6 +291,13 @@ fn update_assignment(
     }
 }
 
+/// The action responsible for deleting a specific authorized identity.
+///
+/// The specific args for this action:
+///
+/// * id_key: an identifier of type key; a public key
+/// * id_user: an identifier of type user; a user ID
+/// * dry_run: validate the inputs but do not submit the changes
 pub struct DeleteAssignmentAction;
 
 impl Action for DeleteAssignmentAction {

--- a/cli/src/action/rbac/mod.rs
+++ b/cli/src/action/rbac/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Actions for handling role-based access control subcommands.
+
 mod assignments;
 mod roles;
 
@@ -30,6 +32,7 @@ pub use roles::{
     CreateRoleAction, DeleteRoleAction, ListRolesAction, ShowRoleAction, UpdateRoleAction,
 };
 
+/// Constructs a new Splinter REST client from the CLI arguments.
 fn new_client(arg_matches: &Option<&ArgMatches<'_>>) -> Result<SplinterRestClient, CliError> {
     let url = arg_matches
         .and_then(|args| args.value_of("url"))

--- a/cli/src/action/rbac/roles.rs
+++ b/cli/src/action/rbac/roles.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Actions to support the RBAC subcommands related to roles.
+
 use std::collections::BTreeSet;
 
 use clap::ArgMatches;
@@ -24,6 +26,11 @@ use crate::error::CliError;
 
 use super::new_client;
 
+/// The action responsible for listing roles.
+///
+/// The specific args for this action:
+///
+/// * format: specifies the output format; one of "human" or "csv"
 pub struct ListRolesAction;
 
 impl Action for ListRolesAction {
@@ -56,6 +63,12 @@ impl Action for ListRolesAction {
     }
 }
 
+/// The action responsible for showing a specific role.
+///
+/// The specific args for this action:
+///
+/// * role_id: the specified role ID
+/// * format: specifies the output format; one of "human", "json", or "yaml"
 pub struct ShowRoleAction;
 
 impl Action for ShowRoleAction {
@@ -94,6 +107,14 @@ impl Action for ShowRoleAction {
     }
 }
 
+/// The action responsible for creating roles.
+///
+/// The specific args for this action:
+///
+/// * role_id: the specified role ID
+/// * display_name: the role's display name
+/// * permission: a permission granted by the resulting role; repeated
+/// * dry_run: validate the inputs but do not submit the role
 pub struct CreateRoleAction;
 
 impl Action for CreateRoleAction {
@@ -134,6 +155,17 @@ impl Action for CreateRoleAction {
     }
 }
 
+/// The action responsible for updating a specific role.
+///
+/// The specific args for this action:
+///
+/// * role_id: the specified role ID
+/// * display_name: the role's display name
+/// * add_permission: a permission to add to the role; repeated
+/// * rm_permission: a permission to remove from the role; repeated
+/// * rm_all: remove all the currently granted permissions from the role
+/// * force: applies the changes, even if a permission is added and removed
+/// * dry_run: validate the inputs but do not submit the changes
 pub struct UpdateRoleAction;
 
 impl Action for UpdateRoleAction {
@@ -257,6 +289,11 @@ fn update_role(
     }
 }
 
+/// The action responsible for deleting a specific role.
+///
+/// The specific args for this action:
+///
+/// * role_id: the specified role ID
 pub struct DeleteRoleAction;
 
 impl Action for DeleteRoleAction {


### PR DESCRIPTION
This change adds documentation comments to the RBAC CLI modules and the action structs provided.
