### PR TITLE
Implement Challenge Authorization

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -31,7 +31,8 @@ use cylinder::Verifier as SignatureVerifier;
 use openssl::hash::{hash, MessageDigest};
 use protobuf::{self, Message};
 
-use crate::admin::store::{self, AdminServiceStore, AuthorizationType};
+use crate::admin::store::{self, AdminServiceStore};
+use crate::admin::token::PeerAuthorizationTokenReader;
 use crate::circuit::routing::{self, RoutingTableWriter};
 use crate::consensus::Proposal;
 use crate::hex::to_hex;

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -753,7 +753,7 @@ impl Service for AdminService {
                     .network_sender()
                     .as_ref()
                     .ok_or(ServiceError::NotStarted)?
-                    .send(&message_context.sender.to_string(), &envelope_bytes)
+                    .send(&message_context.sender, &envelope_bytes)
                     .map_err(|err| ServiceError::UnableToSendMessage(Box::new(err)))?;
                 admin_service_shared
                     .on_protocol_agreement(&message_context.sender, protocol)

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -1269,6 +1269,19 @@ mod tests {
         fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
             Box::new(self.clone())
         }
+
+        #[cfg(feature = "challenge-authorization")]
+        fn send_with_sender(
+            &mut self,
+            recipient: &str,
+            message: &[u8],
+            _sender: &str,
+        ) -> Result<(), error::ServiceSendError> {
+            self.tx
+                .send((recipient.to_string(), message.to_vec()))
+                .expect("Unable to send test message");
+            Ok(())
+        }
     }
 
     struct MockAdminKeyVerifier;

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 use std::iter::ExactSizeIterator;
 use std::sync::mpsc::Sender;
@@ -22,10 +22,9 @@ use cylinder::{PublicKey, Signature, Verifier as SignatureVerifier};
 use protobuf::{Message, RepeatedField};
 
 use crate::admin::store::{
-    AdminServiceStore, AuthorizationType, Circuit as StoreCircuit,
-    CircuitBuilder as StoreCircuitBuilder, CircuitNode, CircuitPredicate,
-    CircuitProposal as StoreProposal, CircuitStatus as StoreCircuitStatus, ProposalType,
-    ProposedCircuit, Service as StoreService, Vote, VoteRecordBuilder,
+    AdminServiceStore, Circuit as StoreCircuit, CircuitBuilder as StoreCircuitBuilder,
+    CircuitPredicate, CircuitProposal as StoreProposal, CircuitStatus as StoreCircuitStatus,
+    ProposalType, ProposedCircuit, Service as StoreService, Vote, VoteRecordBuilder,
 };
 use crate::admin::token::{PeerAuthorizationTokenReader, PeerNode};
 use crate::circuit::routing::{self, RoutingTableWriter};
@@ -3520,16 +3519,6 @@ impl AdminServiceShared {
             .map_err(AdminSharedError::from)
     }
 
-    pub fn get_nodes(&self) -> Result<BTreeMap<String, CircuitNode>, AdminSharedError> {
-        Ok(self
-            .admin_store
-            .list_nodes()
-            .map_err(AdminSharedError::from)?
-            .into_iter()
-            .map(|node| (node.node_id().into(), node))
-            .collect())
-    }
-
     fn verify_signature(&self, payload: &CircuitManagementPayload) -> Result<bool, ServiceError> {
         let header: CircuitManagementPayload_Header =
             Message::parse_from_bytes(payload.get_header())?;
@@ -3617,6 +3606,7 @@ mod tests {
     use crate::admin::service::AdminKeyVerifierError;
     use crate::admin::store;
     use crate::admin::store::diesel::DieselAdminServiceStore;
+    use crate::admin::store::CircuitNode;
     use crate::circuit::routing::memory::RoutingTable;
     use crate::keys::insecure::AllowAllKeyPermissionManager;
     use crate::mesh::{Envelope, Mesh};

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -7272,6 +7272,20 @@ mod tests {
         fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
             Box::new(self.clone())
         }
+
+        #[cfg(feature = "challenge-authorization")]
+        fn send_with_sender(
+            &mut self,
+            recipient: &str,
+            message: &[u8],
+            _sender: &str,
+        ) -> Result<(), ServiceSendError> {
+            self.sent
+                .lock()
+                .expect("sent lock poisoned")
+                .push((recipient.to_string(), message.to_vec()));
+            Ok(())
+        }
     }
 
     struct MockAdminKeyVerifier(bool);

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -27,7 +27,7 @@ use crate::admin::store::{
     CircuitProposal as StoreProposal, CircuitStatus as StoreCircuitStatus, ProposalType,
     ProposedCircuit, Service as StoreService, Vote, VoteRecordBuilder,
 };
-use crate::admin::token::ListPeerAuthorizationTokens;
+use crate::admin::token::{PeerAuthorizationTokenReader, PeerNode};
 use crate::circuit::routing::{self, RoutingTableWriter};
 use crate::consensus::{Proposal, ProposalId, ProposalUpdate};
 use crate::hex::to_hex;

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -80,6 +80,12 @@ pub struct PendingPayload {
     pub members: Vec<PeerAuthorizationToken>,
 }
 
+#[derive(Clone, Debug)]
+pub struct PeerNodePair {
+    pub peer_node: PeerNode,
+    pub local_peer_token: PeerAuthorizationToken,
+}
+
 enum CircuitProposalStatus {
     Accepted,
     Rejected,
@@ -146,6 +152,7 @@ pub struct AdminServiceShared {
     event_store: Box<dyn AdminServiceStore>,
     #[cfg(feature = "challenge-authorization")]
     public_keys: Vec<Vec<u8>>,
+    token_to_peer: HashMap<PeerAuthorizationToken, PeerNodePair>,
 }
 
 impl AdminServiceShared {
@@ -193,6 +200,7 @@ impl AdminServiceShared {
             event_store: admin_service_event_store,
             #[cfg(feature = "challenge-authorization")]
             public_keys,
+            token_to_peer: HashMap::new(),
         }
     }
 
@@ -219,6 +227,17 @@ impl AdminServiceShared {
             #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::Challenge { .. } => false,
         }
+    }
+
+    pub fn set_token_to_peer(
+        &mut self,
+        token_to_peer: HashMap<PeerAuthorizationToken, PeerNodePair>,
+    ) {
+        self.token_to_peer = token_to_peer;
+    }
+
+    pub fn token_to_peer(&self) -> &HashMap<PeerAuthorizationToken, PeerNodePair> {
+        &self.token_to_peer
     }
 
     pub fn network_sender(&self) -> &Option<Box<dyn ServiceNetworkSender>> {

--- a/libsplinter/src/admin/token/mod.rs
+++ b/libsplinter/src/admin/token/mod.rs
@@ -22,6 +22,26 @@ pub mod token_protocol;
 use crate::error::InvalidStateError;
 use crate::peer::PeerAuthorizationToken;
 
-pub trait ListPeerAuthorizationTokens {
+/// Struct used to correlate a `PeerAuthorizationToken` with node information
+#[derive(Clone, Debug, PartialEq)]
+pub struct PeerNode {
+    pub token: PeerAuthorizationToken,
+    pub node_id: String,
+    pub endpoints: Vec<String>,
+    pub admin_service: String,
+}
+
+pub trait PeerAuthorizationTokenReader {
     fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError>;
+
+    fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError>;
+
+    fn get_node_token(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<PeerAuthorizationToken>, InvalidStateError>;
+}
+
+pub fn admin_service_id(node_id: &str) -> String {
+    format!("admin::{}", node_id)
 }

--- a/libsplinter/src/admin/token/token_protobuf.rs
+++ b/libsplinter/src/admin/token/token_protobuf.rs
@@ -16,9 +16,9 @@ use crate::error::InvalidStateError;
 use crate::peer::PeerAuthorizationToken;
 use crate::protos::admin::{Circuit, Circuit_AuthorizationType};
 
-use super::ListPeerAuthorizationTokens;
+use super::{admin_service_id, PeerAuthorizationTokenReader, PeerNode};
 
-impl ListPeerAuthorizationTokens for Circuit {
+impl PeerAuthorizationTokenReader for Circuit {
     fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
         self.get_members()
             .iter()
@@ -46,5 +46,74 @@ impl ListPeerAuthorizationTokens for Circuit {
                 ))),
             })
             .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
+    }
+
+    fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError> {
+        self.get_members()
+            .iter()
+            .map(|member| match self.get_authorization_type() {
+                Circuit_AuthorizationType::TRUST_AUTHORIZATION => Ok(PeerNode {
+                    token: PeerAuthorizationToken::from_peer_id(member.get_node_id()),
+                    node_id: member.get_node_id().to_string(),
+                    endpoints: member.get_endpoints().to_vec(),
+                    admin_service: admin_service_id(member.get_node_id()),
+                }),
+                #[cfg(feature = "challenge-authorization")]
+                Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
+                    if !member.get_public_key().is_empty() {
+                        Ok(PeerNode {
+                            token: PeerAuthorizationToken::from_public_key(member.get_public_key()),
+                            node_id: member.get_node_id().to_string(),
+                            endpoints: member.get_endpoints().to_vec(),
+                            admin_service: admin_service_id(member.get_node_id()),
+                        })
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                                 authorization: {}",
+                            self.get_circuit_id()
+                        )))
+                    }
+                }
+                _ => Err(InvalidStateError::with_message(format!(
+                    "Circuit is missing authorization type: {}",
+                    self.get_circuit_id()
+                ))),
+            })
+            .collect::<Result<Vec<PeerNode>, InvalidStateError>>()
+    }
+
+    fn get_node_token(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<PeerAuthorizationToken>, InvalidStateError> {
+        match self
+            .get_members()
+            .iter()
+            .find(|member| member.get_node_id() == node_id)
+        {
+            Some(member) => match self.get_authorization_type() {
+                Circuit_AuthorizationType::TRUST_AUTHORIZATION => Ok(Some(
+                    PeerAuthorizationToken::from_peer_id(member.get_node_id()),
+                )),
+                #[cfg(feature = "challenge-authorization")]
+                Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
+                    if !member.get_public_key().is_empty() {
+                        Ok(Some(PeerAuthorizationToken::from_public_key(
+                            member.get_public_key(),
+                        )))
+                    } else {
+                        Err(InvalidStateError::with_message(
+                            "Public key not set when requied by a circuit".to_string(),
+                        ))
+                    }
+                }
+                _ => Err(InvalidStateError::with_message(format!(
+                    "Circuit is missing authorization type: {}",
+                    self.get_circuit_id()
+                ))),
+            },
+            None => Ok(None),
+        }
     }
 }

