### PR TITLE
Stabilize "oauth-user-list" feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -127,7 +127,6 @@ experimental = [
     "https-bind",
     "metrics",
     "node-id-store",
-    "oauth-user-list",
     "registry-client",
     "registry-client-reqwest",
     "rest-api-actix-web-3",
@@ -171,7 +170,6 @@ memory = ["sqlite"]
 metrics = ["chrono", "futures-0-3", "influxdb", "metrics-lib", "tokio-0-2"]
 node-id-store = []
 oauth = ["biome", "base64", "oauth2", "reqwest", "rest-api"]
-oauth-user-list = ["oauth"]
 postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
 registry-client = ["registry"]

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -20,14 +20,12 @@ pub(in crate::biome) mod schema;
 
 use diesel::r2d2::{ConnectionManager, Pool};
 
-#[cfg(feature = "oauth-user-list")]
 use super::OAuthUserIter;
 use super::{
     InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
     OAuthUserSessionStoreError,
 };
 
-#[cfg(feature = "oauth-user-list")]
 use operations::list_users::OAuthUserSessionStoreListUsers as _;
 use operations::{
     add_session::OAuthUserSessionStoreAddSession as _,
@@ -86,7 +84,6 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::sqlite::Sqlit
         OAuthUserSessionStoreOperations::new(&*connection).get_user(subject)
     }
 
-    #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserSessionStoreOperations::new(&*connection).list_users()
@@ -138,7 +135,6 @@ impl OAuthUserSessionStore for DieselOAuthUserSessionStore<diesel::pg::PgConnect
         OAuthUserSessionStoreOperations::new(&*connection).get_user(subject)
     }
 
-    #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
         let connection = self.connection_pool.get()?;
         OAuthUserSessionStoreOperations::new(&*connection).list_users()
@@ -475,7 +471,6 @@ pub mod tests {
         assert_eq!(stored_session2.oauth_access_token(), oauth_access_token2);
     }
 
-    #[cfg(feature = "oauth-user-list")]
     /// Verify that a SQLite-backed `DieselOAuthUserSessionStore` correctly supports inserting and
     /// and listing OAuth users.
     ///

--- a/libsplinter/src/biome/oauth/store/diesel/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/mod.rs
@@ -20,16 +20,15 @@ pub(in crate::biome) mod schema;
 
 use diesel::r2d2::{ConnectionManager, Pool};
 
-use super::OAuthUserIter;
 use super::{
-    InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
+    InsertableOAuthUserSession, OAuthUser, OAuthUserIter, OAuthUserSession, OAuthUserSessionStore,
     OAuthUserSessionStoreError,
 };
 
-use operations::list_users::OAuthUserSessionStoreListUsers as _;
 use operations::{
     add_session::OAuthUserSessionStoreAddSession as _,
     get_session::OAuthUserSessionStoreGetSession as _, get_user::OAuthUserSessionStoreGetUser as _,
+    list_users::OAuthUserSessionStoreListUsers as _,
     remove_session::OAuthUserSessionStoreRemoveSession as _,
     update_session::OAuthUserSessionStoreUpdateSession as _, OAuthUserSessionStoreOperations,
 };

--- a/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
@@ -17,7 +17,6 @@
 pub(super) mod add_session;
 pub(super) mod get_session;
 pub(super) mod get_user;
-#[cfg(feature = "oauth-user-list")]
 pub(super) mod list_users;
 pub(super) mod remove_session;
 pub(super) mod update_session;

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -23,9 +23,8 @@ use crate::error::{
     InvalidStateError,
 };
 
-use super::OAuthUserIter;
 use super::{
-    InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
+    InsertableOAuthUserSession, OAuthUser, OAuthUserIter, OAuthUserSession, OAuthUserSessionStore,
     OAuthUserSessionStoreError,
 };
 

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -23,7 +23,6 @@ use crate::error::{
     InvalidStateError,
 };
 
-#[cfg(feature = "oauth-user-list")]
 use super::OAuthUserIter;
 use super::{
     InsertableOAuthUserSession, OAuthUser, OAuthUserSession, OAuthUserSessionStore,
@@ -188,7 +187,6 @@ impl OAuthUserSessionStore for MemoryOAuthUserSessionStore {
             .cloned())
     }
 
