### PR TITLE
Fix Admin Service Tests for ChallengeAuthorization

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3473,6 +3473,7 @@ mod tests {
         circuit.set_members(protobuf::RepeatedField::from_vec(vec![
             splinter_node("test-node", &["inproc://someplace:8000".to_string()]),
             splinter_node("other-node", &["inproc://otherplace:8000".to_string()]),
+            splinter_node("my_peer_id", &["inproc://myplace:8000".to_string()]),
         ]));
         circuit.set_roster(protobuf::RepeatedField::from_vec(vec![
             splinter_service("0123", "sabre"),

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -5848,7 +5848,7 @@ mod tests {
 
         // Set `node_a` to peered
         shared
-            .on_peer_connected(&PeerAuthorizationToken::from_peer_id("other_a"))
+            .on_peer_connected(&PeerAuthorizationToken::from_peer_id("node_a"))
             .expect("Unable to set peer to peered");
 
         shared


### PR DESCRIPTION
Without these change the tests no longer passes after the changes required to support challenge authorization.