### PR TITLE
Stabilize CLI "user-list" under "user" feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -60,6 +60,7 @@ default = [
     "postgres",
     "sqlite",
     "upgrade",
+    "user",
 ]
 
 stable = [
@@ -77,7 +78,6 @@ experimental = [
     "https-certs",
     "node-id-upgrade",
     "registry",
-    "user-list",
 ]
 
 authorization-handler-maintenance = []
@@ -101,7 +101,7 @@ upgrade = [
     "database",
     "splinter/store-factory"
 ]
-user-list = []
+user = []
 
 
 

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -28,7 +28,7 @@ pub mod permissions;
 #[cfg(feature = "authorization-handler-rbac")]
 pub mod rbac;
 pub mod registry;
-#[cfg(feature = "user-list")]
+#[cfg(feature = "user")]
 pub mod user;
 
 use std::collections::HashMap;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1563,7 +1563,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
             ),
     );
 
-    #[cfg(feature = "user-list")]
+    #[cfg(feature = "user")]
     {
         app = app.subcommand(
             SubCommand::with_name("user")
@@ -1736,7 +1736,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     subcommands = subcommands.with_command("permissions", permissions::ListAction);
 
-    #[cfg(feature = "user-list")]
+    #[cfg(feature = "user")]
     {
         use action::user;
         subcommands = subcommands.with_command(


### PR DESCRIPTION
This change stabilizes the "user-list" feature by renaming it to a general "user" feature and moving that to be a "default" feature. Any future user-related features should be stabilized under this general feature.
