### PR TITLE
Fix identity comparison in Peer Manger to decide between inbound/outboud connections

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1932,12 +1932,16 @@ impl AdminServiceShared {
             return Ok(());
         }
 
-        let peer_node_pair = self.token_to_peer.get(peer_id).ok_or_else(|| {
-            AdminSharedError::ServiceProtocolError(format!(
-                "Missing service information for peer token : {}",
-                peer_id
-            ))
-        })?;
+        let peer_node_pair = match self.token_to_peer.get(peer_id) {
+            Some(peer_node_pair) => peer_node_pair,
+            None => {
+                warn!(
+                    "Ignoring connection; missing service information for peer token: {}",
+                    peer_id
+                );
+                return Ok(());
+            }
+        };
 
         // We have already received a service protocol request, don't sent another request
         if self

--- a/libsplinter/src/network/auth/handlers/builder.rs
+++ b/libsplinter/src/network/auth/handlers/builder.rs
@@ -187,6 +187,8 @@ impl AuthorizationDispatchBuilder {
                 !signers.is_empty(),
                 #[cfg(feature = "challenge-authorization")]
                 self.expected_authorization.clone(),
+                #[cfg(feature = "challenge-authorization")]
+                self.local_authorization.clone(),
             )));
 
             auth_dispatcher.set_handler(Box::new(AuthProtocolResponseHandler::new(

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -984,25 +984,17 @@ impl Handler for AuthChallengeSubmitRequestHandler {
 
                 return Ok(());
             }
-        } else if public_keys.len() == 1 {
+        } else if !public_keys.is_empty() {
             // we know this is safe because of above length check
             // defaults to the first key in the list
             public_key::PublicKey::from_bytes(public_keys[0].clone())
         } else {
-            let error_string = {
-                if public_keys.is_empty() {
-                    "No public keys submitted".to_string()
-                } else {
-                    "Too many public keys submitted".to_string()
-                }
-            };
-
             send_authorization_error(
                 &self.auth_manager,
                 context.source_id(),
                 context.source_connection_id(),
                 sender,
-                &error_string,
+                "No public keys submitted",
             )?;
 
             return Ok(());

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -60,6 +60,8 @@ pub struct AuthProtocolRequestHandler {
     challenge_configured: bool,
     #[cfg(feature = "challenge-authorization")]
     expected_authorization: Option<ConnectionAuthorizationType>,
+    #[cfg(feature = "challenge-authorization")]
+    local_authorization: Option<ConnectionAuthorizationType>,
 }
 
 impl AuthProtocolRequestHandler {
@@ -69,6 +71,9 @@ impl AuthProtocolRequestHandler {
         #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
             ConnectionAuthorizationType,
         >,
+        #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+            ConnectionAuthorizationType,
+        >,
     ) -> Self {
         Self {
             auth_manager,
@@ -76,6 +81,8 @@ impl AuthProtocolRequestHandler {
             challenge_configured,
             #[cfg(feature = "challenge-authorization")]
             expected_authorization,
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization,
         }
     }
 }
@@ -160,11 +167,21 @@ impl Handler for AuthProtocolRequestHandler {
                     Some(ConnectionAuthorizationType::Challenge { .. }) => {
                         accepted_authorization_type = vec![PeerAuthorizationType::Challenge]
                     }
+                    // if None, check required local authorization type as well
                     _ => {
-                        // if trust is enabled it was already added
-                        #[cfg(feature = "challenge-authorization")]
-                        if self.challenge_configured {
-                            accepted_authorization_type.push(PeerAuthorizationType::Challenge)
+                        match self.local_authorization {
+                            Some(ConnectionAuthorizationType::Trust { .. }) => (),
+                            Some(ConnectionAuthorizationType::Challenge { .. }) => {
+                                accepted_authorization_type = vec![PeerAuthorizationType::Challenge]
+                            }
+                            _ => {
+                                // if trust is enabled it was already added
+                                #[cfg(feature = "challenge-authorization")]
+                                if self.challenge_configured {
+                                    accepted_authorization_type
+                                        .push(PeerAuthorizationType::Challenge)
+                                }
+                            }
                         }
                     }
                 };

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -121,14 +121,21 @@ impl PeerManagerConnector {
     /// # Arguments
     ///
     /// * `endpoint` - The endpoint associated with the peer.
+    /// * `local_authorization` - The required PeerAuthorizationToken that will be used to identify
+    /// *  the local node.
     pub fn add_unidentified_peer(
         &self,
         endpoint: String,
+        #[cfg(feature = "challenge-authorization")] local_authorization: PeerAuthorizationToken,
     ) -> Result<EndpointPeerRef, PeerUnknownAddError> {
         let (sender, recv) = channel();
 
-        let message =
-            PeerManagerMessage::Request(PeerManagerRequest::AddUnidentified { endpoint, sender });
+        let message = PeerManagerMessage::Request(PeerManagerRequest::AddUnidentified {
+            endpoint,
+            #[cfg(feature = "challenge-authorization")]
+            local_authorization,
+            sender,
+        });
 
         match self.sender.send(message) {
             Ok(()) => (),

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -221,9 +221,10 @@ impl PeerManager {
         endpoint_retry_frequency: u64,
     ) -> Result<PeerManager, PeerManagerError> {
         debug!(
-            "Starting peer manager with retry_interval={}s, max_retry_attempts={} \
+            "Starting peer manager with identity={}, retry_interval={}s, max_retry_attempts={} \
             strict_ref_counts={}, retry_frequency={}, max_retry_frequency={}, and \
             endpoint_retry_frequency={}",
+            identity,
             retry_interval,
             max_retry_attempts,
             strict_ref_counts,

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -658,7 +658,7 @@ fn add_peer(
             endpoint,
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            Some(required_local_auth),
+            required_local_auth,
         );
 
         let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
@@ -712,7 +712,7 @@ fn add_peer(
         active_endpoint,
         PeerStatus::Pending,
         #[cfg(feature = "challenge-authorization")]
-        Some(required_local_auth),
+        required_local_auth,
     );
     let peer_ref = PeerRef::new(peer_id, peer_remover.clone());
     Ok(peer_ref)
@@ -952,10 +952,7 @@ fn handle_notifications(
                             #[cfg(feature = "challenge-authorization")]
                             Some(peer_metadata.id.clone().into()),
                             #[cfg(feature = "challenge-authorization")]
-                            peer_metadata
-                                .required_local_auth
-                                .clone()
-                                .map(|auth_type| auth_type.into()),
+                            Some(peer_metadata.required_local_auth.clone().into()),
                         ) {
                             Ok(()) => break,
                             Err(err) => {
@@ -1064,10 +1061,7 @@ fn handle_disconnection(
                     #[cfg(feature = "challenge-authorization")]
                     Some(identity.clone().into()),
                     #[cfg(feature = "challenge-authorization")]
-                    peer_metadata
-                        .required_local_auth
-                        .clone()
-                        .map(|auth_type| auth_type.into()),
+                    Some(peer_metadata.required_local_auth.clone().into()),
                 ) {
                     Ok(()) => break,
                     Err(err) => {
@@ -1320,7 +1314,7 @@ fn handle_connected(
                 endpoint,
                 PeerStatus::Connected,
                 #[cfg(feature = "challenge-authorization")]
-                Some(requested_endpoint.local_authorization.clone()),
+                requested_endpoint.local_authorization.clone(),
             );
 
             let notification = PeerManagerNotification::Connected { peer: identity };
@@ -1404,10 +1398,7 @@ fn retry_pending(
                 #[cfg(feature = "challenge-authorization")]
                 Some(peer_metadata.id.clone().into()),
                 #[cfg(feature = "challenge-authorization")]
-                peer_metadata
-                    .required_local_auth
-                    .clone()
-                    .map(|auth_type| auth_type.into()),
+                Some(peer_metadata.required_local_auth.clone().into()),
             ) {
                 Ok(()) => peer_metadata.active_endpoint = endpoint.to_string(),
                 // If request_connection errored we will retry in the future

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -52,7 +52,7 @@ pub struct PeerMetadata {
     pub retry_frequency: u64,
     /// The required way the local node must be identified, this is required on retry
     #[cfg(feature = "challenge-authorization")]
-    pub required_local_auth: Option<PeerAuthorizationToken>,
+    pub required_local_auth: PeerAuthorizationToken,
 }
 
 /// A map of peer IDs to peer metadata, which also maintains a redirect table for updated peer IDs.
@@ -116,9 +116,7 @@ impl PeerMap {
         endpoints: Vec<String>,
         active_endpoint: String,
         status: PeerStatus,
-        #[cfg(feature = "challenge-authorization")] required_local_auth: Option<
-            PeerAuthorizationToken,
-        >,
+        #[cfg(feature = "challenge-authorization")] required_local_auth: PeerAuthorizationToken,
     ) {
         let peer_metadata = PeerMetadata {
             id: peer_id.clone(),
@@ -243,7 +241,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
 
         peer_map.insert(
@@ -255,7 +253,7 @@ pub mod tests {
             "next_endpoint1".to_string(),
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
 
         let mut peers = peer_map.peer_ids();
@@ -292,7 +290,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
 
         peer_map.insert(
@@ -304,7 +302,7 @@ pub mod tests {
             "next_endpoint1".to_string(),
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
 
         let peers = peer_map.connection_ids();
@@ -344,7 +342,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
 
         let peer_metadata = peer_map
@@ -387,7 +385,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string(),
@@ -436,7 +434,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Pending,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string()
@@ -482,7 +480,7 @@ pub mod tests {
             last_connection_attempt: Instant::now(),
             retry_frequency: 10,
             #[cfg(feature = "challenge-authorization")]
-            required_local_auth: None,
+            required_local_auth: PeerAuthorizationToken::from_peer_id("my_id"),
         };
 
         if let Ok(()) = peer_map.update_peer(no_peer_metadata) {
@@ -498,7 +496,7 @@ pub mod tests {
             "test_endpoint2".to_string(),
             PeerStatus::Connected,
             #[cfg(feature = "challenge-authorization")]
-            None,
+            PeerAuthorizationToken::from_peer_id("my_id"),
         );
         assert!(peer_map.peers.contains_key(&PeerAuthorizationToken::Trust {
             peer_id: "test_peer".to_string(),

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -185,11 +185,19 @@ OPTIONS
 `--peers PEER-URL` `[,...]`
 : Specifies one or more Splinter nodes that `splinterd` will automatically
   connect to when it starts. The *PEER-URL* argument must specify another node's
-  network endpoint, using the format `protocol_prefix://ip:port`.
+  network endpoint, using the format `protocol_prefix://ip:port` or
+  `protocol-prefix+trust://ip:port` to require trust authorization. Default
+  authorization type is challenge if signing keys are configured.
 
   Specify multiple nodes in a comma-separated list or by repeating the
   `--peers` option. The protocol prefix part of the peer URL specifies the
   type of connection that is created.
+
+`--peering-key PEERING_KEY`
+: The name of the key to use for challenge authorization with specified peers.
+  Defaults to the only key if there is only one key supported otherwise,
+  defaults to `splinterd`. This key is expected to be present in the storage
+  directory.
 
 `--registries REGISTRY-FILE` `[,...]`
 : Specifies one or more read-only Splinter registry files.

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -47,10 +47,17 @@ version = "1"
 #advertised_endpoints = ""
 
 # A comma separated list of splinter nodes the daemon will automatically
-# attempt to connect to on start up
-# example: peers = ["tcps://acme-node-001:8044", "tcps://acme-node-002:8044"]
+# attempt to connect to on start up. If the authorization type used must be
+# trust add +trust after the protocol prefix.
+# example: peers = [
+#   "tcps://acme-node-001:8044",
+#   "tcps+trust://acme-node-002:8044"
+# ]
 #peers = []
 
+# The name of the key that should be used to connect to the peers using
+# challenge authorization
+#peering_key = "splinterd"
 
 # Specifies how often, in seconds, to send a heartbeat. This heartbeat is used
 # to check the health of connections to other Splinter nodes. Use 0 to turn

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -358,6 +358,12 @@ impl ConfigBuilder {
                 .partial_configs
                 .iter()
                 .find_map(|p| p.metrics_password().map(|v| (v, p.source()))),
+            #[cfg(feature = "challenge-authorization")]
+            peering_key: self
+                .partial_configs
+                .iter()
+                .find_map(|p| p.peering_key().map(|v| (v, p.source())))
+                .ok_or_else(|| ConfigError::MissingValue("peering_key".to_string()))?,
             #[cfg(feature = "log-config")]
             appenders: Some({
                 let appenders = self

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -189,6 +189,12 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 });
         }
 
+        #[cfg(feature = "challenge-authorization")]
+        {
+            partial_config = partial_config
+                .with_peering_key(self.matches.value_of("peering_key").map(String::from))
+        }
+
         Ok(partial_config)
     }
 }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -50,6 +50,9 @@ const REGISTRY_FORCED_REFRESH: u64 = 10; // 10 seconds
 const HEARTBEAT: u64 = 30; // 30 seconds
 const ADMIN_TIMEOUT: u64 = 30; // 30 seconds
 
+#[cfg(feature = "challenge-authorization")]
+const PEERING_KEY_NAME: &str = "splinterd";
+
 pub struct DefaultPartialConfigBuilder;
 
 impl DefaultPartialConfigBuilder {
@@ -120,6 +123,11 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 .with_root_logger(root_logger)
                 .with_appenders(Some(appenders))
                 .with_verbosity(Some(log::Level::Info));
+        }
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            partial_config = partial_config.with_peering_key(Some(String::from(PEERING_KEY_NAME)))
         }
 
         Ok(partial_config)

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -97,6 +97,8 @@ pub struct Config {
     metrics_username: Option<(String, ConfigSource)>,
     #[cfg(feature = "metrics")]
     metrics_password: Option<(String, ConfigSource)>,
+    #[cfg(feature = "challenge-authorization")]
+    peering_key: (String, ConfigSource),
     #[cfg(feature = "log-config")]
     root_logger: (RootConfig, ConfigSource),
     #[cfg(feature = "log-config")]
@@ -336,6 +338,11 @@ impl Config {
         }
     }
 
+    #[cfg(feature = "challenge-authorization")]
+    pub fn peering_key(&self) -> &str {
+        &self.peering_key.0
+    }
+
     pub fn config_dir_source(&self) -> &ConfigSource {
         &self.config_dir.1
     }
@@ -564,6 +571,11 @@ impl Config {
         }
     }
 
+    #[cfg(feature = "challenge-authorization")]
+    fn peering_key_source(&self) -> &ConfigSource {
+        &self.peering_key.1
+    }
+
     #[cfg(feature = "log-config")]
     pub fn root_logger(&self) -> &RootConfig {
         &self.root_logger.0
@@ -669,6 +681,12 @@ impl Config {
             "Config: peers: {:?} (source: {:?})",
             self.peers(),
             self.peers_source()
+        );
+        #[cfg(feature = "challenge-authorization")]
+        debug!(
+            "Config: peering_key: {:?} (source: {:?})",
+            self.peering_key(),
+            self.peering_key_source()
         );
         if let (Some(id), Some(source)) = (self.node_id(), self.node_id_source()) {
             debug!("Config: node_id: {} (source: {:?})", id, source,);

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -93,6 +93,8 @@ pub struct PartialConfig {
     metrics_username: Option<String>,
     #[cfg(feature = "metrics")]
     metrics_password: Option<String>,
+    #[cfg(feature = "challenge-authorization")]
+    peering_key: Option<String>,
     #[cfg(feature = "log-config")]
     root_logger: Option<RootConfig>,
     #[cfg(feature = "log-config")]
@@ -163,6 +165,8 @@ impl PartialConfig {
             metrics_username: None,
             #[cfg(feature = "metrics")]
             metrics_password: None,
+            #[cfg(feature = "challenge-authorization")]
+            peering_key: None,
             #[cfg(feature = "log-config")]
             appenders: None,
             #[cfg(feature = "log-config")]
@@ -348,6 +352,11 @@ impl PartialConfig {
     #[cfg(feature = "metrics")]
     pub fn metrics_password(&self) -> Option<String> {
         self.metrics_password.clone()
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    pub fn peering_key(&self) -> Option<String> {
+        self.peering_key.clone()
     }
 
     #[cfg(feature = "log-config")]
@@ -821,6 +830,18 @@ impl PartialConfig {
     ///
     pub fn with_metrics_password(mut self, metrics_password: Option<String>) -> Self {
         self.metrics_password = metrics_password;
+        self
+    }
+    #[cfg(feature = "challenge-authorization")]
+    /// Adds an `peering_key` value to the `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `peering_key` - Add the name of the key that should be used to peer with endpoints
+    ///    passed to the peer option when using challenge authorization
+    ///
+    pub fn with_peering_key(mut self, peering_key: Option<String>) -> Self {
+        self.peering_key = peering_key;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -81,6 +81,8 @@ struct TomlConfig {
     metrics_username: Option<String>,
     #[cfg(feature = "metrics")]
     metrics_password: Option<String>,
+    #[cfg(feature = "challenge-authorization")]
+    peering_key: Option<String>,
     #[cfg(feature = "log-config")]
     appenders: Option<HashMap<String, UnnamedAppenderConfig>>,
     #[cfg(feature = "log-config")]
@@ -217,6 +219,11 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 partial_config = partial_config.with_loggers(self.toml_config.loggers)
             }
             partial_config = partial_config.with_appenders(self.toml_config.appenders);
+        }
+
+        #[cfg(feature = "challenge-authorization")]
+        {
+            partial_config = partial_config.with_peering_key(self.toml_config.peering_key);
         }
 
         // deprecated values, only set if the current value was not set

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -58,6 +58,8 @@ use splinter::network::handlers::{NetworkEchoHandler, NetworkHeartbeatHandler};
 use splinter::orchestrator::ServiceOrchestratorBuilder;
 use splinter::peer::interconnect::NetworkMessageSender;
 use splinter::peer::interconnect::PeerInterconnectBuilder;
+#[cfg(feature = "challenge-authorization")]
+use splinter::peer::PeerAuthorizationToken;
 use splinter::peer::PeerManager;
 use splinter::protos::circuit::CircuitMessageType;
 use splinter::protos::network::NetworkMessageType;
@@ -430,7 +432,11 @@ impl SplinterDaemon {
         // hold on to peer refs for the peers provided to ensure the connections are kept around
         let mut peer_refs = vec![];
         for endpoint in self.initial_peers.iter() {
-            match peer_connector.add_unidentified_peer(endpoint.into()) {
+            match peer_connector.add_unidentified_peer(
+                endpoint.into(),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id(&self.node_id),
+            ) {
                 Ok(peer_ref) => peer_refs.push(peer_ref),
                 Err(err) => error!("Connect Error: {}", err),
             }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -154,6 +154,8 @@ pub struct SplinterDaemon {
     strict_ref_counts: bool,
     #[cfg(feature = "challenge-authorization")]
     signers: Vec<Box<dyn Signer>>,
+    #[cfg(feature = "challenge-authorization")]
+    peering_token: PeerAuthorizationToken,
 }
 
 impl SplinterDaemon {
@@ -435,7 +437,7 @@ impl SplinterDaemon {
             match peer_connector.add_unidentified_peer(
                 endpoint.into(),
                 #[cfg(feature = "challenge-authorization")]
-                PeerAuthorizationToken::from_peer_id(&self.node_id),
+                self.peering_token.clone(),
             ) {
                 Ok(peer_ref) => peer_refs.push(peer_ref),
                 Err(err) => error!("Connect Error: {}", err),
@@ -1064,6 +1066,8 @@ pub struct SplinterDaemonBuilder {
     strict_ref_counts: Option<bool>,
     #[cfg(feature = "challenge-authorization")]
     signers: Option<Vec<Box<dyn Signer>>>,
+    #[cfg(feature = "challenge-authorization")]
+    peering_token: Option<PeerAuthorizationToken>,
 }
 
 impl SplinterDaemonBuilder {
@@ -1225,6 +1229,12 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    #[cfg(feature = "challenge-authorization")]
+    pub fn with_peering_token(mut self, value: Option<PeerAuthorizationToken>) -> Self {
+        self.peering_token = value;
+        self
+    }
+
     pub fn build(self) -> Result<SplinterDaemon, CreateError> {
         let heartbeat = self.heartbeat.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: heartbeat".to_string())
@@ -1308,6 +1318,11 @@ impl SplinterDaemonBuilder {
             vec![]
         });
 
+        #[cfg(feature = "challenge-authorization")]
+        let peering_token = self
+            .peering_token
+            .unwrap_or_else(|| PeerAuthorizationToken::from_peer_id(&node_id));
+
         Ok(SplinterDaemon {
             #[cfg(feature = "authorization-handler-allow-keys")]
             config_dir,
@@ -1350,6 +1365,8 @@ impl SplinterDaemonBuilder {
             strict_ref_counts,
             #[cfg(feature = "challenge-authorization")]
             signers,
+            #[cfg(feature = "challenge-authorization")]
+            peering_token,
         })
     }
 }

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -16,9 +16,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
-#[cfg(feature = "challenge-authorization")]
-use cylinder::KeyLoadError;
-#[cfg(feature = "metrics")]
+#[cfg(any(feature = "metrics", feature = "challenge-authorization"))]
 use splinter::error::InternalError;
 use splinter::transport::socket::TlsInitError;
 
@@ -43,7 +41,7 @@ pub enum UserError {
     #[cfg(feature = "metrics")]
     MetricsError(InternalError),
     #[cfg(feature = "challenge-authorization")]
-    KeyLoadError(KeyLoadError),
+    KeyError(InternalError),
 }
 
 impl UserError {
@@ -75,7 +73,7 @@ impl Error for UserError {
             #[cfg(feature = "metrics")]
             UserError::MetricsError(err) => Some(err),
             #[cfg(feature = "challenge-authorization")]
-            UserError::KeyLoadError(err) => Some(err),
+            UserError::KeyError(err) => Some(err),
         }
     }
 }
@@ -107,7 +105,7 @@ impl fmt::Display for UserError {
             #[cfg(feature = "metrics")]
             UserError::MetricsError(msg) => write!(f, "{}", msg),
             #[cfg(feature = "challenge-authorization")]
-            UserError::KeyLoadError(err) => write!(f, "{}", err),
+            UserError::KeyError(err) => write!(f, "{}", err),
         }
     }
 }

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -40,8 +40,12 @@ use log4rs::Handle;
 use std::convert::TryInto;
 
 use rand::{thread_rng, Rng};
+#[cfg(feature = "challenge-authorization")]
+use splinter::error::InternalError;
 #[cfg(feature = "metrics")]
 use splinter::metrics::influx::InfluxRecorder;
+#[cfg(feature = "challenge-authorization")]
+use splinter::peer::PeerAuthorizationToken;
 
 use crate::config::{
     ClapPartialConfigBuilder, Config, ConfigBuilder, ConfigError, DefaultPartialConfigBuilder,
@@ -155,9 +159,15 @@ fn find_node_id(config: &Config) -> Result<String, UserError> {
     }
 }
 
+#[cfg(feature = "challenge-authorization")]
+type ChallengeAuthorizationArgs = (Vec<Box<dyn Signer>>, Option<PeerAuthorizationToken>);
+
 // load all signing keys from the configured splinterd key file
 #[cfg(feature = "challenge-authorization")]
-fn load_signer_keys(config_dir: &str) -> Result<Vec<Box<dyn Signer>>, UserError> {
+fn load_signer_keys(
+    config_dir: &str,
+    peering_key: &str,
+) -> Result<ChallengeAuthorizationArgs, UserError> {
     let splinterd_key_path = Path::new(config_dir).join("keys");
     let paths = match fs::read_dir(splinterd_key_path) {
         Ok(paths) => paths,
@@ -167,11 +177,13 @@ fn load_signer_keys(config_dir: &str) -> Result<Vec<Box<dyn Signer>>, UserError>
                 unable to read splinterd keys directory: {}",
                 err
             );
-            return Ok(vec![]);
+            return Ok((vec![], None));
         }
     };
 
+    let mut peer_token = None;
     let mut signing_keys = vec![];
+    let mut last_known_key = String::default();
     for path in paths {
         let path = path
             .map_err(|err| {
@@ -183,16 +195,70 @@ fn load_signer_keys(config_dir: &str) -> Result<Vec<Box<dyn Signer>>, UserError>
             .path();
 
         if path.extension() == Some(OsStr::new("priv")) {
-            let private_key = load_key_from_path(&path).map_err(UserError::KeyLoadError)?;
-            signing_keys.push(Secp256k1Context::new().new_signer(private_key));
+            let private_key = load_key_from_path(&path)
+                .map_err(|err| UserError::KeyError(InternalError::from_source(Box::new(err))))?;
+            let signing_key = Secp256k1Context::new().new_signer(private_key);
+
+            if path.file_stem() == Some(OsStr::new(peering_key)) {
+                peer_token = Some(PeerAuthorizationToken::from_public_key(
+                    signing_key
+                        .public_key()
+                        .map_err(|err| {
+                            UserError::KeyError(InternalError::from_source(Box::new(err)))
+                        })?
+                        .as_slice(),
+                ));
+
+                // put configured peering signing key in the front of the Vec
+                signing_keys.insert(0, signing_key);
+            } else {
+                signing_keys.push(signing_key);
+            }
+        } else {
+            last_known_key = path
+                .file_stem()
+                .ok_or_else(|| {
+                    UserError::KeyError(InternalError::with_message(
+                        "Unable to get file name".to_string(),
+                    ))
+                })?
+                .to_str()
+                .ok_or_else(|| {
+                    UserError::KeyError(InternalError::with_message(
+                        "Unable to get file name".to_string(),
+                    ))
+                })?
+                .to_string();
         }
     }
 
     if signing_keys.is_empty() {
         warn!("Starting daemon with no signing keys");
+    } else if peer_token.is_none() {
+        if signing_keys.len() == 1 {
+            let signing_key = &signing_keys[0];
+            peer_token = Some(PeerAuthorizationToken::from_public_key(
+                signing_key
+                    .public_key()
+                    .map_err(|err| UserError::KeyError(InternalError::from_source(Box::new(err))))?
+                    .as_slice(),
+            ));
+            warn!(
+                "Peering key name provided was not found, defaulting to the only key \
+                provided: {}",
+                last_known_key
+            );
+        } else {
+            return Err(UserError::KeyError(InternalError::with_message(format!(
+                "Unable to decide which key to use for required authorization for \
+                provided peers. Peering key {} was not found and there are more then one \
+                configured signing key",
+                peering_key,
+            ))));
+        }
     }
 
-    Ok(signing_keys)
+    Ok((signing_keys, peer_token))
 }
 
 fn main() {
@@ -273,6 +339,12 @@ fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .alias("peer"),
+        )
+        .arg(
+            Arg::with_name("peering_key")
+                .long("peering-key")
+                .help("Key to use for challenge authorization with --peers, defaults to splinterd")
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("registries")
@@ -724,8 +796,10 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
 
     #[cfg(feature = "challenge-authorization")]
     {
-        let signers = load_signer_keys(config.config_dir())?;
-        daemon_builder = daemon_builder.with_signers(signers);
+        let (signers, peering_token) = load_signer_keys(config.config_dir(), config.peering_key())?;
+        daemon_builder = daemon_builder
+            .with_signers(signers)
+            .with_peering_token(peering_token);
     }
 
     let mut node = daemon_builder.build().map_err(|err| {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -335,7 +335,10 @@ fn main() {
         .arg(
             Arg::with_name("peers")
                 .long("peers")
-                .help("Endpoint that service will connect to, protocol-prefix://ip:port")
+                .help(
+                    "Endpoint that service will connect to, protocol-prefix://ip:port or \
+                    protocol-prefix+trust://ip:port to require trust authorization",
+                )
                 .takes_value(true)
                 .multiple(true)
                 .alias("peer"),


### PR DESCRIPTION
If both peers are trying to reconnect at the same time it is possible for two connections to be created for the peer. If this has happens, one connection must be closed but both sides must close the same connection. Previously this was done by comparing the identity of this connection with the local node ID. This however is no longer sufficient with the addition of challenge authorization. This comparison must now be between the connection's identity and the required local authorization used when requesting the connection originally. 

To make this possibly, unidentified peers that are added by endpoint only must now include the required local authorization type so the correct identity is used  in case of future comparison. 

The local authorization used default to challenge auth if it is configured. The key will either be set to splinterd.priv or the only key configured if there is only 1. If there is more than 1 key and splinterd is not one of them a new option has been added to splinterd CLI `--peering-key`. This option takes a name of key that is in the splinterd config directory and will use that for the peering key. 

The `--peer` option also has been updated to take the format `tcp+trust://ipaddr:port/` if the authorization used must be trust. Otherwise default to challenge if supported.
