### PR TITLE
Update --node-public-key to work with --node-file

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,6 +54,10 @@ const CIRCUIT_PROPOSE_AFTER_HELP: &str = r"DETAILS:
           endpoints:
             - tcps://node-2-endpoint:8045
 
+    If using challenge authorization, a public key must be provided for every node using
+    --node-public-key, regardless of if --node or --node-file is used. This public key correlates
+    to the key pair that node will use for identification
+
     For the --service-arg, --service-peer-group, and --service-type options, service IDs can be
     wildcarded with '*' to match multiple services. For example, '--service-type *::scabbard' match
     all services, and '--service-type sc*::scabbard' will match all services with IDs that start


### PR DESCRIPTION
Previously --node-public-key values were only being added
to the nodes defined by --node, however if using challenge
authorization public keys need to be added for nodes that
were added using a --node-file as well.

The node file format is not going to be changed to support adding
the challenge authorization keys directly, so they must be provided
separately on the command line.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>