### PR TITLE
Add configuration option `allow_keys_file`

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -131,6 +131,7 @@ challenge-authorization = [
   "cylinder/key-load",
   "splinter/challenge-authorization"
 ]
+config-allow-keys = ["authorization-handler-allow-keys"]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 health-service = ["health", "health/authorization"]

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -70,6 +70,10 @@ version = "1"
 # service).
 #admin_timeout = 30
 
+# Sets the file for allowable keys. Can be absolute or relative. Relative files
+# are relative to the config directory. Defaults to "allow_keys".
+#allow_keys_file = "allow_keys"
+
 #
 # Registry Options
 #

--- a/splinterd/sample_configs/splinterd.toml.example
+++ b/splinterd/sample_configs/splinterd.toml.example
@@ -109,6 +109,10 @@ heartbeat = 60
 # (in seconds; default 30 seconds)
 admin_timeout = 30
 
+# Sets the file for allowable keys. Can be absolute or relative. Relative files
+# are relative to the config directory. Defaults to "allow_keys".
+allow_keys_file = "allow_keys"
+
 # Domains included in the REST API CORS
 # (default ["*"])
 whitelist = ["*"]

--- a/splinterd/sample_configs/splinterd.toml.example2
+++ b/splinterd/sample_configs/splinterd.toml.example2
@@ -85,6 +85,10 @@ heartbeat = 30
 # (in seconds; default 30 seconds)
 admin_timeout = 30
 
+# Sets the file for allowable keys. Can be absolute or relative. Relative files
+# are relative to the config directory. Defaults to "allow_keys".
+allow_keys_file = "allow_keys"
+
 # Domains included in the REST API CORS
 # (default ["*"])
 whitelist = ["*"]

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -53,6 +53,9 @@ const ADMIN_TIMEOUT: u64 = 30; // 30 seconds
 #[cfg(feature = "challenge-authorization")]
 const PEERING_KEY_NAME: &str = "splinterd";
 
+#[cfg(feature = "config-allow-keys")]
+const ALLOW_KEYS_FILE: &str = "allow_keys";
+
 pub struct DefaultPartialConfigBuilder;
 
 impl DefaultPartialConfigBuilder {
@@ -128,6 +131,12 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
         #[cfg(feature = "challenge-authorization")]
         {
             partial_config = partial_config.with_peering_key(Some(String::from(PEERING_KEY_NAME)))
+        }
+
+        #[cfg(feature = "config-allow-keys")]
+        {
+            partial_config =
+                partial_config.with_allow_keys_file(Some(String::from(ALLOW_KEYS_FILE)))
         }
 
         Ok(partial_config)

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -103,6 +103,8 @@ pub struct PartialConfig {
     loggers: Option<HashMap<String, UnnamedLoggerConfig>>,
     #[cfg(feature = "log-config")]
     verbosity: Option<log::Level>,
+    #[cfg(feature = "config-allow-keys")]
+    allow_keys_file: Option<String>,
 }
 
 impl PartialConfig {
@@ -175,6 +177,8 @@ impl PartialConfig {
             root_logger: None,
             #[cfg(feature = "log-config")]
             verbosity: None,
+            #[cfg(feature = "config-allow-keys")]
+            allow_keys_file: None,
         }
     }
 
@@ -374,6 +378,11 @@ impl PartialConfig {
     #[cfg(feature = "log-config")]
     pub fn verbosity(&self) -> Option<log::Level> {
         self.verbosity
+    }
+
+    #[cfg(feature = "config-allow-keys")]
+    pub fn allow_keys_file(&self) -> Option<String> {
+        self.allow_keys_file.clone()
     }
 
     /// Adds a `config_dir` value to the `PartialConfig` object.
@@ -889,6 +898,18 @@ impl PartialConfig {
     /// * `loggers` - A set of loggers for the logging system to use
     pub fn with_loggers(mut self, loggers: Option<HashMap<String, UnnamedLoggerConfig>>) -> Self {
         self.loggers = loggers;
+        self
+    }
+
+    #[cfg(feature = "config-allow-keys")]
+    /// Adds a `allow_keys_file` value to the  `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `allow_keys_file` - List of public keys to allow
+    ///
+    pub fn with_allow_keys_file(mut self, allow_keys_file: Option<String>) -> Self {
+        self.allow_keys_file = allow_keys_file;
         self
     }
 }


### PR DESCRIPTION
Add a new toml configuration option that allows the user to set the
exact location of the allow_keys file. This file can either be relative
to the config directory, or an absolue path.

This option is behind the feature config-allow-keys.

Signed-off-by: Lee Bradley <bradley@bitwise.io>