### PR TITLE
Replace cargo search in crates publishing

### DIFF
--- a/ci/publish-splinter-crates
+++ b/ci/publish-splinter-crates
@@ -54,16 +54,16 @@ CMD cargo login $CARGO_CRED \
  && cargo clean \
  && cargo test \
  && cargo publish \
- && bash -c '\
-    while true; do echo "Waiting for Splinter publishing to complete"; \
-    cargo search splinter | grep "splinter = " | grep -q $REPO_VERSION; \
-    if [ $? -eq 0 ]; \
-      then break; \
-    fi; \
-    sleep 0.5; done; ' \
  && cd /project/splinter/services/scabbard/libscabbard \
  && sed -i'' -e "s/splinter = {.*$/splinter\ =\ \"$REPO_VERSION\"/" Cargo.toml \
  && rm -f ../../../Cargo.lock ./Cargo.lock \
  && cargo clean \
+ && bash -c '\
+    while true; do echo "Waiting for Splinter publishing to complete"; \
+    cargo check; \
+    if [ $? -eq 0 ]; \
+      then break; \
+    fi; \
+    sleep 10; done; ' \
  && cargo test \
  && cargo publish --allow-dirty


### PR DESCRIPTION
cargo search will sometimes return versions that are updated in the index
but not available to download yet. cargo check will verify that all
dependencies are actually available and buildable before moving on.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>