### PR TITLE
Node store trait

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -126,6 +126,7 @@ experimental = [
     "client-reqwest",
     "https-bind",
     "metrics",
+    "node-id-store",
     "oauth-user-list",
     "registry-client",
     "registry-client-reqwest",
@@ -168,6 +169,7 @@ events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
 metrics = ["chrono", "futures-0-3", "influxdb", "metrics-lib", "tokio-0-2"]
+node-id-store = []
 oauth = ["biome", "base64", "oauth2", "reqwest", "rest-api"]
 oauth-user-list = ["oauth"]
 postgres = ["diesel/postgres", "diesel_migrations"]

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -83,6 +83,8 @@ pub mod keys;
 pub mod mesh;
 pub mod migrations;
 pub mod network;
+#[cfg(feature = "node-id-store")]
+pub mod node_id;
 #[cfg(feature = "oauth")]
 pub mod oauth;
 pub mod orchestrator;

--- a/libsplinter/src/node_id/mod.rs
+++ b/libsplinter/src/node_id/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Traits, types, and implementations for interacting with node_id's
+
+/// Store logic for accessing and modifying an instances node_id.
+pub mod store;

--- a/libsplinter/src/node_id/store/error.rs
+++ b/libsplinter/src/node_id/store/error.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error types and logic for NodeIdStores
+
+use crate::error::InternalError;
+use std::error::Error;
+use std::fmt::Display;
+
+/// Error type for the NodeIdStore trait.
+/// Any errors implimentations of NodeIdStore can generate must be convertable
+/// to a NodeIdStoreError enum member.
+
+#[derive(Debug)]
+/// NodeIdStore error enum
+pub enum NodeIdStoreError {
+    InternalError(InternalError),
+}
+
+impl Display for NodeIdStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeIdStoreError::InternalError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for NodeIdStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            NodeIdStoreError::InternalError(e) => Some(e),
+        }
+    }
+}

--- a/libsplinter/src/node_id/store/mod.rs
+++ b/libsplinter/src/node_id/store/mod.rs
@@ -1,0 +1,30 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// NodeIdStore error types
+pub mod error;
+use error::NodeIdStoreError;
+
+/// Trait for interacting with the instances node_id.
+pub trait NodeIdStore {
+    /// Gets node_id for the instance
+    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError>;
+
+    /// Sets node_id for the instance
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - the desired node_id
+    fn set_node_id(&self, node_id: String) -> Result<(), NodeIdStoreError>;
+}


### PR DESCRIPTION
Basic trait for getting and setting the instances node_id.

Also includes an error type for dealing with diesel errors which will be useful in the implementation phases.