### PR TITLE
Remove biome mentions from migrations doc

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/mod.rs
+++ b/libsplinter/src/migrations/diesel/postgres/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Defines methods and utilities to interact with tables in a PostgreSQL database.
+//! Tools to apply database migrations for Postgres.
 
 embed_migrations!("./src/migrations/diesel/postgres/migrations");
 
@@ -22,7 +22,7 @@ use diesel_migrations::MigrationConnection;
 
 use crate::error::InternalError;
 
-/// Run database migrations to create tables defined by biome
+/// Run all pending database migrations.
 ///
 /// # Arguments
 ///

--- a/libsplinter/src/migrations/diesel/sqlite/mod.rs
+++ b/libsplinter/src/migrations/diesel/sqlite/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Defines methods and utilities to interact with biome tables in a SQLite database.
+//! Tools to apply database migrations for SQLite.
 
 embed_migrations!("./src/migrations/diesel/sqlite/migrations");
 
@@ -22,7 +22,7 @@ use diesel_migrations::MigrationConnection;
 
 use crate::error::InternalError;
 
-/// Run database migrations to create tables defined by biome
+/// Run all pending database migrations.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
This change removes the mention of biome from the module and function documentation.  These references are both out of date (it applies more than just biome migrations) and not accurate (the module only deals with migrations).