### PR TITLE
Explicitly set gameroom splinterd REST API to http

### DIFF
--- a/examples/gameroom/docker-compose.yaml
+++ b/examples/gameroom/docker-compose.yaml
@@ -226,7 +226,7 @@ services:
               --database postgres://admin:admin@splinterd-db-acme:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-acme:8044 \
-              --rest-api-endpoint 0.0.0.0:8085 \
+              --rest-api-endpoint http://0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome-credentials
@@ -376,7 +376,7 @@ services:
               --database postgres://admin:admin@splinterd-db-bubba:5432/splinter \
               --network-endpoints tcps://0.0.0.0:8044 \
               --advertised-endpoints tcps://splinterd-node-bubba:8044 \
-              --rest-api-endpoint 0.0.0.0:8085 \
+              --rest-api-endpoint http://0.0.0.0:8085 \
               --registries http://registry-server:80/registry.yaml \
               --tls-insecure \
               --enable-biome-credentials


### PR DESCRIPTION
This allows gameroom to work when experimental features is enabled,
which turns on HTTPS support and changes the default type to
https if http:// is not included in the endpoint.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>