### PR TITLE
Fix crates publishing

### DIFF
--- a/ci/publish-crates
+++ b/ci/publish-crates
@@ -18,7 +18,7 @@ top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 export VERSION=AUTO_STRICT
 export REPO_VERSION=$($top_dir/bin/get_version)
 
-docker build -f ci/publish-splinter-crates -t publish-splinter-crates ci/
+docker build -f ci/publish-splinter-crates.dockerfile -t publish-splinter-crates ci/
 docker run \
   --rm \
   -v $(pwd):/project/splinter \

--- a/ci/publish-splinter-crates.dockerfile
+++ b/ci/publish-splinter-crates.dockerfile
@@ -26,6 +26,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     gcc \
     libssl-dev \


### PR DESCRIPTION
Some Dockerfiles were renamed recently and the crates publishing script
was not updated with the new name.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>