### PR TITLE
Add challenge-authorization integration tests

### DIFF
--- a/splinterd/src/node/runnable/admin.rs
+++ b/splinterd/src/node/runnable/admin.rs
@@ -128,7 +128,7 @@ impl RunnableAdminSubsystem {
         admin_service_builder = admin_service_builder
             .with_node_id(node_id.clone())
             .with_service_orchestrator(orchestrator)
-            .with_peer_manager_connector(peer_connector)
+            .with_peer_manager_connector(peer_connector.clone())
             .with_admin_service_store(store_factory.get_admin_service_store())
             .with_admin_event_store(store_factory.get_admin_service_store())
             .with_signature_verifier(self.admin_service_verifier)
@@ -205,6 +205,7 @@ impl RunnableAdminSubsystem {
             actix1_resources,
             store_factory,
             admin_service_event_client_variant: running_admin_service_event_client_variant,
+            peer_connector,
         })
     }
 }

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -49,6 +49,7 @@ pub struct RunnableNode {
     pub(super) runnable_network_subsystem: RunnableNetworkSubsystem,
     pub(super) node_id: String,
     pub(super) enable_biome: bool,
+    pub(super) signers: Vec<Box<dyn cylinder::Signer>>,
 }
 
 impl RunnableNode {
@@ -66,6 +67,8 @@ impl RunnableNode {
         let mut admin_subsystem = runnable_admin_subsystem.run()?;
 
         let node_id = self.node_id;
+
+        let signers = self.signers;
 
         let rest_api_variant = match self.rest_api_variant {
             RunnableNodeRestApiVariant::ActixWeb1(rest_api) => {
@@ -172,6 +175,7 @@ impl RunnableNode {
             rest_api_port,
             node_id,
             admin_service_event_client,
+            signers,
         })
     }
 }

--- a/splinterd/src/node/running/admin.rs
+++ b/splinterd/src/node/running/admin.rs
@@ -17,6 +17,7 @@
 use splinter::admin::client::event::{AdminServiceEventClient, AwcAdminServiceEventClientBuilder};
 use splinter::error::InternalError;
 use splinter::events::Reactor;
+use splinter::peer::PeerManagerConnector;
 use splinter::registry::RegistryWriter;
 use splinter::rest_api::actix_web_1::Resource as Actix1Resource;
 use splinter::service::ServiceProcessorShutdownHandle;
@@ -35,6 +36,7 @@ pub struct AdminSubsystem {
     pub(crate) actix1_resources: Vec<Actix1Resource>,
     pub(crate) store_factory: Box<dyn StoreFactory>,
     pub(crate) admin_service_event_client_variant: AdminServiceEventClientVariant,
+    pub(crate) peer_connector: PeerManagerConnector,
 }
 
 impl AdminSubsystem {
@@ -47,6 +49,10 @@ impl AdminSubsystem {
 
     pub fn registry_writer(&self) -> &dyn RegistryWriter {
         &*self.registry_writer
+    }
+
+    pub fn peer_connector(&self) -> &PeerManagerConnector {
+        &self.peer_connector
     }
 
     pub fn admin_service_event_client(

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -52,6 +52,7 @@ pub struct Node {
     pub(super) network_subsystem: network::NetworkSubsystem,
     pub(super) node_id: String,
     pub(super) admin_service_event_client: Box<dyn AdminServiceEventClient>,
+    pub(super) signers: Vec<Box<dyn cylinder::Signer>>,
 }
 
 impl Node {
@@ -65,6 +66,10 @@ impl Node {
 
     pub fn admin_signer(&self) -> &dyn Signer {
         &*self.admin_signer
+    }
+
+    pub fn signers(&self) -> &[Box<dyn Signer>] {
+        &self.signers
     }
 
     pub fn registry_writer(&self) -> &dyn RegistryWriter {
@@ -123,6 +128,7 @@ impl Node {
             rest_api_port,
             mut network_subsystem,
             admin_service_event_client: _,
+            signers,
         } = self;
 
         let rest_api_variant = match rest_api_variant {
@@ -160,6 +166,7 @@ impl Node {
             .with_node_id(node_id)
             .with_rest_api_variant(rest_api_variant)
             .with_admin_signer(admin_signer.to_owned())
+            .with_signers(signers)
             .with_rest_api_port(rest_api_port.into())
             .with_store_factory(store_factory)
             .build()

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -27,6 +27,7 @@ use splinter::admin::client::event::{
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::biome::client::{BiomeClient, ReqwestBiomeClient};
 use splinter::error::InternalError;
+use splinter::peer::PeerManagerConnector;
 use splinter::registry::{
     client::{RegistryClient, ReqwestRegistryClient},
     RegistryWriter,
@@ -74,6 +75,10 @@ impl Node {
 
     pub fn registry_writer(&self) -> &dyn RegistryWriter {
         self.admin_subsystem.registry_writer()
+    }
+
+    pub fn peer_connector(&self) -> &PeerManagerConnector {
+        self.admin_subsystem.peer_connector()
     }
 
     pub fn network_endpoints(&self) -> &[String] {

--- a/splinterd/tests/admin/circuit_abandon.rs
+++ b/splinterd/tests/admin/circuit_abandon.rs
@@ -272,7 +272,13 @@ pub fn test_3_party_circuit_abandon() {
 
     let circuit_id = "ABCDE-01234";
     // Commit a circuit to state
-    commit_3_party_circuit(&circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(
+        &circuit_id,
+        node_a,
+        node_b,
+        node_c,
+        AuthorizationType::Trust,
+    );
 
     // Create the `ServiceId` struct based on the first node's associated `service_id` and the
     // committed `circuit_id`
@@ -296,7 +302,13 @@ pub fn test_3_party_circuit_abandon() {
     // abandoned
     let active_circuit_id = "FGHIJ-56789";
     // Commit the circuit to state
-    commit_3_party_circuit(&active_circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(
+        &active_circuit_id,
+        node_a,
+        node_b,
+        node_c,
+        AuthorizationType::Trust,
+    );
 
     // Create the `ServiceId` struct based on the first node's associated `service_id` and the
     // committed `circuit_id`
@@ -659,12 +671,24 @@ pub fn test_3_party_circuit_abandon_stop() {
 
     let circuit_id = "ABCDE-01234";
     // Commit a circuit to state
-    commit_3_party_circuit(&circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(
+        &circuit_id,
+        node_a,
+        node_b,
+        node_c,
+        AuthorizationType::Trust,
+    );
     // Commit a circuit between the nodes that will remain active while the other circuit is
     // abandoned
     let active_circuit_id = "FGHIJ-56789";
     // Commit the circuit to state
-    commit_3_party_circuit(&active_circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(
+        &active_circuit_id,
+        node_a,
+        node_b,
+        node_c,
+        AuthorizationType::Trust,
+    );
 
     // Stop the second node in the network
     network = network.stop(1).expect("Unable to stop second node");

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -182,6 +182,7 @@ pub(in crate::admin) fn commit_3_party_circuit(
     node_a: &Node,
     node_b: &Node,
     node_c: &Node,
+    auth_type: AuthorizationType,
 ) {
     // Create the list of node details needed to build the `CircuitCreateRequest`
     let node_info = vec![
@@ -258,7 +259,7 @@ pub(in crate::admin) fn commit_3_party_circuit(
                 .expect("Unable to get third node's public key")
                 .as_hex(),
         ],
-        AuthorizationType::Trust,
+        auth_type,
     )
     .expect("Unable to generate circuit request");
     // Submit the `CircuitManagementPayload` to the first node

--- a/splinterd/tests/admin/circuit_commit.rs
+++ b/splinterd/tests/admin/circuit_commit.rs
@@ -38,7 +38,9 @@ pub(in crate::admin) fn commit_2_party_circuit(
             (
                 node_a.network_endpoints().to_vec(),
                 node_a
-                    .admin_signer()
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
                     .public_key()
                     .expect("Unable to get first node's public key"),
             ),
@@ -48,9 +50,11 @@ pub(in crate::admin) fn commit_2_party_circuit(
             (
                 node_b.network_endpoints().to_vec(),
                 node_b
-                    .admin_signer()
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
                     .public_key()
-                    .expect("Unable to get seconds node's public key"),
+                    .expect("Unable to get second node's public key"),
             ),
         ),
     ]
@@ -191,8 +195,9 @@ pub(in crate::admin) fn commit_3_party_circuit(
             (
                 node_a.network_endpoints().to_vec(),
                 node_a
-                    .admin_signer()
-                    .clone()
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
                     .public_key()
                     .expect("Unable to get first node's public key"),
             ),
@@ -202,8 +207,9 @@ pub(in crate::admin) fn commit_3_party_circuit(
             (
                 node_b.network_endpoints().to_vec(),
                 node_b
-                    .admin_signer()
-                    .clone()
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
                     .public_key()
                     .expect("Unable to get second node's public key"),
             ),
@@ -213,8 +219,9 @@ pub(in crate::admin) fn commit_3_party_circuit(
             (
                 node_c.network_endpoints().to_vec(),
                 node_c
-                    .admin_signer()
-                    .clone()
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
                     .public_key()
                     .expect("Unable to get third node's public key"),
             ),

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -351,7 +351,7 @@ pub fn test_3_party_circuit_lifecycle() {
     let node_c_admin_pubkey = admin_pubkey(node_b);
 
     let circuit_id = "ABCDE-01234";
-    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
@@ -556,7 +556,7 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
     let node_c_admin_pubkey = admin_pubkey(node_b);
 
     let circuit_id = "ABCDE-01234";
-    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just past the circuit ready event
     let mut node_a_events = BlockingAdminServiceEventIterator::new(
@@ -1174,7 +1174,7 @@ pub fn test_3_party_circuit_lifecycle_stop() {
     // Get the third node from the network
     let mut node_c = network.node(2).expect("Unable to get third node");
     let circuit_id = "ABCDE-01234";
-    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c, AuthorizationType::Trust);
     // As we've started a new event client, we'll skip just to the circuit ready event and record
     // this event ID. We will use this again once the node has been restarted to catch back up.
     let mut node_a_last_seen_event_id = *BlockingAdminServiceEventIterator::new(
@@ -1474,7 +1474,7 @@ pub fn test_3_party_circuit_disband_rejected_stop() {
     let mut node_c = network.node(2).expect("Unable to get third node");
 
     let circuit_id = "ABCDE-01234";
-    commit_3_party_circuit(circuit_id, node_a, node_b, node_c);
+    commit_3_party_circuit(circuit_id, node_a, node_b, node_c, AuthorizationType::Trust);
 
     // As we've started a new event client, we'll skip just to the circuit ready event and record
     // this event ID. We will use this again once the node has been restarted to catch back up.


### PR DESCRIPTION
This commit includes 4 new integration tests (and the updates required to write them):
1. 3-party circuit creation using challenge authorization
2. 2-party circuit creation using challenge authorization where the nodes are connection view endpoint before the circuit     proposal is submitted 
3. 2-party circuit creation using challenge authorization with restarts - currently ignored due to endpoint restart issue
4. Create two 2-party circuit between two nodes where the nodes both support 2 signing keys and the second circuit sets the second key as the public key for the member of the first node - currently ignored due to bugs within challenge authorization that must be fixed