### PR TITLE
Reduce build failure emails when pushing to forks

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -130,6 +130,8 @@ jobs:
 
   build_docker:
     runs-on: ubuntu-18.04
+    if: >-
+      github.repository_owner == 'Cargill'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Not having up-to-date tags will cause docker builds to fail which results in a
build failure email. The weekly release cadence of splinter makes it likely
that forks may be behind in tags.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>