### PR TITLE
Update bcrypt version to 0.10

### DIFF
--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -34,7 +34,7 @@ actix = { version = "0.9", default-features = false }
 actix-web = "2.0"
 actix-web-actors = "2.0"
 actix-rt = "1.0"
-bcrypt = "0.5"
+bcrypt = "0.10"
 clap = "2"
 ctrlc = "3.0"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -37,7 +37,7 @@ actix-web-3 = { package = "actix-web", version = "3", optional = true, features 
 atomicwrites = "0.2"
 awc = { version = "0.2", optional = true }
 base64 = { version = "0.12", optional = true }
-bcrypt = {version = "0.6", optional = true}
+bcrypt = {version = "0.10", optional = true}
 byteorder = "1"
 chrono = {version = "0.4", optional = true}
 crossbeam-channel = "0.3"


### PR DESCRIPTION
Block-cipher-trait got yanked and our versions of bcrypt depended on it.
New version of bcrypt does not depend on it and fixes the problem.

Signed-off-by: Caleb Hill <hill@bitwise.io>