### PR TITLE
Add REST API endpoint to replace user keys

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -121,6 +121,7 @@ experimental = [
     "biome-client",
     "biome-client-reqwest",
     "biome-notifications",
+    "biome-replace-keys",
     "challenge-authorization",
     "client-reqwest",
     "https-bind",
@@ -159,6 +160,7 @@ biome-credentials = ["bcrypt", "biome"]
 biome-key-management = ["biome"]
 biome-notifications = ["biome"]
 biome-profile = ["biome"]
+biome-replace-keys = ["biome-key-management"]
 challenge-authorization = []
 circuit-template = ["admin-service", "glob"]
 client-reqwest = ["reqwest"]

--- a/libsplinter/src/biome/client/mod.rs
+++ b/libsplinter/src/biome/client/mod.rs
@@ -64,7 +64,7 @@ pub struct UpdateUser {
 }
 
 /// New key pairs to be added while updating a Biome user.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NewKey {
     pub public_key: String,
     pub encrypted_private_key: String,

--- a/libsplinter/src/biome/client/mod.rs
+++ b/libsplinter/src/biome/client/mod.rs
@@ -157,6 +157,14 @@ pub trait BiomeClient {
     /// * `new_display_name`: Updated display name for the key pair
     fn update_key(&self, public_key: &str, new_display_name: &str) -> Result<(), InternalError>;
 
+    /// Replace the current Biome user's keys
+    ///
+    /// # Arguments
+    ///
+    /// * `keys`: New keys for the user
+    #[cfg(feature = "biome-replace-keys")]
+    fn replace_keys(&self, keys: Vec<NewKey>) -> Result<(), InternalError>;
+
     /// Add a key pair for a Biome user.
     ///
     /// # Arguments

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
@@ -40,11 +40,19 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
     #[cfg(feature = "authorization")]
     {
         #[cfg(feature = "biome-replace-keys")]
-        let resource = resource.add_method(
-            Method::Put,
-            Permission::AllowAuthenticated,
-            handle_put(key_store.clone()),
-        );
+        let resource = resource
+            .add_method(
+                Method::Put,
+                Permission::AllowAuthenticated,
+                handle_put(key_store.clone()),
+            )
+            .add_request_guard(
+                ProtocolVersionRangeGuard::new(
+                    protocol::BIOME_REPLACE_KEYS_PROTOCOL_MIN,
+                    protocol::BIOME_PROTOCOL_VERSION,
+                )
+                .with_method(Method::Put),
+            );
 
         resource
             .add_method(
@@ -66,7 +74,15 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
     #[cfg(not(feature = "authorization"))]
     {
         #[cfg(feature = "biome-replace-keys")]
-        let resource = resource.add_method(Method::Put, handle_put(key_store.clone()));
+        let resource = resource
+            .add_method(Method::Put, handle_put(key_store.clone()))
+            .add_request_guard(
+                ProtocolVersionRangeGuard::new(
+                    protocol::BIOME_REPLACE_KEYS_PROTOCOL_MIN,
+                    protocol::BIOME_PROTOCOL_VERSION,
+                )
+                .with_method(Method::Put),
+            );
 
         resource
             .add_method(Method::Post, handle_post(key_store.clone()))

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
@@ -39,6 +39,13 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
         ));
     #[cfg(feature = "authorization")]
     {
+        #[cfg(feature = "biome-replace-keys")]
+        let resource = resource.add_method(
+            Method::Put,
+            Permission::AllowAuthenticated,
+            handle_put(key_store.clone()),
+        );
+
         resource
             .add_method(
                 Method::Post,
@@ -58,6 +65,9 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
     }
     #[cfg(not(feature = "authorization"))]
     {
+        #[cfg(feature = "biome-replace-keys")]
+        let resource = resource.add_method(Method::Put, handle_put(key_store.clone()));
+
         resource
             .add_method(Method::Post, handle_post(key_store.clone()))
             .add_method(Method::Get, handle_get(key_store.clone()))
@@ -162,6 +172,71 @@ fn handle_get(key_store: Arc<dyn KeyStore>) -> HandlerFunction {
                 )
             }
         }
+    })
+}
+
+/// Defines a REST endpoint for updating all keys in the underlying storage
+#[cfg(feature = "biome-replace-keys")]
+fn handle_put(key_store: Arc<dyn KeyStore>) -> HandlerFunction {
+    Box::new(move |request, payload| {
+        let key_store = key_store.clone();
+        let user = match request.extensions().get::<Identity>() {
+            Some(Identity::User(user)) => user.clone(),
+            _ => {
+                return Box::new(
+                    HttpResponse::Unauthorized()
+                        .json(ErrorResponse::unauthorized())
+                        .into_future(),
+                )
+            }
+        };
+
+        Box::new(into_bytes(payload).and_then(move |bytes| {
+            let new_keys = match serde_json::from_slice::<Vec<NewKey>>(&bytes) {
+                Ok(val) => val,
+                Err(err) => {
+                    debug!("Error parsing payload {}", err);
+                    return HttpResponse::BadRequest()
+                        .json(ErrorResponse::bad_request(&format!(
+                            "Failed to parse payload: {}",
+                            err
+                        )))
+                        .into_future();
+                }
+            };
+
+            let new_keys: Vec<Key> = new_keys
+                .iter()
+                .map(|new_key| {
+                    Key::new(
+                        &new_key.public_key,
+                        &new_key.encrypted_private_key,
+                        &user,
+                        &new_key.display_name,
+                    )
+                })
+                .collect();
+
+            match key_store.replace_keys(&user, &new_keys) {
+                Ok(()) => HttpResponse::Ok()
+                    .json(json!({ "message": "Keys replaced successfully" }))
+                    .into_future(),
+                Err(err) => {
+                    debug!("Failed to replace keys in database {}", err);
+                    match err {
+                        KeyStoreError::DuplicateKeyError(msg) => HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&msg))
+                            .into_future(),
+                        KeyStoreError::UserDoesNotExistError(msg) => HttpResponse::BadRequest()
+                            .json(ErrorResponse::bad_request(&msg))
+                            .into_future(),
+                        _ => HttpResponse::InternalServerError()
+                            .json(ErrorResponse::internal_error())
+                            .into_future(),
+                    }
+                }
+            }
+        }))
     })
 }
 

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
@@ -384,6 +384,59 @@ mod tests {
         })
     }
 