--- a/libsplinter/src/admin/token/token_protocol.rs
+++ b/libsplinter/src/admin/token/token_protocol.rs
@@ -16,9 +16,9 @@ use crate::admin::store::{AuthorizationType, Circuit, ProposedCircuit};
 use crate::error::InvalidStateError;
 use crate::peer::PeerAuthorizationToken;
 
-use super::ListPeerAuthorizationTokens;
+use super::{admin_service_id, PeerAuthorizationTokenReader, PeerNode};
 
-impl ListPeerAuthorizationTokens for ProposedCircuit {
+impl PeerAuthorizationTokenReader for ProposedCircuit {
     fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
         self.members()
             .iter()
@@ -41,9 +41,68 @@ impl ListPeerAuthorizationTokens for ProposedCircuit {
             })
             .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
     }
+
+    fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError> {
+        self.members()
+            .iter()
+            .map(|member| match self.authorization_type() {
+                AuthorizationType::Trust => Ok(PeerNode {
+                    token: PeerAuthorizationToken::from_peer_id(member.node_id()),
+                    node_id: member.node_id().to_string(),
+                    endpoints: member.endpoints().to_vec(),
+                    admin_service: admin_service_id(member.node_id()),
+                }),
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(PeerNode {
+                            token: PeerAuthorizationToken::from_public_key(public_key),
+                            node_id: member.node_id().to_string(),
+                            endpoints: member.endpoints().to_vec(),
+                            admin_service: admin_service_id(member.node_id()),
+                        })
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                             authorization: {}",
+                            self.circuit_id()
+                        )))
+                    }
+                }
+            })
+            .collect::<Result<Vec<PeerNode>, InvalidStateError>>()
+    }
+
+    fn get_node_token(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<PeerAuthorizationToken>, InvalidStateError> {
+        match self
+            .members()
+            .iter()
+            .find(|member| member.node_id() == node_id)
+        {
+            Some(member) => match self.authorization_type() {
+                AuthorizationType::Trust => {
+                    Ok(Some(PeerAuthorizationToken::from_peer_id(member.node_id())))
+                }
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(Some(PeerAuthorizationToken::from_public_key(public_key)))
+                    } else {
+                        Err(InvalidStateError::with_message(
+                            "Public key not set when required by a circuit".to_string(),
+                        ))
+                    }
+                }
+            },
+            None => Ok(None),
+        }
+    }
 }
 
-impl ListPeerAuthorizationTokens for Circuit {
+impl PeerAuthorizationTokenReader for Circuit {
     fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError> {
         self.members()
             .iter()
@@ -65,5 +124,64 @@ impl ListPeerAuthorizationTokens for Circuit {
                 }
             })
             .collect::<Result<Vec<PeerAuthorizationToken>, InvalidStateError>>()
+    }
+
+    fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError> {
+        self.members()
+            .iter()
+            .map(|member| match self.authorization_type() {
+                AuthorizationType::Trust => Ok(PeerNode {
+                    token: PeerAuthorizationToken::from_peer_id(member.node_id()),
+                    node_id: member.node_id().to_string(),
+                    endpoints: member.endpoints().to_vec(),
+                    admin_service: admin_service_id(member.node_id()),
+                }),
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(PeerNode {
+                            token: PeerAuthorizationToken::from_public_key(public_key),
+                            node_id: member.node_id().to_string(),
+                            endpoints: member.endpoints().to_vec(),
+                            admin_service: admin_service_id(member.node_id()),
+                        })
+                    } else {
+                        Err(InvalidStateError::with_message(format!(
+                            "No public key set when circuit requries challenge \
+                             authorization: {}",
+                            self.circuit_id()
+                        )))
+                    }
+                }
+            })
+            .collect::<Result<Vec<PeerNode>, InvalidStateError>>()
+    }
+
+    fn get_node_token(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<PeerAuthorizationToken>, InvalidStateError> {
+        match self
+            .members()
+            .iter()
+            .find(|member| member.node_id() == node_id)
+        {
+            Some(member) => match self.authorization_type() {
+                AuthorizationType::Trust => {
+                    Ok(Some(PeerAuthorizationToken::from_peer_id(member.node_id())))
+                }
+                #[cfg(feature = "challenge-authorization")]
+                AuthorizationType::Challenge => {
+                    if let Some(public_key) = member.public_key() {
+                        Ok(Some(PeerAuthorizationToken::from_public_key(public_key)))
+                    } else {
+                        Err(InvalidStateError::with_message(
+                            "Public key not set when required by a circuit".to_string(),
+                        ))
+                    }
+                }
+            },
+            None => Ok(None),
+        }
     }
 }

--- a/libsplinter/src/network/auth/connection_manager.rs
+++ b/libsplinter/src/network/auth/connection_manager.rs
@@ -17,6 +17,8 @@ use crate::network::connection_manager::{
 };
 use crate::transport::Connection;
 
