### PR TITLE
Node id store diesel implementation

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-06-30-154942_node_id_store/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-06-30-154942_node_id_store/down.sql
@@ -1,0 +1,16 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS node_id;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-06-30-154942_node_id_store/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-06-30-154942_node_id_store/up.sql
@@ -1,0 +1,18 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS node_id (
+    id TEXT PRIMARY KEY
+);

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-06-30-154942_node_id_store/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-06-30-154942_node_id_store/down.sql
@@ -1,0 +1,16 @@
+---- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS node_id;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2021-06-30-154942_node_id_store/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2021-06-30-154942_node_id_store/up.sql
@@ -1,0 +1,18 @@
+---- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS node_id (
+    id TEXT PRIMARY KEY
+);

--- a/libsplinter/src/node_id/store/diesel/mod.rs
+++ b/libsplinter/src/node_id/store/diesel/mod.rs
@@ -1,0 +1,64 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Diesel based NodeIdStore
+
+mod models;
+mod operations;
+mod schema;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use super::error::NodeIdStoreError;
+use super::NodeIdStore;
+
+use models::NodeID;
+use operations::{
+    get_node_id::NodeIdGetOperation, set_node_id::NodeIdSetOperation, NodeIdOperations,
+};
+
+/// Database backed NodeIdStore implementation
+pub struct DieselNodeIdStore<Conn: diesel::Connection + 'static> {
+    pool: Pool<ConnectionManager<Conn>>,
+}
+
+impl<C: diesel::Connection> DieselNodeIdStore<C> {
+    /// Constructs new DieselNodeIdStore
+    ///
+    /// # Arguments
+    ///
+    /// * `pool` - Database connection pool
+    pub fn new(pool: Pool<ConnectionManager<C>>) -> Self {
+        Self { pool }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl NodeIdStore for DieselNodeIdStore<diesel::pg::PgConnection> {
+    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError> {
+        NodeIdOperations::new(&*self.pool.get()?).get_node_id()
+    }
+    fn set_node_id(&self, new_id: String) -> Result<(), NodeIdStoreError> {
+        NodeIdOperations::new(&*self.pool.get()?).set_node_id(new_id)
+    }
+}
+#[cfg(feature = "sqlite")]
+impl NodeIdStore for DieselNodeIdStore<diesel::sqlite::SqliteConnection> {
+    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError> {
+        NodeIdOperations::new(&*self.pool.get()?).get_node_id()
+    }
+    fn set_node_id(&self, new_id: String) -> Result<(), NodeIdStoreError> {
+        NodeIdOperations::new(&*self.pool.get()?).set_node_id(new_id)
+    }
+}

--- a/libsplinter/src/node_id/store/diesel/models.rs
+++ b/libsplinter/src/node_id/store/diesel/models.rs
@@ -12,22 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "diesel")]
-pub mod diesel;
-/// NodeIdStore error types
-pub mod error;
+use diesel::{Insertable, Queryable};
 
-use error::NodeIdStoreError;
+use super::schema::node_id;
 
-/// Trait for interacting with the instances node_id.
-pub trait NodeIdStore {
-    /// Gets node_id for the instance
-    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError>;
-
-    /// Sets node_id for the instance
-    ///
-    /// # Arguments
-    ///
-    /// * `node_id` - the desired node_id
-    fn set_node_id(&self, node_id: String) -> Result<(), NodeIdStoreError>;
+#[derive(Queryable, Insertable)]
+#[table_name = "node_id"]
+pub struct NodeID {
+    pub id: String,
 }

--- a/libsplinter/src/node_id/store/diesel/operations/get_node_id.rs
+++ b/libsplinter/src/node_id/store/diesel/operations/get_node_id.rs
@@ -1,0 +1,39 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::prelude::*;
+
+use crate::node_id::store::{diesel::NodeID, NodeIdStoreError};
+
+use super::NodeIdOperations;
+
+pub trait NodeIdGetOperation {
+    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError>;
+}
+
+impl<'a, C> NodeIdGetOperation for NodeIdOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError> {
+        use crate::node_id::store::diesel::schema::node_id::dsl::*;
+        let result = node_id.first::<NodeID>(self.connection);
+        match result {
+            Ok(s) => Ok(Some(s.id)),
+            Err(diesel::result::Error::NotFound) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/libsplinter/src/node_id/store/diesel/operations/mod.rs
+++ b/libsplinter/src/node_id/store/diesel/operations/mod.rs
@@ -12,22 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "diesel")]
-pub mod diesel;
-/// NodeIdStore error types
-pub mod error;
+//! Provides NodeIdStore Operations to NodeIdStore implementors
 
-use error::NodeIdStoreError;
+pub(super) mod get_node_id;
+pub(super) mod set_node_id;
 
-/// Trait for interacting with the instances node_id.
-pub trait NodeIdStore {
-    /// Gets node_id for the instance
-    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError>;
+pub struct NodeIdOperations<'a, C> {
+    connection: &'a C,
+}
 
-    /// Sets node_id for the instance
+impl<'a, C> NodeIdOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    /// Constructs new NodeIdOperations struct
     ///
     /// # Arguments
     ///
-    /// * `node_id` - the desired node_id
-    fn set_node_id(&self, node_id: String) -> Result<(), NodeIdStoreError>;
+    ///  * 'connection' - Database connection
+    pub fn new(connection: &'a C) -> Self {
+        Self { connection }
+    }
 }