+    /// Test PUT to /biome/keys version number
+    ///
+    /// Verify that PUT /biome/keys correctly identifies and rejects
+    /// invalid version numbers
+    ///
+    /// Procedure
+    ///
+    /// 1) Create a new user and log in as that user
+    /// 2) Validate that PUT /biome/keys with a correct version returns 200
+    /// 3) Validate that PUT /biome/keys with an incorrect returns 400
+    #[test]
+    #[cfg(feature = "biome-replace-keys")]
+    fn test_put_key_version() {
+        run_test(|url, client| {
+            let login =
+                create_and_authorize_user(url, &client, "test_post_key@gmail.com", "Admin2193!");
+
+            let test_keys: Vec<PostKey> = vec![PostKey {
+                public_key: "<public_key>".to_string(),
+                encrypted_private_key: "<private_key>".to_string(),
+                display_name: "test_post_key@gmail.com".to_string(),
+            }];
+
+            // Verify that a correct version works
+            assert_eq!(
+                client
+                    .put(&format!("{}/biome/keys", url))
+                    .header("Authorization", format!("Bearer {}", login.token))
+                    .header("SplinterProtocolVersion", "2")
+                    .json(&test_keys)
+                    .send()
+                    .unwrap()
+                    .status()
+                    .as_u16(),
+                200
+            );
+
+            // Verify that an incorrect version does not work
+            assert_eq!(
+                client
+                    .put(&format!("{}/biome/keys", url))
+                    .header("Authorization", format!("Bearer {}", login.token))
+                    .header("SplinterProtocolVersion", "1")
+                    .json(&test_keys)
+                    .send()
+                    .unwrap()
+                    .status()
+                    .as_u16(),
+                400
+            );
+        });
+    }
+
     /// Test happy path for GET /biome/keys/{public_key}
     ///
     /// Verify GET /biome/keys/{public_key} retrieves the

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
@@ -23,6 +23,7 @@ use crate::rest_api::{Resource, RestResourceProvider};
 ///
 /// * `GET /biome/keys` - Get all keys for the authorized user
 /// * `POST /biome/keys` - Add a new key for the authorized user