+#[cfg(feature = "challenge-authorization")]
+use super::ConnectionAuthorizationType;
 use super::{AuthorizationConnector, AuthorizationManagerError, ConnectionAuthorizationState};
 
 impl Authorizer for AuthorizationConnector {
@@ -25,10 +27,20 @@ impl Authorizer for AuthorizationConnector {
         connection_id: String,
         connection: Box<dyn Connection>,
         callback: AuthorizerCallback,
+        #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+            ConnectionAuthorizationType,
+        >,
+        #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+            ConnectionAuthorizationType,
+        >,
     ) -> Result<(), AuthorizerError> {
         self.add_connection(
             connection_id,
             connection,
+            #[cfg(feature = "challenge-authorization")]
+            expected_authorization,
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization,
             Box::new(move |state| (*callback)(state.into())),
         )
         .map_err(AuthorizerError::from)
@@ -42,10 +54,18 @@ impl From<ConnectionAuthorizationState> for AuthorizationResult {
                 connection_id,
                 connection,
                 identity,
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
             } => AuthorizationResult::Authorized {
                 connection_id,
                 connection,
                 identity,
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
             },
 
             ConnectionAuthorizationState::Unauthorized {

--- a/libsplinter/src/network/auth/handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/mod.rs
@@ -93,6 +93,10 @@ pub fn create_authorization_dispatcher(
     {
         auth_dispatcher.set_handler(Box::new(AuthProtocolRequestHandler::new(
             auth_manager.clone(),
+            #[cfg(feature = "challenge-authorization")]
+            !signers.is_empty(),
+            #[cfg(feature = "challenge-authorization")]
+            expected_authorization.clone(),
         )));
 
         auth_dispatcher.set_handler(Box::new(AuthProtocolResponseHandler::new(

--- a/libsplinter/src/network/auth/handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/mod.rs
@@ -15,7 +15,7 @@
 //! Message handlers for authorization messages
 
 mod v0_handlers;
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 mod v1_handlers;
 
 #[cfg(feature = "challenge-authorization")]
@@ -36,11 +36,17 @@ use crate::protos::prelude::*;
 use self::v0_handlers::{
     AuthorizedHandler, ConnectRequestHandler, ConnectResponseHandler, TrustRequestHandler,
 };
-#[cfg(feature = "trust-authorization")]
+#[cfg(feature = "challenge-authorization")]
+use self::v1_handlers::{
+    AuthChallengeNonceRequestHandler, AuthChallengeNonceResponseHandler,
+    AuthChallengeSubmitRequestHandler, AuthChallengeSubmitResponseHandler,
+};
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 use self::v1_handlers::{
     AuthCompleteHandler, AuthProtocolRequestHandler, AuthProtocolResponseHandler,
-    AuthTrustRequestHandler, AuthTrustResponseHandler,
 };
+#[cfg(feature = "trust-authorization")]
+use self::v1_handlers::{AuthTrustRequestHandler, AuthTrustResponseHandler};
 
 /// Create a Dispatcher for Authorization messages
 ///

--- a/libsplinter/src/network/auth/handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/mod.rs
@@ -19,8 +19,11 @@ mod v0_handlers;
 mod v1_handlers;
 
 #[cfg(feature = "challenge-authorization")]
-use cylinder::Signer;
+use cylinder::{Signer, Verifier};
 
+use crate::error::InvalidStateError;
+#[cfg(feature = "challenge-authorization")]
+use crate::network::auth::ConnectionAuthorizationType;
 use crate::network::auth::{
     AuthorizationManagerStateMachine, AuthorizationMessageSender, AuthorizationRemoteAction,
     AuthorizationRemoteState,
@@ -55,12 +58,21 @@ use self::v1_handlers::{AuthTrustRequestHandler, AuthTrustResponseHandler};
 /// itself to handle updating identities (or removing connections with authorization failures).
 ///
 /// The identity provided is sent to connections for Trust authorizations.
+#[allow(clippy::too_many_arguments)]
 pub fn create_authorization_dispatcher(
     identity: String,
-    #[cfg(feature = "challenge-authorization")] _signers: Vec<Box<dyn Signer>>,
+    #[cfg(feature = "challenge-authorization")] signers: Vec<Box<dyn Signer>>,
     auth_manager: AuthorizationManagerStateMachine,
     auth_msg_sender: impl MessageSender<ConnectionId> + Clone + 'static,
-) -> Dispatcher<NetworkMessageType, ConnectionId> {
+    #[cfg(feature = "challenge-authorization")] nonce: Vec<u8>,
+    #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+        ConnectionAuthorizationType,
+    >,
+    #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+        ConnectionAuthorizationType,
+    >,
+    #[cfg(feature = "challenge-authorization")] verifer: Box<dyn Verifier>,
+) -> Result<Dispatcher<NetworkMessageType, ConnectionId>, InvalidStateError> {
     let mut auth_dispatcher = Dispatcher::new(Box::new(auth_msg_sender.clone()));
 
     // v0 message handlers
@@ -77,7 +89,7 @@ pub fn create_authorization_dispatcher(
     auth_dispatcher.set_handler(Box::new(AuthorizedHandler::new(auth_manager.clone())));
 
     // v1 message handlers
-    #[cfg(feature = "trust-authorization")]
+    #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
     {
         auth_dispatcher.set_handler(Box::new(AuthProtocolRequestHandler::new(
             auth_manager.clone(),
@@ -85,16 +97,75 @@ pub fn create_authorization_dispatcher(
 
         auth_dispatcher.set_handler(Box::new(AuthProtocolResponseHandler::new(
             auth_manager.clone(),
+            #[cfg(feature = "trust-authorization")]
             identity,
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization.clone(),
+            #[cfg(not(feature = "challenge-authorization"))]
+            None,
         )));
 
+        auth_dispatcher.set_handler(Box::new(AuthCompleteHandler::new(auth_manager.clone())));
+    }
+
+    #[cfg(feature = "trust-authorization")]
+    {
         auth_dispatcher.set_handler(Box::new(AuthTrustRequestHandler::new(auth_manager.clone())));
 
         auth_dispatcher.set_handler(Box::new(AuthTrustResponseHandler::new(
             auth_manager.clone(),
         )));
+    }
 
-        auth_dispatcher.set_handler(Box::new(AuthCompleteHandler::new(auth_manager.clone())));
+    // If no signers are configured do not configure challenge authorization
+    #[cfg(feature = "challenge-authorization")]
+    if !signers.is_empty() {
+        auth_dispatcher.set_handler(Box::new(AuthChallengeNonceRequestHandler::new(
+            auth_manager.clone(),
+            nonce.clone(),
+        )));
+
+        let signers_to_use = match &local_authorization {
+            Some(ConnectionAuthorizationType::Challenge { public_key }) => {
+                let signer = signers.iter().find(|signer| match signer.public_key() {
+                    Ok(signer_public_key) => signer_public_key.as_slice() == public_key,
+                    Err(_) => false,
+                });
+
+                match signer {
+                    Some(signer) => vec![signer.clone()],
+                    None => {
+                        return Err(InvalidStateError::with_message(
+                            "Required local authorization is not supported".to_string(),
+                        ));
+                    }
+                }
+            }
+
+            // if there is no local_authorization which key is used here does not matter
+            _ => signers.clone(),
+        };
+
+        auth_dispatcher.set_handler(Box::new(AuthChallengeNonceResponseHandler::new(
+            auth_manager.clone(),
+            signers_to_use,
+        )));
+
+        let expected_public_key = match expected_authorization {
+            Some(ConnectionAuthorizationType::Challenge { public_key }) => Some(public_key),
+            _ => None,
+        };
+
+        auth_dispatcher.set_handler(Box::new(AuthChallengeSubmitRequestHandler::new(
+            auth_manager.clone(),
+            verifer,
+            nonce,
+            expected_public_key,
+        )));
+
+        auth_dispatcher.set_handler(Box::new(AuthChallengeSubmitResponseHandler::new(
+            auth_manager.clone(),
+        )));
     }
 
     auth_dispatcher.set_handler(Box::new(AuthorizationErrorHandler::new(auth_manager)));
@@ -103,7 +174,7 @@ pub fn create_authorization_dispatcher(
 
     network_msg_dispatcher.set_handler(Box::new(AuthorizationMessageHandler::new(auth_dispatcher)));
 
-    network_msg_dispatcher
+    Ok(network_msg_dispatcher)
 }
 
 /// The Handler for authorization network messages.

--- a/libsplinter/src/network/auth/handlers/v0_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v0_handlers.rs
@@ -299,6 +299,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    use cylinder::{PublicKey, Signature, VerificationError, Verifier};
     use protobuf::Message;
 
     use crate::network::auth::create_authorization_dispatcher;
@@ -323,7 +324,16 @@ mod tests {
             vec![],
             auth_mgr,
             dispatch_sender,
-        );
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            Box::new(NoopVerifier),
+        )
+        .expect("Unable to build create_authorization_dispatcher");
 
         let connection_id = "test_connection".to_string();
         let mut msg = authorization::ConnectRequest::new();
@@ -387,7 +397,16 @@ mod tests {
             vec![],
             auth_mgr,
             dispatch_sender,
-        );
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            Box::new(NoopVerifier),
+        )
+        .expect("Unable to build create_authorization_dispatcher");
         let connection_id = "test_connection".to_string();
         let mut msg = authorization::ConnectResponse::new();
         msg.set_accepted_authorization_types(
@@ -436,7 +455,16 @@ mod tests {
             vec![],
             auth_mgr,
             dispatch_sender,
-        );
+            #[cfg(feature = "challenge-authorization")]
+            vec![],
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            None,
+            #[cfg(feature = "challenge-authorization")]
+            Box::new(NoopVerifier),
+        )
+        .expect("Unable to build create_authorization_dispatcher");
         let connection_id = "test_connection".to_string();
         // Begin the connection process, otherwise, the response will fail
         let mut msg = authorization::ConnectRequest::new();
@@ -537,6 +565,23 @@ mod tests {
                 .push_back((id, message));
 
             Ok(())
+        }
+    }
+
+    struct NoopVerifier;
+
+    impl Verifier for NoopVerifier {
+        fn algorithm_name(&self) -> &str {
+            unimplemented!()
+        }
+
+        fn verify(
+            &self,
+            _message: &[u8],
+            _signature: &Signature,
+            _public_key: &PublicKey,
+        ) -> Result<bool, VerificationError> {
+            unimplemented!()
         }
     }
 }

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -14,27 +14,42 @@
 
 //! Message handlers for v1 authorization messages
 
+#[cfg(feature = "challenge-authorization")]
+use cylinder::{PublicKey, Signature, Signer, Verifier};
+
+#[cfg(feature = "challenge-authorization")]
+use crate::network::auth::state_machine::challenge_v1::{
+    ChallengeAuthorizationLocalAction, ChallengeAuthorizationLocalState,
+    ChallengeAuthorizationRemoteAction, ChallengeAuthorizationRemoteState,
+};
+#[cfg(feature = "trust-authorization")]
+use crate::network::auth::state_machine::trust_v1::{
+    TrustAuthorizationLocalAction, TrustAuthorizationRemoteAction, TrustAuthorizationRemoteState,
+};
+use crate::network::auth::{
+    AuthorizationLocalAction, AuthorizationLocalState, AuthorizationManagerStateMachine,
+    AuthorizationMessage, AuthorizationRemoteAction, AuthorizationRemoteState,
+    ConnectionAuthorizationType, Identity,
+};
 use crate::network::dispatch::{
     ConnectionId, DispatchError, Handler, MessageContext, MessageSender,
 };
+#[cfg(feature = "challenge-authorization")]
 use crate::protocol::authorization::{
-    AuthComplete, AuthProtocolRequest, AuthProtocolResponse, AuthTrustRequest, AuthTrustResponse,
-    AuthorizationError, PeerAuthorizationType,
+    AuthChallengeNonceRequest, AuthChallengeNonceResponse, AuthChallengeSubmitRequest,
+    AuthChallengeSubmitResponse, SubmitRequest,
 };
+use crate::protocol::authorization::{
+    AuthComplete, AuthProtocolRequest, AuthProtocolResponse, AuthorizationError,
+    PeerAuthorizationType,
+};
+#[cfg(feature = "trust-authorization")]
+use crate::protocol::authorization::{AuthTrustRequest, AuthTrustResponse};
 use crate::protocol::network::NetworkMessage;
 use crate::protocol::{PEER_AUTHORIZATION_PROTOCOL_MIN, PEER_AUTHORIZATION_PROTOCOL_VERSION};
 use crate::protos::authorization;
 use crate::protos::network;
 use crate::protos::prelude::*;
-
-use crate::network::auth::{
-    state_machine::trust_v1::{
-        TrustAuthorizationLocalAction, TrustAuthorizationRemoteAction,
-        TrustAuthorizationRemoteState,
-    },
-    AuthorizationLocalAction, AuthorizationLocalState, AuthorizationManagerStateMachine,
-    AuthorizationMessage, AuthorizationRemoteAction, AuthorizationRemoteState, Identity,
-};
 
 /// Handler for the Authorization Protocol Request Message Type
 pub struct AuthProtocolRequestHandler {
@@ -285,16 +300,19 @@ impl Handler for AuthProtocolResponseHandler {
 }
 
 /// Handler for the Authorization Trust Request Message Type
+#[cfg(feature = "trust-authorization")]
 pub struct AuthTrustRequestHandler {
     auth_manager: AuthorizationManagerStateMachine,
 }
 
+#[cfg(feature = "trust-authorization")]
 impl AuthTrustRequestHandler {
     pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         Self { auth_manager }
     }
 }
 
+#[cfg(feature = "trust-authorization")]
 impl Handler for AuthTrustRequestHandler {
     type Source = ConnectionId;
     type MessageType = authorization::AuthorizationMessageType;
@@ -369,17 +387,20 @@ impl Handler for AuthTrustRequestHandler {
     }
 }
 
+#[cfg(feature = "trust-authorization")]
 /// Handler for the Authorization Trust Response Message Type
 pub struct AuthTrustResponseHandler {
     auth_manager: AuthorizationManagerStateMachine,
 }
 
+#[cfg(feature = "trust-authorization")]
 impl AuthTrustResponseHandler {
     pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
         Self { auth_manager }
     }
 }
 
+#[cfg(feature = "trust-authorization")]
 impl Handler for AuthTrustResponseHandler {
     type Source = ConnectionId;
     type MessageType = authorization::AuthorizationMessageType;
@@ -445,6 +466,540 @@ impl Handler for AuthTrustResponseHandler {
     }
 }
 
+/// Handler for the Authorization Challenge Nonce Request Message Type
+#[cfg(feature = "challenge-authorization")]
+pub struct AuthChallengeNonceRequestHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+    nonce: Vec<u8>,
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl AuthChallengeNonceRequestHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine, nonce: Vec<u8>) -> Self {
+        Self {
+            auth_manager,
+            nonce,
+        }
+    }
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl Handler for AuthChallengeNonceRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthChallengeNonceRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_CHALLENGE_NONCE_REQUEST
+    }
+
+    fn handle(
+        &self,
+        _msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization challenge nonce request from {}",
+            context.source_connection_id()
+        );
+
+        match self.auth_manager.next_remote_state(
+            context.source_connection_id(),
+            AuthorizationRemoteAction::Challenge(
+                ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeNonceRequest,
+            ),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring challenge nonce request message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationRemoteState::Challenge(
+                ChallengeAuthorizationRemoteState::ReceivedAuthChallengeNonce,
+            )) => {
+                let auth_msg =
+                    AuthorizationMessage::AuthChallengeNonceResponse(AuthChallengeNonceResponse {
+                        nonce: self.nonce.clone(),
+                    });
+
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(auth_msg),
+                )?;
+
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+
+                if self
+                    .auth_manager
+                    .next_remote_state(
+                        context.source_connection_id(),
+                        AuthorizationRemoteAction::Challenge(
+                            ChallengeAuthorizationRemoteAction::SendAuthChallengeNonceResponse,
+                        ),
+                    )
+                    .is_err()
+                {
+                    error!(
+                        "Unable to transition from ReceivedAuthChallengeNonceRequest to \
+                        WaitingForAuthChallengeSubmitRequest"
+                    );
+                };
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Challenge Nonce Response Message Type
+#[cfg(feature = "challenge-authorization")]
+pub struct AuthChallengeNonceResponseHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+    signers: Vec<Box<dyn Signer>>,
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl AuthChallengeNonceResponseHandler {
+    pub fn new(
+        auth_manager: AuthorizationManagerStateMachine,
+        signers: Vec<Box<dyn Signer>>,
+    ) -> Self {
+        Self {
+            auth_manager,
+            signers,
+        }
+    }
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl Handler for AuthChallengeNonceResponseHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthChallengeNonceResponse;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_CHALLENGE_NONCE_RESPONSE
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization challenge nonce response from {}",
+            context.source_connection_id()
+        );
+
+        let nonce_request = AuthChallengeNonceResponse::from_proto(msg)?;
+
+        let mut public_keys = vec![];
+
+        let submit_requests = self
+            .signers
+            .iter()
+            .map(|signer| {
+                let signature = signer
+                    .sign(&nonce_request.nonce)
+                    .map_err(|err| {
+                        DispatchError::HandleError(format!(
+                            "Unable to sign provided nonce: {}",
+                            err
+                        ))
+                    })?
+                    .take_bytes();
+
+                let public_key = signer
+                    .public_key()
+                    .map_err(|err| {
+                        DispatchError::HandleError(format!(
+                            "Unable to get public key for signer: {}",
+                            err
+                        ))
+                    })?
+                    .into_bytes();
+
+                public_keys.push(public_key.clone());
+
+                Ok(SubmitRequest {
+                    public_key,
+                    signature,
+                })
+            })
+            .collect::<Result<Vec<SubmitRequest>, DispatchError>>()?;
+
+        match self.auth_manager.next_local_state(
+            context.source_connection_id(),
+            AuthorizationLocalAction::Challenge(
+                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeNonceResponse,
+            ),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring challenge nonce response message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationLocalState::Challenge(
+                ChallengeAuthorizationLocalState::ReceivedAuthChallengeNonceResponse,
+            )) => {
+                let auth_msg =
+                    AuthorizationMessage::AuthChallengeSubmitRequest(AuthChallengeSubmitRequest {
+                        submit_requests,
+                    });
+
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(auth_msg),
+                )?;
+
+                if self
+                    .auth_manager
+                    .next_local_state(
+                        context.source_connection_id(),
+                        AuthorizationLocalAction::Challenge(
+                            ChallengeAuthorizationLocalAction::SendAuthChallengeSubmitRequest,
+                        ),
+                    )
+                    .is_err()
+                {
+                    error!(
+                        "Unable to transition from ReceivedAuthChallengeNonceResponse to \
+                        WaitingForAuthChallengSubmitResponse"
+                    )
+                };
+
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Challenge Submit Request Message Type
+#[cfg(feature = "challenge-authorization")]
+pub struct AuthChallengeSubmitRequestHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+    verifer: Box<dyn Verifier>,
+    nonce: Vec<u8>,
+    expected_public_key: Option<Vec<u8>>,
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl AuthChallengeSubmitRequestHandler {
+    pub fn new(
+        auth_manager: AuthorizationManagerStateMachine,
+        verifer: Box<dyn Verifier>,
+        nonce: Vec<u8>,
+        expected_public_key: Option<Vec<u8>>,
+    ) -> Self {
+        Self {
+            auth_manager,
+            verifer,
+            nonce,
+            expected_public_key,
+        }
+    }
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl Handler for AuthChallengeSubmitRequestHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthChallengeSubmitRequest;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_CHALLENGE_SUBMIT_REQUEST
+    }
+
+    fn handle(
+        &self,
+        msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization challenge submit request from {}",
+            context.source_connection_id()
+        );
+
+        let submit_msg = AuthChallengeSubmitRequest::from_proto(msg)?;
+        let mut public_keys = vec![];
+
+        for request in submit_msg.submit_requests {
+            let verified = self
+                .verifer
+                .verify(
+                    &self.nonce,
+                    &Signature::new(request.signature.to_vec()),
+                    &PublicKey::new(request.public_key.to_vec()),
+                )
+                .map_err(|err| {
+                    DispatchError::HandleError(format!("Unable to verify submit request: {}", err))
+                })?;
+            if !verified {
+                let response = AuthorizationMessage::AuthorizationError(
+                    AuthorizationError::AuthorizationRejected(
+                        "Challenge signature was not valid".into(),
+                    ),
+                );
+
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(response),
+                )?;
+
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+
+                if self
+                    .auth_manager
+                    .next_remote_state(
+                        context.source_connection_id(),
+                        AuthorizationRemoteAction::Unauthorizing,
+                    )
+                    .is_err()
+                {
+                    warn!(
+                        "Unable to update state to Unauthorizing for {}",
+                        context.source_connection_id(),
+                    )
+                };
+
+                return Ok(());
+            }
+            public_keys.push(request.public_key.to_vec());
+        }
+
+        let identity = if let Some(public_key) = &self.expected_public_key {
+            if public_keys.contains(&public_key) {
+                public_key
+            } else {
+                let response = AuthorizationMessage::AuthorizationError(
+                    AuthorizationError::AuthorizationRejected(
+                        "Required public key not submitted".into(),
+                    ),
+                );
+
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(response),
+                )?;
+
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+
+                if self
+                    .auth_manager
+                    .next_remote_state(
+                        context.source_connection_id(),
+                        AuthorizationRemoteAction::Unauthorizing,
+                    )
+                    .is_err()
+                {
+                    warn!(
+                        "Unable to update state to Unauthorizing for {}",
+                        context.source_connection_id(),
+                    )
+                };
+
+                return Ok(());
+            }
+        } else if public_keys.len() == 1 {
+            // we know this is safe because of above length check
+            &public_keys[0]
+        } else {
+            let error_string = {
+                if public_keys.is_empty() {
+                    "No public keys submitted".to_string()
+                } else {
+                    "Too many public keys submitted".to_string()
+                }
+            };
+
+            let response = AuthorizationMessage::AuthorizationError(
+                AuthorizationError::AuthorizationRejected(error_string),
+            );
+
+            let msg_bytes =
+                IntoBytes::<network::NetworkMessage>::into_bytes(NetworkMessage::from(response))?;
+
+            sender
+                .send(context.source_id().clone(), msg_bytes)
+                .map_err(|(recipient, payload)| {
+                    DispatchError::NetworkSendError((recipient.into(), payload))
+                })?;
+
+            if self
+                .auth_manager
+                .next_remote_state(
+                    context.source_connection_id(),
+                    AuthorizationRemoteAction::Unauthorizing,
+                )
+                .is_err()
+            {
+                warn!(
+                    "Unable to update state to Unauthorizing for {}",
+                    context.source_connection_id(),
+                )
+            };
+
+            return Ok(());
+        };
+
+        match self.auth_manager.next_remote_state(
+            context.source_connection_id(),
+            AuthorizationRemoteAction::Challenge(
+                ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeSubmitRequest(
+                    Identity::Challenge {
+                        public_key: identity.clone(),
+                    },
+                ),
+            ),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring challenge nonce response message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationRemoteState::Challenge(
+                ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(_),
+            )) => {
+                let auth_msg =
+                    AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse);
+
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(auth_msg),
+                )?;
+
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        }
+
+        if self
+            .auth_manager
+            .next_remote_state(
+                context.source_connection_id(),
+                AuthorizationRemoteAction::Challenge(
+                    ChallengeAuthorizationRemoteAction::SendAuthChallengeSubmitResponse,
+                ),
+            )
+            .is_err()
+        {
+            error!("Unable to transition from ReceivedAuthChallengSubmitRequest to Done")
+        };
+
+        Ok(())
+    }
+}
+
+/// Handler for the Authorization Challenge Submit Response Message Type
+#[cfg(feature = "challenge-authorization")]
+pub struct AuthChallengeSubmitResponseHandler {
+    auth_manager: AuthorizationManagerStateMachine,
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl AuthChallengeSubmitResponseHandler {
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
+    }
+}
+
+#[cfg(feature = "challenge-authorization")]
+impl Handler for AuthChallengeSubmitResponseHandler {
+    type Source = ConnectionId;
+    type MessageType = authorization::AuthorizationMessageType;
+    type Message = authorization::AuthChallengeSubmitResponse;
+
+    fn match_type(&self) -> Self::MessageType {
+        authorization::AuthorizationMessageType::AUTH_CHALLENGE_SUBMIT_RESPONSE
+    }
+
+    fn handle(
+        &self,
+        _msg: Self::Message,
+        context: &MessageContext<Self::Source, Self::MessageType>,
+        sender: &dyn MessageSender<Self::Source>,
+    ) -> Result<(), DispatchError> {
+        debug!(
+            "Received authorization challenge submit response from {}",
+            context.source_connection_id()
+        );
+
+        match self.auth_manager.next_local_state(
+            context.source_connection_id(),
+            AuthorizationLocalAction::Challenge(
+                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse,
+            ),
+        ) {
+            Err(err) => {
+                warn!(
+                    "Ignoring challenge submit response message from connection {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationLocalState::Authorized) => {
+                let auth_msg = AuthorizationMessage::AuthComplete(AuthComplete);
+                let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                    NetworkMessage::from(auth_msg),
+                )?;
+                sender
+                    .send(context.source_id().clone(), msg_bytes)
+                    .map_err(|(recipient, payload)| {
+                        DispatchError::NetworkSendError((recipient.into(), payload))
+                    })?;
+
+                match self.auth_manager.next_local_state(
+                    context.source_connection_id(),
+                    AuthorizationLocalAction::SendAuthComplete,
+                ) {
+                    Err(err) => {
+                        warn!(
+                            "Cannot transition connection from Authorized {}: {}",
+                            context.source_connection_id(),
+                            err
+                        );
+                    }
+                    Ok(AuthorizationLocalState::WaitForComplete) => (),
+                    Ok(AuthorizationLocalState::AuthorizedAndComplete) => (),
+                    Ok(next_state) => {
+                        panic!("Should not have been able to transition to {}", next_state)
+                    }
+                };
+            }
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        };
+        Ok(())
+    }
+}
+
 /// Handler for the Authorization Complete Message Type
 pub struct AuthCompleteHandler {
     auth_manager: AuthorizationManagerStateMachine,
@@ -475,6 +1030,7 @@ impl Handler for AuthCompleteHandler {
             "Received authorization complete from {}",
             context.source_connection_id()
         );
+
         match self
             .auth_manager
             .received_complete(context.source_connection_id())

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -300,6 +300,14 @@ impl AuthorizationConnector {
                         connection,
                         identity: ConnectionAuthorizationType::Trust { identity },
                     },
+                    #[cfg(feature = "challenge-authorization")]
+                    Identity::Challenge { public_key } => {
+                        ConnectionAuthorizationState::Authorized {
+                            connection_id: connection_id.clone(),
+                            connection,
+                            identity: ConnectionAuthorizationType::Challenge { public_key },
+                        }
+                    }
                 }
             } else {
                 ConnectionAuthorizationState::Unauthorized {

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -22,16 +22,16 @@ use std::fmt;
 use std::sync::{mpsc, Arc, Mutex};
 
 #[cfg(feature = "challenge-authorization")]
-use cylinder::Signer;
+use cylinder::{Signer, VerifierFactory};
 use protobuf::Message;
 
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 use crate::protocol::authorization::AuthProtocolRequest;
 use crate::protocol::authorization::AuthorizationMessage;
-#[cfg(not(feature = "trust-authorization"))]
+#[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
 use crate::protocol::authorization::ConnectRequest;
 use crate::protocol::network::NetworkMessage;
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 use crate::protocol::{PEER_AUTHORIZATION_PROTOCOL_MIN, PEER_AUTHORIZATION_PROTOCOL_VERSION};
 use crate::protos::network;
 use crate::protos::prelude::*;
@@ -39,7 +39,7 @@ use crate::transport::{Connection, RecvError};
 
 use self::handlers::create_authorization_dispatcher;
 use self::pool::{ThreadPool, ThreadPoolBuilder};
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 pub(crate) use self::state_machine::AuthorizationLocalAction;
 pub(crate) use self::state_machine::{
     AuthorizationActionError, AuthorizationLocalState, AuthorizationManagerStateMachine,
@@ -80,6 +80,8 @@ pub struct AuthorizationManager {
     signers: Vec<Box<dyn Signer>>,
     thread_pool: ThreadPool,
     shared: Arc<Mutex<ManagedAuthorizations>>,
+    #[cfg(feature = "challenge-authorization")]
+    verifier_factory: Arc<Mutex<Box<dyn VerifierFactory>>>,
 }
 
 impl AuthorizationManager {
@@ -87,6 +89,9 @@ impl AuthorizationManager {
     pub fn new(
         local_identity: String,
         #[cfg(feature = "challenge-authorization")] signers: Vec<Box<dyn Signer>>,
+        #[cfg(feature = "challenge-authorization")] verifier_factory: Arc<
+            Mutex<Box<dyn VerifierFactory>>,
+        >,
     ) -> Result<Self, AuthorizationManagerError> {
         let thread_pool = ThreadPoolBuilder::new()
             .with_size(AUTHORIZATION_THREAD_POOL_SIZE)
@@ -102,6 +107,8 @@ impl AuthorizationManager {
             signers,
             thread_pool,
             shared,
+            #[cfg(feature = "challenge-authorization")]
+            verifier_factory,
         })
     }
 
@@ -122,6 +129,8 @@ impl AuthorizationManager {
             signers: self.signers.clone(),
             shared: Arc::clone(&self.shared),
             executor: self.thread_pool.executor(),
+            #[cfg(feature = "challenge-authorization")]
+            verifier_factory: self.verifier_factory.clone(),
         }
     }
 }
@@ -145,6 +154,8 @@ pub struct AuthorizationConnector {
     signers: Vec<Box<dyn Signer>>,
     shared: Arc<Mutex<ManagedAuthorizations>>,
     executor: pool::JobExecutor,
+    #[cfg(feature = "challenge-authorization")]
+    verifier_factory: Arc<Mutex<Box<dyn VerifierFactory>>>,
 }
 
 impl AuthorizationConnector {
@@ -152,6 +163,12 @@ impl AuthorizationConnector {
         &self,
         connection_id: String,
         connection: Box<dyn Connection>,
+        #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+            ConnectionAuthorizationType,
+        >,
+        #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+            ConnectionAuthorizationType,
+        >,
         on_complete_callback: Callback,
     ) -> Result<(), AuthorizationManagerError> {
         let mut connection = connection;
@@ -162,6 +179,15 @@ impl AuthorizationConnector {
             shared: Arc::clone(&self.shared),
         };
         let msg_sender = AuthorizationMessageSender { sender: tx };
+        #[cfg(feature = "challenge-authorization")]
+        let verifier = self
+            .verifier_factory
+            .lock()
+            .map_err(|_| AuthorizationManagerError("VerifierFactory lock poisoned".to_string()))?
+            .new_verifier();
+
+        #[cfg(feature = "challenge-authorization")]
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
         let dispatcher = create_authorization_dispatcher(
             self.local_identity.clone(),
             #[cfg(feature = "challenge-authorization")]
@@ -170,10 +196,21 @@ impl AuthorizationConnector {
             #[allow(clippy::redundant_clone)]
             state_machine.clone(),
             msg_sender,
-        );
+            #[cfg(feature = "challenge-authorization")]
+            nonce,
+            #[cfg(feature = "challenge-authorization")]
+            expected_authorization.clone(),
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization.clone(),
+            #[cfg(feature = "challenge-authorization")]
+            verifier,
+        )
+        .map_err(|err| {
+            AuthorizationManagerError(format!("Unable to setup authorization dispatcher: {}", err))
+        })?;
 
         self.executor.execute(move || {
-            #[cfg(not(feature = "trust-authorization"))]
+            #[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
             {
                 let connect_request_bytes = match connect_msg_bytes() {
                     Ok(bytes) => bytes,
@@ -194,7 +231,7 @@ impl AuthorizationConnector {
                 }
             }
 
-            #[cfg(feature = "trust-authorization")]
+            #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
             {
                 let protocol_request_bytes = match protocol_msg_bytes() {
                     Ok(bytes) => bytes,
@@ -298,6 +335,10 @@ impl AuthorizationConnector {
                     Identity::Trust { identity } => ConnectionAuthorizationState::Authorized {
                         connection_id,
                         connection,
+                        #[cfg(feature = "challenge-authorization")]
+                        expected_authorization,
+                        #[cfg(feature = "challenge-authorization")]
+                        local_authorization,
                         identity: ConnectionAuthorizationType::Trust { identity },
                     },
                     #[cfg(feature = "challenge-authorization")]
@@ -306,6 +347,8 @@ impl AuthorizationConnector {
                             connection_id: connection_id.clone(),
                             connection,
                             identity: ConnectionAuthorizationType::Challenge { public_key },
+                            expected_authorization,
+                            local_authorization,
                         }
                     }
                 }
@@ -325,7 +368,7 @@ impl AuthorizationConnector {
     }
 }
 
-#[cfg(not(feature = "trust-authorization"))]
+#[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
 fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationManagerError> {
     let connect_msg = AuthorizationMessage::ConnectRequest(ConnectRequest::Bidirectional);
 
@@ -334,7 +377,7 @@ fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationManagerError> {
     )
 }
 
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 fn protocol_msg_bytes() -> Result<Vec<u8>, AuthorizationManagerError> {
     let connect_msg = AuthorizationMessage::AuthProtocolRequest(AuthProtocolRequest {
         auth_protocol_min: PEER_AUTHORIZATION_PROTOCOL_MIN,
@@ -410,6 +453,11 @@ pub enum ConnectionAuthorizationState {
         connection_id: String,
         identity: ConnectionAuthorizationType,
         connection: Box<dyn Connection>,
+        // information required if reconnect needs to be attempted
+        #[cfg(feature = "challenge-authorization")]
+        expected_authorization: Option<ConnectionAuthorizationType>,
+        #[cfg(feature = "challenge-authorization")]
+        local_authorization: Option<ConnectionAuthorizationType>,
     },
     Unauthorized {
         connection_id: String,
@@ -534,7 +582,7 @@ pub(in crate::network) mod tests {
         assert!(matches!(trust_request, AuthorizationMessage::Authorized(_)));
     }
 
-    #[cfg(feature = "trust-authorization")]
+    #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
     pub(in crate::network) fn negotiation_connection_auth(
         mesh: &Mesh,
         connection_id: &str,

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/local_action.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/local_action.rs
@@ -1,0 +1,43 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum ChallengeAuthorizationLocalAction {
+    SendAuthChallengeNonceRequest,
+    ReceiveAuthChallengeNonceResponse,
+    SendAuthChallengeSubmitRequest,
+    ReceiveAuthChallengeSubmitResponse,
+}
+
+impl fmt::Display for ChallengeAuthorizationLocalAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ChallengeAuthorizationLocalAction::SendAuthChallengeNonceRequest => {
+                f.write_str("SendAuthChallengeNonceRequest")
+            }
+            ChallengeAuthorizationLocalAction::ReceiveAuthChallengeNonceResponse => {
+                f.write_str("ReceiveAuthChallengeNonceResponse")
+            }
+            ChallengeAuthorizationLocalAction::SendAuthChallengeSubmitRequest => {
+                f.write_str("SendAuthChallengeSubmitRequest")
+            }
+            ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse => {
+                f.write_str("ReceiveAuthChallengeSubmitResponse")
+            }
+        }
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/local_state.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/local_state.rs
@@ -1,0 +1,116 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::network::auth::ManagedAuthorizationState;
+
+use super::ChallengeAuthorizationLocalAction;
+use crate::network::auth::state_machine::{
+    AuthorizationActionError, AuthorizationLocalAction, AuthorizationLocalState,
+};
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum ChallengeAuthorizationLocalState {
+    ChallengeConnecting,
+    WaitingForAuthChallengeNonceResponse,
+    ReceivedAuthChallengeNonceResponse,
+    WaitingForAuthChallengeSubmitResponse,
+}
+
+impl ChallengeAuthorizationLocalState {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_local_state(
+        &self,
+        action: ChallengeAuthorizationLocalAction,
+        cur_state: &mut ManagedAuthorizationState,
+    ) -> Result<AuthorizationLocalState, AuthorizationActionError> {
+        match &self {
+            ChallengeAuthorizationLocalState::ChallengeConnecting => match action {
+                ChallengeAuthorizationLocalAction::SendAuthChallengeNonceRequest => {
+                    let new_state = AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse,
+                    );
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Challenge(self.clone()),
+                    AuthorizationLocalAction::Challenge(action),
+                )),
+            },
+            ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse => {
+                match action {
+                    ChallengeAuthorizationLocalAction::ReceiveAuthChallengeNonceResponse => {
+                        let new_state = AuthorizationLocalState::Challenge(
+                            ChallengeAuthorizationLocalState::ReceivedAuthChallengeNonceResponse,
+                        );
+                        cur_state.local_state = new_state.clone();
+                        Ok(new_state)
+                    }
+                    _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                        AuthorizationLocalState::Challenge(self.clone()),
+                        AuthorizationLocalAction::Challenge(action),
+                    )),
+                }
+            }
+            ChallengeAuthorizationLocalState::ReceivedAuthChallengeNonceResponse => match action {
+                ChallengeAuthorizationLocalAction::SendAuthChallengeSubmitRequest => {
+                    let new_state = AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse,
+                    );
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Challenge(self.clone()),
+                    AuthorizationLocalAction::Challenge(action),
+                )),
+            },
+            ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse => match action
+            {
+                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse => {
+                    let new_state = AuthorizationLocalState::Authorized;
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Challenge(self.clone()),
+                    AuthorizationLocalAction::Challenge(action),
+                )),
+            },
+        }
+    }
+}
+
+impl fmt::Display for ChallengeAuthorizationLocalState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            ChallengeAuthorizationLocalState::ChallengeConnecting => "ChallengeConnecting",
+            ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse => {
+                "WaitingForAuthChallengeNonceResponse"
+            }
+            ChallengeAuthorizationLocalState::ReceivedAuthChallengeNonceResponse => {
+                "ReceivedAuthChallengeNonceResponse"
+            }
+            ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse => {
+                "WaitingForAuthChallengeSubmitResponse"
+            }
+        })
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod local_action;
+mod local_state;
+mod remote_action;
+mod remote_state;
+
+pub(crate) use local_action::ChallengeAuthorizationLocalAction;
+pub(crate) use local_state::ChallengeAuthorizationLocalState;
+pub(crate) use remote_action::ChallengeAuthorizationRemoteAction;
+pub(crate) use remote_state::ChallengeAuthorizationRemoteState;

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/remote_action.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/remote_action.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::network::auth::state_machine::Identity;
+
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum ChallengeAuthorizationRemoteAction {
+    ReceiveAuthChallengeNonceRequest,
+    SendAuthChallengeNonceResponse,
+    ReceiveAuthChallengeSubmitRequest(Identity),
+    SendAuthChallengeSubmitResponse,
+}
+
+impl fmt::Display for ChallengeAuthorizationRemoteAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeNonceRequest => {
+                f.write_str("ReceiveAuthChallengeNonceRequest")
+            }
+            ChallengeAuthorizationRemoteAction::SendAuthChallengeNonceResponse => {
+                f.write_str("SendAuthChallengeNonceResponse")
+            }
+            ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeSubmitRequest(_) => {
+                f.write_str("ReceiveAuthChallengeSubmitRequest")
+            }
+            ChallengeAuthorizationRemoteAction::SendAuthChallengeSubmitResponse => {
+                f.write_str("SendAuthChallengeSubmitResponse")
+            }
+        }
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/remote_state.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/remote_state.rs
@@ -1,0 +1,119 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use crate::network::auth::ManagedAuthorizationState;
+
+use crate::network::auth::state_machine::{
+    AuthorizationActionError, AuthorizationRemoteAction, AuthorizationRemoteState, Identity,
+};
+
+use super::ChallengeAuthorizationRemoteAction;
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum ChallengeAuthorizationRemoteState {
+    ChallengeConnecting,
+    ReceivedAuthChallengeNonce,
+    WaitingForAuthChallengeSubmitRequest,
+    ReceivedAuthChallengeSubmitRequest(Identity),
+}
+
+impl ChallengeAuthorizationRemoteState {
+    /// Transitions from one authorization state to another
+    ///
+    /// Errors
+    ///
+    /// The errors are error messages that should be returned on the appropriate message
+    pub(crate) fn next_remote_state(
+        &self,
+        action: ChallengeAuthorizationRemoteAction,
+        cur_state: &mut ManagedAuthorizationState,
+    ) -> Result<AuthorizationRemoteState, AuthorizationActionError> {
+        match &self {
+            ChallengeAuthorizationRemoteState::ChallengeConnecting => match action {
+                ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeNonceRequest => {
+                    let new_state = AuthorizationRemoteState::Challenge(
+                        ChallengeAuthorizationRemoteState::ReceivedAuthChallengeNonce,
+                    );
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Challenge(self.clone()),
+                    AuthorizationRemoteAction::Challenge(action),
+                )),
+            },
+            ChallengeAuthorizationRemoteState::ReceivedAuthChallengeNonce => match action {
+                ChallengeAuthorizationRemoteAction::SendAuthChallengeNonceResponse => {
+                    let new_state = AuthorizationRemoteState::Challenge(
+                        ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest,
+                    );
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Challenge(self.clone()),
+                    AuthorizationRemoteAction::Challenge(action),
+                )),
+            },
+            ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest => match action
+            {
+                ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeSubmitRequest(identity) => {
+                    let new_state = AuthorizationRemoteState::Challenge(
+                        ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(
+                            identity,
+                        ),
+                    );
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Challenge(self.clone()),
+                    AuthorizationRemoteAction::Challenge(action),
+                )),
+            },
+            ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(identity) => {
+                match action {
+                    ChallengeAuthorizationRemoteAction::SendAuthChallengeSubmitResponse => {
+                        let new_state = AuthorizationRemoteState::Done(identity.clone());
+                        cur_state.remote_state = new_state.clone();
+                        Ok(new_state)
+                    }
+                    _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                        AuthorizationRemoteState::Challenge(self.clone()),
+                        AuthorizationRemoteAction::Challenge(action),
+                    )),
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for ChallengeAuthorizationRemoteState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            ChallengeAuthorizationRemoteState::ChallengeConnecting => "ChallengeConnecting",
+            ChallengeAuthorizationRemoteState::ReceivedAuthChallengeNonce => {
+                "ReceivedAuthChallengeNonce"
+            }
+            ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest => {
+                "WaitingForAuthChallengeSubmitRequest"
+            }
+            ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(_) => {
+                "ReceivedAuthChallengeSubmitRequest"
+            }
+        })
+    }
+}

