### PR TITLE
Wrap the SigningContext in an Arc<Mutex>

### DIFF
--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use cylinder::VerifierFactory;
 use splinter::admin::service::admin_service_id;
 use splinter::circuit::handlers::{
     AdminDirectMessageHandler, CircuitDirectMessageHandler, CircuitErrorHandler,
@@ -47,6 +49,7 @@ pub struct RunnableNetworkSubsystem {
     pub heartbeat_interval: Duration,
     pub strict_ref_counts: bool,
     pub network_endpoints: Option<Vec<String>>,
+    pub signing_context: Arc<Mutex<Box<dyn VerifierFactory>>>,
 }
 
 impl RunnableNetworkSubsystem {


### PR DESCRIPTION
This is required because the authorization manager will require
a VerifierFactory. Currently the factory is the context but the
context was being passed to the scabbard factory. It is not
recommended to create more then one context so it has to be
wrapped in an arc mutex so it can be shared.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>