### PR TITLE
Node id block startup if file exists

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -103,6 +103,7 @@ experimental = [
     "log-config",
     "metrics",
     "node",
+    "node-file-block",
     "oauth-user-list",
     "scabbard-back-pressure",
     "service-arg-validation",
@@ -155,6 +156,7 @@ node = [
     "splinter/biome-client",
     "splinter/biome-client-reqwest",
 ]
+node-file-block = ["splinter/node-id-store",]
 oauth = [
     "splinter/oauth"
 ]

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -37,8 +37,6 @@ pub enum UserError {
         context: String,
         source: Option<Box<dyn Error>>,
     },
-    #[cfg(feature = "metrics")]
-    MetricsError(InternalError),
     #[cfg(feature = "challenge-authorization")]
     KeyError(InternalError),
     InternalError(InternalError),
@@ -70,8 +68,6 @@ impl Error for UserError {
             UserError::ConfigError(err) => Some(err),
             UserError::IoError { source, .. } => source.as_ref().map(|err| &**err as &dyn Error),
             UserError::DaemonError { source, .. } => source.as_ref().map(|err| &**err),
-            #[cfg(feature = "metrics")]
-            UserError::MetricsError(err) => Some(err),
             #[cfg(feature = "challenge-authorization")]
             UserError::KeyError(err) => Some(err),
             UserError::InternalError(err) => Some(err),
@@ -103,8 +99,6 @@ impl fmt::Display for UserError {
                     f.write_str(context)
                 }
             }
-            #[cfg(feature = "metrics")]
-            UserError::MetricsError(msg) => write!(f, "{}", msg),
             #[cfg(feature = "challenge-authorization")]
             UserError::KeyError(err) => write!(f, "{}", err),
             UserError::InternalError(err) => write!(f, "{}", err),

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -37,8 +37,6 @@ pub enum UserError {
         context: String,
         source: Option<Box<dyn Error>>,
     },
-    #[cfg(feature = "challenge-authorization")]
-    KeyError(InternalError),
     InternalError(InternalError),
 }
 
@@ -68,8 +66,6 @@ impl Error for UserError {
             UserError::ConfigError(err) => Some(err),
             UserError::IoError { source, .. } => source.as_ref().map(|err| &**err as &dyn Error),
             UserError::DaemonError { source, .. } => source.as_ref().map(|err| &**err),
-            #[cfg(feature = "challenge-authorization")]
-            UserError::KeyError(err) => Some(err),
             UserError::InternalError(err) => Some(err),
         }
     }
@@ -99,8 +95,6 @@ impl fmt::Display for UserError {
                     f.write_str(context)
                 }
             }
-            #[cfg(feature = "challenge-authorization")]
-            UserError::KeyError(err) => write!(f, "{}", err),
             UserError::InternalError(err) => write!(f, "{}", err),
         }
     }

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -16,7 +16,6 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
-#[cfg(any(feature = "metrics", feature = "challenge-authorization"))]
 use splinter::error::InternalError;
 use splinter::transport::socket::TlsInitError;
 
@@ -42,6 +41,7 @@ pub enum UserError {
     MetricsError(InternalError),
     #[cfg(feature = "challenge-authorization")]
     KeyError(InternalError),
+    InternalError(InternalError),
 }
 
 impl UserError {
@@ -74,6 +74,7 @@ impl Error for UserError {
             UserError::MetricsError(err) => Some(err),
             #[cfg(feature = "challenge-authorization")]
             UserError::KeyError(err) => Some(err),
+            UserError::InternalError(err) => Some(err),
         }
     }
 }
@@ -106,6 +107,7 @@ impl fmt::Display for UserError {
             UserError::MetricsError(msg) => write!(f, "{}", msg),
             #[cfg(feature = "challenge-authorization")]
             UserError::KeyError(err) => write!(f, "{}", err),
+            UserError::InternalError(err) => write!(f, "{}", err),
         }
     }
 }
@@ -131,6 +133,12 @@ impl From<GetTransportError> for UserError {
 impl From<ConfigError> for UserError {
     fn from(error: ConfigError) -> Self {
         UserError::ConfigError(error)
+    }
+}
+
+impl From<InternalError> for UserError {
+    fn from(error: InternalError) -> Self {
+        UserError::InternalError(error)
     }
 }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -195,8 +195,9 @@ fn load_signer_keys(
             .path();
 
         if path.extension() == Some(OsStr::new("priv")) {
-            let private_key = load_key_from_path(&path)
-                .map_err(|err| UserError::KeyError(InternalError::from_source(Box::new(err))))?;
+            let private_key = load_key_from_path(&path).map_err(|err| {
+                UserError::InternalError(InternalError::from_source(Box::new(err)))
+            })?;
             let signing_key = Secp256k1Context::new().new_signer(private_key);
 
             if path.file_stem() == Some(OsStr::new(peering_key)) {
@@ -204,7 +205,7 @@ fn load_signer_keys(
                     signing_key
                         .public_key()
                         .map_err(|err| {
-                            UserError::KeyError(InternalError::from_source(Box::new(err)))
+                            UserError::InternalError(InternalError::from_source(Box::new(err)))
                         })?
                         .as_slice(),
                 ));
@@ -218,13 +219,13 @@ fn load_signer_keys(
             last_known_key = path
                 .file_stem()
                 .ok_or_else(|| {
-                    UserError::KeyError(InternalError::with_message(
+                    UserError::InternalError(InternalError::with_message(
                         "Unable to get file name".to_string(),
                     ))
                 })?
                 .to_str()
                 .ok_or_else(|| {
-                    UserError::KeyError(InternalError::with_message(
+                    UserError::InternalError(InternalError::with_message(
                         "Unable to get file name".to_string(),
                     ))
                 })?
@@ -240,7 +241,9 @@ fn load_signer_keys(
             peer_token = Some(PeerAuthorizationToken::from_public_key(
                 signing_key
                     .public_key()
-                    .map_err(|err| UserError::KeyError(InternalError::from_source(Box::new(err))))?
+                    .map_err(|err| {
+                        UserError::InternalError(InternalError::from_source(Box::new(err)))
+                    })?
                     .as_slice(),
             ));
             warn!(
@@ -249,12 +252,14 @@ fn load_signer_keys(
                 last_known_key
             );
         } else {
-            return Err(UserError::KeyError(InternalError::with_message(format!(
-                "Unable to decide which key to use for required authorization for \
+            return Err(UserError::InternalError(InternalError::with_message(
+                format!(
+                    "Unable to decide which key to use for required authorization for \
                 provided peers. Peering key {} was not found and there are more then one \
                 configured signing key",
-                peering_key,
-            ))));
+                    peering_key,
+                ),
+            )));
         }
     }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -635,7 +635,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
         })?;
 
         InfluxRecorder::init(metrics_url, metrics_db, metrics_username, metrics_password)
-            .map_err(UserError::MetricsError)?
+            .map_err(UserError::InternalError)?
     }
 
     Ok(())


### PR DESCRIPTION
As node_id moves into the database eventually we want splinterd not to start with the old node_id storage file in place. This makes splinterd check for the file and exit with an error message if it exists.