### PR TITLE
Move authorization feature to default in health service

### DIFF
--- a/services/health/Cargo.toml
+++ b/services/health/Cargo.toml
@@ -29,10 +29,11 @@ log = "0.3.0"
 splinter = { path = "../../libsplinter", features = ["rest-api", "rest-api-actix"] }
 
 [features]
-default = []
+default = [
+  "authorization",
+]
 
 stable = [
-  "authorization",
   "default"
 ]
 


### PR DESCRIPTION
This change moves the authorization feature to the set of default features, in order to match the other sub-projects in the workspace.  It fixes an issue where `cargo build` fails at the workspace level.
