### PR TITLE
Update a peer's ID to include both their authorization type as well as the local nodes

### DIFF
--- a/libsplinter/protos/authorization.proto
+++ b/libsplinter/protos/authorization.proto
@@ -186,7 +186,9 @@ message AuthChallengeSubmitRequest {
 // v1 challenge response
 //
 // Returned if the signature and public key are valid
-message AuthChallengeSubmitResponse {}
+message AuthChallengeSubmitResponse {
+    bytes public_key = 1;
+}
 
 // Returned if authorization is complete
 message AuthComplete {}

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -37,7 +37,7 @@ use crate::consensus::Proposal;
 use crate::hex::to_hex;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::{ServiceDefinition, ServiceOrchestrator};
-use crate::peer::{PeerManagerConnector, PeerManagerNotification};
+use crate::peer::{PeerManagerConnector, PeerManagerNotification, PeerTokenPair};
 use crate::protocol::{ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION};
 use crate::protos::admin::{
     AdminMessage, AdminMessage_Type, CircuitManagementPayload, ServiceProtocolVersionResponse,
@@ -310,7 +310,11 @@ impl AdminService {
                     }
 
                     token_to_peer.insert(
-                        member.token.clone(),
+                        PeerTokenPair::new(
+                            member.token.clone(),
+                            #[cfg(feature = "challenge-authorization")]
+                            local_required_auth.clone(),
+                        ),
                         PeerNodePair {
                             peer_node: member.clone(),
                             local_peer_token: local_required_auth.clone(),
@@ -505,7 +509,11 @@ impl AdminService {
                     }
 
                     token_to_peer.insert(
-                        member.token.clone(),
+                        PeerTokenPair::new(
+                            member.token.clone(),
+                            #[cfg(feature = "challenge-authorization")]
+                            local_required_auth.clone(),
+                        ),
                         PeerNodePair {
                             peer_node: member.clone(),
                             local_peer_token: local_required_auth.clone(),
@@ -1032,7 +1040,7 @@ mod tests {
                 ),
             ],
             #[cfg(feature = "challenge-authorization")]
-            "node_id".to_string(),
+            "test-node".to_string(),
         );
 
         let authorization_manager = AuthorizationManager::new(

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -1020,16 +1020,20 @@ mod tests {
             .listen("inproc://orchestator")
             .expect("Unable to get listener");
 
-        let inproc_authorizer = InprocAuthorizer::new(vec![
-            (
-                "inproc://orchestator".to_string(),
-                "orchestator".to_string(),
-            ),
-            (
-                "inproc://otherplace:8000".to_string(),
-                "other-node".to_string(),
-            ),
-        ]);
+        let inproc_authorizer = InprocAuthorizer::new(
+            vec![
+                (
+                    "inproc://orchestator".to_string(),
+                    "orchestator".to_string(),
+                ),
+                (
+                    "inproc://otherplace:8000".to_string(),
+                    "other-node".to_string(),
+                ),
+            ],
+            #[cfg(feature = "challenge-authorization")]
+            "node_id".to_string(),
+        );
 
         let authorization_manager = AuthorizationManager::new(
             "test-node".into(),

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -7174,20 +7174,24 @@ mod tests {
         };
 
         let mesh = Mesh::new(2, 2);
-        let inproc_authorizer = InprocAuthorizer::new(vec![
-            (
-                "inproc://orchestator".to_string(),
-                "orchestator".to_string(),
-            ),
-            (
-                "inproc://otherplace:8000".to_string(),
-                "other-node".to_string(),
-            ),
-            (
-                "inproc://someplace:8000".to_string(),
-                "test-node".to_string(),
-            ),
-        ]);
+        let inproc_authorizer = InprocAuthorizer::new(
+            vec![
+                (
+                    "inproc://orchestator".to_string(),
+                    "orchestator".to_string(),
+                ),
+                (
+                    "inproc://otherplace:8000".to_string(),
+                    "other-node".to_string(),
+                ),
+                (
+                    "inproc://someplace:8000".to_string(),
+                    "test-node".to_string(),
+                ),
+            ],
+            #[cfg(feature = "challenge-authorization")]
+            "node_id".to_string(),
+        );
 
         let authorization_manager = AuthorizationManager::new(
             "test-node".into(),

--- a/libsplinter/src/admin/token/mod.rs
+++ b/libsplinter/src/admin/token/mod.rs
@@ -20,7 +20,7 @@ pub mod token_protobuf;
 pub mod token_protocol;
 
 use crate::error::InvalidStateError;
-use crate::peer::PeerAuthorizationToken;
+use crate::peer::{PeerAuthorizationToken, PeerTokenPair};
 
 /// Struct used to correlate a `PeerAuthorizationToken` with node information
 #[derive(Clone, Debug, PartialEq)]
@@ -32,7 +32,10 @@ pub struct PeerNode {
 }
 
 pub trait PeerAuthorizationTokenReader {
-    fn list_tokens(&self) -> Result<Vec<PeerAuthorizationToken>, InvalidStateError>;
+    fn list_tokens(
+        &self,
+        #[cfg(feature = "challenge-authorization")] local_node: &str,
+    ) -> Result<Vec<PeerTokenPair>, InvalidStateError>;
 
     fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError>;
 

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -75,7 +75,7 @@ mod tests {
 
     use super::*;
     use crate::network::dispatch::{DispatchLoopBuilder, Dispatcher};
-    use crate::peer::PeerAuthorizationToken;
+    use crate::peer::{PeerAuthorizationToken, PeerTokenPair};
     use crate::protos::circuit::ServiceConnectRequest;
     use crate::protos::network::NetworkMessageType;
 
@@ -114,7 +114,12 @@ mod tests {
         // Dispatch network message
         network_dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("PEER").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("PEER"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &NetworkMessageType::CIRCUIT,
                 circuit_bytes.clone(),
             )

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -15,7 +15,7 @@
 use crate::circuit::handlers::create_message;
 use crate::circuit::routing::{RoutingTableReader, RoutingTableWriter, Service, ServiceId};
 use crate::network::dispatch::{DispatchError, Handler, MessageContext, MessageSender, PeerId};
-use crate::peer::PeerAuthorizationToken;
+use crate::peer::PeerTokenPair;
 use crate::protos::circuit::{
     CircuitMessageType, ServiceConnectRequest, ServiceConnectResponse,
     ServiceConnectResponse_Status, ServiceDisconnectRequest, ServiceDisconnectResponse,
@@ -105,9 +105,7 @@ impl Handler for ServiceConnectRequestHandler {
                     response.set_status(ServiceConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE);
                     response.set_error_message(format!("{} is not allowed on this node", unique_id))
                 } else {
-                    service.set_peer_id(PeerAuthorizationToken::from(
-                        context.source_peer_id().clone(),
-                    ));
+                    service.set_peer_id(PeerTokenPair::from(context.source_peer_id().clone()));
                     let mut writer = self.routing_table_writer.clone();
                     writer
                         .add_service(unique_id, service)
@@ -320,7 +318,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                 connect_bytes.clone(),
             )
@@ -330,7 +333,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
             |msg: ServiceConnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -370,7 +377,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("BAD").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("BAD"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                 connect_bytes.clone(),
             )
@@ -380,7 +392,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("BAD"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("BAD"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
             |msg: ServiceConnectResponse| {
                 assert_eq!(msg.get_service_id(), "BAD");
@@ -419,7 +435,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                 connect_bytes.clone(),
             )
@@ -432,7 +453,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
             |msg: ServiceConnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -464,7 +489,14 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .unwrap();
-        service.set_peer_id(PeerAuthorizationToken::from_peer_id("abc_network"));
+        service.set_peer_id(
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc_network"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            )
+            .into(),
+        );
         writer
             .add_service(id, service)
             .expect("Unable to add circuit");
@@ -479,7 +511,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_CONNECT_REQUEST,
                 connect_bytes.clone(),
             )
@@ -489,7 +526,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
             |msg: ServiceConnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -523,7 +564,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                 disconnect_bytes.clone(),
             )
@@ -533,7 +579,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
             |msg: ServiceDisconnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -574,7 +624,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("BAD").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("BAD"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                 disconnect_bytes.clone(),
             )
@@ -584,7 +639,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("BAD"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("BAD"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
             |msg: ServiceDisconnectResponse| {
                 assert_eq!(msg.get_service_id(), "BAD");
@@ -619,7 +678,14 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .unwrap();
-        service.set_peer_id(PeerAuthorizationToken::from_peer_id("abc_network"));
+        service.set_peer_id(
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc_network"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            )
+            .into(),
+        );
         writer
             .add_service(id, service)
             .expect("Unable to add circuit");
@@ -634,7 +700,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                 disconnect_bytes.clone(),
             )
@@ -644,7 +715,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
             |msg: ServiceDisconnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -681,7 +756,12 @@ mod tests {
 
         dispatcher
             .dispatch(
-                PeerAuthorizationToken::from_peer_id("abc").into(),
+                PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("abc"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("123"),
+                )
+                .into(),
                 &CircuitMessageType::SERVICE_DISCONNECT_REQUEST,
                 disconnect_bytes.clone(),
             )
@@ -691,7 +771,11 @@ mod tests {
         assert_network_message(
             message,
             id.into(),
-            PeerAuthorizationToken::from_peer_id("abc"),
+            PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("abc"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("123"),
+            ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
             |msg: ServiceDisconnectResponse| {
                 assert_eq!(msg.get_service_id(), "abc");
@@ -745,8 +829,8 @@ mod tests {
 
     fn assert_network_message<M: protobuf::Message, F: Fn(M)>(
         message: Vec<u8>,
-        recipient: PeerAuthorizationToken,
-        expected_recipient: PeerAuthorizationToken,
+        recipient: PeerTokenPair,
+        expected_recipient: PeerTokenPair,
         expected_circuit_msg_type: CircuitMessageType,
         detail_assertions: F,
     ) {

--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -44,7 +44,7 @@ use self::error::RoutingTableReaderError;
 use crate::error::InternalError;
 #[cfg(feature = "challenge-authorization")]
 use crate::error::InvalidStateError;
-use crate::peer::PeerAuthorizationToken;
+use crate::peer::{PeerAuthorizationToken, PeerTokenPair};
 
 /// Interface for updating the routing table
 pub trait RoutingTableWriter: Send {
@@ -318,7 +318,7 @@ pub struct Service {
     service_type: String,
     node_id: String,
     arguments: Vec<(String, String)>,
-    peer_id: Option<PeerAuthorizationToken>,
+    peer_id: Option<PeerTokenPair>,
 }
 
 impl Service {
@@ -366,11 +366,11 @@ impl Service {
     }
 
     /// Returns the local peer ID for the service
-    pub fn peer_id(&self) -> &Option<PeerAuthorizationToken> {
+    pub fn peer_id(&self) -> &Option<PeerTokenPair> {
         &self.peer_id
     }
 
-    pub fn set_peer_id(&mut self, peer_id: PeerAuthorizationToken) {
+    pub fn set_peer_id(&mut self, peer_id: PeerTokenPair) {
         self.peer_id = Some(peer_id)
     }
 

--- a/libsplinter/src/network/auth/handlers/builder.rs
+++ b/libsplinter/src/network/auth/handlers/builder.rs
@@ -180,7 +180,10 @@ impl AuthorizationDispatchBuilder {
 
         // allow redundant_clone, must be cloned here if trust-authorization is enabled
         #[allow(clippy::redundant_clone)]
-        auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(identity.to_string())));
+        auth_dispatcher.set_handler(Box::new(ConnectResponseHandler::new(
+            identity.to_string(),
+            auth_manager.clone(),
+        )));
 
         auth_dispatcher.set_handler(Box::new(TrustRequestHandler::new(auth_manager.clone())));
 

--- a/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
@@ -388,10 +388,11 @@ impl Handler for AuthChallengeSubmitRequestHandler {
             Ok(AuthorizationRemoteState::Challenge(
                 ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(_),
             )) => {
-                let auth_msg =
-                    AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse{
-                        public_key: identity.into_bytes()
-                    });
+                let auth_msg = AuthorizationMessage::AuthChallengeSubmitResponse(
+                    AuthChallengeSubmitResponse {
+                        public_key: identity.into_bytes(),
+                    },
+                );
 
                 let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
                     NetworkMessage::from(auth_msg),
@@ -446,7 +447,7 @@ impl Handler for AuthChallengeSubmitResponseHandler {
 
     fn handle(
         &self,
-        _msg: Self::Message,
+        msg: Self::Message,
         context: &MessageContext<Self::Source, Self::MessageType>,
         sender: &dyn MessageSender<Self::Source>,
     ) -> Result<(), DispatchError> {
@@ -455,10 +456,18 @@ impl Handler for AuthChallengeSubmitResponseHandler {
             context.source_connection_id()
         );
 
+        let submit_msg = AuthChallengeSubmitResponse::from_proto(msg)?;
+
+        let public_key = submit_msg.public_key;
+
         match self.auth_manager.next_local_state(
             context.source_connection_id(),
             AuthorizationLocalAction::Challenge(
-                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse,
+                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse(
+                    Identity::Challenge {
+                        public_key: public_key::PublicKey::from_bytes(public_key),
+                    },
+                ),
             ),
         ) {
             Err(err) => {
@@ -556,6 +565,7 @@ mod tests {
                     local_state: AuthorizationLocalState::WaitingForAuthProtocolResponse,
                     remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
                     received_complete: true,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -662,6 +672,7 @@ mod tests {
                     ),
                     remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
                     received_complete: true,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -771,6 +782,7 @@ mod tests {
                         ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest,
                     ),
                     received_complete: true,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -894,6 +906,7 @@ mod tests {
                         ChallengeAuthorizationRemoteState::WaitingForAuthChallengeSubmitRequest,
                     ),
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -1026,6 +1039,7 @@ mod tests {
                         public_key: public_key.clone(),
                     }),
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -1057,7 +1071,12 @@ mod tests {
             .expect("Unable to build authorization dispatcher");
 
         let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
-            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse),
+            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse {
+                public_key: local_signer
+                    .public_key()
+                    .expect("unable to get public key")
+                    .into_bytes(),
+            }),
         )
         .expect("Unable to get message bytes");
 
@@ -1110,7 +1129,6 @@ mod tests {
     /// 2) the handler should send a AuthComplete
     /// 3) verify state is AuthorizedAndComplete and Done(Identity)
     #[test]
-
     fn auth_challenge_submit_response_complete() {
         let connection_id = "test_connection".to_string();
         let other_signer = new_signer();
@@ -1137,6 +1155,7 @@ mod tests {
                         public_key: public_key.clone(),
                     }),
                     received_complete: true,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -1168,7 +1187,12 @@ mod tests {
             .expect("Unable to build authorization dispatcher");
 
         let msg_bytes = IntoBytes::<authorization::AuthorizationMessage>::into_bytes(
-            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse),
+            AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse {
+                public_key: local_signer
+                    .public_key()
+                    .expect("unable to get public key")
+                    .into_bytes(),
+            }),
         )
         .expect("Unable to get message bytes");
 

--- a/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/challenge.rs
@@ -370,7 +370,7 @@ impl Handler for AuthChallengeSubmitRequestHandler {
             AuthorizationRemoteAction::Challenge(
                 ChallengeAuthorizationRemoteAction::ReceiveAuthChallengeSubmitRequest(
                     Identity::Challenge {
-                        public_key: identity,
+                        public_key: identity.clone(),
                     },
                 ),
             ),
@@ -389,7 +389,9 @@ impl Handler for AuthChallengeSubmitRequestHandler {
                 ChallengeAuthorizationRemoteState::ReceivedAuthChallengeSubmitRequest(_),
             )) => {
                 let auth_msg =
-                    AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse);
+                    AuthorizationMessage::AuthChallengeSubmitResponse(AuthChallengeSubmitResponse{
+                        public_key: identity.into_bytes()
+                    });
 
                 let msg_bytes = IntoBytes::<network::NetworkMessage>::into_bytes(
                     NetworkMessage::from(auth_msg),

--- a/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
@@ -24,6 +24,8 @@ pub mod trust;
 use crate::network::auth::state_machine::challenge_v1::ChallengeAuthorizationLocalAction;
 #[cfg(feature = "trust-authorization")]
 use crate::network::auth::state_machine::trust_v1::TrustAuthorizationLocalAction;
+#[cfg(feature = "trust-authorization")]
+use crate::network::auth::Identity;
 use crate::network::auth::{
     AuthorizationLocalAction, AuthorizationLocalState, AuthorizationManagerStateMachine,
     AuthorizationMessage, AuthorizationRemoteAction, AuthorizationRemoteState,
@@ -321,7 +323,11 @@ impl Handler for AuthProtocolResponseHandler {
                                 .next_local_state(
                                     context.source_connection_id(),
                                     AuthorizationLocalAction::Trust(
-                                        TrustAuthorizationLocalAction::SendAuthTrustRequest,
+                                        TrustAuthorizationLocalAction::SendAuthTrustRequest(
+                                            Identity::Trust {
+                                                identity: self.identity.to_string(),
+                                            },
+                                        ),
                                     ),
                                 )
                                 .is_err()
@@ -364,7 +370,11 @@ impl Handler for AuthProtocolResponseHandler {
                                 .next_local_state(
                                     context.source_connection_id(),
                                     AuthorizationLocalAction::Trust(
-                                        TrustAuthorizationLocalAction::SendAuthTrustRequest,
+                                        TrustAuthorizationLocalAction::SendAuthTrustRequest(
+                                            Identity::Trust {
+                                                identity: self.identity.to_string(),
+                                            },
+                                        ),
                                     ),
                                 )
                                 .is_err()
@@ -722,6 +732,7 @@ mod tests {
                         identity: "other_identity".to_string(),
                     }),
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();

--- a/libsplinter/src/network/auth/handlers/v1_handlers/trust.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/trust.rs
@@ -244,6 +244,7 @@ mod tests {
                     local_state: AuthorizationLocalState::WaitingForAuthProtocolResponse,
                     remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -323,6 +324,7 @@ mod tests {
                     ),
                     remote_state: AuthorizationRemoteState::SentAuthProtocolResponse,
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -426,6 +428,7 @@ mod tests {
                         identity: "other_identity".to_string(),
                     }),
                     received_complete: false,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();
@@ -525,6 +528,7 @@ mod tests {
                         identity: "other_identity".to_string(),
                     }),
                     received_complete: true,
+                    local_authorization: None,
                 },
             );
         let mock_sender = MockSender::new();

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/local_action.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/local_action.rs
@@ -14,13 +14,15 @@
 
 use std::fmt;
 
+use crate::network::auth::state_machine::Identity;
+
 /// The state transitions that can be applied on a connection during authorization.
 #[derive(PartialEq, Debug)]
 pub(crate) enum ChallengeAuthorizationLocalAction {
     SendAuthChallengeNonceRequest,
     ReceiveAuthChallengeNonceResponse,
     SendAuthChallengeSubmitRequest,
-    ReceiveAuthChallengeSubmitResponse,
+    ReceiveAuthChallengeSubmitResponse(Identity),
 }
 
 impl fmt::Display for ChallengeAuthorizationLocalAction {
@@ -35,7 +37,7 @@ impl fmt::Display for ChallengeAuthorizationLocalAction {
             ChallengeAuthorizationLocalAction::SendAuthChallengeSubmitRequest => {
                 f.write_str("SendAuthChallengeSubmitRequest")
             }
-            ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse => {
+            ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse(_) => {
                 f.write_str("ReceiveAuthChallengeSubmitResponse")
             }
         }

--- a/libsplinter/src/network/auth/state_machine/challenge_v1/local_state.rs
+++ b/libsplinter/src/network/auth/state_machine/challenge_v1/local_state.rs
@@ -84,7 +84,8 @@ impl ChallengeAuthorizationLocalState {
             },
             ChallengeAuthorizationLocalState::WaitingForAuthChallengeSubmitResponse => match action
             {
-                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse => {
+                ChallengeAuthorizationLocalAction::ReceiveAuthChallengeSubmitResponse(identity) => {
+                    cur_state.local_authorization = Some(identity);
                     let new_state = AuthorizationLocalState::Authorized;
                     cur_state.local_state = new_state.clone();
                     Ok(new_state)

--- a/libsplinter/src/network/auth/state_machine/trust_v1.rs
+++ b/libsplinter/src/network/auth/state_machine/trust_v1.rs
@@ -76,14 +76,14 @@ impl fmt::Display for TrustAuthorizationRemoteAction {
 /// The state transitions that can be applied on a connection during authorization.
 #[derive(PartialEq, Debug)]
 pub(crate) enum TrustAuthorizationLocalAction {
-    SendAuthTrustRequest,
+    SendAuthTrustRequest(Identity),
     ReceiveAuthTrustResponse,
 }
 
 impl fmt::Display for TrustAuthorizationLocalAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TrustAuthorizationLocalAction::SendAuthTrustRequest => {
+            TrustAuthorizationLocalAction::SendAuthTrustRequest(_) => {
                 f.write_str("SendAuthTrustRequest")
             }
             TrustAuthorizationLocalAction::ReceiveAuthTrustResponse => {
@@ -106,7 +106,8 @@ impl TrustAuthorizationLocalState {
     ) -> Result<AuthorizationLocalState, AuthorizationActionError> {
         match &self {
             TrustAuthorizationLocalState::TrustConnecting => match action {
-                TrustAuthorizationLocalAction::SendAuthTrustRequest => {
+                TrustAuthorizationLocalAction::SendAuthTrustRequest(identity) => {
+                    cur_state.local_authorization = Some(identity);
                     let new_state = AuthorizationLocalState::Trust(
                         TrustAuthorizationLocalState::WaitingForAuthTrustResponse,
                     );

--- a/libsplinter/src/network/connection_manager/builder.rs
+++ b/libsplinter/src/network/connection_manager/builder.rs
@@ -367,6 +367,7 @@ fn send_heartbeats<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
             }
             ConnectionMetadataExt::Inbound {
                 ref mut disconnected,
+                ..
             } => {
                 trace!(
                     "Sending heartbeat to {} ({})",

--- a/libsplinter/src/network/connection_manager/builder.rs
+++ b/libsplinter/src/network/connection_manager/builder.rs
@@ -359,6 +359,7 @@ fn send_heartbeats<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
                         subscribers.broadcast(ConnectionManagerNotification::Disconnected {
                             endpoint: metadata.endpoint.clone(),
                             identity: metadata.identity.clone(),
+                            connection_id: metadata.connection_id.clone(),
                         });
                         reconnections.push(metadata.clone());
                     }
@@ -385,6 +386,7 @@ fn send_heartbeats<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
                         subscribers.broadcast(ConnectionManagerNotification::Disconnected {
                             endpoint: metadata.endpoint.clone(),
                             identity: metadata.identity.clone(),
+                            connection_id: metadata.connection_id.clone(),
                         });
                     }
                 } else {

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -967,6 +967,7 @@ where
                 endpoint: endpoint.to_string(),
                 attempts: reconnection_attempts,
                 identity,
+                connection_id: connection_id.to_string(),
             });
         }
         Ok(())
@@ -1483,6 +1484,7 @@ mod tests {
                     identity: ConnectionAuthorizationType::Trust {
                         identity: "some-peer".into()
                     },
+                    connection_id: "test_id",
                 }
         );
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -612,24 +612,33 @@ where
                 // notification.
                 match connection.extended_metadata {
                     ConnectionMetadataExt::Outbound {
-                        ref reconnecting, ..
+                        ref reconnecting,
+                        #[cfg(feature = "challenge-authorization")]
+                        ref local_authorization,
+                        ..
                     } => {
                         if !reconnecting {
                             subscribers.broadcast(ConnectionManagerNotification::Connected {
                                 endpoint: outbound.endpoint.to_string(),
                                 connection_id: outbound.connection_id.to_string(),
                                 identity,
+                                #[cfg(feature = "challenge-authorization")]
+                                local_identity: local_authorization.clone(),
                             });
                         }
                     }
                     ConnectionMetadataExt::Inbound {
-                        ref disconnected, ..
+                        ref disconnected,
+                        #[cfg(feature = "challenge-authorization")]
+                        ref local_authorization,
                     } => {
                         if !disconnected {
                             subscribers.broadcast(ConnectionManagerNotification::Connected {
                                 endpoint: outbound.endpoint.to_string(),
                                 connection_id: outbound.connection_id.to_string(),
                                 identity,
+                                #[cfg(feature = "challenge-authorization")]
+                                local_identity: local_authorization.clone(),
                             });
                         }
                     }
@@ -753,7 +762,7 @@ where
                             #[cfg(feature = "challenge-authorization")]
                             expected_authorization,
                             #[cfg(feature = "challenge-authorization")]
-                            local_authorization,
+                            local_authorization: local_authorization.clone(),
                         },
                     },
                 );
@@ -762,6 +771,8 @@ where
                     endpoint,
                     connection_id,
                     identity,
+                    #[cfg(feature = "challenge-authorization")]
+                    local_identity: local_authorization,
                 });
             }
             AuthorizationResult::Unauthorized { connection_id, .. } => {
@@ -1247,6 +1258,10 @@ mod tests {
                     identity: ConnectionAuthorizationType::Trust {
                         identity: "some-peer".into()
                     },
+                    #[cfg(feature = "challenge-authorization")]
+                    local_identity: ConnectionAuthorizationType::Trust {
+                        identity: "test_identity".into()
+                    }
                 }
         );
 
@@ -1324,6 +1339,10 @@ mod tests {
                     identity: ConnectionAuthorizationType::Trust {
                         identity: "some-peer".into()
                     },
+                    #[cfg(feature = "challenge-authorization")]
+                    local_identity: ConnectionAuthorizationType::Trust {
+                        identity: "test_identity".into()
+                    }
                 }
         );
 
@@ -1478,6 +1497,10 @@ mod tests {
                     identity: ConnectionAuthorizationType::Trust {
                         identity: "some-peer".into()
                     },
+                    #[cfg(feature = "challenge-authorization")]
+                    local_identity: ConnectionAuthorizationType::Trust {
+                        identity: "test_identity".into()
+                    }
                 }
         );
 
@@ -1497,7 +1520,7 @@ mod tests {
                     identity: ConnectionAuthorizationType::Trust {
                         identity: "some-peer".into()
                     },
-                    connection_id: "test_id",
+                    connection_id: "test_id".into(),
                 }
         );
 
@@ -1514,6 +1537,10 @@ mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: "some-peer".into()
                 },
+                #[cfg(feature = "challenge-authorization")]
+                local_identity: ConnectionAuthorizationType::Trust {
+                    identity: "test_identity".into()
+                }
             }
         );
 

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -37,10 +37,12 @@ pub enum ConnectionManagerNotification {
     Disconnected {
         endpoint: String,
         identity: ConnectionAuthorizationType,
+        connection_id: String,
     },
     NonFatalConnectionError {
         endpoint: String,
         attempts: u64,
         identity: ConnectionAuthorizationType,
+        connection_id: String,
     },
 }

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -23,6 +23,8 @@ pub enum ConnectionManagerNotification {
         endpoint: String,
         connection_id: String,
         identity: ConnectionAuthorizationType,
+        #[cfg(feature = "challenge-authorization")]
+        local_identity: ConnectionAuthorizationType,
     },
     FatalConnectionError {
         endpoint: String,

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -33,6 +33,8 @@ pub enum ConnectionManagerNotification {
         endpoint: String,
         connection_id: String,
         identity: ConnectionAuthorizationType,
+        #[cfg(feature = "challenge-authorization")]
+        local_identity: ConnectionAuthorizationType,
     },
     Disconnected {
         endpoint: String,

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -41,7 +41,7 @@ use crate::transport::matrix::{
 
 use super::connector::{PeerLookup, PeerLookupProvider};
 use super::error::PeerInterconnectError;
-use super::PeerAuthorizationToken;
+use super::PeerTokenPair;
 
 const DEFAULT_PENDING_QUEUE_SIZE: usize = 100;
 const DEFAULT_TIME_BETWEEN_ATTEMPTS: u64 = 10; // 10 seconds
@@ -52,7 +52,7 @@ const DEFAULT_INITIAL_ATTEMPTS: usize = 3; // 3 attempts
 pub(crate) enum SendRequest {
     Shutdown,
     Message {
-        recipient: PeerAuthorizationToken,
+        recipient: PeerTokenPair,
         payload: Vec<u8>,
     },
 }
@@ -81,9 +81,9 @@ impl NetworkMessageSender {
     /// * `payload` - the bytes of the message that should be sent
     pub fn send(
         &self,
-        recipient: PeerAuthorizationToken,
+        recipient: PeerTokenPair,
         payload: Vec<u8>,
-    ) -> Result<(), (PeerAuthorizationToken, Vec<u8>)> {
+    ) -> Result<(), (PeerTokenPair, Vec<u8>)> {
         self.sender
             .send(SendRequest::Message { recipient, payload })
             .map_err(|err| match err.0 {
@@ -373,7 +373,7 @@ fn run_recv_loop<R>(
 where
     R: ConnectionMatrixReceiver + 'static,
 {
-    let mut connection_id_to_peer_id: HashMap<String, PeerAuthorizationToken> = HashMap::new();
+    let mut connection_id_to_peer_id: HashMap<String, PeerTokenPair> = HashMap::new();
     loop {
         // receive messages from peers
         let envelope = match message_receiver.recv() {
@@ -456,7 +456,7 @@ fn run_send_loop<S>(
 where
     S: ConnectionMatrixSender + 'static,
 {
-    let mut peer_id_to_connection_id: HashMap<PeerAuthorizationToken, String> = HashMap::new();
+    let mut peer_id_to_connection_id: HashMap<PeerTokenPair, String> = HashMap::new();
     loop {
         // receive message from internal handlers to send over the network
         let (recipient, payload) = match receiver.recv() {
@@ -538,7 +538,7 @@ fn run_pending_recv_loop(
     receiver: Receiver<RetryIncoming>,
     dispatch_msg_sender: DispatchMessageSender<NetworkMessageType>,
 ) -> Result<(), String> {
-    let mut connection_id_to_peer_id: HashMap<String, PeerAuthorizationToken> = HashMap::new();
+    let mut connection_id_to_peer_id: HashMap<String, PeerTokenPair> = HashMap::new();
     let mut pending_queue = VecDeque::new();
     loop {
         match receiver.recv() {
@@ -646,7 +646,7 @@ pub mod tests {
         dispatch_channel, DispatchError, DispatchLoopBuilder, Dispatcher, Handler, MessageContext,
         MessageSender, PeerId,
     };
-    use crate::peer::{PeerManager, PeerManagerNotification};
+    use crate::peer::{PeerAuthorizationToken, PeerManager, PeerManagerNotification};
     use crate::protos::network::NetworkEcho;
     use crate::threading::lifecycle::ShutdownHandle;
     use crate::transport::{inproc::InprocTransport, Connection, Transport};
@@ -800,7 +800,11 @@ pub mod tests {
 
         assert_eq!(
             peer_ref.peer_id(),
-            &PeerAuthorizationToken::from_peer_id("test_peer"),
+            &PeerTokenPair::new(
+                PeerAuthorizationToken::from_peer_id("test_peer"),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_peer_id("my_id"),
+            )
         );
 
         // timeout after 60 seconds
@@ -811,7 +815,11 @@ pub mod tests {
         assert_eq!(
             notification,
             PeerManagerNotification::Connected {
-                peer: PeerAuthorizationToken::from_peer_id("test_peer")
+                peer: PeerTokenPair::new(
+                    PeerAuthorizationToken::from_peer_id("test_peer"),
+                    #[cfg(feature = "challenge-authorization")]
+                    PeerAuthorizationToken::from_peer_id("my_id"),
+                )
             }
         );
 
@@ -930,7 +938,12 @@ pub mod tests {
             } else {
                 assert_eq!(
                     message_context.source_peer_id(),
-                    &PeerId::from(PeerAuthorizationToken::from_peer_id("test_peer"))
+                    &PeerTokenPair::new(
+                        PeerAuthorizationToken::from_peer_id("test_peer"),
+                        #[cfg(feature = "challenge-authorization")]
+                        PeerAuthorizationToken::from_peer_id("my_id"),
+                    )
+                    .into()
                 );
                 let echo_bytes = message.write_to_bytes().unwrap();
 

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -993,9 +993,9 @@ pub mod tests {
                     identity: self.authorized_id.clone(),
                 },
                 #[cfg(feature = "challenge-authorization")]
-                expected_authorization,
+                expected_authorization: expected_authorization.unwrap(),
                 #[cfg(feature = "challenge-authorization")]
-                local_authorization,
+                local_authorization: local_authorization.unwrap(),
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -958,7 +958,7 @@ fn handle_notifications(
 ) {
     match notification {
         // If a connection has disconnected, forward notification to subscribers
-        ConnectionManagerNotification::Disconnected { endpoint, identity } => handle_disconnection(
+        ConnectionManagerNotification::Disconnected { endpoint, identity, .. } => handle_disconnection(
             endpoint,
             PeerAuthorizationToken::from(identity),
             unreferenced_peers,
@@ -970,6 +970,7 @@ fn handle_notifications(
             endpoint,
             attempts,
             identity,
+            ..
         } => {
             // Check if the disconnected peer has reached the retry limit, if so try to find a
             // different endpoint that can be connected to

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -2783,7 +2783,7 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
-            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+            #[cfg(feature = "challenge-authorization")] _expected_authorization: Option<
                 ConnectionAuthorizationType,
             >,
             #[cfg(feature = "challenge-authorization")] local_authorization: Option<
@@ -2798,11 +2798,17 @@ pub mod tests {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
                 connection,
-                identity: ConnectionAuthorizationType::Trust { identity },
+                identity: ConnectionAuthorizationType::Trust {
+                    identity: identity.clone(),
+                },
                 #[cfg(feature = "challenge-authorization")]
-                expected_authorization,
+                expected_authorization: ConnectionAuthorizationType::Trust { identity },
                 #[cfg(feature = "challenge-authorization")]
-                local_authorization,
+                local_authorization: local_authorization.unwrap_or(
+                    ConnectionAuthorizationType::Trust {
+                        identity: "my_id".into(),
+                    },
+                ),
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/peer/peer_ref.rs
+++ b/libsplinter/src/peer/peer_ref.rs
@@ -16,7 +16,7 @@
 //!
 //! The public interface includes the structs [`PeerRef`] and [`EndpointPeerRef`]
 
-use super::PeerAuthorizationToken;
+use super::PeerTokenPair;
 use crate::peer::connector::PeerRemover;
 
 /// Used to keep track of peer references. When dropped, the `PeerRef` will send a request to the
@@ -24,13 +24,13 @@ use crate::peer::connector::PeerRemover;
 /// exist.
 #[derive(Debug, PartialEq)]
 pub struct PeerRef {
-    peer_id: PeerAuthorizationToken,
+    peer_id: PeerTokenPair,
     peer_remover: PeerRemover,
 }
 
 impl PeerRef {
     /// Creates a new `PeerRef`
-    pub(super) fn new(peer_id: PeerAuthorizationToken, peer_remover: PeerRemover) -> Self {
+    pub(super) fn new(peer_id: PeerTokenPair, peer_remover: PeerRemover) -> Self {
         PeerRef {
             peer_id,
             peer_remover,
@@ -38,7 +38,7 @@ impl PeerRef {
     }
 
     /// Returns the peer ID this reference is for
-    pub fn peer_id(&self) -> &PeerAuthorizationToken {
+    pub fn peer_id(&self) -> &PeerTokenPair {
         &self.peer_id
     }
 }

--- a/libsplinter/src/peer/unreferenced.rs
+++ b/libsplinter/src/peer/unreferenced.rs
@@ -1,0 +1,58 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs for keeping track of unreferenced peers
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use super::PeerAuthorizationToken;
+
+/// An entry of unreferenced peers, that may have connected externally, but have not yet been
+/// requested locally.
+#[derive(Debug)]
+pub struct UnreferencedPeer {
+    pub endpoint: String,
+    pub connection_id: String,
+    pub local_authorization: Option<PeerAuthorizationToken>,
+}
+
+/// An entry for a peer that was only requested by endpoint.
+#[derive(Debug)]
+pub struct RequestedEndpoint {
+    pub endpoint: String,
+    #[cfg(feature = "challenge-authorization")]
+    pub local_authorization: PeerAuthorizationToken,
+}
+
+pub struct UnreferencedPeerState {
+    pub peers: HashMap<PeerAuthorizationToken, UnreferencedPeer>,
+    // The list of endpoints that have been requested without an ID
+    pub requested_endpoints: HashMap<String, RequestedEndpoint>,
+    // Last time connection to the requested endpoints was tried
+    pub last_connection_attempt: Instant,
+    // How often to try to connect to requested endpoints
+    pub retry_frequency: u64,
+}
+
+impl UnreferencedPeerState {
+    fn new(retry_frequency: u64) -> Self {
+        UnreferencedPeerState {
+            peers: HashMap::default(),
+            requested_endpoints: HashMap::default(),
+            last_connection_attempt: Instant::now(),
+            retry_frequency,
+        }
+    }
+}

--- a/libsplinter/src/protocol/authorization.rs
+++ b/libsplinter/src/protocol/authorization.rs
@@ -299,7 +299,9 @@ pub struct AuthChallengeSubmitRequest {
 ///
 /// This message is returned if challenge submit request is accepted
 #[derive(Debug)]
-pub struct AuthChallengeSubmitResponse;
+pub struct AuthChallengeSubmitResponse {
+    pub public_key: Vec<u8>,
+}
 
 impl FromProto<authorization::AuthComplete> for AuthComplete {
     fn from_proto(_: authorization::AuthComplete) -> Result<Self, ProtoConversionError> {
@@ -473,16 +475,20 @@ impl FromNative<AuthChallengeSubmitRequest> for authorization::AuthChallengeSubm
 }
 
 impl FromNative<AuthChallengeSubmitResponse> for authorization::AuthChallengeSubmitResponse {
-    fn from_native(_: AuthChallengeSubmitResponse) -> Result<Self, ProtoConversionError> {
-        Ok(authorization::AuthChallengeSubmitResponse::new())
+    fn from_native(response: AuthChallengeSubmitResponse) -> Result<Self, ProtoConversionError> {
+        let mut proto_response = authorization::AuthChallengeSubmitResponse::new();
+        proto_response.set_public_key(response.public_key);
+        Ok(proto_response)
     }
 }
 
 impl FromProto<authorization::AuthChallengeSubmitResponse> for AuthChallengeSubmitResponse {
     fn from_proto(
-        _: authorization::AuthChallengeSubmitResponse,
+        mut source: authorization::AuthChallengeSubmitResponse,
     ) -> Result<Self, ProtoConversionError> {
-        Ok(AuthChallengeSubmitResponse)
+        Ok(AuthChallengeSubmitResponse {
+            public_key: source.take_public_key(),
+        })
     }
 }
 

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -738,10 +738,10 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
-            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+            #[cfg(feature = "challenge-authorization")] _expected_authorization: Option<
                 ConnectionAuthorizationType,
             >,
-            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+            #[cfg(feature = "challenge-authorization")] _local_authorization: Option<
                 ConnectionAuthorizationType,
             >,
         ) -> Result<(), AuthorizerError> {
@@ -752,9 +752,13 @@ pub mod tests {
                     identity: self.authorized_id.clone(),
                 },
                 #[cfg(feature = "challenge-authorization")]
-                expected_authorization,
+                expected_authorization: ConnectionAuthorizationType::Trust {
+                    identity: self.authorized_id.clone(),
+                },
                 #[cfg(feature = "challenge-authorization")]
-                local_authorization,
+                local_authorization: ConnectionAuthorizationType::Trust {
+                    identity: "local_id".into(),
+                },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -523,6 +523,7 @@ impl ServiceConnectionAgent {
                 endpoint,
                 connection_id,
                 identity,
+                ..
             } => {
                 let identity = match identity {
                     ConnectionAuthorizationType::Trust { identity } => identity,

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -777,10 +777,10 @@ mod tests {
             connection_id: String,
             connection: Box<dyn Connection>,
             callback: AuthorizerCallback,
-            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
+            #[cfg(feature = "challenge-authorization")] _expected_authorization: Option<
                 ConnectionAuthorizationType,
             >,
-            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
+            #[cfg(feature = "challenge-authorization")] _local_authorization: Option<
                 ConnectionAuthorizationType,
             >,
         ) -> Result<(), AuthorizerError> {
@@ -791,9 +791,13 @@ mod tests {
                     identity: self.authorized_id.clone(),
                 },
                 #[cfg(feature = "challenge-authorization")]
-                expected_authorization,
+                expected_authorization: ConnectionAuthorizationType::Trust {
+                    identity: self.authorized_id.clone(),
+                },
                 #[cfg(feature = "challenge-authorization")]
-                local_authorization,
+                local_authorization: ConnectionAuthorizationType::Trust {
+                    identity: "local_id".into(),
+                },
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))
         }

--- a/splinterd/src/daemon.rs
+++ b/splinterd/src/daemon.rs
@@ -278,7 +278,11 @@ impl SplinterDaemon {
             format!("health::{}", &self.node_id),
         ));
 
-        let inproc_authorizer = InprocAuthorizer::new(inproc_ids);
+        let inproc_authorizer = InprocAuthorizer::new(
+            inproc_ids,
+            #[cfg(feature = "challenge-authorization")]
+            self.node_id.clone(),
+        );
 
         let mut authorizers = Authorizers::new();
         authorizers.add_authorizer("inproc", inproc_authorizer);

--- a/splinterd/src/node/runnable/network.rs
+++ b/splinterd/src/node/runnable/network.rs
@@ -227,7 +227,7 @@ impl RunnableNetworkSubsystem {
         ];
 
         // Set up Authorization
-        let inproc_authorizer = InprocAuthorizer::new(inproc_ids);
+        let inproc_authorizer = InprocAuthorizer::new(inproc_ids, node_id.to_string());
 
         let authorization_manager =
             AuthorizationManager::new(node_id.to_string(), signers, signing_context)

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -176,7 +176,6 @@ pub fn test_2_party_circuit_creation_challenge_authorization_unidentified_peer()
 /// 9. Repeat steps 1-8 for a different circuit that sets the member public key for the first node
 ///    to the second configured key.
 #[test]
-#[ignore]
 pub fn test_2_party_circuit_creation_challenge_authorization_different_key() {
     // Start a 2-node network
     let mut network = Network::new()

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use splinter::admin::client::event::{EventType, PublicKey};
 use splinter::admin::messages::AuthorizationType;
-use splinter::peer::{PeerAuthorizationToken, PeerManagerNotification};
+use splinter::peer::{PeerAuthorizationToken, PeerManagerNotification, PeerTokenPair};
 use splinterd::node::{Node, RestApiVariant};
 
 use crate::admin::circuit_commit::{commit_2_party_circuit, commit_3_party_circuit};
@@ -131,14 +131,26 @@ pub fn test_2_party_circuit_creation_challenge_authorization_unidentified_peer()
     assert_eq!(
         notification,
         TestEnum::Notification(PeerManagerNotification::Connected {
-            peer: PeerAuthorizationToken::from_public_key(
-                node_b
-                    .signers()
-                    .get(0)
-                    .expect("node does not have enough signers configured")
-                    .public_key()
-                    .expect("Unable to get first node's public key")
-                    .as_slice(),
+            peer: PeerTokenPair::new(
+                PeerAuthorizationToken::from_public_key(
+                    node_b
+                        .signers()
+                        .get(0)
+                        .expect("node does not have enough signers configured")
+                        .public_key()
+                        .expect("Unable to get first node's public key")
+                        .as_slice(),
+                ),
+                #[cfg(feature = "challenge-authorization")]
+                PeerAuthorizationToken::from_public_key(
+                    node_a
+                        .signers()
+                        .get(0)
+                        .expect("node does not have enough signers configured")
+                        .public_key()
+                        .expect("Unable to get first node's public key")
+                        .as_slice(),
+                )
             )
         })
     );


### PR DESCRIPTION
This PR replaces the use of PeerAuthorizationToken for the peer
with a PeerTokenPair which contains both the peer's authorization
along with the local nodes authorization type. This is required
because a node should be able to connect to another node over
different connections using different public keys.

The PeerManager, PeerMap, PeerConnector and PeerInterconnect have
all been updated to use PeerTokenPair as the Peer ID for the peers.

Dispatcher PeerID has been updated to use PeerTokenPair along with
all of the message handlers.

Finally, the admin service has also been updated to user PeerTokenPair.
This required an update the admin service hack so the admin service id
has been updated to include both the peers public key and the local
nodes id "admin::public_key::PUBLIC_KEY::public_key::PUBLIC_KEY"