--- a/libsplinter/src/network/auth/state_machine/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/mod.rs
@@ -29,7 +29,13 @@ use super::{ManagedAuthorizationState, ManagedAuthorizations};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Identity {
-    Trust { identity: String },
+    Trust {
+        identity: String,
+    },
+    #[cfg(feature = "challenge-authorization")]
+    Challenge {
+        public_key: Vec<u8>,
+    },
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/libsplinter/src/network/connection_manager/builder.rs
+++ b/libsplinter/src/network/connection_manager/builder.rs
@@ -25,7 +25,7 @@ use crate::transport::Transport;
 use super::error::ConnectionManagerError;
 use super::{
     AuthResult, Authorizer, CmMessage, CmRequest, ConnectionManager, ConnectionManagerNotification,
-    ConnectionManagerState, ConnectionMetadataExt, SubscriberMap,
+    ConnectionManagerState, ConnectionMetadataExt, OutboundConnection, SubscriberMap,
 };
 
 const DEFAULT_HEARTBEAT_INTERVAL: u64 = 10;
@@ -222,9 +222,19 @@ fn handle_request<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
             endpoint,
             sender,
             connection_id,
+            #[cfg(feature = "challenge-authorization")]
+            expected_authorization,
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization,
         } => state.add_outbound_connection(
-            &endpoint,
-            connection_id,
+            OutboundConnection {
+                endpoint,
+                connection_id,
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
+            },
             sender,
             internal_sender,
             authorizer,

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -88,12 +88,15 @@ impl PeerManagerConnector {
         &self,
         peer_id: PeerAuthorizationToken,
         endpoints: Vec<String>,
+        #[cfg(feature = "challenge-authorization")] required_local_auth: PeerAuthorizationToken,
     ) -> Result<PeerRef, PeerRefAddError> {
         let (sender, recv) = channel();
 
         let message = PeerManagerMessage::Request(PeerManagerRequest::AddPeer {
             peer_id,
             endpoints,
+            #[cfg(feature = "challenge-authorization")]
+            required_local_auth,
             sender,
         });
 

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -793,12 +793,14 @@ pub mod tests {
             .add_peer_ref(
                 PeerAuthorizationToken::from_peer_id("test_peer"),
                 vec!["test".to_string()],
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("my_id"),
             )
             .expect("Unable to add peer");
 
         assert_eq!(
             peer_ref.peer_id(),
-            &PeerAuthorizationToken::from_peer_id("test_peer")
+            &PeerAuthorizationToken::from_peer_id("test_peer"),
         );
 
         // timeout after 60 seconds
@@ -977,6 +979,12 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
+            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
+            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -984,6 +992,10 @@ pub mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -50,6 +50,9 @@ pub struct PeerMetadata {
     pub last_connection_attempt: Instant,
     /// How long to wait before trying to reconnect to a peer
     pub retry_frequency: u64,
+    /// The required way the local node must be identified, this is required on retry
+    #[cfg(feature = "challenge-authorization")]
+    pub required_local_auth: Option<PeerAuthorizationToken>,
 }
 
 /// A map of peer IDs to peer metadata, which also maintains a redirect table for updated peer IDs.
@@ -113,6 +116,9 @@ impl PeerMap {
         endpoints: Vec<String>,
         active_endpoint: String,
         status: PeerStatus,
+        #[cfg(feature = "challenge-authorization")] required_local_auth: Option<
+            PeerAuthorizationToken,
+        >,
     ) {
         let peer_metadata = PeerMetadata {
             id: peer_id.clone(),
@@ -122,6 +128,8 @@ impl PeerMap {
             connection_id,
             last_connection_attempt: Instant::now(),
             retry_frequency: self.initial_retry_frequency,
+            #[cfg(feature = "challenge-authorization")]
+            required_local_auth,
         };
 
         self.peers.insert(peer_id.clone(), peer_metadata);
@@ -234,6 +242,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
 
         peer_map.insert(
@@ -244,6 +254,8 @@ pub mod tests {
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
             PeerStatus::Connected,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
 
         let mut peers = peer_map.peer_ids();
@@ -279,6 +291,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
 
         peer_map.insert(
@@ -289,6 +303,8 @@ pub mod tests {
             vec!["endpoint1".to_string(), "endpoint2".to_string()],
             "next_endpoint1".to_string(),
             PeerStatus::Connected,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
 
         let peers = peer_map.connection_ids();
@@ -327,6 +343,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
 
         let peer_metadata = peer_map
@@ -368,6 +386,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string(),
@@ -415,6 +435,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string()
@@ -459,6 +481,8 @@ pub mod tests {
             status: PeerStatus::Connected,
             last_connection_attempt: Instant::now(),
             retry_frequency: 10,
+            #[cfg(feature = "challenge-authorization")]
+            required_local_auth: None,
         };
 
         if let Ok(()) = peer_map.update_peer(no_peer_metadata) {
@@ -473,6 +497,8 @@ pub mod tests {
             vec!["test_endpoint1".to_string(), "test_endpoint2".to_string()],
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
+            #[cfg(feature = "challenge-authorization")]
+            None,
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string(),

--- a/libsplinter/src/peer/token.rs
+++ b/libsplinter/src/peer/token.rs
@@ -127,6 +127,20 @@ impl From<ConnectionAuthorizationType> for PeerAuthorizationToken {
     }
 }
 
+impl From<PeerAuthorizationToken> for ConnectionAuthorizationType {
+    fn from(peer_token: PeerAuthorizationToken) -> Self {
+        match peer_token {
+            PeerAuthorizationToken::Trust { peer_id } => {
+                ConnectionAuthorizationType::Trust { identity: peer_id }
+            }
+            #[cfg(feature = "challenge-authorization")]
+            PeerAuthorizationToken::Challenge { public_key } => {
+                ConnectionAuthorizationType::Challenge { public_key }
+            }
+        }
+    }
+}
+
 impl Ord for PeerAuthorizationToken {
     fn cmp(&self, other: &Self) -> Ordering {
         self.id_as_string().cmp(&other.id_as_string())

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -115,8 +115,8 @@ pub(crate) const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
 pub(crate) const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
 
 // Peer authorization protocol versions
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 pub const PEER_AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(feature = "trust-authorization")]
+#[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 pub(crate) const PEER_AUTHORIZATION_PROTOCOL_MIN: u32 = 1;

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -99,6 +99,16 @@ pub trait ServiceNetworkSender: Send {
 
     /// Clone this instance into Boxed, dynamic trait
     fn clone_box(&self) -> Box<dyn ServiceNetworkSender>;
+
+    /// Send the message bytes to the given recipient (another service) with a configurable
+    /// message sender
+    #[cfg(feature = "challenge-authorization")]
+    fn send_with_sender(
+        &mut self,
+        recipient: &str,
+        message: &[u8],
+        sender: &str,
+    ) -> Result<(), ServiceSendError>;
 }
 
 impl Clone for Box<dyn ServiceNetworkSender> {

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -738,6 +738,12 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
+            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
+            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -745,6 +751,10 @@ pub mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -188,6 +188,8 @@ impl ServiceConnectionManager {
     /// For example:
     ///
     /// ```no_run
+    /// # use std::sync::{Arc, Mutex};
+    /// # use cylinder::secp256k1::Secp256k1Context;
     /// # use splinter::mesh::Mesh;
     /// # use splinter::network::auth::AuthorizationManager;
     /// # use splinter::network::connection_manager::{Authorizer, ConnectionManager};
@@ -199,6 +201,8 @@ impl ServiceConnectionManager {
     /// #   "test_identity".into(),
     /// #    #[cfg(feature = "challenge-authorization")]
     /// #    vec![],
+    /// #    #[cfg(feature = "challenge-authorization")]
+    /// #    Arc::new(Mutex::new(Box::new(Secp256k1Context::new()))),
     /// # ).unwrap();
     /// # let authorizer: Box<dyn Authorizer + Send> = Box::new(auth_mgr.authorization_connector());
     /// let mut cm = ConnectionManager::builder()
@@ -771,6 +775,12 @@ mod tests {
             connection_id: String,
             connection: Box<dyn Connection>,
             callback: AuthorizerCallback,
+            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
+            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+                ConnectionAuthorizationType,
+            >,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -778,6 +788,10 @@ mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
+                #[cfg(feature = "challenge-authorization")]
+                expected_authorization,
+                #[cfg(feature = "challenge-authorization")]
+                local_authorization,
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -557,5 +557,15 @@ mod tests {
         fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
             Box::new(self.clone())
         }
+
+        #[cfg(feature = "challenge-authorization")]
+        fn send_with_sender(
+            &mut self,
+            _recipient: &str,
+            _message: &[u8],
+            _sender: &str,
+        ) -> Result<(), ServiceSendError> {
+            Ok(())
+        }
     }
 }

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -730,6 +730,16 @@ pub mod tests {
         fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
             Box::new(self.clone())
         }
+
+        #[cfg(feature = "challenge-authorization")]
+        fn send_with_sender(
+            &mut self,
+            _recipient: &str,
+            _message: &[u8],
+            _sender: &str,
+        ) -> Result<(), ServiceSendError> {
+            Ok(())
+        }
     }
 
     /// Verifies that the given service connects on start and disconnects on stop.

--- a/services/scabbard/libscabbard/src/service/shared.rs
+++ b/services/scabbard/libscabbard/src/service/shared.rs
@@ -408,5 +408,15 @@ mod tests {
         fn clone_box(&self) -> Box<dyn ServiceNetworkSender> {
             Box::new(self.clone())
         }
+
+        #[cfg(feature = "challenge-authorization")]
+        fn send_with_sender(
+            &mut self,
+            _recipient: &str,
+            _message: &[u8],
+            _sender: &str,
+        ) -> Result<(), ServiceSendError> {
+            Ok(())
+        }
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -242,6 +242,8 @@ impl SplinterDaemon {
             self.node_id.clone(),
             #[cfg(feature = "challenge-authorization")]
             self.signers.clone(),
+            #[cfg(feature = "challenge-authorization")]
+            signing_context.clone(),
         )
         .map_err(|err| {
             StartError::NetworkError(format!("Unable to create authorization manager: {}", err))

--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -47,6 +47,7 @@ pub struct AdminSubsystemBuilder {
     scabbard_config: Option<ScabbardConfig>,
     registries: Option<Vec<String>>,
     admin_service_event_client_variant: AdminServiceEventClientVariant,
+    public_keys: Option<Vec<Vec<u8>>>,
 }
 
 impl AdminSubsystemBuilder {
@@ -62,6 +63,7 @@ impl AdminSubsystemBuilder {
             scabbard_config: None,
             registries: None,
             admin_service_event_client_variant: AdminServiceEventClientVariant::ActixWebClient,
+            public_keys: None,
         }
     }
 
@@ -131,6 +133,12 @@ impl AdminSubsystemBuilder {
         self
     }
 
+    /// Specifies the public keys set in the admin service
+    pub fn with_public_keys(mut self, public_keys: Vec<Vec<u8>>) -> Self {
+        self.public_keys = Some(public_keys);
+        self
+    }
+
     pub fn build(mut self) -> Result<RunnableAdminSubsystem, InternalError> {
         let node_id = self.node_id.take().ok_or_else(|| {
             InternalError::with_message("Cannot build AdminSubsystem without a node id".to_string())
@@ -176,6 +184,8 @@ impl AdminSubsystemBuilder {
             })?
             .new_verifier();
 
+        let public_keys = self.public_keys.unwrap_or_default();
+
         let scabbard_service_factory = self
             .scabbard_config
             .map(|config| {
@@ -204,6 +214,7 @@ impl AdminSubsystemBuilder {
             scabbard_service_factory,
             registries,
             admin_service_event_client_variant,
+            public_keys,
         })
     }
 }

--- a/splinterd/src/node/builder/network.rs
+++ b/splinterd/src/node/builder/network.rs
@@ -32,6 +32,7 @@ pub struct NetworkSubsystemBuilder {
     strict_ref_counts: bool,
     network_endpoints: Option<Vec<String>>,
     signing_context: Option<Arc<Mutex<Box<dyn cylinder::VerifierFactory>>>>,
+    signers: Option<Vec<Box<dyn cylinder::Signer>>>,
 }
 
 impl NetworkSubsystemBuilder {
@@ -73,6 +74,12 @@ impl NetworkSubsystemBuilder {
         self
     }
 
+    /// Specifies the signers for the node to use in challenge_authorization
+    pub fn with_signers(mut self, signers: Vec<Box<dyn cylinder::Signer>>) -> Self {
+        self.signers = Some(signers);
+        self
+    }
+
     pub fn build(mut self) -> Result<RunnableNetworkSubsystem, InternalError> {
         let node_id = self.node_id.take().ok_or_else(|| {
             InternalError::with_message(
@@ -85,6 +92,8 @@ impl NetworkSubsystemBuilder {
                 "Cannot build NetworkSubsystem without a signing context".to_string(),
             )
         })?;
+
+        let signers = self.signers.unwrap_or_default();
 
         // keep as option, if not provided will be set to tcp://127.0.0.1:0
         let network_endpoints = self.network_endpoints;
@@ -103,6 +112,7 @@ impl NetworkSubsystemBuilder {
             strict_ref_counts: self.strict_ref_counts,
             network_endpoints,
             signing_context,
+            signers,
         })
     }
 }

--- a/splinterd/src/node/runnable/admin.rs
+++ b/splinterd/src/node/runnable/admin.rs
@@ -49,6 +49,7 @@ pub struct RunnableAdminSubsystem {
     pub scabbard_service_factory: Option<ScabbardFactory>,
     pub registries: Option<Vec<String>>,
     pub admin_service_event_client_variant: AdminServiceEventClientVariant,
+    pub public_keys: Vec<Vec<u8>>,
 }
 
 impl RunnableAdminSubsystem {
@@ -136,7 +137,8 @@ impl RunnableAdminSubsystem {
             ))
             .with_coordinator_timeout(admin_timeout)
             .with_routing_table_writer(routing_writer)
-            .with_admin_event_store(store_factory.get_admin_service_store());
+            .with_admin_event_store(store_factory.get_admin_service_store())
+            .with_public_keys(self.public_keys.to_vec());
 
         let circuit_resource_provider =
             CircuitResourceProvider::new(node_id, store_factory.get_admin_service_store());

--- a/splinterd/tests/admin/circuit_abandon.rs
+++ b/splinterd/tests/admin/circuit_abandon.rs
@@ -17,6 +17,7 @@
 
 use std::time::Duration;
 
+use splinter::admin::messages::AuthorizationType;
 use splinterd::node::RestApiVariant;
 
 use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
@@ -66,7 +67,7 @@ pub fn test_2_party_circuit_abandon() {
     let node_b = network.node(1).expect("Unable to get second node");
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
-    commit_2_party_circuit(&circuit_id, node_a, node_b);
+    commit_2_party_circuit(&circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // Create the `ServiceId` struct based on the first node's associated `service_id` and the
     // committed `circuit_id`
@@ -90,7 +91,7 @@ pub fn test_2_party_circuit_abandon() {
     // abandoned
     let active_circuit_id = "FGHIJ-56789";
     // Commit the circuit to state
-    commit_2_party_circuit(&active_circuit_id, node_a, node_b);
+    commit_2_party_circuit(&active_circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // Create the `ServiceId` struct based on the first node's associated `service_id` and the
     // committed `circuit_id`
@@ -513,12 +514,12 @@ pub fn test_2_party_circuit_abandon_stop() {
     let mut node_b = network.node(1).expect("Unable to get second node");
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
-    commit_2_party_circuit(&circuit_id, node_a, node_b);
+    commit_2_party_circuit(&circuit_id, node_a, node_b, AuthorizationType::Trust);
     // Commit a circuit between the 2 nodes that will remain active while the other circuit is
     // abandoned
     let active_circuit_id = "FGHIJ-56789";
     // Commit the circuit to state
-    commit_2_party_circuit(&active_circuit_id, node_a, node_b);
+    commit_2_party_circuit(&active_circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 
 use splinter::admin::client::event::{EventType, PublicKey};
+use splinter::admin::messages::AuthorizationType;
 use splinterd::node::{Node, RestApiVariant};
 
 use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
@@ -114,15 +115,29 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     let circuit_id = "ABCDE-01234";
 
     let node_a_event_client = node_a
@@ -142,6 +157,7 @@ pub fn test_2_party_circuit_creation_proposal_rejected() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node
@@ -246,19 +262,40 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
         (
             node_c.node_id().to_string(),
-            node_c.network_endpoints().to_vec(),
+            (
+                node_c.network_endpoints().to_vec(),
+                node_c
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get third node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     let circuit_id = "ABCDE-01234";
 
     let node_a_event_client = node_a
@@ -282,6 +319,7 @@ pub fn test_3_party_circuit_creation_proposal_rejected() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node
@@ -450,15 +488,29 @@ pub fn test_2_party_circuit_creation_stop() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     let circuit_id = "ABCDE-01234";
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");
@@ -474,6 +526,7 @@ pub fn test_2_party_circuit_creation_stop() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node
@@ -609,15 +662,29 @@ pub fn test_2_party_circuit_proposal_rejected_stop() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     let circuit_id = "ABCDE-01234";
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");
@@ -633,6 +700,7 @@ pub fn test_2_party_circuit_proposal_rejected_stop() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node
@@ -766,19 +834,40 @@ pub fn test_3_party_circuit_creation_stop() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
         (
             node_c.node_id().to_string(),
-            node_c.network_endpoints().to_vec(),
+            (
+                node_c.network_endpoints().to_vec(),
+                node_c
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get third node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");
     node_a = network.node(0).expect("Unable to get first node");
@@ -793,6 +882,7 @@ pub fn test_3_party_circuit_creation_stop() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node
@@ -1026,19 +1116,40 @@ pub fn test_3_party_circuit_proposal_rejected_stop() {
     let node_info = vec![
         (
             node_a.node_id().to_string(),
-            node_a.network_endpoints().to_vec(),
+            (
+                node_a.network_endpoints().to_vec(),
+                node_a
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
         ),
         (
             node_b.node_id().to_string(),
-            node_b.network_endpoints().to_vec(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get seconds node's public key"),
+            ),
         ),
         (
             node_c.node_id().to_string(),
-            node_c.network_endpoints().to_vec(),
+            (
+                node_c.network_endpoints().to_vec(),
+                node_c
+                    .admin_signer()
+                    .clone()
+                    .public_key()
+                    .expect("Unable to get third node's public key"),
+            ),
         ),
     ]
     .into_iter()
-    .collect::<HashMap<String, Vec<String>>>();
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");
     node_a = network.node(0).expect("Unable to get first node");
@@ -1053,6 +1164,7 @@ pub fn test_3_party_circuit_proposal_rejected_stop() {
             .public_key()
             .expect("Unable to get first node's public key")
             .as_hex()],
+        AuthorizationType::Trust,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -48,7 +48,36 @@ pub fn test_2_party_circuit_creation() {
 
     let circuit_id = "ABCDE-01234";
 
-    commit_2_party_circuit(circuit_id, node_a, node_b);
+    commit_2_party_circuit(circuit_id, node_a, node_b, AuthorizationType::Trust);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// Test that a 2-party circuit may be created on a 2-node network using challenge authorization.
+///
+/// 1. Create and submit a `CircuitCreateRequest` from the first node
+/// 2. Wait until the proposal is available to the second node, using `list_proposals`
+/// 3. Verify the same proposal is available on each node
+/// 4. Submit the same `CircuitCreateRequest` created in the first step from the second node
+/// 5. Validate the duplicate proposal submitted in the previous step results in an error
+/// 6. Create and submit a `CircuitProposalVote` from the second node to accept the proposal
+/// 7. Wait until the circuit is available on the first node, using `list_circuits`
+/// 8. Verify the same circuit is available to each node
+#[test]
+pub fn test_2_party_circuit_creation_challenge_authorization() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .add_nodes_with_defaults(2)
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+
+    let circuit_id = "ABCDE-01234";
+
+    commit_2_party_circuit(circuit_id, node_a, node_b, AuthorizationType::Challenge);
 
     shutdown!(network).expect("Unable to shutdown network");
 }

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -16,6 +16,7 @@
 //! the process of creating and then disbanding a circuit between two and three nodes.
 
 use splinter::admin::client::event::{BlockingAdminServiceEventIterator, EventType, PublicKey};
+use splinter::admin::messages::AuthorizationType;
 use splinterd::node::{Node, RestApiVariant};
 
 use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
@@ -208,7 +209,7 @@ pub fn test_2_party_circuit_disband_proposal_rejected() {
     let node_b_admin_pubkey = admin_pubkey(node_b);
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
-    commit_2_party_circuit(&circuit_id, node_a, node_b);
+    commit_2_party_circuit(&circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
@@ -767,7 +768,7 @@ pub fn test_2_party_circuit_lifecycle_stop() {
     let mut node_b = network.node(1).expect("Unable to get second node");
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
-    commit_2_party_circuit(&circuit_id, node_a, node_b);
+    commit_2_party_circuit(&circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just to the circuit ready event and record
     // this event ID. We will use this again once the node has been restarted to catch back up.
@@ -967,7 +968,7 @@ pub fn test_2_party_circuit_disband_rejected_stop() {
     let mut node_b = network.node(1).expect("Unable to get second node");
     let circuit_id = "ABCDE-01234";
     // Commit the circuit to state
-    commit_2_party_circuit(&circuit_id, node_a, node_b);
+    commit_2_party_circuit(&circuit_id, node_a, node_b, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just to the circuit ready event and record
     // this event ID. We will use this again once the node has been restarted to catch back up.


### PR DESCRIPTION
This PR sets up the new challenge authorization message
handlers in create_authorization_dispatcher. To properly set
up the challenge authorization handlers information about the
expected authorization from the remote node, as well as what
authorization type the local node should use. This information
will be known by the node adding the peer from the PeerManager
and must be passed down to the ConnectionManager and the
AuthorizationManager.

This information must also be stored to be used again on
connection restarts and trying new peer endpoints.

The admin service needs to be updated to be get the required local
authorization as well as keep track of a token to peer map to be
able to properly handle connection/disconnection notifications
as well as making it easier to map the token to the members
admin service.

An integration test has been added that tests circuit creation when
using challenge authorization as the required authorization type.