### PR TITLE
Update cli usage in docker files

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -199,7 +199,7 @@ services:
               --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
-              --enable-biome-credentials
+              --enable-biome
         "
 
     splinterd-db-acme:
@@ -325,7 +325,7 @@ services:
               --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
-              --enable-biome-credentials
+              --enable-biome
         "
 
     splinterd-db-bubba:

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -228,7 +228,7 @@ services:
               --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
-              --enable-biome-credentials
+              --enable-biome
         "
 
     splinterd-db-acme:
@@ -377,7 +377,7 @@ services:
               --rest-api-endpoint 0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
-              --enable-biome-credentials
+              --enable-biome
         "
 
     splinterd-db-bubba:

--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -127,7 +127,7 @@ services:
               --network-endpoint 0.0.0.0:8044 \
               --rest-api-endpoint 0.0.0.0:8085 \
               --tls-insecure \
-              --enable-biome-credentials
+              --enable-biome
       "
 
   splinterd-db-node:

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
         splinterd -c ./project/tests/splinterd-node-0-docker.toml -vv \
             --database postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test \
             --tls-insecure \
-            --enable-biome-credentials
+            --enable-biome
       "
 
   db-test:


### PR DESCRIPTION
`splinter --enable-biome-credentials` is no longer a cli arg and has
been replaced by `splinter --enable-biome`. This change updates the
gameroom docker examples so they start.

Signed-off-by: Caleb Hill <hill@bitwise.io>