### PR TITLE
Stabilize the `tap` feature for metric support in libsplinter

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -107,6 +107,7 @@ stable = [
     "rest-api-cors",
     "sqlite",
     "store-factory",
+    "tap",
     "trust-authorization",
 ]
 
@@ -130,7 +131,6 @@ experimental = [
     "rest-api-actix-web-3",
     "service-arg-validation",
     "service-network",
-    "tap",
     "ws-transport",
     "zmq-transport",
 ]


### PR DESCRIPTION
Moves the feature from experimental to stable.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>