### PR TITLE
Make Challenge default authorization type

### DIFF
--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -140,8 +140,21 @@ impl Action for CircuitProposeAction {
         #[cfg(feature = "challenge-authorization")]
         #[allow(clippy::single_match)]
         match args.value_of("authorization_type") {
-            Some(auth_type) => builder.set_authorization_type(auth_type)?,
-            None => (),
+            Some(auth_type) => {
+                if args.value_of("compat_version") == Some("0.4") && auth_type == "challenge" {
+                    return Err(CliError::ActionError(
+                        "Challlenge authorization is not compatible with \
+                        Splinter v0.4"
+                            .to_string(),
+                    ));
+                }
+                builder.set_authorization_type(auth_type)?;
+            }
+            None => {
+                if args.value_of("compat_version") == Some("0.4") {
+                    builder.set_authorization_type("trust")?;
+                }
+            }
         }
 
         if let Some(management_type) = args.value_of("management_type") {

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -21,7 +21,9 @@ use gameroom_database::{
 };
 use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
-use splinter::admin::messages::{CreateCircuit, CreateCircuitBuilder, SplinterNode};
+use splinter::admin::messages::{
+    AuthorizationType, CreateCircuit, CreateCircuitBuilder, SplinterNode,
+};
 use splinter::circuit::template::CircuitCreateTemplate;
 use splinter::protocol;
 use splinter::protos::admin::{
@@ -174,7 +176,8 @@ pub async fn propose_gameroom(
         }
     };
 
-    let mut create_circuit_builder = CreateCircuitBuilder::new();
+    let mut create_circuit_builder =
+        CreateCircuitBuilder::new().with_authorization_type(&AuthorizationType::Trust);
 
     create_circuit_builder = match template.apply_to_builder(create_circuit_builder) {
         Ok(builder) => builder,

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -191,12 +191,22 @@ impl CreateCircuitBuilder {
             .members
             .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
 
+        #[cfg(not(feature = "challenge-authorization"))]
         let authorization_type = self.authorization_type.unwrap_or_else(|| {
             debug!(
                 "Building circuit create request with default authorization_type: {:?}",
                 AuthorizationType::Trust
             );
             AuthorizationType::Trust
+        });
+
+        #[cfg(feature = "challenge-authorization")]
+        let authorization_type = self.authorization_type.unwrap_or_else(|| {
+            debug!(
+                "Building circuit create request with default authorization_type: {:?}",
+                AuthorizationType::Challenge
+            );
+            AuthorizationType::Challenge
         });
 
         let persistence = self.persistence.unwrap_or_else(|| {
@@ -515,7 +525,10 @@ mod tests {
             .all(|c| c.is_ascii_alphanumeric()));
         assert_eq!(circuit.roster, vec![service]);
         assert_eq!(circuit.members, vec![node]);
+        #[cfg(not(feature = "challenge-authorization"))]
         assert_eq!(circuit.authorization_type, AuthorizationType::Trust);
+        #[cfg(feature = "challenge-authorization")]
+        assert_eq!(circuit.authorization_type, AuthorizationType::Challenge);
         assert_eq!(circuit.persistence, PersistenceType::Any);
         assert_eq!(circuit.durability, DurabilityType::NoDurability);
         assert_eq!(circuit.routes, RouteType::Any);

--- a/libsplinter/src/network/auth/handlers/v0_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v0_handlers.rs
@@ -299,6 +299,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
     use cylinder::{PublicKey, Signature, VerificationError, Verifier};
     use protobuf::Message;
 
@@ -326,7 +328,7 @@ mod tests {
         #[cfg(feature = "challenge-authorization")]
         {
             dispatcher_builder = dispatcher_builder
-                .with_signers(&vec![])
+                .with_signers(&vec![new_signer()])
                 .with_nonce(&vec![])
                 .with_expected_authorization(None)
                 .with_local_authorization(None)
@@ -401,7 +403,7 @@ mod tests {
         #[cfg(feature = "challenge-authorization")]
         {
             dispatcher_builder = dispatcher_builder
-                .with_signers(&vec![])
+                .with_signers(&vec![new_signer()])
                 .with_nonce(&vec![])
                 .with_expected_authorization(None)
                 .with_local_authorization(None)
@@ -461,7 +463,7 @@ mod tests {
         #[cfg(feature = "challenge-authorization")]
         {
             dispatcher_builder = dispatcher_builder
-                .with_signers(&vec![])
+                .with_signers(&vec![new_signer()])
                 .with_nonce(&vec![])
                 .with_expected_authorization(None)
                 .with_local_authorization(None)
@@ -589,5 +591,12 @@ mod tests {
         ) -> Result<bool, VerificationError> {
             unimplemented!()
         }
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    fn new_signer() -> Box<dyn Signer> {
+        let context = Secp256k1Context::new();
+        let key = context.new_random_private_key();
+        context.new_signer(key)
     }
 }

--- a/libsplinter/src/network/auth/handlers/v1_handlers.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers.rs
@@ -57,8 +57,6 @@ use crate::public_key;
 pub struct AuthProtocolRequestHandler {
     auth_manager: AuthorizationManagerStateMachine,
     #[cfg(feature = "challenge-authorization")]
-    challenge_configured: bool,
-    #[cfg(feature = "challenge-authorization")]
     expected_authorization: Option<ConnectionAuthorizationType>,
     #[cfg(feature = "challenge-authorization")]
     local_authorization: Option<ConnectionAuthorizationType>,
@@ -67,7 +65,6 @@ pub struct AuthProtocolRequestHandler {
 impl AuthProtocolRequestHandler {
     pub fn new(
         auth_manager: AuthorizationManagerStateMachine,
-        #[cfg(feature = "challenge-authorization")] challenge_configured: bool,
         #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
             ConnectionAuthorizationType,
         >,
@@ -77,8 +74,6 @@ impl AuthProtocolRequestHandler {
     ) -> Self {
         Self {
             auth_manager,
-            #[cfg(feature = "challenge-authorization")]
-            challenge_configured,
             #[cfg(feature = "challenge-authorization")]
             expected_authorization,
             #[cfg(feature = "challenge-authorization")]
@@ -163,24 +158,20 @@ impl Handler for AuthProtocolRequestHandler {
                 match self.expected_authorization {
                     #[cfg(feature = "trust-authorization")]
                     Some(ConnectionAuthorizationType::Trust { .. }) => (),
-                    #[cfg(feature = "challenge-authorization")]
                     Some(ConnectionAuthorizationType::Challenge { .. }) => {
                         accepted_authorization_type = vec![PeerAuthorizationType::Challenge]
                     }
                     // if None, check required local authorization type as well
                     _ => {
                         match self.local_authorization {
+                            #[cfg(feature = "trust-authorization")]
                             Some(ConnectionAuthorizationType::Trust { .. }) => (),
                             Some(ConnectionAuthorizationType::Challenge { .. }) => {
                                 accepted_authorization_type = vec![PeerAuthorizationType::Challenge]
                             }
                             _ => {
                                 // if trust is enabled it was already added
-                                #[cfg(feature = "challenge-authorization")]
-                                if self.challenge_configured {
-                                    accepted_authorization_type
-                                        .push(PeerAuthorizationType::Challenge)
-                                }
+                                accepted_authorization_type.push(PeerAuthorizationType::Challenge)
                             }
                         }
                     }

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -964,6 +964,8 @@ mod tests {
     #[cfg(feature = "challenge-authorization")]
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "challenge-authorization")]
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
     use cylinder::{PublicKey, Signature, VerificationError, Verifier, VerifierFactory};
     use protobuf::Message;
 
@@ -1161,7 +1163,7 @@ mod tests {
         let auth_mgr = AuthorizationManager::new(
             "test_identity".into(),
             #[cfg(feature = "challenge-authorization")]
-            vec![],
+            vec![new_signer()],
             #[cfg(feature = "challenge-authorization")]
             Arc::new(Mutex::new(Box::new(NoopFactory))),
         )
@@ -1238,7 +1240,7 @@ mod tests {
         let auth_mgr = AuthorizationManager::new(
             "test_identity".into(),
             #[cfg(feature = "challenge-authorization")]
-            vec![],
+            vec![new_signer()],
             #[cfg(feature = "challenge-authorization")]
             Arc::new(Mutex::new(Box::new(NoopFactory))),
         )
@@ -1392,7 +1394,7 @@ mod tests {
         let auth_mgr = AuthorizationManager::new(
             "test_identity".into(),
             #[cfg(feature = "challenge-authorization")]
-            vec![],
+            vec![new_signer()],
             #[cfg(feature = "challenge-authorization")]
             Arc::new(Mutex::new(Box::new(NoopFactory))),
         )
@@ -1567,7 +1569,7 @@ mod tests {
         let auth_mgr = AuthorizationManager::new(
             "test_identity".into(),
             #[cfg(feature = "challenge-authorization")]
-            vec![],
+            vec![new_signer()],
             #[cfg(feature = "challenge-authorization")]
             Arc::new(Mutex::new(Box::new(NoopFactory))),
         )
@@ -1708,5 +1710,12 @@ mod tests {
         fn new_verifier(&self) -> Box<dyn Verifier> {
             Box::new(NoopVerifier)
         }
+    }
+
+    #[cfg(feature = "challenge-authorization")]
+    fn new_signer() -> Box<dyn Signer> {
+        let context = Secp256k1Context::new();
+        let key = context.new_random_private_key();
+        context.new_signer(key)
     }
 }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -1235,8 +1235,8 @@ impl SplinterDaemonBuilder {
     }
 
     #[cfg(feature = "challenge-authorization")]
-    pub fn with_peering_token(mut self, value: Option<PeerAuthorizationToken>) -> Self {
-        self.peering_token = value;
+    pub fn with_peering_token(mut self, value: PeerAuthorizationToken) -> Self {
+        self.peering_token = Some(value);
         self
     }
 
@@ -1318,15 +1318,14 @@ impl SplinterDaemonBuilder {
         })?;
 
         #[cfg(feature = "challenge-authorization")]
-        let signers = self.signers.unwrap_or_else(|| {
-            warn!("Starting daemon with no signing keys");
-            vec![]
-        });
+        let signers = self.signers.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: signers".to_string())
+        })?;
 
         #[cfg(feature = "challenge-authorization")]
-        let peering_token = self
-            .peering_token
-            .unwrap_or_else(|| PeerAuthorizationToken::from_peer_id(&node_id));
+        let peering_token = self.peering_token.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: peering_token".to_string())
+        })?;
 
         Ok(SplinterDaemon {
             #[cfg(feature = "authorization-handler-allow-keys")]


### PR DESCRIPTION
This PR changes it so that challenge is the default authorization type if challenge-authorization is enabled. This includes updating the splinterd to require configuring at least one key pair to be used in challenge authorization. 