### PR TITLE
Bump sawtooth-sabre dependency version

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -34,7 +34,7 @@ openssl = "0.10"
 protobuf = "2.23"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth = { version = "0.6", default-features = false, features = ["lmdb-store", "receipt-store"] }
-sawtooth-sabre = "0.7"
+sawtooth-sabre = "0.7.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Sabre 0.7.2 depends on wasmi 0.9 which includes fixes for a bug that caused
a memory leak.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>