--- a/libsplinter/src/node_id/store/diesel/operations/set_node_id.rs
+++ b/libsplinter/src/node_id/store/diesel/operations/set_node_id.rs
@@ -1,0 +1,64 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::insert_into;
+use diesel::prelude::*;
+
+use crate::node_id::store::{diesel::NodeID, NodeIdStoreError};
+
+use super::{get_node_id::NodeIdGetOperation, NodeIdOperations};
+
+pub trait NodeIdSetOperation {
+    fn set_node_id(&self, new_id: String) -> Result<(), NodeIdStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> NodeIdSetOperation for NodeIdOperations<'a, diesel::sqlite::SqliteConnection> {
+    fn set_node_id(&self, new_id: String) -> Result<(), NodeIdStoreError> {
+        use super::super::schema::node_id::dsl::*;
+        self.connection.transaction(|| match self.get_node_id() {
+            Ok(Some(db_id)) => diesel::update(node_id.find(db_id))
+                .set(id.eq(new_id))
+                .execute(self.connection)
+                .map(|_| ())
+                .map_err(|e| e.into()),
+            Ok(None) => insert_into(node_id)
+                .values(NodeID { id: new_id })
+                .execute(self.connection)
+                .map(|_| ())
+                .map_err(|e| e.into()),
+            Err(e) => Err(e),
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> NodeIdSetOperation for NodeIdOperations<'a, diesel::pg::PgConnection> {
+    fn set_node_id(&self, new_id: String) -> Result<(), NodeIdStoreError> {
+        use super::super::schema::node_id::dsl::*;
+        self.connection.transaction(|| match self.get_node_id() {
+            Ok(Some(db_id)) => diesel::update(node_id.find(db_id))
+                .set(id.eq(new_id))
+                .execute(self.connection)
+                .map(|_| ())
+                .map_err(|e| e.into()),
+            Ok(None) => insert_into(node_id)
+                .values(NodeID { id: new_id })
+                .execute(self.connection)
+                .map(|_| ())
+                .map_err(|e| e.into()),
+            Err(e) => Err(e),
+        })
+    }
+}

--- a/libsplinter/src/node_id/store/diesel/schema.rs
+++ b/libsplinter/src/node_id/store/diesel/schema.rs
@@ -12,22 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "diesel")]
-pub mod diesel;
-/// NodeIdStore error types
-pub mod error;
-
-use error::NodeIdStoreError;
-
-/// Trait for interacting with the instances node_id.
-pub trait NodeIdStore {
-    /// Gets node_id for the instance
-    fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError>;
-
-    /// Sets node_id for the instance
-    ///
-    /// # Arguments
-    ///
-    /// * `node_id` - the desired node_id
-    fn set_node_id(&self, node_id: String) -> Result<(), NodeIdStoreError>;
+table! {
+    node_id {
+        id -> Text,
+    }
 }

--- a/libsplinter/src/store/memory.rs
+++ b/libsplinter/src/store/memory.rs
@@ -157,4 +157,11 @@ impl StoreFactory for MemoryStoreFactory {
     fn get_biome_user_profile_store(&self) -> Box<dyn UserProfileStore> {
         Box::new(self.biome_profile_store.clone())
     }
+
+    #[cfg(feature = "node-id-store")]
+    fn get_node_id_store(&self) -> Box<dyn crate::node_id::store::NodeIdStore> {
+        Box::new(crate::node_id::store::diesel::DieselNodeIdStore::new(
+            self.pool.clone(),
+        ))
+    }
 }

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -68,6 +68,9 @@ pub trait StoreFactory {
 
     #[cfg(feature = "biome-profile")]
     fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore>;
+
+    #[cfg(feature = "node-id-store")]
+    fn get_node_id_store(&self) -> Box<dyn crate::node_id::store::NodeIdStore>;
 }
 
 /// Creates a `StoreFactory` backed by the given connection

--- a/libsplinter/src/store/postgres.rs
+++ b/libsplinter/src/store/postgres.rs
@@ -94,4 +94,10 @@ impl StoreFactory for PgStoreFactory {
     fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore> {
         Box::new(crate::biome::DieselUserProfileStore::new(self.pool.clone()))
     }
+    #[cfg(feature = "node-id-store")]
+    fn get_node_id_store(&self) -> Box<dyn crate::node_id::store::NodeIdStore> {
+        Box::new(crate::node_id::store::diesel::DieselNodeIdStore::new(
+            self.pool.clone(),
+        ))
+    }
 }

--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -96,6 +96,13 @@ impl StoreFactory for SqliteStoreFactory {
     fn get_biome_user_profile_store(&self) -> Box<dyn crate::biome::UserProfileStore> {
         Box::new(crate::biome::DieselUserProfileStore::new(self.pool.clone()))
     }
+
+    #[cfg(feature = "node-id-store")]
+    fn get_node_id_store(&self) -> Box<dyn crate::node_id::store::NodeIdStore> {
+        Box::new(crate::node_id::store::diesel::DieselNodeIdStore::new(
+            self.pool.clone(),
+        ))
+    }
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
Moving node_ids into the database requires that there be somewhere to put them and methods to get and set it once in the db.