### PR TITLE
Add user subject to error log message

### DIFF
--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -123,7 +123,11 @@ pub fn make_callback_route(
                                         ) {
                                             Ok(_) => debug!("User profile saved"),
                                             Err(err) => {
-                                                error!("Failed to save profile: {}", err);
+                                                error!(
+                                                    "Failed to save profile for account: {}, {}",
+                                                    user_info.subject.clone(),
+                                                    err
+                                                );
                                                 return Box::new(
                                                     HttpResponse::InternalServerError()
                                                         .json(ErrorResponse::internal_error())
@@ -229,7 +233,11 @@ pub fn make_callback_route(
                                     ) {
                                         Ok(_) => debug!("User profile saved"),
                                         Err(err) => {
-                                            error!("Failed to save profile: {}", err);
+                                            error!(
+                                                "Failed to save profile for account: {}, {}",
+                                                user_info.subject.clone(),
+                                                err
+                                            );
                                             return Box::new(
                                                 HttpResponse::InternalServerError()
                                                     .json(ErrorResponse::internal_error())


### PR DESCRIPTION
Based on a comment in the biome-profile stabilization doc, log the user's subject in the error message if saving profile fails.