### PR TITLE
Allow endpoints to belong to multiple tokens that are PeerAuthorizationToken::Challenge 

### DIFF
--- a/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
@@ -174,8 +174,6 @@ impl Handler for AuthChallengeNonceResponseHandler {
 
         let nonce_request = AuthChallengeNonceResponse::from_proto(msg)?;
 
-        let mut public_keys = vec![];
-
         let submit_requests = self
             .signers
             .iter()
@@ -199,8 +197,6 @@ impl Handler for AuthChallengeNonceResponseHandler {
                         ))
                     })?
                     .into_bytes();
-
-                public_keys.push(public_key.clone());
 
                 Ok(SubmitRequest {
                     public_key,

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -725,6 +725,7 @@ where
                 {
                     subscribers.broadcast(ConnectionManagerNotification::FatalConnectionError {
                         endpoint,
+                        connection_id,
                         error: err,
                     });
 
@@ -767,6 +768,7 @@ where
                 // and will not be added.
                 subscribers.broadcast(ConnectionManagerNotification::FatalConnectionError {
                     endpoint,
+                    connection_id: connection_id.clone(),
                     error: ConnectionManagerError::Unauthorized(connection_id),
                 });
             }
@@ -801,6 +803,7 @@ where
                 {
                     subscribers.broadcast(ConnectionManagerNotification::FatalConnectionError {
                         endpoint,
+                        connection_id,
                         error: err,
                     });
                     return;
@@ -829,6 +832,7 @@ where
                 // and will not be added.
                 subscribers.broadcast(ConnectionManagerNotification::FatalConnectionError {
                     endpoint,
+                    connection_id: connection_id.clone(),
                     error: ConnectionManagerError::Unauthorized(connection_id),
                 });
             }

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -26,6 +26,7 @@ pub enum ConnectionManagerNotification {
     },
     FatalConnectionError {
         endpoint: String,
+        connection_id: String,
         error: ConnectionManagerError,
     },
     InboundConnection {

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -389,11 +389,17 @@ impl PeerRemover {
     ///
     /// # Arguments
     /// * `endpoint` - the endpoint of the `EndpointPeerRef` that has been dropped
-    pub fn remove_peer_ref_by_endpoint(&self, endpoint: &str) -> Result<(), PeerRefRemoveError> {
+    /// * `connection_id` - the connection id used for the endpoint
+    pub fn remove_peer_ref_by_endpoint(
+        &self,
+        endpoint: &str,
+        connection_id: &str,
+    ) -> Result<(), PeerRefRemoveError> {
         let (sender, recv) = channel();
 
         let message = PeerManagerMessage::Request(PeerManagerRequest::RemovePeerByEndpoint {
             endpoint: endpoint.to_string(),
+            connection_id: connection_id.to_string(),
             sender,
         });
 

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1019,15 +1019,17 @@ fn handle_notifications(
             ref_map,
             retry_frequency,
         ),
-        ConnectionManagerNotification::FatalConnectionError { endpoint, error } => {
-            handle_fatal_connection(
-                endpoint,
-                error.to_string(),
-                peers,
-                subscribers,
-                max_retry_attempts,
-            )
-        }
+        ConnectionManagerNotification::FatalConnectionError {
+            connection_id,
+            error,
+            ..
+        } => handle_fatal_connection(
+            connection_id,
+            error.to_string(),
+            peers,
+            subscribers,
+            max_retry_attempts,
+        ),
     }
 }
 
@@ -1222,7 +1224,7 @@ fn handle_connected(
     ref_map: &mut RefMap<PeerAuthorizationToken>,
     retry_frequency: u64,
 ) {
-    if let Some(mut peer_metadata) = peers.get_peer_from_endpoint(&endpoint).cloned() {
+    if let Some(mut peer_metadata) = peers.get_by_connection_id(&connection_id).cloned() {
         match peer_metadata.status {
             PeerStatus::Pending => {
                 info!(
@@ -1369,13 +1371,13 @@ fn handle_connected(
 }
 
 fn handle_fatal_connection(
-    endpoint: String,
+    connection_id: String,
     error: String,
     peers: &mut PeerMap,
     subscribers: &mut SubscriberMap,
     max_retry_frequency: u64,
 ) {
-    if let Some(mut peer_metadata) = peers.get_peer_from_endpoint(&endpoint).cloned() {
+    if let Some(mut peer_metadata) = peers.get_by_connection_id(&connection_id).cloned() {
         warn!(
             "Peer {} encountered a fatal connection error: {}",
             peer_metadata.id, error

--- a/libsplinter/src/peer/peer_ref.rs
+++ b/libsplinter/src/peer/peer_ref.rs
@@ -61,14 +61,16 @@ impl Drop for PeerRef {
 #[derive(Debug, PartialEq)]
 pub struct EndpointPeerRef {
     endpoint: String,
+    connection_id: String,
     peer_remover: PeerRemover,
 }
 
 impl EndpointPeerRef {
     /// Creates a new `EndpointPeerRef`
-    pub(super) fn new(endpoint: String, peer_remover: PeerRemover) -> Self {
+    pub(super) fn new(endpoint: String, connection_id: String, peer_remover: PeerRemover) -> Self {
         EndpointPeerRef {
             endpoint,
+            connection_id,
             peer_remover,
         }
     }
@@ -83,7 +85,7 @@ impl Drop for EndpointPeerRef {
     fn drop(&mut self) {
         match self
             .peer_remover
-            .remove_peer_ref_by_endpoint(&self.endpoint)
+            .remove_peer_ref_by_endpoint(&self.endpoint, &self.connection_id)
         {
             Ok(_) => (),
             Err(err) => error!(

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -574,7 +574,9 @@ impl ServiceConnectionAgent {
                     );
                 }
             }
-            ConnectionManagerNotification::FatalConnectionError { endpoint, error } => {
+            ConnectionManagerNotification::FatalConnectionError {
+                endpoint, error, ..
+            } => {
                 if let Some(info) = self.services.remove_connection_by_endoint(&endpoint) {
                     error!(
                         "Service processor {} connection failed: {}; removing",

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -161,10 +161,201 @@ pub fn test_2_party_circuit_creation_challenge_authorization_unidentified_peer()
 /// 6. Create and submit a `CircuitProposalVote` from the second node to accept the proposal
 /// 7. Wait for the `CircuitReady` event from each node's event client
 /// 8. Verify the same circuit is available to each node
-/// 9. Repeat steps 1-8 for a different circuit that sets the member public keys to the nodes
-///    second configured key.
+/// 9. Repeat steps 1-8 for a different circuit that sets the member public key for the first node
+///    to the second configured key.
 #[test]
 #[ignore]
+pub fn test_2_party_circuit_creation_challenge_authorization_different_key() {
+    // Start a 2-node network
+    let mut network = Network::new()
+        .with_default_rest_api_variant(RestApiVariant::ActixWeb1)
+        .set_num_of_keys(2)
+        .add_nodes_with_defaults(2)
+        .expect("Unable to start 2-node ActixWeb1 network");
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+
+    let first_circuit_id = "ABCDE-01234";
+
+    commit_2_party_circuit(
+        first_circuit_id,
+        node_a,
+        node_b,
+        AuthorizationType::Challenge,
+    );
+
+    let second_circuit_id = "ABCDE-56789";
+    // Get the first node in the network
+    let node_a = network.node(0).expect("Unable to get first node");
+    // Get the second node in the network
+    let node_b = network.node(1).expect("Unable to get second node");
+
+    // Create the list of node details needed to build the `CircuitCreateRequest`
+    let node_info = vec![
+        (
+            node_a.node_id().to_string(),
+            (
+                node_a.network_endpoints().to_vec(),
+                // get the second signer (not the normal key in the first position)
+                node_a
+                    .signers()
+                    .get(1)
+                    .expect("node does not have enough signers configured")
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
+        ),
+        (
+            node_b.node_id().to_string(),
+            (
+                node_b.network_endpoints().to_vec(),
+                node_b
+                    .signers()
+                    .get(0)
+                    .expect("node does not have enough signers configured")
+                    .public_key()
+                    .expect("Unable to get first node's public key"),
+            ),
+        ),
+    ]
+    .into_iter()
+    .collect::<HashMap<String, (Vec<String>, cylinder::PublicKey)>>();
+
+    let node_b_admin_pubkey = admin_pubkey(node_b);
+
+    let node_a_event_client = node_a
+        .admin_service_event_client(&format!("test_circuit_{}", &second_circuit_id), None)
+        .expect("Unable to get event client");
+    let node_b_event_client = node_b
+        .admin_service_event_client(&format!("test_circuit_{}", &second_circuit_id), None)
+        .expect("Unable to get event client");
+
+    let circuit_payload_bytes = make_create_circuit_payload(
+        &second_circuit_id,
+        node_a.node_id(),
+        node_info,
+        &*node_a.admin_signer().clone_box(),
+        &vec![
+            node_a
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get first node's public key")
+                .as_hex(),
+            node_b
+                .admin_signer()
+                .public_key()
+                .expect("Unable to get second node's public key")
+                .as_hex(),
+        ],
+        AuthorizationType::Challenge,
+    )
+    .expect("Unable to generate circuit request");
+    // Submit the `CircuitManagementPayload` to the first node
+    let res = node_a
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes.clone());
+    assert!(res.is_ok());
+
+    // Wait for the proposal event from each node.
+    let proposal_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let proposal_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+
+    assert_eq!(&EventType::ProposalSubmitted, proposal_a_event.event_type());
+    assert_eq!(&EventType::ProposalSubmitted, proposal_b_event.event_type());
+    assert_eq!(proposal_a_event.proposal(), proposal_b_event.proposal());
+
+    // Submit the same `CircuitManagmentPayload` to create the circuit to the second node
+    // to validate this duplicate proposal is rejected
+    let duplicate_res = node_b
+        .admin_service_client()
+        .submit_admin_payload(circuit_payload_bytes);
+    assert!(
+        duplicate_res.is_err(),
+        "node {} erroneously accepted a duplicate proposal",
+        node_b.node_id()
+    );
+
+    // Create the `CircuitProposalVote` to be sent to a node
+    // Uses `true` for the `accept` argument to create a vote to accept the proposal
+    let vote_payload_bytes = make_circuit_proposal_vote_payload(
+        proposal_a_event.proposal().clone(),
+        node_b.node_id(),
+        &*node_b.admin_signer().clone_box(),
+        true,
+    );
+    let res = node_b
+        .admin_service_client()
+        .submit_admin_payload(vote_payload_bytes);
+    assert!(res.is_ok());
+
+    // Wait for proposal accepted
+    let accepted_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let accepted_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_b_admin_pubkey.clone()
+        },
+        accepted_a_event.event_type(),
+    );
+    assert_eq!(
+        &EventType::ProposalAccepted {
+            requester: node_b_admin_pubkey.clone()
+        },
+        accepted_b_event.event_type(),
+    );
+    assert_eq!(accepted_a_event.proposal(), accepted_b_event.proposal());
+
+    // Wait for circuit ready.
+    let ready_a_event = node_a_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    let ready_b_event = node_b_event_client
+        .next_event()
+        .expect("Unable to get next event");
+    assert_eq!(ready_a_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_b_event.event_type(), &EventType::CircuitReady);
+    assert_eq!(ready_a_event.proposal(), ready_b_event.proposal());
+
+    let circuit_a = node_a
+        .admin_service_client()
+        .fetch_circuit(&second_circuit_id)
+        .expect("Unable to get circuit from node_a")
+        .expect("Circuit was not found");
+    let circuit_b = node_b
+        .admin_service_client()
+        .fetch_circuit(&second_circuit_id)
+        .expect("Unable to get circuit from node_b")
+        .expect("Circuit was not found");
+
+    assert_eq!(circuit_a, circuit_b);
+
+    shutdown!(network).expect("Unable to shutdown network");
+}
+
+/// Test that two 2-party circuit may be created on a 2-node network using challenge authorization,
+/// where the second circuit has a different key for the both nodes defined in the circuit.
+///
+/// 1. Create and submit a `CircuitCreateRequest` from the first node
+/// 2. Wait for the `ProposalSubmitted` event from each node's event client
+/// 3. Verify the same proposal is available on each node
+/// 4. Submit the same `CircuitCreateRequest` created in the first step from the second node
+/// 5. Validate the duplicate proposal submitted in the previous step results in an error
+/// 6. Create and submit a `CircuitProposalVote` from the second node to accept the proposal
+/// 7. Wait for the `CircuitReady` event from each node's event client
+/// 8. Verify the same circuit is available to each node
+/// 9. Repeat steps 1-8 for a different circuit that sets the member's public keys to the nodes
+///    second configured key.
+#[test]
 pub fn test_2_party_circuit_creation_challenge_authorization_different_keys() {
     // Start a 2-node network
     let mut network = Network::new()
@@ -212,9 +403,11 @@ pub fn test_2_party_circuit_creation_challenge_authorization_different_keys() {
             (
                 node_b.network_endpoints().to_vec(),
                 node_b
-                    .admin_signer()
+                    .signers()
+                    .get(1)
+                    .expect("node does not have enough signers configured")
                     .public_key()
-                    .expect("Unable to get seconds node's public key"),
+                    .expect("Unable to get first node's public key"),
             ),
         ),
     ]


### PR DESCRIPTION
Before challenge authorization was implemented, their was a requirement that endpoints to peer id had a 1:1 relationship (same with connections to endpoints), however with challenge authorization, the different peer ids must have its own connection. This means that as long as two peer id's are not different trust ids, the peers can share the same endpoint(s). 

This PR relaxes the requirement for unique endpoints in the ConnectionManager, PeerMananger, and PeerMap. 

This PR also updates the protocol agreement in the admin service to be based on the PeerAuthorizationToken instead of on the admin service id, this ensures that all connections are correctly waited for and verified. 

An integration tests is added that created two circuit, with different keys for both nodes in each circuit. The original test that has two circuits where one node's keys stays the same is still ignored and requires more bug fixes that will be coming soon. 