+/// * `PUT /biome/keys` - Replace keys for the authorized user
 /// * `PATCH /biome/keys` - Update the display name associated with a key for the authorized user
 /// * `GET /biome/keys/{public_key}` - Retrieve the authorized user's key that corresponds to
 ///   `public_key`

--- a/libsplinter/src/biome/key_management/store/mod.rs
+++ b/libsplinter/src/biome/key_management/store/mod.rs
@@ -48,6 +48,25 @@ pub trait KeyStore: Sync + Send {
         new_display_name: &str,
     ) -> Result<(), KeyStoreError>;
 
+    /// Replaces all keys in the underlying storage for the user
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id`: The ID owner of the key records to be updated.
+    /// * `keys`: The array of new keys for the user
+    #[cfg(feature = "biome-replace-keys")]
+    fn replace_keys(&self, user_id: &str, keys: &[Key]) -> Result<(), KeyStoreError> {
+        for key in self.list_keys(Some(user_id))? {
+            self.remove_key(&key.public_key, user_id)?;
+        }
+
+        for key in keys {
+            self.add_key(key.clone())?;
+        }
+
+        Ok(())
+    }
+
     /// Removes a key from the underlying storage
     ///
     /// # Arguments
@@ -104,6 +123,11 @@ where
         new_display_name: &str,
     ) -> Result<(), KeyStoreError> {
         (**self).update_key(public_key, user_id, new_display_name)
+    }
+
+    #[cfg(feature = "biome-replace-keys")]
+    fn replace_keys(&self, user_id: &str, keys: &[Key]) -> Result<(), KeyStoreError> {
+        (**self).replace_keys(user_id, keys)
     }
 
     fn remove_key(&self, public_key: &str, user_id: &str) -> Result<Key, KeyStoreError> {

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -91,7 +91,7 @@ pub(crate) const REGISTRY_FETCH_NODE_MIN: u32 = 1;
     feature = "biome-notifications",
     feature = "oauth"
 ))]
-pub const BIOME_PROTOCOL_VERSION: u32 = 1;
+pub const BIOME_PROTOCOL_VERSION: u32 = 2;
 
 #[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
 pub(crate) const BIOME_REGISTER_PROTOCOL_MIN: u32 = 1;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -106,6 +106,8 @@ pub(crate) const BIOME_VERIFY_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(all(feature = "biome-key-management", feature = "rest-api",))]
 pub(crate) const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;
+#[cfg(all(feature = "biome-replace-keys", feature = "rest-api",))]
+pub(crate) const BIOME_REPLACE_KEYS_PROTOCOL_MIN: u32 = 2;
 
 #[cfg(all(feature = "biome-profile", feature = "rest-api",))]
 pub(crate) const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;

--- a/libsplinter/src/rest_api/actix_web_1/resource.rs
+++ b/libsplinter/src/rest_api/actix_web_1/resource.rs
@@ -15,10 +15,13 @@
 use std::sync::Arc;
 
 use actix_web::{
-    error::ErrorBadRequest, http::header, web, Error as ActixError, HttpRequest, HttpResponse,
+    error::ErrorBadRequest,
+    http::{header, Method as ActixMethod},
+    web, Error as ActixError, HttpRequest, HttpResponse,
 };
 use futures::{future::IntoFuture, stream::Stream, Future};
 use protobuf::{self, Message};
+use std::cmp::PartialEq;
 
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::{Permission, PermissionMap};
@@ -45,6 +48,19 @@ impl std::fmt::Display for Method {
             Method::Patch => f.write_str("PATCH"),
             Method::Delete => f.write_str("DELETE"),
             Method::Head => f.write_str("HEAD"),
+        }
+    }
+}
+
+impl PartialEq<ActixMethod> for Method {
+    fn eq(&self, other: &ActixMethod) -> bool {
+        match self {
+            Method::Get => other == ActixMethod::GET,
+            Method::Post => other == ActixMethod::POST,
+            Method::Put => other == ActixMethod::PUT,
+            Method::Patch => other == ActixMethod::PATCH,
+            Method::Delete => other == ActixMethod::DELETE,
+            Method::Head => other == ActixMethod::HEAD,
         }
     }
 }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -82,6 +82,7 @@ default = [
     "biome-credentials",
     "biome-key-management",
     "biome-profile",
+    "biome-replace-keys",
     "database-postgres",
     "database-sqlite",
     "oauth",
@@ -125,6 +126,7 @@ authorization-handler-rbac = [
 biome-credentials = ["splinter/biome-credentials"]
 biome-key-management = ["splinter/biome-key-management"]
 biome-profile = ["splinter/biome-profile"]
+biome-replace-keys = ["splinter/biome-replace-keys"]
 challenge-authorization = [
   "cylinder/key-load",
   "splinter/challenge-authorization"

--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -15,7 +15,7 @@
 openapi: '3.0.0'
 
 info:
-  version: 0.5.14
+  version: 0.5.15
   title: splinterd API
   description: REST API for the Splinter daemon
 
@@ -1700,6 +1700,45 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/BiomeUserKey'
+        401:
+          description: The client is unauthorized
+        500:
+          description: Internal server error occurred
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorBiome'
+    put:
+      tags:
+      - Biome
+      description: Replace all keys for the user
+      parameters:
+        - $ref: "#/components/parameters/auth"
+        - $ref: "#/components/parameters/protocol_version"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/BiomeUserKey'
+      responses:
+        200:
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Keys replaced successfully"
+        400:
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         401:
           description: The client is unauthorized
         500:

--- a/splinterd/tests/admin/biome.rs
+++ b/splinterd/tests/admin/biome.rs
@@ -233,6 +233,61 @@ fn test_biome_key_management() {
         .get_key("01234")
         .expect("Unable to retrieve key")
         .is_none());
+
+    // Validate the second key exists
+    assert!(node
+        .biome_client(Some(&auth_token))
+        .get_key("43210")
+        .expect("Unable to retrieve key")
+        .is_some());
+
+    #[cfg(feature = "biome-replace-keys")]
+    {
+        // The keys we are posting and using as a basis of comparison later
+        // These keys must be in ascending order by public_key
+        let expected_keys = vec![
+            NewKey {
+                public_key: "10293".to_string(),
+                encrypted_private_key: "48472".to_string(),
+                display_name: "replacement_key2".to_string(),
+            },
+            NewKey {
+                public_key: "89212".to_string(),
+                encrypted_private_key: "72612".to_string(),
+                display_name: "replacement_key".to_string(),
+            },
+            NewKey {
+                public_key: "93838".to_string(),
+                encrypted_private_key: "17279".to_string(),
+                display_name: "replacement_key3".to_string(),
+            },
+        ];
+
+        // Attempt to replace the keys, using the biome user's access token returned at log-in
+        assert!(node
+            .biome_client(Some(&auth_token))
+            .replace_keys(expected_keys.clone())
+            .is_ok());
+
+        // List the user's keys, using the biome user's access token returned at log-in
+        let mut keys = node
+            .biome_client(Some(&auth_token))
+            .list_user_keys()
+            .expect("Unable to list Biome user keys")
+            .into_iter()
+            .map(|key| NewKey {
+                public_key: key.public_key,
+                encrypted_private_key: key.encrypted_private_key,
+                display_name: key.display_name,
+            })
+            .collect::<Vec<NewKey>>();
+
+        keys.sort_by(|a, b| a.public_key.partial_cmp(&b.public_key).unwrap());
+
+        // Validate all keys are returned
+        assert_eq!(keys, expected_keys);
+    }
+
     // Shutdown the network
     shutdown!(network).expect("Unable to shutdown network");
 }


### PR DESCRIPTION
Add a new PUT REST API endpoint at /biome/keys that replaces all of a
user's keys with a new set of keys.

Signed-off-by: Lee Bradley <bradley@bitwise.io>