### PR TITLE
Scabbard Commit Hash Store trait and LMDB Implementation

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -63,6 +63,7 @@ stable = [
   "client-reqwest",
   "default",
   "events",
+  "lmdb",
   "rest-api",
   "rest-api-actix",
 ]
@@ -87,6 +88,7 @@ commit-store = []
 diesel-receipt-store = ["diesel"]
 events = ["splinter/events"]
 factory-builder = []
+lmdb = []
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
 service-arg-validation = ["splinter/service-arg-validation"]

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -72,6 +72,7 @@ experimental = [
   "stable",
   # The following features are experimental:
   "back-pressure",
+  "commit-store",
   "diesel-receipt-store",
   "factory-builder",
   "metrics",
@@ -82,6 +83,7 @@ authorization = ["splinter/authorization"]
 back-pressure = []
 client = []
 client-reqwest = ["client", "reqwest"]
+commit-store = []
 diesel-receipt-store = ["diesel"]
 events = ["splinter/events"]
 factory-builder = []

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -36,3 +36,5 @@ mod hex;
 pub mod protocol;
 pub mod protos;
 pub mod service;
+#[cfg(feature = "commit-store")]
+pub mod store;

--- a/services/scabbard/libscabbard/src/store/error.rs
+++ b/services/scabbard/libscabbard/src/store/error.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error types and logic for CommitHashStores.
+
+use std::error::Error;
+use std::fmt::Display;
+
+use splinter::error::{
+    InternalError, InvalidArgumentError, InvalidStateError, ResourceTemporarilyUnavailableError,
+};
+
+/// Error type for the [CommitHashStore](super::CommitHashStore) trait.
+///
+/// Any errors implementations of [CommitHashStore](super::CommitHashStore) can generate must be
+/// convertible to a CommitHashStoreError enum member.
+
+#[derive(Debug)]
+/// Error states for fallible [CommitHashStore](super::CommitHashStore) operations.
+pub enum CommitHashStoreError {
+    Internal(InternalError),
+    InvalidArgument(InvalidArgumentError),
+    InvalidState(InvalidStateError),
+    ResourceTemporarilyUnavailable(ResourceTemporarilyUnavailableError),
+}
+
+impl Display for CommitHashStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommitHashStoreError::Internal(e) => e.fmt(f),
+            CommitHashStoreError::InvalidArgument(e) => e.fmt(f),
+            CommitHashStoreError::InvalidState(e) => e.fmt(f),
+            CommitHashStoreError::ResourceTemporarilyUnavailable(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for CommitHashStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            CommitHashStoreError::Internal(e) => Some(e),
+            CommitHashStoreError::InvalidArgument(e) => Some(e),
+            CommitHashStoreError::InvalidState(e) => Some(e),
+            CommitHashStoreError::ResourceTemporarilyUnavailable(e) => Some(e),
+        }
+    }
+}
+
+impl From<InternalError> for CommitHashStoreError {
+    fn from(err: InternalError) -> Self {
+        CommitHashStoreError::Internal(err)
+    }
+}
+
+impl From<InvalidArgumentError> for CommitHashStoreError {
+    fn from(err: InvalidArgumentError) -> Self {
+        CommitHashStoreError::InvalidArgument(err)
+    }
+}
+
+impl From<InvalidStateError> for CommitHashStoreError {
+    fn from(err: InvalidStateError) -> Self {
+        CommitHashStoreError::InvalidState(err)
+    }
+}

