### PR TITLE
Trim line breaks off node_id's from file

### DIFF
--- a/libsplinter/src/node_id/store/file/mod.rs
+++ b/libsplinter/src/node_id/store/file/mod.rs
@@ -36,7 +36,7 @@ impl NodeIdStore for FileNodeIdStore {
     fn get_node_id(&self) -> Result<Option<String>, NodeIdStoreError> {
         fs::read_to_string(&self.filename)
             .map_err(|e| e.into())
-            .map(Some)
+            .map(|s| Some(s.trim_end().to_string()))
     }
 
     fn set_node_id(&self, node_id: String) -> Result<(), NodeIdStoreError> {


### PR DESCRIPTION
The node_id file is supposed to support having a line break/white space after
the node_id string. This change just trims the node_id string of any
tailing white space.

Signed-off-by: Caleb Hill <hill@bitwise.io>