### PR TITLE
Fix expired web socket endpoint test

### DIFF
--- a/libsplinter/src/events/ws.rs
+++ b/libsplinter/src/events/ws.rs
@@ -16,7 +16,7 @@
 //!
 //! Module for establishing WebSocket connections with Splinter Services.
 //!
-//!```
+//!``` no_run
 //! use std::{thread::sleep, time};
 //! use splinter::events::{WsResponse, WebSocketClient, Reactor, ParseBytes};
 //!


### PR DESCRIPTION
echo.websocket.org has gone offline and broken the doc tests because it
never completes. This change just turns off the documentation tests for
this file.

Signed-off-by: Caleb Hill <hill@bitwise.io>