### PR TITLE
Properly set authorization type in JsonAdminEvent

### DIFF
--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -628,7 +628,7 @@ impl From<store::CircuitProposal> for CircuitProposal {
                     public_key: node.public_key().clone(),
                 })
                 .collect::<Vec<SplinterNode>>(),
-            authorization_type: AuthorizationType::Trust,
+            authorization_type: AuthorizationType::from(store_circuit.authorization_type()),
             persistence: PersistenceType::Any,
             durability: DurabilityType::NoDurability,
             routes: RouteType::Any,


### PR DESCRIPTION
When converting the store::AdminServiceEvent to
messages::AdminServiceEvent, the authorization type was
always being set to Trust, resulting in the incorrect
authorization type to be returned in the JsonAdminEvent
from the event client.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>