### PR TITLE
Update the state-dir help to not include YAML storage

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -324,7 +324,7 @@ fn main() {
         .arg(
             Arg::with_name("state_dir")
                 .long("state-dir")
-                .help("Storage directory when storage is YAML")
+                .help("Path to the directory containing state files")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
YAML storage is being removed.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>