### PR TITLE
Stabilize cli/permissions by removing the feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -76,7 +76,6 @@ experimental = [
     "upgrade",
     "https-certs",
     "user-list",
-    "permissions",
     "registry",
 ]
 
@@ -93,7 +92,6 @@ health = []
 upgrade = ["database", "splinter/store-factory"]
 
 https-certs = []
-permissions = []
 
 database = ["diesel"]
 postgres = [

--- a/cli/src/action/api/mod.rs
+++ b/cli/src/action/api/mod.rs
@@ -189,7 +189,6 @@ impl SplinterRestClient {
     }
 
     /// Lists all REST API permissions for a Splinter node.
-    #[cfg(feature = "permissions")]
     pub fn list_permissions(&self) -> Result<Vec<Permission>, CliError> {
         Client::new()
             .get(&format!("{}/authorization/permissions", self.url))

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -24,7 +24,6 @@ pub mod health;
 pub mod keygen;
 #[cfg(feature = "authorization-handler-maintenance")]
 pub mod maintenance;
-#[cfg(feature = "permissions")]
 pub mod permissions;
 #[cfg(feature = "authorization-handler-rbac")]
 pub mod rbac;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1524,7 +1524,6 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         );
     }
 
-    #[cfg(feature = "permissions")]
     {
         app = app.subcommand(
             SubCommand::with_name("permissions")
@@ -1727,7 +1726,6 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             )
     }
 
-    #[cfg(feature = "permissions")]
     {
         use action::permissions;
         subcommands = subcommands.with_command("permissions", permissions::ListAction)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,7 +34,7 @@ use flexi_logger::FlexiLoggerError;
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
 use log::Record;
 
-use action::{admin, certs, circuit, keygen, registry, Action, SubcommandActions};
+use action::{admin, certs, circuit, keygen, permissions, registry, Action, SubcommandActions};
 use error::CliError;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
@@ -1524,36 +1524,34 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         );
     }
 
-    {
-        app = app.subcommand(
-            SubCommand::with_name("permissions")
-                .about("Lists REST API permissions for a Splinter node")
-                .arg(
-                    Arg::with_name("format")
-                        .short("F")
-                        .long("format")
-                        .help("Output format")
-                        .possible_values(&["human", "csv", "json"])
-                        .default_value("human")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("url")
-                        .short("U")
-                        .long("url")
-                        .help("URL of the Splinter daemon REST API")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("private_key_file")
-                        .value_name("private-key-file")
-                        .short("k")
-                        .long("key")
-                        .takes_value(true)
-                        .help("Name or path of private key"),
-                ),
-        )
-    }
+    app = app.subcommand(
+        SubCommand::with_name("permissions")
+            .about("Lists REST API permissions for a Splinter node")
+            .arg(
+                Arg::with_name("format")
+                    .short("F")
+                    .long("format")
+                    .help("Output format")
+                    .possible_values(&["human", "csv", "json"])
+                    .default_value("human")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("url")
+                    .short("U")
+                    .long("url")
+                    .help("URL of the Splinter daemon REST API")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("private_key_file")
+                    .value_name("private-key-file")
+                    .short("k")
+                    .long("key")
+                    .takes_value(true)
+                    .help("Name or path of private key"),
+            ),
+    );
 
     #[cfg(feature = "user-list")]
     {
@@ -1726,10 +1724,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             )
     }
 
-    {
-        use action::permissions;
-        subcommands = subcommands.with_command("permissions", permissions::ListAction)
-    }
+    subcommands = subcommands.with_command("permissions", permissions::ListAction);
 
     #[cfg(feature = "user-list")]
     {


### PR DESCRIPTION
This change stabilizes the feature "permissions" by removing the feature.  The splinter daemon has no way of disabling this endpoint, and so there is no reason to disable the subcommand at compile-time.