### PR TITLE
Update metrics feature to use v0.17 of metrics in libsplinter 

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -51,8 +51,7 @@ hyper = { version = "0.12", optional = true }
 jsonwebtoken = { version = "6.0", optional = true }
 influxdb = { version = "0.4.0", features = ["derive"], optional = true }
 log = "0.3.0"
-# rename to not conflict with splinter::metrics
-metrics-lib = {package = "metrics", version = "0.12", features = ["std"], optional = true}
+metrics = {version = "0.17", features = ["std"], optional = true}
 mio = { version = "0.6", default-features = false }
 mio-extras = "2"
 oauth2 = { version = "3.0", optional = true }
@@ -126,12 +125,12 @@ experimental = [
     "challenge-authorization",
     "client-reqwest",
     "https-bind",
-    "metrics",
     "registry-client",
     "registry-client-reqwest",
     "rest-api-actix-web-3",
     "service-arg-validation",
     "service-network",
+    "tap",
     "ws-transport",
     "zmq-transport",
 ]
@@ -165,7 +164,6 @@ cylinder-jwt = ["cylinder/jwt", "rest-api"]
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
-metrics = ["chrono", "futures-0-3", "influxdb", "metrics-lib", "tokio-0-2"]
 node-id-store = []
 oauth = ["biome", "base64", "oauth2", "reqwest", "rest-api"]
 postgres = ["diesel/postgres", "diesel_migrations"]
@@ -189,6 +187,7 @@ service-arg-validation = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]
 store-factory = []
+tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-0-2"]
 trust-authorization = []
 ws-transport = ["tungstenite"]
 zmq-transport = ["zmq"]

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -1048,11 +1048,11 @@ impl AdminServiceShared {
         // initialize circuit and proposal metrics
         gauge!(
             "splinter.admin.circuits.active",
-            self.admin_store.count_circuits(&[])? as i64
+            self.admin_store.count_circuits(&[])? as f64
         );
         gauge!(
             "splinter.admin.proposals",
-            self.admin_store.count_proposals(&[])? as i64
+            self.admin_store.count_proposals(&[])? as f64
         );
         Ok(())
     }
@@ -1172,7 +1172,7 @@ impl AdminServiceShared {
                 ServiceError::UnableToHandleMessage(Box::new(AdminSharedError::SplinterStateError(
                     String::from("Unable to get count of circuits"),
                 )))
-            })? as i64
+            })? as f64
         );
 
         // The circuit is able to be abandoned, so we will proceed with removing the circuit's

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -28,13 +28,13 @@ extern crate diesel;
 #[macro_use]
 #[cfg(feature = "diesel")]
 extern crate diesel_migrations;
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 #[macro_use]
-extern crate metrics_lib;
+extern crate metrics;
 
 // macros_use must come before any modules that make use of the macro
 #[macro_use]
-pub mod metrics;
+pub mod tap;
 
 #[macro_export]
 macro_rules! rwlock_read_unwrap {

--- a/libsplinter/src/peer/peer_map.rs
+++ b/libsplinter/src/peer/peer_map.rs
@@ -79,7 +79,7 @@ impl PeerMap {
         #[cfg(not(feature = "challenge-authorization"))] local_identity: PeerAuthorizationToken,
     ) -> Self {
         // initialize peers metric
-        gauge!("splinter.peer_manager.peers", 0);
+        gauge!("splinter.peer_manager.peers", 0.0);
 
         PeerMap {
             peers: HashMap::new(),
@@ -152,7 +152,7 @@ impl PeerMap {
             }
         }
 
-        gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
+        gauge!("splinter.peer_manager.peers", self.peers.len() as f64);
     }
 
     /// Removes a peer and its endpoints.
@@ -175,10 +175,10 @@ impl PeerMap {
                     }
                 }
             }
-            gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
+            gauge!("splinter.peer_manager.peers", self.peers.len() as f64);
             Some(peer_metadata)
         } else {
-            gauge!("splinter.peer_manager.peers", self.peers.len() as i64);
+            gauge!("splinter.peer_manager.peers", self.peers.len() as f64);
             None
         }
     }

