### PR TITLE
Add system keygen command to docker files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
         done && \
         splinter database migrate -C postgres://splinter_admin:splinter_test@splinter-db:5432/splinter && \
         splinter cert generate --skip && \
+        splinter keygen --system --skip && \
         splinterd \
             -c ./configs/splinterd-node-0-docker.toml \
             --registries file://./registries/registry.yaml \

--- a/examples/gameroom/docker-compose-dockerhub.yaml
+++ b/examples/gameroom/docker-compose-dockerhub.yaml
@@ -192,6 +192,7 @@ services:
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
           splinter cert generate --skip && \
+          splinter keygen --system --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \
@@ -318,6 +319,7 @@ services:
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
           splinter cert generate --skip && \
+          splinter keygen --system --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \

--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -221,6 +221,7 @@ services:
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-acme:5432/splinter && \
           splinter cert generate --skip && \
+          splinter keygen --system --skip && \
           splinterd -c ./configs/splinterd-node-acme.toml -vv \
               --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \
@@ -370,6 +371,7 @@ services:
           done && \
           splinter database migrate -C postgres://admin:admin@splinterd-db-bubba:5432/splinter && \
           splinter cert generate --skip && \
+          splinter keygen --system --skip && \
           splinterd -c ./configs/splinterd-node-bubba.toml -vv \
               --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \

--- a/examples/gameroom/tests/docker-compose.yaml
+++ b/examples/gameroom/tests/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
         done &&
         splinter database migrate -C postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test &&
         splinter cert generate --skip &&
+        splinter keygen --system --skip && \
         splinterd -c ./project/tests/splinterd-node-0-docker.toml -vv \
             --database postgres://gameroom_test:gameroom_test@db-test:5432/gameroom_test \
             --tls-insecure \


### PR DESCRIPTION
If challenge-authorization is enabled, a key must
be configured for the splinterd to be used in
challenge authorization. This commit adds the
command:

  splinter keygen --system --skip

to the dockerfiles to create a keypair of one does
not exist.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>