### PR TITLE
Remove spurious documentation from node_id errors

### DIFF
--- a/libsplinter/src/node_id/store/mod.rs
+++ b/libsplinter/src/node_id/store/mod.rs
@@ -14,7 +14,6 @@
 
 #[cfg(feature = "diesel")]
 pub mod diesel;
-/// NodeIdStore error types
 pub mod error;
 
 use error::NodeIdStoreError;


### PR DESCRIPTION
Based off comments on PR
`https://github.com/Cargill/splinter/pull/1446`, this line shouldn't be
here and makes the documentation not make much sense. Removing it fixes
the understandability and doc standards issues.

Signed-off-by: Caleb Hill <hill@bitwise.io>