-    #[cfg(feature = "oauth-user-list")]
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError> {
         let internal = self.internal.lock().map_err(|_| {
             OAuthUserSessionStoreError::Internal(InternalError::with_message(

--- a/libsplinter/src/biome/oauth/store/mod.rs
+++ b/libsplinter/src/biome/oauth/store/mod.rs
@@ -390,7 +390,6 @@ pub trait OAuthUserSessionStore: Send + Sync {
     /// exists
     fn get_user(&self, subject: &str) -> Result<Option<OAuthUser>, OAuthUserSessionStoreError>;
 
-    #[cfg(feature = "oauth-user-list")]
     /// Returns the list of OAuth users, including the Biome user ID if it exists
     fn list_users(&self) -> Result<OAuthUserIter, OAuthUserSessionStoreError>;
 
@@ -404,13 +403,11 @@ impl Clone for Box<dyn OAuthUserSessionStore> {
     }
 }
 
-#[cfg(feature = "oauth-user-list")]
 /// An iterator over OauthUsers, with a well-known count of values.
 pub struct OAuthUserIter {
     inner: Box<dyn ExactSizeIterator<Item = OAuthUser>>,
 }
 
-#[cfg(feature = "oauth-user-list")]
 impl OAuthUserIter {
     pub fn new(users: Vec<OAuthUser>) -> Self {
         Self {
@@ -419,7 +416,6 @@ impl OAuthUserIter {
     }
 }
 
-#[cfg(feature = "oauth-user-list")]
 impl Iterator for OAuthUserIter {
     type Item = OAuthUser;
 
@@ -432,7 +428,6 @@ impl Iterator for OAuthUserIter {
     }
 }
 
-#[cfg(feature = "oauth-user-list")]
 impl ExactSizeIterator for OAuthUserIter {
     fn len(&self) -> usize {
         self.inner.len()

--- a/libsplinter/src/oauth/rest_api/actix/mod.rs
+++ b/libsplinter/src/oauth/rest_api/actix/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub(super) mod callback;
-#[cfg(feature = "oauth-user-list")]
 pub(super) mod list_users;
 pub(super) mod login;
 pub(super) mod logout;

--- a/libsplinter/src/oauth/rest_api/mod.rs
+++ b/libsplinter/src/oauth/rest_api/mod.rs
@@ -20,11 +20,7 @@ mod resources;
 
 use crate::biome::OAuthUserSessionStore;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(
-    feature = "authorization",
-    feature = "rest-api-actix",
-    feature = "oauth-user-list"
-))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix",))]
 use crate::rest_api::auth::authorization::Permission;
 
 #[cfg(feature = "biome-profile")]
@@ -32,11 +28,7 @@ use crate::biome::UserProfileStore;
 
 use super::OAuthClient;
 
-#[cfg(all(
-    feature = "authorization",
-    feature = "rest-api-actix",
-    feature = "oauth-user-list"
-))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix",))]
 const OAUTH_USER_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "oauth.users.read",
     permission_display_name: "OAuth Users read",
@@ -82,9 +74,6 @@ impl OAuthResourceProvider {
 /// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
 /// * `GET /oauth/callback` - Receive the authorization code from the provider
 /// * `GET /oauth/logout` - Remove the user's access and refresh tokens
-///
-/// The following endpoint is only available if the `oauth-user-list` feature is enabled:
-///
 /// * `GET` /oauth/users` - Get a list of the OAuth users
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
@@ -109,7 +98,6 @@ impl RestResourceProvider for OAuthResourceProvider {
                 ),
                 actix::logout::make_logout_route(self.oauth_user_session_store.clone()),
             ]);
-            #[cfg(feature = "oauth-user-list")]
             resources.append(&mut vec![
                 actix::list_users::make_oauth_list_users_resource(
                     self.oauth_user_session_store.clone(),

--- a/libsplinter/src/oauth/rest_api/resources/mod.rs
+++ b/libsplinter/src/oauth/rest_api/resources/mod.rs
@@ -13,5 +13,4 @@
 // limitations under the License.
 
 pub(super) mod callback;
-#[cfg(feature = "oauth-user-list")]
 pub(super) mod list_users;

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -74,7 +74,7 @@ pub(crate) const OAUTH_CALLBACK_MIN: u32 = 1;
 pub(crate) const OAUTH_LOGIN_MIN: u32 = 1;
 #[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
 pub(crate) const OAUTH_LOGOUT_MIN: u32 = 1;
-#[cfg(all(feature = "oauth-user-list", feature = "rest-api-actix"))]
+#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
 pub(crate) const OAUTH_USER_READ_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(feature = "registry")]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -105,7 +105,6 @@ experimental = [
     "metrics",
     "node",
     "node-file-block",
-    "oauth-user-list",
     "scabbard-back-pressure",
     "service-arg-validation",
     "service-endpoint",
@@ -162,7 +161,6 @@ node-file-block = ["splinter/node-id-store",]
 oauth = [
     "splinter/oauth"
 ]
-oauth-user-list = ["splinter/oauth-user-list"]
 rest-api-cors = ["splinter/rest-api-cors"]
 scabbard-back-pressure = ["scabbard/back-pressure"]
 service-arg-validation = [


### PR DESCRIPTION
This PR stabilizes the `"oauth-user-list"` feature by removing it. The functionality will be guarded by the more general`"oauth"` feature. 