--- a/services/scabbard/libscabbard/src/store/lmdb/mod.rs
+++ b/services/scabbard/libscabbard/src/store/lmdb/mod.rs
@@ -1,0 +1,212 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! LMDB-backed CommitHashStore implementations.
+
+use splinter::error::{InternalError, InvalidArgumentError, InvalidStateError};
+use transact::database::{lmdb::LmdbDatabase, Database, DatabaseError};
+
+use crate::hex;
+
+use super::{CommitHashStore, CommitHashStoreError};
+
+const CURRENT_STATE_ROOT_INDEX: &str = "current_state_root";
+
+/// Provides commit log storage using an LMDB database in a legacy configuration.
+///
+/// The legacy database configuration requires a index "current_state_root" configured on the
+/// database instance.  This is expected externally. It also doesn't support multiple services per
+/// store, as it expects a unique DB instance per store.
+pub struct LmdbCommitHashStore {
+    db: LmdbDatabase,
+}
+
+impl LmdbCommitHashStore {
+    /// Constructs a new commit log store around an LMDB database instance.
+    pub fn new(db: LmdbDatabase) -> Self {
+        Self { db }
+    }
+}
+
+impl CommitHashStore for LmdbCommitHashStore {
+    fn get_current_commit_hash(&self) -> Result<Option<String>, CommitHashStoreError> {
+        let reader = self
+            .db
+            .get_reader()
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        match reader.index_get(CURRENT_STATE_ROOT_INDEX, b"HEAD") {
+            Ok(current_commit_hash) => Ok(current_commit_hash.map(|bytes| hex::to_hex(&bytes))),
+            Err(DatabaseError::ReaderError(msg)) if msg.starts_with("Not an index") => Err(
+                CommitHashStoreError::InvalidState(InvalidStateError::with_message(
+                    "Missing current_state_root index in LMDB database".into(),
+                )),
+            ),
+            Err(err) => Err(CommitHashStoreError::Internal(InternalError::from_source(
+                Box::new(err),
+            ))),
+        }
+    }
+
+    fn set_current_commit_hash(&self, commit_hash: &str) -> Result<(), CommitHashStoreError> {
+        let current_root_bytes = hex::parse_hex(commit_hash).map_err(|e| {
+            InvalidArgumentError::new(
+                "commit_hash".into(),
+                format!("The commit hash provided is invalid: {}", e),
+            )
+        })?;
+
+        let mut writer = self
+            .db
+            .get_writer()
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        match writer.index_put(CURRENT_STATE_ROOT_INDEX, b"HEAD", &current_root_bytes) {
+            Ok(()) => (),
+
+            Err(DatabaseError::WriterError(msg)) if msg.starts_with("Not an index") => {
+                return Err(CommitHashStoreError::InvalidState(
+                    InvalidStateError::with_message(
+                        "Missing current_state_root index in LMDB database".into(),
+                    ),
+                ))
+            }
+            Err(err) => {
+                return Err(CommitHashStoreError::Internal(InternalError::from_source(
+                    Box::new(err),
+                )))
+            }
+        }
+
+        writer
+            .commit()
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env;
+    use std::error::Error;
+    use std::fs::remove_file;
+    use std::panic;
+    use std::path::Path;
+    use std::thread;
+
+    use transact::{
+        database::{lmdb::LmdbContext, DatabaseError},
+        state::merkle::INDEXES,
+    };
+
+    /// Test that a hash can be stored with an LMDB back-end
+    /// (Note, this test only uses a single service ID, as the LMDB implementation assumes that
+    /// there is single file representing all of the scabbard state, with a single index table
+    /// supporting the commit hash).
+    #[test]
+    fn test_lmdb_store() -> Result<(), Box<dyn Error>> {
+        run_lmdb_test(|dbpath| {
+            let mut indexes = INDEXES.to_vec();
+            indexes.push(CURRENT_STATE_ROOT_INDEX);
+            let db = make_lmdb(&indexes, dbpath)?;
+
+            let commit_log_store = LmdbCommitHashStore::new(db);
+
+            assert_eq!(None, commit_log_store.get_current_commit_hash()?);
+
+            commit_log_store.set_current_commit_hash("abcdef0123456789")?;
+
+            assert_eq!(
+                Some("abcdef0123456789".to_string()),
+                commit_log_store.get_current_commit_hash()?
+            );
+
+            Ok(())
+        })
+    }
+
+    /// Test that the LMDB implementation returns an error on get or set if the index table is not
+    /// present.
+    #[test]
+    fn test_lmdb_store_missing_index() -> Result<(), Box<dyn Error>> {
+        run_lmdb_test(|dbpath| {
+            let db = make_lmdb(&INDEXES, dbpath)?;
+
+            let commit_log_store = LmdbCommitHashStore::new(db);
+
+            let res = commit_log_store.get_current_commit_hash();
+
+            assert!(
+                matches!(res, Err(CommitHashStoreError::InvalidState(_))),
+                "Expected invalid state error, got {:?}",
+                res
+            );
+
+            let res = commit_log_store.set_current_commit_hash("abcdef0123456789");
+
+            assert!(
+                matches!(res, Err(CommitHashStoreError::InvalidState(_))),
+                "Expected invalid state error, got {:?}",
+                res
+            );
+
+            Ok(())
+        })
+    }
+
+    pub fn run_lmdb_test<T>(test: T) -> Result<(), Box<dyn Error>>
+    where
+        T: FnOnce(&str) -> Result<(), Box<dyn Error>> + panic::UnwindSafe,
+    {
+        let dbpath = temp_db_path()?;
+
+        let testpath = dbpath.clone();
+        let result = panic::catch_unwind(move || test(&testpath));
+
+        remove_file(dbpath)?;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                panic::resume_unwind(err);
+            }
+        }
+    }
+
+    fn make_lmdb(indexes: &[&str], merkle_path: &str) -> Result<LmdbDatabase, Box<dyn Error>> {
+        let ctx = LmdbContext::new(
+            Path::new(merkle_path),
+            indexes.len(),
+            Some(120 * 1024 * 1024),
+        )
+        .map_err(|err| DatabaseError::InitError(format!("{}", err)))?;
+
+        Ok(LmdbDatabase::new(ctx, indexes)
+            .map_err(|err| DatabaseError::InitError(format!("{}", err)))?)
+    }
+
+    fn temp_db_path() -> Result<String, Box<dyn Error>> {
+        let mut temp_dir = env::temp_dir();
+
+        let thread_id = thread::current().id();
+        temp_dir.push(format!("merkle-{:?}.lmdb", thread_id));
+        Ok(temp_dir
+            .to_str()
+            .ok_or_else(|| InternalError::with_message("Unable to convert path to string".into()))?
+            .to_string())
+    }
+}

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -15,6 +15,8 @@
 //! Stores required for a scabbard services operation.
 
 mod error;
