### PR TITLE
Fix features guards around parse_hex

### DIFF
--- a/libsplinter/src/hex.rs
+++ b/libsplinter/src/hex.rs
@@ -29,7 +29,7 @@ pub fn to_hex(bytes: &[u8]) -> String {
     buf
 }
 
-#[cfg(feature = "admin-service")]
+#[cfg(any(feature = "admin-service", feature = "challenge-authorization"))]
 pub fn parse_hex(hex: &str) -> Result<Vec<u8>, HexError> {
     if hex.len() % 2 != 0 {
         return Err(HexError {


### PR DESCRIPTION
parse_hex was solely guarded by the admin-service feature
but is also required if challenge-authorization is enabled.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>