### PR TITLE
Fix warnings that were being emitted from biome test

### DIFF
--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/mod.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/mod.rs
@@ -290,15 +290,21 @@ mod tests {
         pub username: String,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct RegistrationResponse {
-        pub message: String,
+        #[serde(rename = "message")]
+        pub _message: String,
         pub data: RegistrationUser,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct LoginResponse {
-        pub message: String,
+        #[serde(rename = "message")]
+        pub _message: String,
         pub user_id: String,
         pub token: String,
         pub refresh_token: String,
@@ -334,9 +340,12 @@ mod tests {
         hashed_password: String,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct PostVerifyResponse {
-        pub message: String,
+        #[serde(rename = "message")]
+        pub _message: String,
         pub user_id: String,
     }
 

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/mod.rs
@@ -77,12 +77,17 @@ mod tests {
         pub hashed_password: String,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct LoginResponse {
-        pub message: String,
-        pub user_id: String,
+        #[serde(rename = "message")]
+        pub _message: String,
+        #[serde(rename = "user_id")]
+        pub _user_id: String,
         pub token: String,
-        pub refresh_token: String,
+        #[serde(rename = "refresh_token")]
+        pub _refresh_token: String,
     }
 
     #[derive(Serialize)]
@@ -92,17 +97,23 @@ mod tests {
         pub display_name: String,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct Key {
         pub public_key: String,
-        pub user_id: String,
+        #[serde(rename = "user_id")]
+        pub _user_id: String,
         pub display_name: String,
         pub encrypted_private_key: String,
     }
 
+    // ignored fields test that the server provides the field, but its not important to test the
+    // contents
     #[derive(Deserialize)]
     struct PostKeyResponse {
-        pub message: String,
+        #[serde(rename = "message")]
+        pub _message: String,
         pub data: Key,
     }
 


### PR DESCRIPTION
The warnings were being raised because several fields in
the test specific biome items were not being read. But
by keeping the fields in the structs the fields can still
be checked that they are in the returned response.

This commit puts an underscore in front of the unused fields
to remove the warning and adds a serde rename so the response
can still be deserialized correctly.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>