### PR TITLE
Enforce key set in circuit is supported locally

### DIFF
--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -271,6 +271,23 @@ impl AdminService {
                     ServiceStartError::Internal("Circuit does not have the local node".to_string())
                 })?;
 
+            let is_local = self
+                .admin_service_shared
+                .lock()
+                .map_err(|_| {
+                    ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
+                })?
+                .is_local_node(&local_required_auth);
+
+            if !is_local {
+                return Err(ServiceStartError::Internal(format!(
+                    "Circuit {} contains unsupported token for \
+                    local node: {}",
+                    circuit.circuit_id(),
+                    local_required_auth
+                )));
+            }
+
             let members = circuit.list_nodes().map_err(|err| {
                 ServiceStartError::Internal(format!(
                     "Unable to get peer tokens for members: {}",
@@ -447,6 +464,23 @@ impl AdminService {
                 .ok_or_else(|| {
                     ServiceStartError::Internal("Circuit does not have the local node".to_string())
                 })?;
+
+            let is_local = self
+                .admin_service_shared
+                .lock()
+                .map_err(|_| {
+                    ServiceStartError::PoisonedLock("the admin shared lock was poisoned".into())
+                })?
+                .is_local_node(&local_required_auth);
+
+            if !is_local {
+                return Err(ServiceStartError::Internal(format!(
+                    "Proposal {} contains unsupported token for \
+                    local node: {}",
+                    proposal.circuit_id(),
+                    local_required_auth
+                )));
+            }
 
             let members = proposal.circuit().list_nodes().map_err(|err| {
                 ServiceStartError::Internal(format!(

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -961,6 +961,15 @@ impl AdminServiceShared {
                 )))
             })?;
 
+        if !self.is_local_node(&local_required_auth) {
+            return Err(ServiceError::UnableToHandleMessage(Box::new(
+                AdminSharedError::ValidationFailed(format!(
+                    "Circuit contains unsupported token for local node: {}",
+                    local_required_auth
+                )),
+            )));
+        }
+
         let members = proposed_circuit.list_nodes().map_err(|err| {
             ServiceError::UnableToHandleMessage(Box::new(AdminSharedError::ValidationFailed(
                 format!("Unable to get peer tokens for members: {}", err),
@@ -1647,6 +1656,15 @@ impl AdminServiceShared {
                         ),
                     ))
                 })?;
+
+            if !self.is_local_node(&local_required_auth) {
+                return Err(ServiceError::UnableToHandleMessage(Box::new(
+                    AdminSharedError::ValidationFailed(format!(
+                        "Circuit contains unsupported token for local node: {}",
+                        local_required_auth
+                    )),
+                )));
+            }
 
             let peer_members = store_proposed_circuit.list_nodes().map_err(|err| {
                 ServiceError::UnableToHandleMessage(Box::new(AdminSharedError::ValidationFailed(


### PR DESCRIPTION
This commit enforces that existing circuits/proposals
and new proposals have the local nodes public key
configured correctly if using challenge authorization.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>