### PR TITLE
Add unit test for trust v1 and challenge v1 message handlers

### DIFF
--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -1220,3 +1220,1397 @@ fn send_authorization_error(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use cylinder::{
+        secp256k1::Secp256k1Context, Context, PublicKey, Signature, VerificationError, Verifier,
+    };
+    use protobuf::Message;
+
+    #[cfg(feature = "challenge-authorization")]
+    use crate::network::auth::state_machine::challenge_v1::ChallengeAuthorizationLocalState;
+    #[cfg(feature = "trust-authorization")]
+    use crate::network::auth::state_machine::trust_v1::TrustAuthorizationLocalState;
+    use crate::network::auth::AuthorizationDispatchBuilder;
+    use crate::network::auth::ManagedAuthorizationState;
+    use crate::protos::network::NetworkMessageType;
+    use crate::protos::{authorization, network};
+
+    /// Test that an auth protocol request is properly handled via the dispatcher when no
+    /// required authorization types are set
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send an AuthProtocolResponse with both trust and challenge
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn protocol_request_dispatch_no_required_auth() {
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr)
+            .expect("Unable to build authorization dispatcher");
+
+        let connection_id = "test_connection".to_string();
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthProtocolRequest(AuthProtocolRequest {
+                auth_protocol_min: 1,
+                auth_protocol_max: 1,
+            }),
+        )
+        .expect("Unable to get message bytes for auth protocol request");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let auth_protocol_response: authorization::AuthProtocolResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_PROTOCOL_RESPONSE,
+            &message_bytes,
+        );
+        assert_eq!(1, auth_protocol_response.get_auth_protocol());
+
+        assert_eq!(
+            vec![
+                authorization::AuthProtocolResponse_PeerAuthorizationType::TRUST,
+                #[cfg(feature = "challenge-authorization")]
+                authorization::AuthProtocolResponse_PeerAuthorizationType::CHALLENGE
+            ],
+            auth_protocol_response
+                .get_accepted_authorization_type()
+                .to_vec()
+        );
+    }
+
+    /// Test that an auth protocol request is properly handled via the dispatcher when challenge
+    /// is set as required authorization types
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send an AuthProtocolResponse with only challenge
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn protocol_request_dispatch_challenge_required_auth() {
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    new_signer()
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr)
+            .expect("Unable to build authorization dispatcher");
+
+        let connection_id = "test_connection".to_string();
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthProtocolRequest(AuthProtocolRequest {
+                auth_protocol_min: 1,
+                auth_protocol_max: 1,
+            }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let auth_protocol_response: authorization::AuthProtocolResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_PROTOCOL_RESPONSE,
+            &message_bytes,
+        );
+        assert_eq!(1, auth_protocol_response.get_auth_protocol());
+
+        assert_eq!(
+            vec![authorization::AuthProtocolResponse_PeerAuthorizationType::CHALLENGE],
+            auth_protocol_response
+                .get_accepted_authorization_type()
+                .to_vec()
+        );
+    }
+
+    /// Test that an auth protocol response is properly handled via the dispatcher when trust is
+    /// is set as the accepted authorization type.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send an AuthTrustRequest with the provided identity
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn protocol_response_trust() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::WaitingForAuthProtocolResponse,
+                    remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr)
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthProtocolResponse(AuthProtocolResponse {
+                auth_protocol: 1,
+                accepted_authorization_type: vec![PeerAuthorizationType::Trust],
+            }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let trust_request: authorization::AuthTrustRequest = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_TRUST_REQUEST,
+            &message_bytes,
+        );
+        assert_eq!("mock_identity", trust_request.get_identity());
+    }
+
+    /// Test that a trust request is properly handled. Also verify end state is set to
+    /// WaitingForAuthTrustResponse and Done.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send AuthTrustResponse Message
+    /// 3) verify the states are set to WaitingForAuthTrustResponse and Done(identity)
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn trust_request() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Trust(
+                        TrustAuthorizationLocalState::WaitingForAuthTrustResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthTrustRequest(AuthTrustRequest {
+                identity: "other_identity".to_string(),
+            }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _trust_response: authorization::AuthTrustResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_TRUST_RESPONSE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::Trust(
+                TrustAuthorizationLocalState::WaitingForAuthTrustResponse
+            )
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Trust {
+                identity: "other_identity".to_string()
+            })
+        );
+        assert_eq!(managed_state.received_complete, false);
+    }
+
+    /// Test that a trust response is properly handled. Also verify end state is set to
+    /// WaitForComplete because received_complete is set to false
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send AuthComplete Message
+    /// 3) verify that because auth complete has not been received, the states are set to
+    ///    WaitingForComplete and Done(identity)
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn trust_response() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Trust(
+                        TrustAuthorizationLocalState::WaitingForAuthTrustResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Done(Identity::Trust {
+                        identity: "other_identity".to_string(),
+                    }),
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthTrustResponse(AuthTrustResponse),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _trust_response: authorization::AuthComplete = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_COMPLETE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::WaitForComplete,
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Trust {
+                identity: "other_identity".to_string()
+            })
+        );
+        assert_eq!(managed_state.received_complete, false);
+    }
+
+    /// Test that a trust response is properly handled. Also verify end state is set to
+    /// AuthorizedAndComplete because received_complete is set to true
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send AuthComplete Message
+    /// 3) verify that because auth complete has  been received, the states are set to
+    ///    AuthorizedAndComplete and Done(identity)
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn trust_response_complete() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Trust(
+                        TrustAuthorizationLocalState::WaitingForAuthTrustResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Done(Identity::Trust {
+                        identity: "other_identity".to_string(),
+                    }),
+                    received_complete: true,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthTrustResponse(AuthTrustResponse),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _trust_response: authorization::AuthComplete = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_COMPLETE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::AuthorizedAndComplete,
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Trust {
+                identity: "other_identity".to_string()
+            })
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    /// Test that a protocol response is properly handled when only challenge is in
+    /// accepted_authorization_type
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send AuthChallengeNonceRequest
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn protocol_response_challenge() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::WaitingForAuthProtocolResponse,
+                    remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
+                    received_complete: true,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let other_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthProtocolResponse(AuthProtocolResponse {
+                auth_protocol: 1,
+                accepted_authorization_type: vec![PeerAuthorizationType::Challenge],
+            }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _nonce_request: authorization::AuthChallengeNonceRequest = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_CHALLENGE_NONCE_REQUEST,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::Challenge(
+                ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse
+            ),
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::SentAuthProtocolResponse
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    /// Test that an AuthChallengeNonceRequest is properly handled.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send AuthChallengeNonceResponse with the expected nonce
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn auth_challenge_nonce_request() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
+                    received_complete: true,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let other_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthChallengeNonceRequest(AuthChallengeNonceRequest),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let nonce_response: authorization::AuthChallengeNonceResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_CHALLENGE_NONCE_RESPONSE,
+            &message_bytes,
+        );
+
+        assert_eq!(&nonce, nonce_response.get_nonce());
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::Challenge(
+                ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse
+            ),
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Challenge(
+                ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest
+            )
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    /// Test that an AuthChallengeNonceResponse is properly handled.
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send a AuthChallengeSubmitRequest
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn auth_challenge_nonce_response() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeNonceResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Challenge(
+                        ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest,
+                    ),
+                    received_complete: true,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let other_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthChallengeNonceResponse(AuthChallengeNonceResponse { nonce }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let submit_requests: authorization::AuthChallengeSubmitRequest = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_CHALLENGE_SUBMIT_REQUEST,
+            &message_bytes,
+        );
+
+        assert_eq!(1, submit_requests.get_submit_requests().len());
+
+        let submit_request = submit_requests
+            .get_submit_requests()
+            .get(0)
+            .expect("Unable to get submit request");
+
+        assert_eq!(
+            local_signer
+                .public_key()
+                .expect("unable to get public key")
+                .as_slice(),
+            submit_request.get_public_key()
+        );
+
+        assert!(!submit_request.get_signature().is_empty());
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::Challenge(
+                ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse
+            ),
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Challenge(
+                ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest
+            )
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    /// Test that an AuthChallengeSubmitRequest is properly handled.
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send a AuthChallengeSubmitResponse
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn auth_challenge_submit_request() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Challenge(
+                        ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest,
+                    ),
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let other_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthChallengeSubmitRequest(AuthChallengeSubmitRequest {
+                submit_requests: vec![SubmitRequest {
+                    public_key: other_signer
+                        .public_key()
+                        .expect("Unable to get public key")
+                        .into_bytes(),
+                    signature: other_signer
+                        .sign(&nonce)
+                        .expect("Unable to sign nonce")
+                        .take_bytes(),
+                }],
+            }),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _submit_response: authorization::AuthChallengeSubmitResponse = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_CHALLENGE_SUBMIT_RESPONSE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::Challenge(
+                ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse
+            ),
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("Unable to get public key")
+                        .into_bytes()
+                ),
+            })
+        );
+        assert_eq!(managed_state.received_complete, false);
+    }
+
+    /// Test that an AuthChallengeSubmitResponse is properly handled. Also verify state is set to
+    /// WaitForComplete because received_complete is false
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send a AuthComplete
+    /// 3) verify state is WaitForComplete and Done(Identity)
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn auth_challenge_submit_response() {
+        let connection_id = "test_connection".to_string();
+        let other_signer = new_signer();
+        // need to setup expected authorization state
+        let public_key = public_key::PublicKey::from_bytes(
+            other_signer
+                .public_key()
+                .expect("unable to get public key")
+                .into_bytes(),
+        );
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Done(Identity::Challenge {
+                        public_key: public_key.clone(),
+                    }),
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _auth_complete: authorization::AuthComplete = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_COMPLETE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::WaitForComplete
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Challenge { public_key })
+        );
+        assert_eq!(managed_state.received_complete, false);
+    }
+
+    /// Test that an AuthChallengeSubmitResponse is properly handled. Also verify state is set to
+    /// AuthorizedAndComplete because received_complete is true
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send a AuthComplete
+    /// 3) verify state is AuthorizedAndComplete and Done(Identity)
+    #[test]
+    #[cfg(feature = "challenge-authorization")]
+    fn auth_challenge_submit_response_complete() {
+        let connection_id = "test_connection".to_string();
+        let other_signer = new_signer();
+        // need to setup expected authorization state
+        let public_key = public_key::PublicKey::from_bytes(
+            other_signer
+                .public_key()
+                .expect("unable to get public key")
+                .into_bytes(),
+        );
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::Challenge(
+                        ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse,
+                    ),
+                    remote_state: AuthorizationRemoteState::Done(Identity::Challenge {
+                        public_key: public_key.clone(),
+                    }),
+                    received_complete: true,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        let local_signer = new_signer();
+        let nonce: Vec<u8> = (0..70).map(|_| rand::random::<u8>()).collect();
+        let dispatcher = AuthorizationDispatchBuilder::new()
+            .with_identity("mock_identity")
+            .with_signers(&[local_signer.clone()])
+            .with_nonce(&nonce)
+            .with_expected_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    other_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_local_authorization(Some(ConnectionAuthorizationType::Challenge {
+                public_key: public_key::PublicKey::from_bytes(
+                    local_signer
+                        .public_key()
+                        .expect("unable to get public key")
+                        .into_bytes(),
+                ),
+            }))
+            .with_verifier(Box::new(NoopVerifier))
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        let (recipient, message_bytes) = mock_sender
+            .next_outbound()
+            .expect("Unable to receive message over the network");
+        let recipient: String = recipient.into();
+        assert_eq!(&connection_id, &recipient);
+
+        let _auth_complete: authorization::AuthComplete = expect_auth_message(
+            authorization::AuthorizationMessageType::AUTH_COMPLETE,
+            &message_bytes,
+        );
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::AuthorizedAndComplete,
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Challenge { public_key })
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    /// Test that an AuthComplete is properly handled. Also verify state is set to
+    /// AuthorizedAndComplete
+    ///
+    /// This is verified by:
+    ///
+    /// 1) no error from the dispatcher
+    /// 2) the handler should send a AuthComplete
+    /// 3) verify state is AuthorizedAndComplete and Done(Identity)
+    #[test]
+    #[cfg(feature = "trust-authorization")]
+    fn auth_complete() {
+        let connection_id = "test_connection".to_string();
+        // need to setup expected authorization state
+        let auth_mgr = AuthorizationManagerStateMachine::default();
+        auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .insert(
+                connection_id.to_string(),
+                ManagedAuthorizationState {
+                    local_state: AuthorizationLocalState::WaitForComplete,
+                    remote_state: AuthorizationRemoteState::Done(Identity::Trust {
+                        identity: "other_identity".to_string(),
+                    }),
+                    received_complete: false,
+                },
+            );
+        let mock_sender = MockSender::new();
+        let dispatch_sender = mock_sender.clone();
+        // mut is required if chalenge authorization is enabled
+        #[allow(unused_mut)]
+        let mut dispatcher_builder =
+            AuthorizationDispatchBuilder::new().with_identity("mock_identity");
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            dispatcher_builder = dispatcher_builder
+                .with_signers(&[new_signer()])
+                .with_nonce(&vec![])
+                .with_expected_authorization(None)
+                .with_local_authorization(None)
+                .with_verifier(Box::new(NoopVerifier))
+        }
+
+        let dispatcher = dispatcher_builder
+            .build(dispatch_sender, auth_mgr.clone())
+            .expect("Unable to build authorization dispatcher");
+
+        let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
+            AuthorizationMessage::AuthComplete(AuthComplete),
+        )
+        .expect("Unable to get message bytes");
+
+        assert_eq!(
+            Ok(()),
+            dispatcher.dispatch(
+                connection_id.clone().into(),
+                &NetworkMessageType::AUTHORIZATION,
+                msg_bytes
+            )
+        );
+
+        assert_eq!(mock_sender.next_outbound(), None);
+
+        let managed_state = auth_mgr
+            .shared
+            .lock()
+            .expect("lock poisoned")
+            .states
+            .get(&connection_id)
+            .cloned()
+            .expect("missing managed state for connection id");
+
+        assert_eq!(
+            managed_state.local_state,
+            AuthorizationLocalState::AuthorizedAndComplete,
+        );
+        assert_eq!(
+            managed_state.remote_state,
+            AuthorizationRemoteState::Done(Identity::Trust {
+                identity: "other_identity".to_string()
+            })
+        );
+        assert_eq!(managed_state.received_complete, true);
+    }
+
+    fn expect_auth_message<M: protobuf::Message>(
+        message_type: authorization::AuthorizationMessageType,
+        msg_bytes: &[u8],
+    ) -> M {
+        let network_msg: network::NetworkMessage =
+            Message::parse_from_bytes(msg_bytes).expect("Unable to parse network message");
+        assert_eq!(NetworkMessageType::AUTHORIZATION, network_msg.message_type);
+
+        let auth_msg: authorization::AuthorizationMessage =
+            Message::parse_from_bytes(network_msg.get_payload())
+                .expect("Unable to parse auth message");
+
+        assert_eq!(message_type, auth_msg.message_type);
+
+        match Message::parse_from_bytes(auth_msg.get_payload()) {
+            Ok(msg) => msg,
+            Err(err) => panic!(
+                "unable to parse message for type {:?}: {:?}",
+                message_type, err
+            ),
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockSender {
+        outbound: Arc<Mutex<VecDeque<(ConnectionId, Vec<u8>)>>>,
+    }
+
+    impl MockSender {
+        fn new() -> Self {
+            Self {
+                outbound: Arc::new(Mutex::new(VecDeque::new())),
+            }
+        }
+
+        fn next_outbound(&self) -> Option<(ConnectionId, Vec<u8>)> {
+            self.outbound.lock().expect("lock was poisoned").pop_front()
+        }
+    }
+
+    impl MessageSender<ConnectionId> for MockSender {
+        fn send(&self, id: ConnectionId, message: Vec<u8>) -> Result<(), (ConnectionId, Vec<u8>)> {
+            self.outbound
+                .lock()
+                .expect("lock was poisoned")
+                .push_back((id, message));
+
+            Ok(())
+        }
+    }
+
+    struct NoopVerifier;
+
+    impl Verifier for NoopVerifier {
+        fn algorithm_name(&self) -> &str {
+            unimplemented!()
+        }
+
+        fn verify(
+            &self,
+            _message: &[u8],
+            _signature: &Signature,
+            _public_key: &PublicKey,
+        ) -> Result<bool, VerificationError> {
+            Ok(true)
+        }
+    }
+
+    fn new_signer() -> Box<dyn Signer> {
+        let context = Secp256k1Context::new();
+        let key = context.new_random_private_key();
+        context.new_signer(key)
+    }
+}

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -383,34 +383,6 @@ impl Handler for AuthProtocolResponseHandler {
                         }
                     }
                     _ => {
-                        #[cfg(feature = "challenge-authorization")]
-                        if protocol_request
-                            .accepted_authorization_type
-                            .iter()
-                            .any(|t| matches!(t, PeerAuthorizationType::Challenge))
-                        {
-                            let nonce_request = AuthorizationMessage::AuthChallengeNonceRequest(
-                                AuthChallengeNonceRequest,
-                            );
-
-                            let action = AuthorizationLocalAction::Challenge(
-                                ChallengeAuthorizationLocalAction::SendAuthChallengeNonceRequest,
-                            );
-                            if self
-                                .auth_manager
-                                .next_local_state(context.source_connection_id(), action)
-                                .is_err()
-                            {
-                                error!(
-                                    "Unable to transition from ReceivedAuthProtocolResponse to \
-                                    WaitingForAuthChallengeNonceResponse"
-                                )
-                            };
-
-                            msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
-                                NetworkMessage::from(nonce_request),
-                            )?;
-                        }
                         #[cfg(feature = "trust-authorization")]
                         if protocol_request
                             .accepted_authorization_type
@@ -440,6 +412,35 @@ impl Handler for AuthProtocolResponseHandler {
 
                             msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
                                 NetworkMessage::from(trust_request),
+                            )?;
+                        }
+
+                        #[cfg(feature = "challenge-authorization")]
+                        if protocol_request
+                            .accepted_authorization_type
+                            .iter()
+                            .any(|t| matches!(t, PeerAuthorizationType::Challenge))
+                        {
+                            let nonce_request = AuthorizationMessage::AuthChallengeNonceRequest(
+                                AuthChallengeNonceRequest,
+                            );
+
+                            let action = AuthorizationLocalAction::Challenge(
+                                ChallengeAuthorizationLocalAction::SendAuthChallengeNonceRequest,
+                            );
+                            if self
+                                .auth_manager
+                                .next_local_state(context.source_connection_id(), action)
+                                .is_err()
+                            {
+                                error!(
+                                    "Unable to transition from ReceivedAuthProtocolResponse to \
+                                    WaitingForAuthChallengeNonceResponse"
+                                )
+                            };
+
+                            msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
+                                NetworkMessage::from(nonce_request),
                             )?;
                         }
 


### PR DESCRIPTION
Also includes a fix for a bug that would result in Trust being used when Challenge should be the default