### PR TITLE
Add specificity to pending batches metric

### DIFF
--- a/docker/metrics/grafana/dashboards/splinter_metrics.json
+++ b/docker/metrics/grafana/dashboards/splinter_metrics.json
@@ -316,12 +316,19 @@
       "steppedLine": false,
       "targets": [
         {
+          "alias": "pending batches [[tag_service]]",
           "groupBy": [
             {
               "params": [
                 "$__interval"
               ],
               "type": "time"
+            },
+            {
+              "params": [
+                "service"
+              ],
+              "type": "tag"
             },
             {
               "params": [

--- a/libsplinter/src/metrics/mod.rs
+++ b/libsplinter/src/metrics/mod.rs
@@ -19,6 +19,7 @@ pub mod influx;
 #[macro_export]
 macro_rules! counter {
     ($t:tt, $v:expr) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
 }
 
 // no-op `gauge` macro for when the `metrics` feature is not enabled
@@ -26,6 +27,7 @@ macro_rules! counter {
 #[macro_export]
 macro_rules! gauge {
     ($t:tt, $v:expr) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
 }
 
 // no-op `histogram` macro for when the `metrics` feature is not enabled
@@ -33,4 +35,5 @@ macro_rules! gauge {
 #[macro_export]
 macro_rules! histogram {
     ($t:tt, $v:expr) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
 }

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -421,6 +421,8 @@ mod tests {
             Some(Box::new(service_sender.clone())),
             peer_services.clone(),
             "svc0".to_string(),
+            #[cfg(feature = "metrics")]
+            "vzrQS-rvwf4".to_string(),
             Secp256k1Context::new().new_verifier(),
             #[cfg(feature = "back-pressure")]
             ScabbardVersion::V2,

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -131,6 +131,8 @@ impl Scabbard {
             None,
             peer_services,
             service_id.clone(),
+            #[cfg(feature = "metrics")]
+            circuit_id.to_string(),
             signature_verifier,
             #[cfg(feature = "back-pressure")]
             version,


### PR DESCRIPTION
This change fixes an issue where pending batches from multiple scabbard
circuits would override one another, by adding a tag that clears up
which specific circuit the pending batches list originates from.

Signed-off-by: Lee Bradley <bradley@bitwise.io>