### PR TITLE
Add https support to scabbard cli

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -69,6 +69,7 @@ experimental = [
   "back-pressure",
   "factory-builder",
   "metrics",
+  "https",
 ]
 
 authorization = ["splinter/authorization"]
@@ -80,3 +81,4 @@ factory-builder = []
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
 service-arg-validation = ["splinter/service-arg-validation"]
+https = []


### PR DESCRIPTION
This change adds https support to the scabbard cli. Previously, the cli
would only allow users to pass urls with the "http" schema. This change
also adds associated tests to validate the parsing functionality.

Signed-off-by: Lee Bradley <bradley@bitwise.io>