### PR TITLE
Add splinter upgrade command to docker images

### DIFF
--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -191,6 +191,7 @@ services:
             sleep 1
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
+          splinter upgrade -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
@@ -317,6 +318,7 @@ services:
             sleep 1
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
+          splinter upgrade -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -220,6 +220,7 @@ services:
             sleep 1
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
+          splinter upgrade -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
@@ -369,6 +370,7 @@ services:
             sleep 1
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
+          splinter upgrade -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
           splinter cert generate --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -75,6 +75,7 @@ services:
             sleep 1
         done &&
         splinter database migrate -C postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test &&
+        splinter upgrade -C postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test &&
         splinter cert generate --skip &&
         splinterd -c ./project/tests/splinterd-node-0-docker.toml -vv \
             --database postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test \


### PR DESCRIPTION
Not running `splinter upgrade` before starting splinterd can block the
daemon from starting. There is no harm in running the `upgrade` command.
This change adds `splinter upgrade` calls to all places in docker files
that call `splinter database migrate` before starting a node. 

This solves the problem of fresh builds throwing this error "Failed to start daemon, unable to start the Splinter daemon: unable to set up storage: Run the `splinter upgrade` command to update outdated state files to a Splinter 0.5 database"

Signed-off-by: Caleb Hill <hill@bitwise.io>