--- a/libsplinter/src/tap/mod.rs
+++ b/libsplinter/src/tap/mod.rs
@@ -22,11 +22,11 @@
 //! - `gauge`: Updates a gauge.
 //! - `histogram`: Records a histogram.
 
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 pub mod influx;
 
 /// no-op `counter` macro for when the `metrics` feature is not enabled
-#[cfg(not(feature = "metrics"))]
+#[cfg(not(feature = "tap"))]
 #[macro_export]
 macro_rules! counter {
     ($t:tt, $v:expr) => {};
@@ -34,7 +34,7 @@ macro_rules! counter {
 }
 
 /// no-op `gauge` macro for when the `metrics` feature is not enabled
-#[cfg(not(feature = "metrics"))]
+#[cfg(not(feature = "tap"))]
 #[macro_export]
 macro_rules! gauge {
     ($t:tt, $v:expr) => {};
@@ -42,7 +42,7 @@ macro_rules! gauge {
 }
 
 /// no-op `histogram` macro for when the `metrics` feature is not enabled
-#[cfg(not(feature = "metrics"))]
+#[cfg(not(feature = "tap"))]
 #[macro_export]
 macro_rules! histogram {
     ($t:tt, $v:expr) => {};

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -30,7 +30,7 @@ cylinder = "0.2"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 futures = { version = "0.1", optional = true }
 log = "0.3.0"
-metrics = { version = "0.12", optional = true}
+metrics = { version = "0.17", optional = true}
 openssl = "0.10"
 protobuf = "2.23"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }

--- a/services/scabbard/libscabbard/src/service/shared.rs
+++ b/services/scabbard/libscabbard/src/service/shared.rs
@@ -107,7 +107,7 @@ impl ScabbardShared {
         };
 
         // initialize pending_batches metric
-        scabbard_shared.update_pending_batches(0);
+        scabbard_shared.update_pending_batches(0.0);
 
         scabbard_shared
     }
@@ -140,7 +140,7 @@ impl ScabbardShared {
     /// * `_batches` - The number of pending batches for this service. It is prefixed with an
     /// underscore due to rust recognizing the metrics macro noop when the metrics feature is
     /// disabled
-    fn update_pending_batches(&self, _batches: i64) {
+    fn update_pending_batches(&self, _batches: f64) {
         gauge!(
             "splinter.scabbard.pending_batches",
             _batches,
@@ -150,7 +150,7 @@ impl ScabbardShared {
 
     pub fn add_batch_to_queue(&mut self, batch: BatchPair) -> Result<(), ScabbardError> {
         self.batch_queue.push_back(batch);
-        self.update_pending_batches(self.batch_queue.len() as i64);
+        self.update_pending_batches(self.batch_queue.len() as f64);
 
         #[cfg(feature = "back-pressure")]
         {
@@ -187,7 +187,7 @@ impl ScabbardShared {
 
         // if the batch is some, the length of pending batches has changed
         if batch.is_some() {
-            self.update_pending_batches(self.batch_queue.len() as i64);
+            self.update_pending_batches(self.batch_queue.len() as f64);
         }
 
         #[cfg(feature = "back-pressure")]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -105,7 +105,7 @@ experimental = [
     "health-service",
     "https-bind",
     "log-config",
-    "metrics",
+    "tap",
     "node",
     "node-file-block",
     "scabbard-back-pressure",
@@ -139,8 +139,8 @@ scabbard-receipt-store = ["scabbard/diesel-receipt-store"]
 health-service = ["health", "health/authorization"]
 https-bind = ["splinter/https-bind"]
 log-config = []
-metrics = [
-  "splinter/metrics",
+tap = [
+  "splinter/tap",
   "scabbard/metrics",
 ]
 node = [

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -338,22 +338,22 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.strict_ref_counts().map(|v| (v, p.source())))
                 .ok_or_else(|| ConfigError::MissingValue("strict_ref_counts".to_string()))?,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_db: self
                 .partial_configs
                 .iter()
                 .find_map(|p| p.metrics_db().map(|v| (v, p.source()))),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_url: self
                 .partial_configs
                 .iter()
                 .find_map(|p| p.metrics_url().map(|v| (v, p.source()))),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_username: self
                 .partial_configs
                 .iter()
                 .find_map(|p| p.metrics_username().map(|v| (v, p.source()))),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_password: self
                 .partial_configs
                 .iter()

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -170,7 +170,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 )
         }
 
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "tap")]
         {
             partial_config = partial_config
                 .with_metrics_db(self.matches.value_of("metrics_db").map(String::from))

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -35,13 +35,13 @@ const OAUTH_CLIENT_SECRET_ENV: &str = "OAUTH_CLIENT_SECRET";
 const OAUTH_REDIRECT_URL_ENV: &str = "OAUTH_REDIRECT_URL";
 #[cfg(feature = "oauth")]
 const OAUTH_OPENID_URL_ENV: &str = "OAUTH_OPENID_URL";
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 const METRICS_DB_ENV: &str = "SPLINTER_METRICS_DB";
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 const METRICS_URL_ENV: &str = "SPLINTER_METRICS_URL";
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 const METRICS_USERNAME_ENV: &str = "SPLINTER_METRICS_USERNAME";
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 const METRICS_PASSWORD_ENV: &str = "SPLINTER_METRICS_PASSWORD";
 
 pub struct EnvPartialConfigBuilder;
@@ -125,7 +125,7 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
                 .with_oauth_openid_url(env::var(OAUTH_OPENID_URL_ENV).ok());
         }
 
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "tap")]
         {
             config = config
                 .with_metrics_db(env::var(METRICS_DB_ENV).ok())

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -89,13 +89,13 @@ pub struct Config {
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<(Vec<String>, ConfigSource)>,
     strict_ref_counts: (bool, ConfigSource),
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_db: Option<(String, ConfigSource)>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_url: Option<(String, ConfigSource)>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_username: Option<(String, ConfigSource)>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_password: Option<(String, ConfigSource)>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: (String, ConfigSource),
@@ -304,7 +304,7 @@ impl Config {
         self.strict_ref_counts.0
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_db(&self) -> Option<&str> {
         if let Some((db, _)) = &self.metrics_db {
             Some(db)
@@ -313,7 +313,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_url(&self) -> Option<&str> {
         if let Some((url, _)) = &self.metrics_url {
             Some(url)
@@ -322,7 +322,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_username(&self) -> Option<&str> {
         if let Some((username, _)) = &self.metrics_username {
             Some(username)
@@ -331,7 +331,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_password(&self) -> Option<&str> {
         if let Some((password, _)) = &self.metrics_password {
             Some(password)
@@ -537,7 +537,7 @@ impl Config {
         &self.strict_ref_counts.1
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_db_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.metrics_db {
             Some(source)
@@ -546,7 +546,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_url_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.metrics_url {
             Some(source)
@@ -555,7 +555,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_username_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.metrics_username {
             Some(source)
@@ -564,7 +564,7 @@ impl Config {
         }
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_password_source(&self) -> Option<&ConfigSource> {
         if let Some((_, source)) = &self.metrics_password {
             Some(source)
@@ -828,7 +828,7 @@ impl Config {
             self.strict_ref_counts(),
             self.strict_ref_counts_source()
         );
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "tap")]
         {
             if let (Some(db), Some(source)) = (self.metrics_db(), self.metrics_db_source()) {
                 debug!("Config: metrics_db: {:?} (source: {:?})", db, source,);

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -85,13 +85,13 @@ pub struct PartialConfig {
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<Vec<String>>,
     strict_ref_counts: Option<bool>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_db: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_url: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_username: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: Option<String>,
@@ -159,13 +159,13 @@ impl PartialConfig {
             #[cfg(feature = "oauth")]
             oauth_openid_scopes: None,
             strict_ref_counts: None,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_db: None,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_url: None,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_username: None,
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             metrics_password: None,
             #[cfg(feature = "challenge-authorization")]
             peering_key: None,
@@ -338,22 +338,22 @@ impl PartialConfig {
         self.strict_ref_counts
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_db(&self) -> Option<String> {
         self.metrics_db.clone()
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_url(&self) -> Option<String> {
         self.metrics_url.clone()
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_username(&self) -> Option<String> {
         self.metrics_username.clone()
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     pub fn metrics_password(&self) -> Option<String> {
         self.metrics_password.clone()
     }
@@ -792,7 +792,7 @@ impl PartialConfig {
         self
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     /// Adds an `metrics_db` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -804,7 +804,7 @@ impl PartialConfig {
         self
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     /// Adds an `metrics_url` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -816,7 +816,7 @@ impl PartialConfig {
         self
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     /// Adds an `metrics_username` value to the `PartialConfig` object.
     ///
     /// # Arguments
@@ -829,7 +829,7 @@ impl PartialConfig {
         self
     }
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     /// Adds an `metrics_password` value to the `PartialConfig` object.
     ///
     /// # Arguments

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -73,13 +73,13 @@ struct TomlConfig {
     oauth_openid_auth_params: Option<Vec<(String, String)>>,
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<Vec<String>>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_db: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_url: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_username: Option<String>,
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     metrics_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: Option<String>,
@@ -197,7 +197,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_oauth_openid_scopes(self.toml_config.oauth_openid_scopes);
         }
 
-        #[cfg(feature = "metrics")]
+        #[cfg(feature = "tap")]
         {
             partial_config = partial_config
                 .with_metrics_db(self.toml_config.metrics_db)

--- a/splinterd/src/error.rs
+++ b/splinterd/src/error.rs
@@ -25,7 +25,7 @@ use crate::daemon::StartError;
 #[derive(Debug)]
 pub enum UserError {
     TransportError(GetTransportError),
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     MissingArgument(String),
     InvalidArgument(String),
     ConfigError(ConfigError),
@@ -60,7 +60,7 @@ impl Error for UserError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             UserError::TransportError(err) => Some(err),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             UserError::MissingArgument(_) => None,
             UserError::InvalidArgument(_) => None,
             UserError::ConfigError(err) => Some(err),
@@ -75,7 +75,7 @@ impl fmt::Display for UserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             UserError::TransportError(err) => write!(f, "unable to get transport: {}", err),
-            #[cfg(feature = "metrics")]
+            #[cfg(feature = "tap")]
             UserError::MissingArgument(msg) => write!(f, "missing required argument: {}", msg),
             UserError::InvalidArgument(msg) => write!(f, "required argument is invalid: {}", msg),
             UserError::ConfigError(msg) => {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -42,12 +42,12 @@ use std::convert::TryInto;
 use rand::{thread_rng, Rng};
 #[cfg(any(feature = "challenge-authorization", feature = "node-file-block"))]
 use splinter::error::InternalError;
-#[cfg(feature = "metrics")]
-use splinter::metrics::influx::InfluxRecorder;
 #[cfg(feature = "challenge-authorization")]
 use splinter::peer::PeerAuthorizationToken;
 #[cfg(feature = "node-file-block")]
 use splinter::store::create_store_factory;
+#[cfg(feature = "tap")]
+use splinter::tap::influx::InfluxRecorder;
 
 use crate::config::{
     ClapPartialConfigBuilder, Config, ConfigBuilder, ConfigError, DefaultPartialConfigBuilder,
@@ -582,7 +582,7 @@ fn main() {
                 .multiple(true),
         );
 
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     let app = app
         .arg(
             Arg::with_name("metrics_db")
@@ -677,7 +677,7 @@ fn main() {
     }
 }
 
-#[cfg(feature = "metrics")]
+#[cfg(feature = "tap")]
 fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
     let metrics_configured = config.metrics_db().is_some()
         || config.metrics_url().is_some()
@@ -779,7 +779,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
     }
 
     // set up metric recorder as soon as possilbe
-    #[cfg(feature = "metrics")]
+    #[cfg(feature = "tap")]
     setup_metrics_recorder(&config)?;
 
     let transport = build_transport(&config)?;


### PR DESCRIPTION
lipsplinter was using v0.12 of the metrics library. Before
stabilization we want to update it to use the newest version
which is currently 0.17.

This commit updates the API to match the changes made in the new
versions which include the following:
  - Change what is passed to trait methods
  - Adds handler for GaugeValue and keeps track of existing gauge values
    similar to counter
  - Replace use of Cow with metrics::SharedString (wrapper around Cow)
  - Implement register methods on the Recorder trait

Finally, the metrics features and module has been renamed to tap, like
tap a tree. This is required because previously the metrics crate
was renamed in libspinter to metrics_lib to differentiate between
the local metrics and the crate. However in 0.17 the macros have
been moved to their own crate and reference the metrics crate within
the macros which breaks the rename. Therefore, we must rename the
feature/module within libsplinter.