### PR TITLE
Add splinterd db version detection and requirement

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/mod.rs
+++ b/libsplinter/src/migrations/diesel/postgres/mod.rs
@@ -17,6 +17,8 @@
 embed_migrations!("./src/migrations/diesel/postgres/migrations");
 
 use diesel::pg::PgConnection;
+use diesel::Connection;
+use diesel_migrations::MigrationConnection;
 
 use crate::error::InternalError;
 
@@ -32,4 +34,28 @@ pub fn run_migrations(conn: &PgConnection) -> Result<(), InternalError> {
     info!("Successfully applied PostgreSQL migrations");
 
     Ok(())
+}
+
+/// Get whether there are any pending migrations
+///
+/// # Arguments
+///
+/// * `conn` - Connection to PostgreSQL database
+///
+pub fn any_pending_migrations(conn: &PgConnection) -> Result<bool, InternalError> {
+    let current_version = conn.latest_run_migration_version().unwrap_or(None);
+
+    // Diesel 1.4 only allows access to the list of migrations via attempting
+    // to run the migrations, so we'll do that in a test transaction.
+    let latest_version =
+        conn.test_transaction::<Result<Option<String>, InternalError>, (), _>(|| {
+            Ok(match embedded_migrations::run(conn) {
+                Ok(_) => conn
+                    .latest_run_migration_version()
+                    .map_err(|err| InternalError::from_source(Box::new(err))),
+                Err(err) => Err(InternalError::from_source(Box::new(err))),
+            })
+        })?;
+
+    Ok(current_version == latest_version)
 }

--- a/libsplinter/src/migrations/mod.rs
+++ b/libsplinter/src/migrations/mod.rs
@@ -30,6 +30,10 @@
 mod diesel;
 
 #[cfg(feature = "postgres")]
+pub use self::diesel::postgres::any_pending_migrations as any_pending_postgres_migrations;
+#[cfg(feature = "postgres")]
 pub use self::diesel::postgres::run_migrations as run_postgres_migrations;
+#[cfg(feature = "sqlite")]
+pub use self::diesel::sqlite::any_pending_migrations as any_pending_sqlite_migrations;
 #[cfg(feature = "sqlite")]
 pub use self::diesel::sqlite::run_migrations as run_sqlite_migrations;


### PR DESCRIPTION
Add a startup check in splinterd that checks if the database that the
daemon uses is out of date. If so, splinterd aborts and informs the user
that they must run the `splinter database migrate` cli command.

Signed-off-by: Lee Bradley <bradley@bitwise.io>