### PR TITLE
Add Splinter specific PublicKey struct

### DIFF
--- a/libsplinter/src/admin/service/builder.rs
+++ b/libsplinter/src/admin/service/builder.rs
@@ -27,6 +27,8 @@ use crate::error::InvalidStateError;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::ServiceOrchestrator;
 use crate::peer::PeerManagerConnector;
+#[cfg(feature = "challenge-authorization")]
+use crate::public_key::PublicKey;
 #[cfg(feature = "service-arg-validation")]
 use crate::service::validation::ServiceArgValidator;
 
@@ -55,7 +57,7 @@ pub struct AdminServiceBuilder {
     routing_table_writer: Option<Box<dyn RoutingTableWriter>>,
     event_store: Option<Box<dyn AdminServiceStore>>,
     #[cfg(feature = "challenge-authorization")]
-    public_keys: Option<Vec<Vec<u8>>>,
+    public_keys: Option<Vec<PublicKey>>,
 }
 
 impl AdminServiceBuilder {
@@ -154,7 +156,7 @@ impl AdminServiceBuilder {
 
     /// Sets the public keys
     #[cfg(feature = "challenge-authorization")]
-    pub fn with_public_keys(mut self, public_keys: Vec<Vec<u8>>) -> Self {
+    pub fn with_public_keys(mut self, public_keys: Vec<PublicKey>) -> Self {
         self.public_keys = Some(public_keys);
 
         self

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -47,6 +47,8 @@ use crate::protos::admin::{
     Circuit_PersistenceType, Circuit_RouteType, MemberReady, RemovedProposal,
     ServiceProtocolVersionRequest, SplinterNode, SplinterService,
 };
+#[cfg(feature = "challenge-authorization")]
+use crate::public_key;
 use crate::service::error::ServiceError;
 #[cfg(feature = "service-arg-validation")]
 use crate::service::validation::ServiceArgValidator;
@@ -155,7 +157,7 @@ pub struct AdminServiceShared {
     // Mailbox of AdminServiceEvent values
     event_store: Box<dyn AdminServiceStore>,
     #[cfg(feature = "challenge-authorization")]
-    public_keys: Vec<Vec<u8>>,
+    public_keys: Vec<public_key::PublicKey>,
     token_to_peer: HashMap<PeerAuthorizationToken, PeerNodePair>,
 }
 
@@ -175,7 +177,7 @@ impl AdminServiceShared {
         key_permission_manager: Box<dyn KeyPermissionManager>,
         routing_table_writer: Box<dyn RoutingTableWriter>,
         admin_service_event_store: Box<dyn AdminServiceStore>,
-        #[cfg(feature = "challenge-authorization")] public_keys: Vec<Vec<u8>>,
+        #[cfg(feature = "challenge-authorization")] public_keys: Vec<public_key::PublicKey>,
     ) -> Self {
         AdminServiceShared {
             node_id,

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -91,6 +91,8 @@ pub mod orchestrator;
 pub mod peer;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "challenge-authorization")]
+pub mod public_key;
 #[cfg(feature = "registry")]
 pub mod registry;
 #[cfg(feature = "rest-api")]

--- a/libsplinter/src/network/auth/handlers/builder.rs
+++ b/libsplinter/src/network/auth/handlers/builder.rs
@@ -223,7 +223,9 @@ impl AuthorizationDispatchBuilder {
             let signers_to_use = match &self.local_authorization {
                 Some(ConnectionAuthorizationType::Challenge { public_key }) => {
                     let signer = signers.iter().find(|signer| match signer.public_key() {
-                        Ok(signer_public_key) => signer_public_key.as_slice() == public_key,
+                        Ok(signer_public_key) => {
+                            signer_public_key.as_slice() == public_key.as_slice()
+                        }
                         Err(_) => false,
                     });
 

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -35,6 +35,8 @@ use crate::protocol::network::NetworkMessage;
 use crate::protocol::{PEER_AUTHORIZATION_PROTOCOL_MIN, PEER_AUTHORIZATION_PROTOCOL_VERSION};
 use crate::protos::network;
 use crate::protos::prelude::*;
+#[cfg(feature = "challenge-authorization")]
+use crate::public_key::PublicKey;
 use crate::transport::{Connection, RecvError};
 
 use self::handlers::AuthorizationDispatchBuilder;
@@ -453,7 +455,7 @@ pub enum ConnectionAuthorizationType {
     },
     #[cfg(feature = "challenge-authorization")]
     Challenge {
-        public_key: Vec<u8>,
+        public_key: PublicKey,
     },
 }
 

--- a/libsplinter/src/network/auth/state_machine/mod.rs
+++ b/libsplinter/src/network/auth/state_machine/mod.rs
@@ -21,6 +21,9 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "challenge-authorization")]
+use crate::public_key::PublicKey;
+
+#[cfg(feature = "challenge-authorization")]
 use self::challenge_v1::{
     ChallengeAuthorizationLocalAction, ChallengeAuthorizationLocalState,
     ChallengeAuthorizationRemoteAction, ChallengeAuthorizationRemoteState,
@@ -41,7 +44,7 @@ pub enum Identity {
     },
     #[cfg(feature = "challenge-authorization")]
     Challenge {
-        public_key: Vec<u8>,
+        public_key: PublicKey,
     },
 }
 

--- a/libsplinter/src/peer/token.rs
+++ b/libsplinter/src/peer/token.rs
@@ -60,15 +60,6 @@ impl PeerAuthorizationToken {
         }
     }
 
-    #[cfg(feature = "challenge-authorization")]
-    /// Check if the token is challenge and has the provided public key
-    pub fn has_public_key(&self, public_keys: &[Vec<u8>]) -> bool {
-        match self {
-            PeerAuthorizationToken::Trust { .. } => false,
-            PeerAuthorizationToken::Challenge { public_key } => public_keys.contains(&public_key),
-        }
-    }
-
     /// Get the ID if the token is trust, else None
     pub fn peer_id(&self) -> Option<&str> {
         match self {

--- a/libsplinter/src/peer/token.rs
+++ b/libsplinter/src/peer/token.rs
@@ -22,6 +22,8 @@ use std::fmt;
 #[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 use crate::network::auth::ConnectionAuthorizationType;
+#[cfg(feature = "challenge-authorization")]
+use crate::public_key::PublicKey;
 
 /// The authorization type specific peer ID
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -31,7 +33,7 @@ pub enum PeerAuthorizationToken {
     },
     #[cfg(feature = "challenge-authorization")]
     Challenge {
-        public_key: Vec<u8>,
+        public_key: PublicKey,
     },
 }
 
@@ -47,7 +49,7 @@ impl PeerAuthorizationToken {
     /// Get a challenge token from a provided public_key
     pub fn from_public_key(public_key: &[u8]) -> Self {
         PeerAuthorizationToken::Challenge {
-            public_key: public_key.to_vec(),
+            public_key: PublicKey::from_bytes(public_key.to_vec()),
         }
     }
 
@@ -71,7 +73,7 @@ impl PeerAuthorizationToken {
 
     #[cfg(feature = "challenge-authorization")]
     /// Get the public key if the token is challenge, else None
-    pub fn public_key(&self) -> Option<&[u8]> {
+    pub fn public_key(&self) -> Option<&PublicKey> {
         match self {
             PeerAuthorizationToken::Trust { .. } => None,
             PeerAuthorizationToken::Challenge { public_key } => Some(public_key),
@@ -84,7 +86,7 @@ impl PeerAuthorizationToken {
             PeerAuthorizationToken::Trust { peer_id } => peer_id.to_string(),
             #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::Challenge { public_key } => {
-                format!("public_key::{}", to_hex(public_key))
+                format!("public_key::{}", to_hex(public_key.as_slice()))
             }
         }
     }
@@ -98,7 +100,11 @@ impl fmt::Display for PeerAuthorizationToken {
             }
             #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::Challenge { public_key } => {
-                write!(f, "Challenge ( public_key: {} )", to_hex(public_key))
+                write!(
+                    f,
+                    "Challenge ( public_key: {} )",
+                    to_hex(public_key.as_slice())
+                )
             }
         }
     }

--- a/libsplinter/src/public_key.rs
+++ b/libsplinter/src/public_key.rs
@@ -1,0 +1,52 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Splinter specific representation of a public key
+
+use std::cmp::Ordering;
+
+/// Local representation of a public ket
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PublicKey {
+    bytes: Vec<u8>,
+}
+
+impl PublicKey {
+    /// Create a `PublicKey` from bytes
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        PublicKey { bytes }
+    }
+
+    /// Consumes the public key and returns it as bytes
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Returns the public key as bytes
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.bytes.cmp(&other.bytes)
+    }
+}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -61,6 +61,8 @@ use splinter::peer::interconnect::PeerInterconnectBuilder;
 use splinter::peer::PeerManager;
 use splinter::protos::circuit::CircuitMessageType;
 use splinter::protos::network::NetworkMessageType;
+#[cfg(feature = "challenge-authorization")]
+use splinter::public_key::PublicKey;
 use splinter::registry::{
     LocalYamlRegistry, RegistryReader, RemoteYamlRegistry, RemoteYamlShutdownHandle, RwRegistry,
     UnifiedRegistry,
@@ -496,8 +498,8 @@ impl SplinterDaemon {
             admin_service_builder = admin_service_builder.with_public_keys(
                 self.signers
                     .iter()
-                    .map(|signer| Ok(signer.public_key()?.into_bytes()))
-                    .collect::<Result<Vec<Vec<u8>>, SigningError>>()
+                    .map(|signer| Ok(PublicKey::from_bytes(signer.public_key()?.into_bytes())))
+                    .collect::<Result<Vec<PublicKey>, SigningError>>()
                     .map_err(|err| {
                         StartError::AdminServiceError(format!(
                             "Unable to get public keys from signer for Admin message handler:

--- a/splinterd/src/node/builder/admin.rs
+++ b/splinterd/src/node/builder/admin.rs
@@ -22,6 +22,7 @@ use scabbard::service::ScabbardFactoryBuilder;
 use splinter::circuit::routing::RoutingTableWriter;
 use splinter::error::InternalError;
 use splinter::peer::PeerManagerConnector;
+use splinter::public_key::PublicKey;
 use splinter::store::{memory::MemoryStoreFactory, StoreFactory};
 use splinter::transport::inproc::InprocTransport;
 
@@ -47,7 +48,7 @@ pub struct AdminSubsystemBuilder {
     scabbard_config: Option<ScabbardConfig>,
     registries: Option<Vec<String>>,
     admin_service_event_client_variant: AdminServiceEventClientVariant,
-    public_keys: Option<Vec<Vec<u8>>>,
+    public_keys: Option<Vec<PublicKey>>,
 }
 
 impl AdminSubsystemBuilder {
@@ -134,7 +135,7 @@ impl AdminSubsystemBuilder {
     }
 
     /// Specifies the public keys set in the admin service
-    pub fn with_public_keys(mut self, public_keys: Vec<Vec<u8>>) -> Self {
+    pub fn with_public_keys(mut self, public_keys: Vec<PublicKey>) -> Self {
         self.public_keys = Some(public_keys);
         self
     }

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use cylinder::{secp256k1::Secp256k1Context, Context, Signer, VerifierFactory};
 use rand::{thread_rng, Rng};
 use splinter::error::InternalError;
+use splinter::public_key::PublicKey;
 use splinter::rest_api::actix_web_1::RestApiBuilder as RestApiBuilder1;
 use splinter::rest_api::actix_web_3::RestApiBuilder as RestApiBuilder3;
 use splinter::rest_api::auth::{
@@ -206,10 +207,12 @@ impl NodeBuilder {
             .admin_subsystem_builder
             .with_node_id(node_id.clone())
             .with_signing_context(signing_context.clone())
-            .with_public_keys(vec![admin_signer
-                .public_key()
-                .map_err(|err| InternalError::from_source(Box::new(err)))?
-                .into_bytes()]);
+            .with_public_keys(vec![PublicKey::from_bytes(
+                admin_signer
+                    .public_key()
+                    .map_err(|err| InternalError::from_source(Box::new(err)))?
+                    .into_bytes(),
+            )]);
 
         let rest_api_variant = match self.rest_api_variant {
             RestApiVariant::ActixWeb1 => RunnableNodeRestApiVariant::ActixWeb1(

--- a/splinterd/src/node/runnable/admin.rs
+++ b/splinterd/src/node/runnable/admin.rs
@@ -25,6 +25,7 @@ use splinter::error::InternalError;
 use splinter::events::Reactor;
 use splinter::orchestrator::ServiceOrchestratorBuilder;
 use splinter::peer::PeerManagerConnector;
+use splinter::public_key::PublicKey;
 use splinter::registry::{LocalYamlRegistry, RegistryReader, UnifiedRegistry};
 use splinter::rest_api::actix_web_1::RestResourceProvider as _;
 use splinter::service::ServiceProcessorBuilder;
@@ -49,7 +50,7 @@ pub struct RunnableAdminSubsystem {
     pub scabbard_service_factory: Option<ScabbardFactory>,
     pub registries: Option<Vec<String>>,
     pub admin_service_event_client_variant: AdminServiceEventClientVariant,
-    pub public_keys: Vec<Vec<u8>>,
+    pub public_keys: Vec<PublicKey>,
 }
 
 impl RunnableAdminSubsystem {


### PR DESCRIPTION
This struct will be used for internal splinter structs
so we don't need to use the Cylinder's public key as
a part of the splinter API but also is more specific then
a Vec.