### PR TITLE
Update the authorization state machine to match the new design

### DIFF
--- a/libsplinter/src/network/auth/connection_manager.rs
+++ b/libsplinter/src/network/auth/connection_manager.rs
@@ -14,7 +14,6 @@
 
 use crate::network::connection_manager::{
     AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
-    ConnectionAuthorizationType,
 };
 use crate::transport::Connection;
 
@@ -46,7 +45,7 @@ impl From<ConnectionAuthorizationState> for AuthorizationResult {
             } => AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity: ConnectionAuthorizationType::Trust { identity },
+                identity,
             },
 
             ConnectionAuthorizationState::Unauthorized {

--- a/libsplinter/src/network/auth/handlers/v0_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v0_handlers.rs
@@ -26,8 +26,8 @@ use crate::protos::prelude::*;
 
 use crate::network::auth::{
     state_machine::trust_v0::{TrustV0AuthorizationAction, TrustV0AuthorizationState},
-    AuthorizationAction, AuthorizationActionError, AuthorizationManagerStateMachine,
-    AuthorizationState, Identity,
+    AuthorizationActionError, AuthorizationManagerStateMachine, AuthorizationRemoteAction,
+    AuthorizationRemoteState, Identity,
 };
 
 pub struct AuthorizedHandler {
@@ -59,9 +59,9 @@ impl Handler for AuthorizedHandler {
             "Received authorize message from {}",
             context.source_connection_id()
         );
-        match self.auth_manager.next_state(
+        match self.auth_manager.next_remote_state(
             context.source_connection_id(),
-            AuthorizationAction::TrustV0(TrustV0AuthorizationAction::RemoteAuthorizing),
+            AuthorizationRemoteAction::TrustV0(TrustV0AuthorizationAction::RemoteAuthorizing),
         ) {
             Err(err) => {
                 warn!(
@@ -108,9 +108,9 @@ impl Handler for ConnectRequestHandler {
         sender: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
         let connect_request = ConnectRequest::from_proto(msg)?;
-        match self.auth_manager.next_state(
+        match self.auth_manager.next_remote_state(
             context.source_connection_id(),
-            AuthorizationAction::Connecting,
+            AuthorizationRemoteAction::Connecting,
         ) {
             Err(AuthorizationActionError::AlreadyConnecting) => {
                 debug!(
@@ -125,7 +125,7 @@ impl Handler for ConnectRequestHandler {
                     err
                 );
             }
-            Ok(AuthorizationState::TrustV0(TrustV0AuthorizationState::Connecting)) => {
+            Ok(AuthorizationRemoteState::TrustV0(TrustV0AuthorizationState::Connecting)) => {
                 debug!("Beginning handshake for {}", context.source_connection_id(),);
                 // Send a connect request of our own
 
@@ -252,9 +252,9 @@ impl Handler for TrustRequestHandler {
         sender: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
         let trust_request = TrustRequest::from_proto(msg)?;
-        match self.auth_manager.next_state(
+        match self.auth_manager.next_remote_state(
             context.source_connection_id(),
-            AuthorizationAction::TrustV0(TrustV0AuthorizationAction::TrustIdentifyingV0(
+            AuthorizationRemoteAction::TrustV0(TrustV0AuthorizationAction::TrustIdentifyingV0(
                 Identity::Trust {
                     identity: trust_request.identity,
                 },
@@ -267,10 +267,10 @@ impl Handler for TrustRequestHandler {
                     err
                 );
             }
-            Ok(AuthorizationState::TrustV0(TrustV0AuthorizationState::RemoteIdentified(
+            Ok(AuthorizationRemoteState::TrustV0(TrustV0AuthorizationState::RemoteIdentified(
                 Identity::Trust { identity },
             )))
-            | Ok(AuthorizationState::AuthComplete(Some(Identity::Trust { identity }))) => {
+            | Ok(AuthorizationRemoteState::Done(Identity::Trust { identity })) => {
                 debug!(
                     "Sending Authorized message to connection {} after receiving identity {}",
                     context.source_connection_id(),

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -28,9 +28,12 @@ use crate::protos::network;
 use crate::protos::prelude::*;
 
 use crate::network::auth::{
-    state_machine::trust_v1::{TrustAuthorizationAction, TrustAuthorizationState},
-    AuthorizationAction, AuthorizationManagerStateMachine, AuthorizationMessage,
-    AuthorizationState, Identity,
+    state_machine::trust_v1::{
+        TrustAuthorizationLocalAction, TrustAuthorizationRemoteAction,
+        TrustAuthorizationRemoteState,
+    },
+    AuthorizationLocalAction, AuthorizationLocalState, AuthorizationManagerStateMachine,
+    AuthorizationMessage, AuthorizationRemoteAction, AuthorizationRemoteState, Identity,
 };
 
 /// Handler for the Authorization Protocol Request Message Type
@@ -67,7 +70,7 @@ impl Handler for AuthProtocolRequestHandler {
 
         match self.auth_manager.next_remote_state(
             context.source_connection_id(),
-            AuthorizationAction::ProtocolAgreeing,
+            AuthorizationRemoteAction::ReceiveAuthProtocolRequest,
         ) {
             Err(err) => {
                 warn!(
@@ -77,7 +80,7 @@ impl Handler for AuthProtocolRequestHandler {
                 );
             }
 
-            Ok(AuthorizationState::ProtocolAgreeing) => {
+            Ok(AuthorizationRemoteState::ReceivedAuthProtocolRequest) => {
                 let version = supported_protocol_version(
                     protocol_request.auth_protocol_min,
                     protocol_request.auth_protocol_max,
@@ -105,7 +108,7 @@ impl Handler for AuthProtocolRequestHandler {
                         .auth_manager
                         .next_remote_state(
                             context.source_connection_id(),
-                            AuthorizationAction::Unauthorizing,
+                            AuthorizationRemoteAction::Unauthorizing,
                         )
                         .is_err()
                     {
@@ -137,6 +140,20 @@ impl Handler for AuthProtocolRequestHandler {
                     .map_err(|(recipient, payload)| {
                         DispatchError::NetworkSendError((recipient.into(), payload))
                     })?;
+
+                if self
+                    .auth_manager
+                    .next_remote_state(
+                        context.source_connection_id(),
+                        AuthorizationRemoteAction::SendAuthProtocolResponse,
+                    )
+                    .is_err()
+                {
+                    error!(
+                        "Unable to transition from ReceivedAuthProtocolRequest to \
+                        SentAuthProtocolResponse"
+                    )
+                };
             }
             Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
         }
@@ -213,9 +230,9 @@ impl Handler for AuthProtocolResponseHandler {
         );
         let protocol_request = AuthProtocolResponse::from_proto(msg)?;
 
-        match self.auth_manager.next_state(
+        match self.auth_manager.next_local_state(
             context.source_connection_id(),
-            AuthorizationAction::ProtocolAgreeing,
+            AuthorizationLocalAction::ReceiveAuthProtocolResponse,
         ) {
             Err(err) => {
                 warn!(
@@ -224,8 +241,7 @@ impl Handler for AuthProtocolResponseHandler {
                     err
                 );
             }
-
-            Ok(AuthorizationState::ProtocolAgreeing) => {
+            Ok(AuthorizationLocalState::ReceivedAuthProtocolResponse) => {
                 if protocol_request
                     .accepted_authorization_type
                     .iter()
@@ -234,6 +250,22 @@ impl Handler for AuthProtocolResponseHandler {
                     let trust_request = AuthorizationMessage::AuthTrustRequest(AuthTrustRequest {
                         identity: self.identity.clone(),
                     });
+
+                    if self
+                        .auth_manager
+                        .next_local_state(
+                            context.source_connection_id(),
+                            AuthorizationLocalAction::Trust(
+                                TrustAuthorizationLocalAction::SendAuthTrustRequest,
+                            ),
+                        )
+                        .is_err()
+                    {
+                        error!(
+                            "Unable to transition from ReceivedAuthProtocolResponse to \
+                            WaitingForAuthTrustResponse"
+                        )
+                    };
 
                     let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
                         NetworkMessage::from(trust_request),
@@ -285,11 +317,11 @@ impl Handler for AuthTrustRequestHandler {
         let trust_request = AuthTrustRequest::from_proto(msg)?;
         match self.auth_manager.next_remote_state(
             context.source_connection_id(),
-            AuthorizationAction::Trust(TrustAuthorizationAction::TrustIdentifying(
-                Identity::Trust {
+            AuthorizationRemoteAction::Trust(
+                TrustAuthorizationRemoteAction::ReceiveAuthTrustRequest(Identity::Trust {
                     identity: trust_request.identity.to_string(),
-                },
-            )),
+                }),
+            ),
         ) {
             Err(err) => {
                 warn!(
@@ -299,7 +331,9 @@ impl Handler for AuthTrustRequestHandler {
                 );
                 return Ok(());
             }
-            Ok(AuthorizationState::Trust(TrustAuthorizationState::Identified(_))) => {
+            Ok(AuthorizationRemoteState::Trust(
+                TrustAuthorizationRemoteState::ReceivedAuthTrustRequest(_),
+            )) => {
                 debug!(
                     "Sending trust response to connection {} after receiving identity {}",
                     context.source_connection_id(),
@@ -322,21 +356,14 @@ impl Handler for AuthTrustRequestHandler {
             .auth_manager
             .next_remote_state(
                 context.source_connection_id(),
-                AuthorizationAction::Trust(TrustAuthorizationAction::Authorizing),
+                AuthorizationRemoteAction::Trust(
+                    TrustAuthorizationRemoteAction::SendAuthTrustResponse,
+                ),
             )
             .is_err()
         {
-            error!("Unable to transition from TrustIdentified to Authorized")
+            error!("Unable to transition from ReceivedAuthTrustRequest to Done")
         };
-
-        let auth_msg = AuthorizationMessage::AuthComplete(AuthComplete);
-        let msg_bytes =
-            IntoBytes::<network::NetworkMessage>::into_bytes(NetworkMessage::from(auth_msg))?;
-        sender
-            .send(context.source_id().clone(), msg_bytes)
-            .map_err(|(recipient, payload)| {
-                DispatchError::NetworkSendError((recipient.into(), payload))
-            })?;
 
         Ok(())
     }
@@ -345,15 +372,11 @@ impl Handler for AuthTrustRequestHandler {
 /// Handler for the Authorization Trust Response Message Type
 pub struct AuthTrustResponseHandler {
     auth_manager: AuthorizationManagerStateMachine,
-    identity: String,
 }
 
 impl AuthTrustResponseHandler {
-    pub fn new(auth_manager: AuthorizationManagerStateMachine, identity: String) -> Self {
-        Self {
-            auth_manager,
-            identity,
-        }
+    pub fn new(auth_manager: AuthorizationManagerStateMachine) -> Self {
+        Self { auth_manager }
     }
 }
 
@@ -370,19 +393,17 @@ impl Handler for AuthTrustResponseHandler {
         &self,
         _msg: Self::Message,
         context: &MessageContext<Self::Source, Self::MessageType>,
-        _sender: &dyn MessageSender<Self::Source>,
+        sender: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
         debug!(
             "Received authorization trust response from {}",
             context.source_connection_id()
         );
-        match self.auth_manager.next_state(
+        match self.auth_manager.next_local_state(
             context.source_connection_id(),
-            AuthorizationAction::Trust(TrustAuthorizationAction::TrustIdentifying(
-                Identity::Trust {
-                    identity: self.identity.to_string(),
-                },
-            )),
+            AuthorizationLocalAction::Trust(
+                TrustAuthorizationLocalAction::ReceiveAuthTrustResponse,
+            ),
         ) {
             Err(err) => {
                 warn!(
@@ -391,9 +412,34 @@ impl Handler for AuthTrustResponseHandler {
                     err
                 );
             }
-            Ok(AuthorizationState::Trust(TrustAuthorizationState::Identified(_))) => (),
+            Ok(AuthorizationLocalState::Authorized) => (),
             Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
         }
+
+        let auth_msg = AuthorizationMessage::AuthComplete(AuthComplete);
+        let msg_bytes =
+            IntoBytes::<network::NetworkMessage>::into_bytes(NetworkMessage::from(auth_msg))?;
+        sender
+            .send(context.source_id().clone(), msg_bytes)
+            .map_err(|(recipient, payload)| {
+                DispatchError::NetworkSendError((recipient.into(), payload))
+            })?;
+
+        match self.auth_manager.next_local_state(
+            context.source_connection_id(),
+            AuthorizationLocalAction::SendAuthComplete,
+        ) {
+            Err(err) => {
+                warn!(
+                    "Cannot transition connection from Authorized {}: {}",
+                    context.source_connection_id(),
+                    err
+                );
+            }
+            Ok(AuthorizationLocalState::WaitForComplete) => (),
+            Ok(AuthorizationLocalState::AuthorizedAndComplete) => (),
+            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+        };
 
         Ok(())
     }
@@ -429,10 +475,10 @@ impl Handler for AuthCompleteHandler {
             "Received authorization complete from {}",
             context.source_connection_id()
         );
-        match self.auth_manager.next_state(
-            context.source_connection_id(),
-            AuthorizationAction::Trust(TrustAuthorizationAction::Authorizing),
-        ) {
+        match self
+            .auth_manager
+            .received_complete(context.source_connection_id())
+        {
             Err(err) => {
                 warn!(
                     "Ignoring authorization complete message from connection {}: {}",
@@ -440,9 +486,7 @@ impl Handler for AuthCompleteHandler {
                     err
                 );
             }
-            Ok(AuthorizationState::Trust(TrustAuthorizationState::Authorized(_)))
-            | Ok(AuthorizationState::AuthComplete(_)) => (),
-            Ok(next_state) => panic!("Should not have been able to transition to {}", next_state),
+            Ok(()) => (),
         }
 
         Ok(())

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -367,6 +367,17 @@ impl ManagedAuthorizations {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub enum ConnectionAuthorizationType {
+    Trust {
+        identity: String,
+    },
+    #[cfg(feature = "challenge-authorization")]
+    Challenge {
+        public_key: Vec<u8>,
+    },
+}
+
 pub enum ConnectionAuthorizationState {
     Authorized {
         connection_id: String,

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -41,7 +41,7 @@ use self::handlers::create_authorization_dispatcher;
 use self::pool::{ThreadPool, ThreadPoolBuilder};
 pub(crate) use self::state_machine::{
     AuthorizationAction, AuthorizationActionError, AuthorizationManagerStateMachine,
-    AuthorizationState,
+    AuthorizationState, Identity,
 };
 
 const AUTHORIZATION_THREAD_POOL_SIZE: usize = 8;
@@ -272,11 +272,13 @@ impl AuthorizationConnector {
                 }
             };
 
-            let auth_state = if let Some(identity) = authed_identity {
-                ConnectionAuthorizationState::Authorized {
-                    connection_id,
-                    connection,
-                    identity,
+            let auth_state = if let Some(auth_identity) = authed_identity {
+                match auth_identity {
+                    Identity::Trust { identity } => ConnectionAuthorizationState::Authorized {
+                        connection_id,
+                        connection,
+                        identity: ConnectionAuthorizationType::Trust { identity },
+                    },
                 }
             } else {
                 ConnectionAuthorizationState::Unauthorized {
@@ -338,7 +340,7 @@ impl ManagedAuthorizations {
         }
     }
 
-    fn take_connection_identity(&mut self, connection_id: &str) -> Option<String> {
+    fn take_connection_identity(&mut self, connection_id: &str) -> Option<Identity> {
         self.states.remove(connection_id).and_then(|managed_state| {
             match managed_state.remote_state {
                 AuthorizationState::AuthComplete(Some(identity)) => Some(identity),
@@ -381,7 +383,7 @@ pub enum ConnectionAuthorizationType {
 pub enum ConnectionAuthorizationState {
     Authorized {
         connection_id: String,
-        identity: String,
+        identity: ConnectionAuthorizationType,
         connection: Box<dyn Connection>,
     },
     Unauthorized {

--- a/libsplinter/src/network/auth/state_machine/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/mod.rs
@@ -20,7 +20,10 @@ use std::sync::{Arc, Mutex};
 
 use self::trust_v0::{TrustV0AuthorizationAction, TrustV0AuthorizationState};
 #[cfg(feature = "trust-authorization")]
-use self::trust_v1::{TrustAuthorizationAction, TrustAuthorizationState};
+use self::trust_v1::{
+    TrustAuthorizationLocalAction, TrustAuthorizationLocalState, TrustAuthorizationRemoteAction,
+    TrustAuthorizationRemoteState,
+};
 
 use super::{ManagedAuthorizationState, ManagedAuthorizations};
 
@@ -30,57 +33,154 @@ pub enum Identity {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub(crate) enum AuthorizationState {
-    Unknown,
-    AuthComplete(Option<Identity>),
+pub(crate) enum AuthorizationRemoteState {
+    Start,
+    Done(Identity),
     Unauthorized,
 
     #[cfg(feature = "trust-authorization")]
-    ProtocolAgreeing,
+    ReceivedAuthProtocolRequest,
+    #[cfg(feature = "trust-authorization")]
+    SentAuthProtocolResponse,
+
     TrustV0(TrustV0AuthorizationState),
     #[cfg(feature = "trust-authorization")]
-    Trust(TrustAuthorizationState),
+    Trust(TrustAuthorizationRemoteState),
 }
 
-impl fmt::Display for AuthorizationState {
+impl fmt::Display for AuthorizationRemoteState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AuthorizationState::Unknown => f.write_str("Unknown"),
-            #[cfg(feature = "trust-authorization")]
-            AuthorizationState::ProtocolAgreeing => f.write_str("ProtocolAgreeing"),
-            AuthorizationState::TrustV0(action) => write!(f, "TrustV0: {}", action),
-            #[cfg(feature = "trust-authorization")]
-            AuthorizationState::Trust(action) => write!(f, "Trust: {}", action),
+            AuthorizationRemoteState::Start => f.write_str("Start"),
+            AuthorizationRemoteState::Done(_) => f.write_str("Done"),
+            AuthorizationRemoteState::Unauthorized => f.write_str("Unauthorized"),
 
-            AuthorizationState::AuthComplete(_) => f.write_str("Authorization Complete"),
-            AuthorizationState::Unauthorized => f.write_str("Unauthorized"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteState::ReceivedAuthProtocolRequest => {
+                f.write_str("ReceivedAuthProtocolRequest")
+            }
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteState::SentAuthProtocolResponse => {
+                f.write_str("SentAuthProtocolResponse")
+            }
+            AuthorizationRemoteState::TrustV0(state) => write!(f, "TrustV0: {}", state),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteState::Trust(state) => write!(f, "Trust: {}", state),
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum AuthorizationLocalState {
+    Start,
+    #[cfg(feature = "trust-authorization")]
+    WaitingForAuthProtocolResponse,
+    #[cfg(feature = "trust-authorization")]
+    ReceivedAuthProtocolResponse,
+    #[cfg(feature = "trust-authorization")]
+    Authorized,
+    #[cfg(feature = "trust-authorization")]
+    WaitForComplete,
+    AuthorizedAndComplete,
+    Unauthorized,
+
+    #[cfg(feature = "trust-authorization")]
+    Trust(TrustAuthorizationLocalState),
+}
+
+impl fmt::Display for AuthorizationLocalState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationLocalState::Start => f.write_str("Start"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalState::Authorized => f.write_str("Authorized"),
+            AuthorizationLocalState::Unauthorized => f.write_str("Unauthorized"),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalState::WaitingForAuthProtocolResponse => {
+                f.write_str("WaitingForAuthProtocolResponse")
+            }
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalState::ReceivedAuthProtocolResponse => {
+                f.write_str("ReceivedAuthProtocolResponse")
+            }
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalState::WaitForComplete => f.write_str("WaitForComplete"),
+            AuthorizationLocalState::AuthorizedAndComplete => f.write_str("AuthorizedAndComplete"),
+
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalState::Trust(action) => write!(f, "Trust: {}", action),
         }
     }
 }
 
 /// The state transitions that can be applied on a connection during authorization.
 #[derive(PartialEq, Debug)]
-pub(crate) enum AuthorizationAction {
+pub(crate) enum AuthorizationRemoteAction {
     Connecting,
+
     #[cfg(feature = "trust-authorization")]
-    ProtocolAgreeing,
+    ReceiveAuthProtocolRequest,
+    #[cfg(feature = "trust-authorization")]
+    SendAuthProtocolResponse,
+
     TrustV0(TrustV0AuthorizationAction),
     #[cfg(feature = "trust-authorization")]
-    Trust(TrustAuthorizationAction),
+    Trust(TrustAuthorizationRemoteAction),
 
     Unauthorizing,
 }
 
-impl fmt::Display for AuthorizationAction {
+impl fmt::Display for AuthorizationRemoteAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AuthorizationAction::Connecting => f.write_str("Connecting"),
-            AuthorizationAction::Unauthorizing => f.write_str("Unauthorizing"),
+            AuthorizationRemoteAction::Connecting => f.write_str("Connecting"),
             #[cfg(feature = "trust-authorization")]
-            AuthorizationAction::ProtocolAgreeing => f.write_str("ProtocolAgreeing"),
-            AuthorizationAction::TrustV0(_) => f.write_str("TrustV0"),
+            AuthorizationRemoteAction::ReceiveAuthProtocolRequest => {
+                f.write_str("ReceiveAuthProtocolRequest")
+            }
             #[cfg(feature = "trust-authorization")]
-            AuthorizationAction::Trust(_) => f.write_str("Trust"),
+            AuthorizationRemoteAction::SendAuthProtocolResponse => {
+                f.write_str("SendAuthProtocolResponse")
+            }
+            AuthorizationRemoteAction::TrustV0(action) => write!(f, "TrusV0t: {}", action),
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteAction::Trust(action) => write!(f, "Trust: {}", action),
+
+            AuthorizationRemoteAction::Unauthorizing => f.write_str("Unauthorizing"),
+        }
+    }
+}
+
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+#[cfg(feature = "trust-authorization")]
+pub(crate) enum AuthorizationLocalAction {
+    SendAuthProtocolRequest,
+    ReceiveAuthProtocolResponse,
+
+    #[cfg(feature = "trust-authorization")]
+    Trust(TrustAuthorizationLocalAction),
+
+    SendAuthComplete,
+    Unauthorizing,
+}
+
+#[cfg(feature = "trust-authorization")]
+impl fmt::Display for AuthorizationLocalAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AuthorizationLocalAction::SendAuthProtocolRequest => {
+                f.write_str("SendAuthProtocolRequest")
+            }
+            AuthorizationLocalAction::ReceiveAuthProtocolResponse => {
+                f.write_str("SendAuthProtocolResponse")
+            }
+
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationLocalAction::Trust(action) => write!(f, "Trust: {}", action),
+
+            AuthorizationLocalAction::SendAuthComplete => f.write_str("SendAuthComplete"),
+            AuthorizationLocalAction::Unauthorizing => f.write_str("Unauthorizing"),
         }
     }
 }
@@ -89,7 +189,9 @@ impl fmt::Display for AuthorizationAction {
 #[derive(PartialEq, Debug)]
 pub(crate) enum AuthorizationActionError {
     AlreadyConnecting,
-    InvalidMessageOrder(AuthorizationState, AuthorizationAction),
+    InvalidRemoteMessageOrder(AuthorizationRemoteState, AuthorizationRemoteAction),
+    #[cfg(feature = "trust-authorization")]
+    InvalidLocalMessageOrder(AuthorizationLocalState, AuthorizationLocalAction),
     InternalError(String),
 }
 
@@ -99,8 +201,20 @@ impl fmt::Display for AuthorizationActionError {
             AuthorizationActionError::AlreadyConnecting => {
                 f.write_str("Already attempting to connect")
             }
-            AuthorizationActionError::InvalidMessageOrder(start, action) => {
-                write!(f, "Attempting to transition from {} via {}", start, action)
+            AuthorizationActionError::InvalidRemoteMessageOrder(start, action) => {
+                write!(
+                    f,
+                    "Attempting to transition from remote state {} via {}",
+                    start, action
+                )
+            }
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationActionError::InvalidLocalMessageOrder(start, action) => {
+                write!(
+                    f,
+                    "Attempting to transition from locale state {} via {}",
+                    start, action
+                )
             }
             AuthorizationActionError::InternalError(msg) => f.write_str(&msg),
         }
@@ -118,11 +232,12 @@ impl AuthorizationManagerStateMachine {
     /// Errors
     ///
     /// The errors are error messages that should be returned on the appropriate message
-    pub(crate) fn next_state(
+    #[cfg(feature = "trust-authorization")]
+    pub(crate) fn next_local_state(
         &self,
         connection_id: &str,
-        action: AuthorizationAction,
-    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        action: AuthorizationLocalAction,
+    ) -> Result<AuthorizationLocalState, AuthorizationActionError> {
         let mut shared = self.shared.lock().map_err(|_| {
             AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
         })?;
@@ -132,77 +247,79 @@ impl AuthorizationManagerStateMachine {
                 .states
                 .entry(connection_id.to_string())
                 .or_insert(ManagedAuthorizationState {
-                    local_state: AuthorizationState::Unknown,
-                    remote_state: AuthorizationState::Unknown,
+                    local_state: AuthorizationLocalState::Start,
+                    remote_state: AuthorizationRemoteState::Start,
+                    received_complete: false,
                 });
 
-        if action == AuthorizationAction::Unauthorizing {
-            cur_state.local_state = AuthorizationState::Unauthorized;
-            cur_state.remote_state = AuthorizationState::Unauthorized;
-            return Ok(AuthorizationState::Unauthorized);
+        if action == AuthorizationLocalAction::Unauthorizing {
+            cur_state.local_state = AuthorizationLocalState::Unauthorized;
+            cur_state.remote_state = AuthorizationRemoteState::Unauthorized;
+            return Ok(AuthorizationLocalState::Unauthorized);
         }
 
         match cur_state.local_state.clone() {
-            AuthorizationState::Unknown => match action {
-                AuthorizationAction::Connecting => {
-                    if cur_state.local_state
-                        == AuthorizationState::TrustV0(TrustV0AuthorizationState::Connecting)
-                    {
-                        return Err(AuthorizationActionError::AlreadyConnecting);
-                    };
-                    cur_state.local_state =
-                        AuthorizationState::TrustV0(TrustV0AuthorizationState::Connecting);
-                    cur_state.remote_state = AuthorizationState::AuthComplete(None);
-                    Ok(AuthorizationState::TrustV0(
-                        TrustV0AuthorizationState::Connecting,
-                    ))
+            AuthorizationLocalState::Start => match action {
+                AuthorizationLocalAction::SendAuthProtocolRequest => {
+                    cur_state.local_state = AuthorizationLocalState::WaitingForAuthProtocolResponse;
+                    Ok(AuthorizationLocalState::WaitingForAuthProtocolResponse)
                 }
-                #[cfg(feature = "trust-authorization")]
-                AuthorizationAction::ProtocolAgreeing => {
-                    cur_state.local_state = AuthorizationState::ProtocolAgreeing;
-                    Ok(AuthorizationState::ProtocolAgreeing)
-                }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Unknown,
-                    action,
-                )),
-            },
-            AuthorizationState::TrustV0(state) => match action {
-                AuthorizationAction::TrustV0(action) => {
-                    let new_state = state.next_state(action)?;
-                    cur_state.local_state = new_state.clone();
-                    Ok(new_state)
-                }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::TrustV0(state),
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Start,
                     action,
                 )),
             },
             // v1 state transitions
-            #[cfg(feature = "trust-authorization")]
-            AuthorizationState::ProtocolAgreeing => match action {
-                AuthorizationAction::Trust(action) => {
-                    let new_state =
-                        TrustAuthorizationState::TrustConnecting.next_state(action, cur_state)?;
+            AuthorizationLocalState::WaitingForAuthProtocolResponse => match action {
+                AuthorizationLocalAction::ReceiveAuthProtocolResponse => {
+                    cur_state.local_state = AuthorizationLocalState::ReceivedAuthProtocolResponse;
+                    Ok(AuthorizationLocalState::ReceivedAuthProtocolResponse)
+                }
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Start,
+                    action,
+                )),
+            },
+            AuthorizationLocalState::ReceivedAuthProtocolResponse => match action {
+                #[cfg(feature = "trust-authorization")]
+                AuthorizationLocalAction::Trust(action) => {
+                    let new_state = TrustAuthorizationLocalState::TrustConnecting
+                        .next_local_state(action, cur_state)?;
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::ProtocolAgreeing,
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::WaitingForAuthProtocolResponse,
                     action,
                 )),
             },
             #[cfg(feature = "trust-authorization")]
-            AuthorizationState::Trust(state) => match action {
-                AuthorizationAction::Trust(action) => {
-                    let new_state = state.next_state(action, cur_state)?;
+            AuthorizationLocalState::Trust(state) => match action {
+                AuthorizationLocalAction::Trust(action) => {
+                    let new_state = state.next_local_state(action, cur_state)?;
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(state),
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Trust(state),
                     action,
                 )),
             },
-            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+            AuthorizationLocalState::Authorized => match action {
+                AuthorizationLocalAction::SendAuthComplete => {
+                    let new_state = if cur_state.received_complete {
+                        AuthorizationLocalState::AuthorizedAndComplete
+                    } else {
+                        AuthorizationLocalState::WaitForComplete
+                    };
+
+                    cur_state.local_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Authorized,
+                    action,
+                )),
+            },
+            _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
                 cur_state.local_state.clone(),
                 action,
             )),
@@ -214,12 +331,11 @@ impl AuthorizationManagerStateMachine {
     /// Errors
     ///
     /// The errors are error messages that should be returned on the appropriate message
-    #[cfg(feature = "trust-authorization")]
     pub(crate) fn next_remote_state(
         &self,
         connection_id: &str,
-        action: AuthorizationAction,
-    ) -> Result<AuthorizationState, AuthorizationActionError> {
+        action: AuthorizationRemoteAction,
+    ) -> Result<AuthorizationRemoteState, AuthorizationActionError> {
         let mut shared = self.shared.lock().map_err(|_| {
             AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
         })?;
@@ -229,56 +345,123 @@ impl AuthorizationManagerStateMachine {
                 .states
                 .entry(connection_id.to_string())
                 .or_insert(ManagedAuthorizationState {
-                    local_state: AuthorizationState::Unknown,
-                    remote_state: AuthorizationState::Unknown,
+                    local_state: AuthorizationLocalState::Start,
+                    remote_state: AuthorizationRemoteState::Start,
+                    received_complete: false,
                 });
 
-        if action == AuthorizationAction::Unauthorizing {
-            cur_state.local_state = AuthorizationState::Unauthorized;
-            cur_state.remote_state = AuthorizationState::Unauthorized;
-            return Ok(AuthorizationState::Unauthorized);
+        if action == AuthorizationRemoteAction::Unauthorizing {
+            cur_state.local_state = AuthorizationLocalState::Unauthorized;
+            cur_state.remote_state = AuthorizationRemoteState::Unauthorized;
+            return Ok(AuthorizationRemoteState::Unauthorized);
         }
 
         match cur_state.remote_state.clone() {
-            AuthorizationState::Unknown => match action {
-                AuthorizationAction::ProtocolAgreeing => {
-                    cur_state.remote_state = AuthorizationState::ProtocolAgreeing;
-                    Ok(AuthorizationState::ProtocolAgreeing)
+            AuthorizationRemoteState::Start => match action {
+                AuthorizationRemoteAction::Connecting => {
+                    if cur_state.remote_state
+                        == AuthorizationRemoteState::TrustV0(TrustV0AuthorizationState::Connecting)
+                    {
+                        return Err(AuthorizationActionError::AlreadyConnecting);
+                    };
+                    // this state is not used in trust v0 so send to finished
+                    cur_state.local_state = AuthorizationLocalState::AuthorizedAndComplete;
+                    cur_state.remote_state =
+                        AuthorizationRemoteState::TrustV0(TrustV0AuthorizationState::Connecting);
+                    Ok(AuthorizationRemoteState::TrustV0(
+                        TrustV0AuthorizationState::Connecting,
+                    ))
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Unknown,
-                    action,
-                )),
-            },
-            // v1 state transitions
-            AuthorizationState::ProtocolAgreeing => match action {
-                AuthorizationAction::Trust(action) => {
-                    let new_state = TrustAuthorizationState::TrustConnecting
-                        .next_remote_state(action, cur_state)?;
-                    cur_state.remote_state = new_state.clone();
-                    Ok(new_state)
+                #[cfg(feature = "trust-authorization")]
+                AuthorizationRemoteAction::ReceiveAuthProtocolRequest => {
+                    cur_state.remote_state = AuthorizationRemoteState::ReceivedAuthProtocolRequest;
+                    Ok(AuthorizationRemoteState::ReceivedAuthProtocolRequest)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::ProtocolAgreeing,
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Start,
                     action,
                 )),
             },
             #[cfg(feature = "trust-authorization")]
-            AuthorizationState::Trust(state) => match action {
-                AuthorizationAction::Trust(action) => {
+            AuthorizationRemoteState::ReceivedAuthProtocolRequest => match action {
+                AuthorizationRemoteAction::SendAuthProtocolResponse => {
+                    cur_state.remote_state = AuthorizationRemoteState::SentAuthProtocolResponse;
+                    Ok(AuthorizationRemoteState::SentAuthProtocolResponse)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Start,
+                    action,
+                )),
+            },
+            AuthorizationRemoteState::TrustV0(state) => match action {
+                AuthorizationRemoteAction::TrustV0(action) => {
+                    let new_state = state.next_local_state(action)?;
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::TrustV0(state),
+                    action,
+                )),
+            },
+            // v1 state transitions
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteState::SentAuthProtocolResponse => match action {
+                #[cfg(feature = "trust-authorization")]
+                AuthorizationRemoteAction::Trust(action) => {
+                    let new_state = TrustAuthorizationRemoteState::TrustConnecting
+                        .next_remote_state(action, cur_state)?;
+                    cur_state.remote_state = new_state.clone();
+                    Ok(new_state)
+                }
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::SentAuthProtocolResponse,
+                    action,
+                )),
+            },
+            #[cfg(feature = "trust-authorization")]
+            AuthorizationRemoteState::Trust(state) => match action {
+                AuthorizationRemoteAction::Trust(action) => {
                     let new_state = state.next_remote_state(action, cur_state)?;
                     cur_state.remote_state = new_state.clone();
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(state),
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Trust(state),
                     action,
                 )),
             },
-            _ => Err(AuthorizationActionError::InvalidMessageOrder(
+            _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
                 cur_state.remote_state.clone(),
                 action,
             )),
         }
+    }
+
+    #[cfg(feature = "trust-authorization")]
+    pub(crate) fn received_complete(
+        &self,
+        connection_id: &str,
+    ) -> Result<(), AuthorizationActionError> {
+        let mut shared = self.shared.lock().map_err(|_| {
+            AuthorizationActionError::InternalError("Authorization pool lock was poisoned".into())
+        })?;
+
+        let mut cur_state =
+            shared
+                .states
+                .entry(connection_id.to_string())
+                .or_insert(ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Start,
+                    remote_state: AuthorizationRemoteState::Start,
+                    received_complete: false,
+                });
+
+        cur_state.received_complete = true;
+
+        if cur_state.local_state == AuthorizationLocalState::WaitForComplete {
+            cur_state.local_state = AuthorizationLocalState::AuthorizedAndComplete;
+        }
+        Ok(())
     }
 }

--- a/libsplinter/src/network/auth/state_machine/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/mod.rs
@@ -24,12 +24,15 @@ use self::trust_v1::{TrustAuthorizationAction, TrustAuthorizationState};
 
 use super::{ManagedAuthorizationState, ManagedAuthorizations};
 
-type Identity = String;
+#[derive(Debug, PartialEq, Clone)]
+pub enum Identity {
+    Trust { identity: String },
+}
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum AuthorizationState {
     Unknown,
-    AuthComplete(Option<String>),
+    AuthComplete(Option<Identity>),
     Unauthorized,
 
     #[cfg(feature = "trust-authorization")]

--- a/libsplinter/src/network/auth/state_machine/trust_v0.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v0.rs
@@ -20,7 +20,7 @@ use super::{AuthorizationAction, AuthorizationActionError, AuthorizationState, I
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum TrustV0AuthorizationState {
     Connecting,
-    RemoteIdentified(String),
+    RemoteIdentified(Identity),
     RemoteAccepted,
 }
 

--- a/libsplinter/src/network/auth/state_machine/trust_v1.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v1.rs
@@ -21,8 +21,8 @@ use super::{AuthorizationAction, AuthorizationActionError, AuthorizationState, I
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum TrustAuthorizationState {
     TrustConnecting,
-    Identified(String),
-    Authorized(String),
+    Identified(Identity),
+    Authorized(Identity),
 }
 
 impl fmt::Display for TrustAuthorizationState {
@@ -83,11 +83,12 @@ impl TrustAuthorizationState {
                                 local_id,
                             )) => {
                                 cur_state.remote_state =
-                                    AuthorizationState::AuthComplete(Some(local_id.to_string()));
-                                AuthorizationState::AuthComplete(Some(identity.to_string()))
+                                    AuthorizationState::AuthComplete(Some(local_id.clone()));
+
+                                AuthorizationState::AuthComplete(Some(identity.clone()))
                             }
                             _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                identity.to_string(),
+                                identity.clone(),
                             )),
                         }
                     };
@@ -138,11 +139,11 @@ impl TrustAuthorizationState {
                                 local_id,
                             )) => {
                                 cur_state.local_state =
-                                    AuthorizationState::AuthComplete(Some(local_id.to_string()));
-                                AuthorizationState::AuthComplete(Some(identity.to_string()))
+                                    AuthorizationState::AuthComplete(Some(local_id.clone()));
+                                AuthorizationState::AuthComplete(Some(identity.clone()))
                             }
                             _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                identity.to_string(),
+                                identity.clone(),
                             )),
                         }
                     };

--- a/libsplinter/src/network/auth/state_machine/trust_v1.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v1.rs
@@ -16,98 +16,124 @@ use std::fmt;
 
 use crate::network::auth::ManagedAuthorizationState;
 
-use super::{AuthorizationAction, AuthorizationActionError, AuthorizationState, Identity};
+use super::{
+    AuthorizationActionError, AuthorizationLocalAction, AuthorizationLocalState,
+    AuthorizationRemoteAction, AuthorizationRemoteState, Identity,
+};
 
 #[derive(PartialEq, Debug, Clone)]
-pub(crate) enum TrustAuthorizationState {
+pub(crate) enum TrustAuthorizationLocalState {
     TrustConnecting,
-    Identified(Identity),
-    Authorized(Identity),
+    WaitingForAuthTrustResponse,
 }
 
-impl fmt::Display for TrustAuthorizationState {
+impl fmt::Display for TrustAuthorizationLocalState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
-            TrustAuthorizationState::TrustConnecting => "Connecting",
-            TrustAuthorizationState::Identified(_) => "Trust Identified",
-            TrustAuthorizationState::Authorized(_) => "Authorized",
+            TrustAuthorizationLocalState::TrustConnecting => "TrustConnecting",
+            TrustAuthorizationLocalState::WaitingForAuthTrustResponse => {
+                "WaitingForAuthTrustResponse"
+            }
+        })
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum TrustAuthorizationRemoteState {
+    TrustConnecting,
+    ReceivedAuthTrustRequest(Identity),
+}
+
+impl fmt::Display for TrustAuthorizationRemoteState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            TrustAuthorizationRemoteState::TrustConnecting => "TrustConnecting",
+            TrustAuthorizationRemoteState::ReceivedAuthTrustRequest(_) => "ReceiveAuthTrustRequest",
         })
     }
 }
 
 /// The state transitions that can be applied on a connection during authorization.
 #[derive(PartialEq, Debug)]
-pub(crate) enum TrustAuthorizationAction {
-    TrustIdentifying(Identity),
-    Authorizing,
+pub(crate) enum TrustAuthorizationRemoteAction {
+    ReceiveAuthTrustRequest(Identity),
+    SendAuthTrustResponse,
 }
 
-impl fmt::Display for TrustAuthorizationAction {
+impl fmt::Display for TrustAuthorizationRemoteAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TrustAuthorizationAction::TrustIdentifying(_) => f.write_str("TrustIdentifying"),
-            TrustAuthorizationAction::Authorizing => f.write_str("Authorizing"),
+            TrustAuthorizationRemoteAction::ReceiveAuthTrustRequest(_) => {
+                f.write_str("ReceiveAuthTrustRequest")
+            }
+            TrustAuthorizationRemoteAction::SendAuthTrustResponse => {
+                f.write_str("SendAuthTrustResponse")
+            }
         }
     }
 }
 
-impl TrustAuthorizationState {
+/// The state transitions that can be applied on a connection during authorization.
+#[derive(PartialEq, Debug)]
+pub(crate) enum TrustAuthorizationLocalAction {
+    SendAuthTrustRequest,
+    ReceiveAuthTrustResponse,
+}
+
+impl fmt::Display for TrustAuthorizationLocalAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TrustAuthorizationLocalAction::SendAuthTrustRequest => {
+                f.write_str("SendAuthTrustRequest")
+            }
+            TrustAuthorizationLocalAction::ReceiveAuthTrustResponse => {
+                f.write_str("ReceiveAuthTrustResponse")
+            }
+        }
+    }
+}
+
+impl TrustAuthorizationLocalState {
     /// Transitions from one authorization state to another
     ///
     /// Errors
     ///
     /// The errors are error messages that should be returned on the appropriate message
-    pub(crate) fn next_state(
+    pub(crate) fn next_local_state(
         &self,
-        action: TrustAuthorizationAction,
+        action: TrustAuthorizationLocalAction,
         cur_state: &mut ManagedAuthorizationState,
-    ) -> Result<AuthorizationState, AuthorizationActionError> {
+    ) -> Result<AuthorizationLocalState, AuthorizationActionError> {
         match &self {
-            TrustAuthorizationState::TrustConnecting => match action {
-                TrustAuthorizationAction::TrustIdentifying(identity) => {
-                    let new_state =
-                        AuthorizationState::Trust(TrustAuthorizationState::Identified(identity));
+            TrustAuthorizationLocalState::TrustConnecting => match action {
+                TrustAuthorizationLocalAction::SendAuthTrustRequest => {
+                    let new_state = AuthorizationLocalState::Trust(
+                        TrustAuthorizationLocalState::WaitingForAuthTrustResponse,
+                    );
                     cur_state.local_state = new_state.clone();
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(self.clone()),
-                    AuthorizationAction::Trust(action),
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Trust(self.clone()),
+                    AuthorizationLocalAction::Trust(action),
                 )),
             },
-            TrustAuthorizationState::Identified(identity) => match action {
-                TrustAuthorizationAction::Authorizing => {
-                    let new_state = {
-                        match &cur_state.remote_state {
-                            AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                local_id,
-                            )) => {
-                                cur_state.remote_state =
-                                    AuthorizationState::AuthComplete(Some(local_id.clone()));
-
-                                AuthorizationState::AuthComplete(Some(identity.clone()))
-                            }
-                            _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                identity.clone(),
-                            )),
-                        }
-                    };
-
+            TrustAuthorizationLocalState::WaitingForAuthTrustResponse => match action {
+                TrustAuthorizationLocalAction::ReceiveAuthTrustResponse => {
+                    let new_state = AuthorizationLocalState::Authorized;
                     cur_state.local_state = new_state.clone();
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(self.clone()),
-                    AuthorizationAction::Trust(action),
+                _ => Err(AuthorizationActionError::InvalidLocalMessageOrder(
+                    AuthorizationLocalState::Trust(self.clone()),
+                    AuthorizationLocalAction::Trust(action),
                 )),
             },
-            _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                AuthorizationState::Trust(self.clone()),
-                AuthorizationAction::Trust(action),
-            )),
         }
     }
+}
 
+impl TrustAuthorizationRemoteState {
     /// Transitions from one authorization state to another
     ///
     /// Errors
@@ -115,51 +141,33 @@ impl TrustAuthorizationState {
     /// The errors are error messages that should be returned on the appropriate message
     pub(crate) fn next_remote_state(
         &self,
-        action: TrustAuthorizationAction,
+        action: TrustAuthorizationRemoteAction,
         cur_state: &mut ManagedAuthorizationState,
-    ) -> Result<AuthorizationState, AuthorizationActionError> {
+    ) -> Result<AuthorizationRemoteState, AuthorizationActionError> {
         match &self {
-            TrustAuthorizationState::TrustConnecting => match action {
-                TrustAuthorizationAction::TrustIdentifying(identity) => {
-                    let new_state =
-                        AuthorizationState::Trust(TrustAuthorizationState::Identified(identity));
+            TrustAuthorizationRemoteState::TrustConnecting => match action {
+                TrustAuthorizationRemoteAction::ReceiveAuthTrustRequest(identity) => {
+                    let new_state = AuthorizationRemoteState::Trust(
+                        TrustAuthorizationRemoteState::ReceivedAuthTrustRequest(identity),
+                    );
                     cur_state.remote_state = new_state.clone();
                     Ok(new_state)
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(self.clone()),
-                    AuthorizationAction::Trust(action),
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Trust(self.clone()),
+                    AuthorizationRemoteAction::Trust(action),
                 )),
             },
-            TrustAuthorizationState::Identified(identity) => match action {
-                TrustAuthorizationAction::Authorizing => {
-                    let new_state = {
-                        match &cur_state.local_state {
-                            AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                local_id,
-                            )) => {
-                                cur_state.local_state =
-                                    AuthorizationState::AuthComplete(Some(local_id.clone()));
-                                AuthorizationState::AuthComplete(Some(identity.clone()))
-                            }
-                            _ => AuthorizationState::Trust(TrustAuthorizationState::Authorized(
-                                identity.clone(),
-                            )),
-                        }
-                    };
-
-                    cur_state.remote_state = new_state.clone();
-                    Ok(new_state)
+            TrustAuthorizationRemoteState::ReceivedAuthTrustRequest(identity) => match action {
+                TrustAuthorizationRemoteAction::SendAuthTrustResponse => {
+                    cur_state.remote_state = AuthorizationRemoteState::Done(identity.clone());
+                    Ok(AuthorizationRemoteState::Done(identity.clone()))
                 }
-                _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                    AuthorizationState::Trust(self.clone()),
-                    AuthorizationAction::Trust(action),
+                _ => Err(AuthorizationActionError::InvalidRemoteMessageOrder(
+                    AuthorizationRemoteState::Trust(self.clone()),
+                    AuthorizationRemoteAction::Trust(action),
                 )),
             },
-            _ => Err(AuthorizationActionError::InvalidMessageOrder(
-                AuthorizationState::Trust(self.clone()),
-                AuthorizationAction::Trust(action),
-            )),
         }
     }
 }

--- a/libsplinter/src/network/connection_manager/authorizers.rs
+++ b/libsplinter/src/network/connection_manager/authorizers.rs
@@ -21,12 +21,10 @@
 
 use std::collections::HashMap;
 
+use crate::network::auth::ConnectionAuthorizationType;
 use crate::transport::Connection;
 
-use super::{
-    AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
-    ConnectionAuthorizationType,
-};
+use super::{AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError};
 
 /// Authorize Inproc Connections with predefined identities.
 ///

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -30,6 +30,7 @@ pub use error::{AuthorizerError, ConnectionManagerError};
 pub use notification::ConnectionManagerNotification;
 
 use crate::error::InternalError;
+use crate::network::auth::ConnectionAuthorizationType;
 use crate::threading::lifecycle::ShutdownHandle;
 use crate::threading::pacemaker;
 use crate::transport::matrix::{ConnectionMatrixLifeCycle, ConnectionMatrixSender};
@@ -401,17 +402,6 @@ impl ShutdownHandle for ConnectionManager {
             ))
         })
     }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum ConnectionAuthorizationType {
-    Trust {
-        identity: String,
-    },
-    #[cfg(feature = "challenge-authorization")]
-    Challenge {
-        public_key: Vec<u8>,
-    },
 }
 
 /// Metadata describing a connection managed by the connection manager.

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::network::auth::ConnectionAuthorizationType;
+
 use super::error::ConnectionManagerError;
-use super::ConnectionAuthorizationType;
 
 /// Messages that will be dispatched to all subscription handlers
 #[derive(Debug, PartialEq, Clone)]

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -638,9 +638,9 @@ pub mod tests {
     use std::time::Duration;
 
     use crate::mesh::{Envelope, Mesh};
+    use crate::network::auth::ConnectionAuthorizationType;
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
-        ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
     };
     use crate::network::dispatch::{
         dispatch_channel, DispatchError, DispatchLoopBuilder, Dispatcher, Handler, MessageContext,

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1437,9 +1437,9 @@ pub mod tests {
     use protobuf::Message;
 
     use crate::mesh::Mesh;
+    use crate::network::auth::ConnectionAuthorizationType;
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
-        ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
     };
     use crate::protos::network::{NetworkMessage, NetworkMessageType};
     use crate::threading::lifecycle::ShutdownHandle;

--- a/libsplinter/src/peer/token.rs
+++ b/libsplinter/src/peer/token.rs
@@ -21,7 +21,7 @@ use std::fmt;
 
 #[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
-use crate::network::connection_manager::ConnectionAuthorizationType;
+use crate::network::auth::ConnectionAuthorizationType;
 
 /// The authorization type specific peer ID
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -429,9 +429,9 @@ pub mod tests {
     use std::collections::VecDeque;
 
     use crate::mesh::{Envelope, Mesh};
+    use crate::network::auth::ConnectionAuthorizationType;
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerError, ConnectionAuthorizationType,
-        ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
     };
     use crate::network::dispatch::{
         dispatch_channel, ConnectionId, DispatchError, DispatchLoopBuilder, Dispatcher, Handler,

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -23,9 +23,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
-use crate::network::connection_manager::{
-    ConnectionAuthorizationType, ConnectionManagerNotification, Connector,
-};
+use crate::network::auth::ConnectionAuthorizationType;
+use crate::network::connection_manager::{ConnectionManagerNotification, Connector};
 
 use self::error::ServiceConnectionAgentError;
 pub use self::error::ServiceConnectionError;
@@ -654,8 +653,7 @@ mod tests {
 
     use crate::mesh::Mesh;
     use crate::network::connection_manager::{
-        AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError,
-        ConnectionAuthorizationType, ConnectionManager,
+        AuthorizationResult, Authorizer, AuthorizerCallback, AuthorizerError, ConnectionManager,
     };
     use crate::threading::lifecycle::ShutdownHandle;
     use crate::transport::{inproc::InprocTransport, Connection, Transport};


### PR DESCRIPTION
Update the state machine to match the design described in the
challenge authorization design doc:

https://www.splinter.dev/community/planning/challenge_authorization.html

Note this commit is only for trust v1 and the related changes to keep
trust v0 working.

Challenge authorization will be added in a future commit.