### PR TITLE
Fix features guards for `trust-authorization` stabilization

### DIFF
--- a/libsplinter/src/network/auth/handlers/builder.rs
+++ b/libsplinter/src/network/auth/handlers/builder.rs
@@ -191,6 +191,8 @@ impl AuthorizationDispatchBuilder {
         // v1 message handlers
         #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
         {
+            // allow unused mut, required if challenge-authorization is enabled
+            #![allow(unused_mut)]
             let mut auth_protocol_request_builder = AuthProtocolRequestHandlerBuilder::default()
                 .with_auth_manager(auth_manager.clone());
 

--- a/libsplinter/src/network/auth/handlers/v1_handlers/builders.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/builders.rs
@@ -89,6 +89,7 @@ impl AuthProtocolResponseHandlerBuilder {
         self
     }
 
+    #[cfg(feature = "challenge-authorization")]
     pub fn with_required_local_auth(
         mut self,
         required_local_auth: Option<ConnectionAuthorizationType>,

--- a/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
@@ -531,16 +531,16 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
-    use cylinder::{
-        secp256k1::Secp256k1Context, Context, PublicKey, Signature, Signer, VerificationError,
-        Verifier,
-    };
+    #[cfg(feature = "challenge-authorization")]
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
+    use cylinder::{PublicKey, Signature, VerificationError, Verifier};
     use protobuf::Message;
 
     use crate::network::auth::{AuthorizationDispatchBuilder, Identity, ManagedAuthorizationState};
     use crate::protocol::authorization::AuthComplete;
     use crate::protos::network::NetworkMessageType;
     use crate::protos::{authorization, network};
+    #[cfg(feature = "challenge-authorization")]
     use crate::public_key;
 
     /// Test that an auth protocol request is properly handled via the dispatcher when no
@@ -851,6 +851,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "challenge-authorization")]
     fn new_signer() -> Box<dyn Signer> {
         let context = Secp256k1Context::new();
         let key = context.new_random_private_key();

--- a/libsplinter/src/network/auth/handlers/v1_handlers/trust.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/trust.rs
@@ -209,10 +209,9 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
-    use cylinder::{
-        secp256k1::Secp256k1Context, Context, PublicKey, Signature, Signer, VerificationError,
-        Verifier,
-    };
+    #[cfg(feature = "challenge-authorization")]
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
+    use cylinder::{PublicKey, Signature, VerificationError, Verifier};
     use protobuf::Message;
 
     use crate::network::auth::state_machine::trust_v1::TrustAuthorizationLocalState;
@@ -664,6 +663,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "challenge-authorization")]
     fn new_signer() -> Box<dyn Signer> {
         let context = Secp256k1Context::new();
         let key = context.new_random_private_key();

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -28,7 +28,7 @@ use protobuf::Message;
 #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
 use crate::protocol::authorization::AuthProtocolRequest;
 use crate::protocol::authorization::AuthorizationMessage;
-#[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
+#[cfg(not(any(feature = "trust-authorization", feature = "challenge-authorization")))]
 use crate::protocol::authorization::ConnectRequest;
 use crate::protocol::network::NetworkMessage;
 #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
@@ -221,7 +221,7 @@ impl AuthorizationConnector {
             })?;
 
         self.executor.execute(move || {
-            #[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
+            #[cfg(not(any(feature = "trust-authorization", feature = "challenge-authorization")))]
             {
                 let connect_request_bytes = match connect_msg_bytes() {
                     Ok(bytes) => bytes,
@@ -379,7 +379,7 @@ impl AuthorizationConnector {
     }
 }
 
-#[cfg(not(all(feature = "trust-authorization", feature = "challenge-authorization")))]
+#[cfg(not(any(feature = "trust-authorization", feature = "challenge-authorization")))]
 fn connect_msg_bytes() -> Result<Vec<u8>, AuthorizationManagerError> {
     let connect_msg = AuthorizationMessage::ConnectRequest(ConnectRequest::Bidirectional);
 
@@ -593,7 +593,7 @@ pub(in crate::network) mod tests {
         assert!(matches!(trust_request, AuthorizationMessage::Authorized(_)));
     }
 
-    #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]
+    #[cfg(feature = "trust-authorization")]
     pub(in crate::network) fn negotiation_connection_auth(
         mesh: &Mesh,
         connection_id: &str,


### PR DESCRIPTION
The following feature guard issues were found when trying to move `trust-authorization` to stable.