### PR TITLE
Add a --skip option to splinter keygen

### DIFF
--- a/cli/man/splinter-keygen.1.md
+++ b/cli/man/splinter-keygen.1.md
@@ -41,6 +41,9 @@ FLAGS
 : Decreases verbosity (the opposite of -v). When specified, only errors or
   warnings will be output.
 
+`--skip`
+: Skip generating the files if they exist. Cannot use  `--skip` with `--force`.
+
 `--system`
 : Generates system keys for `splinterd` in `/etc/splinter/keys`.
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -121,6 +121,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                     .help("Overwrite files if they exist"),
             )
             .arg(
+                Arg::with_name("skip")
+                    .long("skip")
+                    .conflicts_with("force")
+                    .help("Skip generating the files if they exist"),
+            )
+            .arg(
                 Arg::with_name("system")
                     .long("system")
                     .help("Generate system keys in /etc/splinter/keys"),


### PR DESCRIPTION
If the key already exists, the command will log that it is
skipping and exit without error.

This also updates the create_key_pair function to not return
the public key as bytes as this was never used.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>