### PR TITLE
Change allow_keys file test to look for blank file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
         then
           splinter admin keygen acme
         fi && \
-        if [ ! -f /etc/splinter/allow_keys ]
+        if [ ! -s /etc/splinter/allow_keys ]
         then
           echo $$(cat /acme.pub) > /etc/splinter/allow_keys
         fi && \

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -182,7 +182,7 @@ services:
           then
             splinter admin keygen acme -d /keys
           fi && \
-          if [ ! -f /etc/splinter/allow_keys ]
+          if [ ! -s /etc/splinter/allow_keys ]
           then
             echo $$(cat /keys/acme.pub) > /etc/splinter/allow_keys
           fi && \
@@ -308,7 +308,7 @@ services:
           then
             splinter admin keygen bubba -d /keys
           fi && \
-          if [ ! -f /etc/splinter/allow_keys ]
+          if [ ! -s /etc/splinter/allow_keys ]
           then
             echo $$(cat /keys/bubba.pub) > /etc/splinter/allow_keys
           fi && \

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
           then
             splinter admin keygen acme -d /keys
           fi && \
-          if [ ! -f /etc/splinter/allow_keys ]
+          if [ ! -s /etc/splinter/allow_keys ]
           then
             echo $$(cat /keys/acme.pub) > /etc/splinter/allow_keys
           fi && \
@@ -360,7 +360,7 @@ services:
           then
             splinter admin keygen bubba -d /keys
           fi && \
-          if [ ! -f /etc/splinter/allow_keys ]
+          if [ ! -s /etc/splinter/allow_keys ]
           then
             echo $$(cat /keys/bubba.pub) > /etc/splinter/allow_keys
           fi && \

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
         then
           splinter admin keygen cypress -d /keys
         fi && \
-        if [ ! -f /etc/splinter/allow_keys ]
+        if [ ! -s /etc/splinter/allow_keys ]
         then
           echo $$(cat /keys/cypress.pub) > /etc/splinter/allow_keys
         fi && \

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
     entrypoint: |
       bash -c "
         # Grant permissions to the Cylinder key used for authorization by the tests
-        if [ ! -f /etc/splinter/allow_keys ]
+        if [ ! -s /etc/splinter/allow_keys ]
         then
           echo "02091a06cc46c5e0d88e89284936edb16800b03b56a8f1b7ec292f232b7c8385a2" > /etc/splinter/allow_keys
         fi && \


### PR DESCRIPTION
As of commit b38c4c55, this file is created by the postinst scripts so testing
for nonexistence no longer works.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>