+#[cfg(feature = "lmdb")]
+pub mod lmdb;
 
 pub use error::CommitHashStoreError;
 

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stores required for a scabbard services operation.
+
+mod error;
+
+pub use error::CommitHashStoreError;
+
+/// A store for the current commit hash value.
+///
+/// The commit hash, for Scabbard's purposes is the current state root hash of the Merkle-Radix
+/// tree after transactions have been applied.
+pub trait CommitHashStore {
+    /// Returns the current commit hash for the instance
+    fn get_current_commit_hash(&self) -> Result<Option<String>, CommitHashStoreError>;
+
+    /// Sets the current commit hash value.
+    ///
+    /// The commit hash, for Scabbard's purposes is the current state root hash of the Merkle-Radix
+    /// tree after transactions have been applied.
+    ///
+    /// # Arguments
+    ///
+    /// * `current_commit_hash` - the new "current" commit hash.
+    fn set_current_commit_hash(&self, commit_hash: &str) -> Result<(), CommitHashStoreError>;
+}


### PR DESCRIPTION
This change adds the `CommitLogStore` trait to libscabbard and implements a "Legacy" LMDB version that uses the `index_get/put` against an existing DB. The legacy implementation can properly detect if they LMDB instance supplied is has the index pre-configured and return an invalid state error, if not.