### PR TITLE
Deprecate yaml address feedback

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -197,10 +197,6 @@ impl ConfigBuilder {
         // for the specific field. If no value is found, an error is returned.
         Ok(Config {
             config_dir,
-            storage: self
-                .partial_configs
-                .iter()
-                .find_map(|p| p.storage().map(|v| (v, p.source()))),
             tls_cert_dir,
             tls_ca_file,
             tls_client_cert,
@@ -365,7 +361,6 @@ mod tests {
     use super::*;
 
     /// Example configuration values.
-    static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_CA_CERTS: &str = "/etc/splinter/certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "/etc/splinter/certs/client.crt";
     static EXAMPLE_CLIENT_KEY: &str = "/etc/splinter/certs/client.key";
@@ -384,7 +379,6 @@ mod tests {
 
     /// Asserts the example configuration values.
     fn assert_config_values(config: PartialConfig) {
-        assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
         assert_eq!(config.tls_cert_dir(), None);
         assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(
@@ -454,7 +448,6 @@ mod tests {
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the `PartialConfig` fields by chaining the builder methods.
         partial_config = partial_config
-            .with_storage(Some(EXAMPLE_STORAGE.to_string()))
             .with_tls_cert_dir(None)
             .with_tls_ca_file(Some(EXAMPLE_CA_CERTS.to_string()))
             .with_tls_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()))
@@ -501,7 +494,6 @@ mod tests {
         // Create a new `PartialConfig` object.
         let mut partial_config = PartialConfig::new(ConfigSource::Default);
         // Populate the `PartialConfig` fields by separately applying the builder methods.
-        partial_config = partial_config.with_storage(Some(EXAMPLE_STORAGE.to_string()));
         partial_config = partial_config.with_tls_ca_file(Some(EXAMPLE_CA_CERTS.to_string()));
         partial_config = partial_config.with_tls_client_cert(Some(EXAMPLE_CLIENT_CERT.to_string()));
         partial_config = partial_config.with_tls_client_key(Some(EXAMPLE_CLIENT_KEY.to_string()));

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -47,7 +47,6 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
 
         partial_config = partial_config
             .with_config_dir(self.matches.value_of("config_dir").map(String::from))
-            .with_storage(self.matches.value_of("storage").map(String::from))
             .with_tls_cert_dir(self.matches.value_of("tls_cert_dir").map(String::from))
             .with_tls_ca_file(self.matches.value_of("tls_ca_file").map(String::from))
             .with_tls_client_cert(self.matches.value_of("tls_client_cert").map(String::from))
@@ -190,7 +189,6 @@ mod tests {
     use clap::ArgMatches;
 
     /// Example configuration values.
-    static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
     static EXAMPLE_CLIENT_KEY: &str = "certs/client.key";
@@ -210,7 +208,6 @@ mod tests {
 
     /// Asserts config values based on the example values.
     fn assert_config_values(config: PartialConfig) {
-        assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
         assert_eq!(config.tls_cert_dir(), None);
         assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(
@@ -281,7 +278,6 @@ mod tests {
                 (@arg config: -c --config +takes_value)
                 (@arg node_id: --("node-id") +takes_value)
                 (@arg display_name: --("display-name") +takes_value)
-                (@arg storage: --("storage") +takes_value)
                 (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
                 (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
                 (@arg service_endpoint: --("service-endpoint") +takes_value)
@@ -307,7 +303,6 @@ mod tests {
                 (@arg config: -c --config +takes_value)
                 (@arg node_id: --("node-id") +takes_value)
                 (@arg display_name: --("display-name") +takes_value)
-                (@arg storage: --("storage") +takes_value)
                 (@arg network_endpoints: -n --("network-endpoints") +takes_value +multiple)
                 (@arg advertised_endpoints: -a --("advertised-endpoints") +takes_value +multiple)
                 (@arg service_endpoint: --("service-endpoint") +takes_value)
@@ -347,8 +342,6 @@ mod tests {
             EXAMPLE_NODE_ID,
             "--display-name",
             EXAMPLE_DISPLAY_NAME,
-            "--storage",
-            EXAMPLE_STORAGE,
             "--network-endpoints",
             EXAMPLE_NETWORK_ENDPOINT,
             "--advertised-endpoints",

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -109,7 +109,6 @@ mod tests {
 
     /// Asserts config values based on the default values.
     fn assert_default_values(config: PartialConfig) {
-        assert_eq!(config.storage(), None);
         assert_eq!(config.tls_cert_dir(), Some(String::from(TLS_CERT_DIR)));
         assert_eq!(config.tls_ca_file(), Some(String::from(TLS_CA_FILE)));
         assert_eq!(

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -34,7 +34,6 @@ pub enum ConfigSource {
 pub struct PartialConfig {
     source: ConfigSource,
     config_dir: Option<String>,
-    storage: Option<String>,
     tls_cert_dir: Option<String>,
     tls_ca_file: Option<String>,
     tls_client_cert: Option<String>,
@@ -97,7 +96,6 @@ impl PartialConfig {
         PartialConfig {
             source,
             config_dir: None,
-            storage: None,
             tls_cert_dir: None,
             tls_ca_file: None,
             tls_client_cert: None,
@@ -161,10 +159,6 @@ impl PartialConfig {
 
     pub fn config_dir(&self) -> Option<String> {
         self.config_dir.clone()
-    }
-
-    pub fn storage(&self) -> Option<String> {
-        self.storage.clone()
     }
 
     pub fn tls_cert_dir(&self) -> Option<String> {
@@ -343,17 +337,6 @@ impl PartialConfig {
     ///
     pub fn with_config_dir(mut self, config_dir: Option<String>) -> Self {
         self.config_dir = config_dir;
-        self
-    }
-
-    /// Adds a `storage` value to the `PartialConfig` object.
-    ///
-    /// # Arguments
-    ///
-    /// * `storage` - The type of storage that should be used to store circuit state.
-    ///
-    pub fn with_storage(mut self, storage: Option<String>) -> Self {
-        self.storage = storage;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -28,7 +28,6 @@ const TOML_VERSION: &str = "1";
 /// will impact the valid format of the config file.
 #[derive(Deserialize, Default, Debug)]
 struct TomlConfig {
-    storage: Option<String>,
     tls_cert_dir: Option<String>,
     tls_ca_file: Option<String>,
     tls_client_cert: Option<String>,
@@ -140,7 +139,6 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
 
         partial_config = partial_config
             // with current values
-            .with_storage(self.toml_config.storage)
             .with_tls_cert_dir(self.toml_config.tls_cert_dir)
             .with_tls_ca_file(self.toml_config.tls_ca_file)
             .with_tls_client_cert(self.toml_config.tls_client_cert)
@@ -252,7 +250,6 @@ mod tests {
     static TEST_TOML: &str = "config_test.toml";
 
     /// Example configuration values.
-    static EXAMPLE_STORAGE: &str = "yaml";
     static EXAMPLE_CERT_DIR: &str = "/cert_dir";
     static EXAMPLE_CA_CERTS: &str = "certs/ca.pem";
     static EXAMPLE_CLIENT_CERT: &str = "certs/client.crt";
@@ -281,7 +278,6 @@ mod tests {
     /// Converts a list of tuples to a toml `Table` `Value` used to write a toml file.
     fn get_toml_value() -> Value {
         let values = vec![
-            ("storage".to_string(), EXAMPLE_STORAGE.to_string()),
             ("tls_ca_file".to_string(), EXAMPLE_CA_CERTS.to_string()),
             (
                 "tls_client_cert".to_string(),
@@ -379,7 +375,6 @@ mod tests {
 
     /// Asserts config values based on the example configuration values.
     fn assert_config_values(config: PartialConfig) {
-        assert_eq!(config.storage(), Some(EXAMPLE_STORAGE.to_string()));
         assert_eq!(config.tls_cert_dir(), None);
         assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(
@@ -446,7 +441,6 @@ mod tests {
 
     /// Asserts config values based on the example configuration values.
     fn assert_deprecated_config_values(config: PartialConfig) {
-        assert_eq!(config.storage(), None);
         assert_eq!(config.tls_cert_dir(), Some(EXAMPLE_CERT_DIR.to_string()));
         assert_eq!(config.tls_ca_file(), Some(EXAMPLE_CA_CERTS.to_string()));
         assert_eq!(

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -173,7 +173,7 @@ impl SplinterDaemon {
             let proposals_location = Path::new(&self.state_dir).join("circuit_proposals.yaml");
 
             let circuits_location_exists = circuits_location.exists();
-            let proposals_location_exists = circuits_location.exists();
+            let proposals_location_exists = proposals_location.exists();
 
             if circuits_location_exists || proposals_location_exists {
                 if circuits_location_exists {


### PR DESCRIPTION
Two changes in response to stabilization feedback
* Correct the proposals file detection
* Remove storage option from config and tests