### PR TITLE
Breakout list of endpoints in circuit show

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -364,7 +364,7 @@ impl fmt::Display for ProposalSlice {
         );
 
         for member in self.circuit.members.iter() {
-            display_string += &format!("\n    {} ({:?})\n", member.node_id, member.endpoints);
+            display_string += &format!("\n    {}\n", member.node_id);
             #[cfg(feature = "challenge-authorization")]
             if let Some(public_key) = &member.public_key {
                 display_string += &format!("        Public Key: {}\n", public_key);
@@ -382,6 +382,11 @@ impl fmt::Display for ProposalSlice {
                 }
                 display_string += &format!("{}\n", vote_string);
             }
+            display_string += &"        Endpoints:\n".to_string();
+            for endpoint in member.endpoints.iter() {
+                display_string += &format!("            {}\n", endpoint);
+            }
+
             for service in self.circuit.roster.iter() {
                 if service.node_id == member.node_id {
                     display_string += &format!(


### PR DESCRIPTION
When the endpoints were switched to a list the
cli for circuit show was switched to use the debug
string of the vec.

This commit breaks out the list of endpoint to be
printed like below:

```
    Endpoints:
        tcp://127.0.0.1:18044
	tcp://127.0.0.1:28044
```
so now 
```
Proposal to create: Fr89U-pS5q1
    Display Name: circuit01
    Circuit Status: Active
    Schema Version: 2
    Management Type: manual

    n20959 (["tcp://127.0.0.1:18044"])
        Public Key: 0372a7ee5e43a241fb0d622e02a53797507d1b4d289286577157b1ed72a82a6edd
        Vote: ACCEPT (implied as requester):
            03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
        Service (scabbard): a000
            admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
            version:
              2
            peer_services:
                b000

    n8198 (["tcp://127.0.0.1:28044"])
        Public Key: 02bf74d9263327a571763c6557f50d7995bf3dec86387fc8e5f9f75a74b15919a4
        Vote: PENDING
        Service (scabbard): b000
            admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
            version:
              2
            peer_services:
                a000
```
would look like
```
Proposal to create: Fr89U-pS5q1
    Display Name: circuit01
    Circuit Status: Active
    Schema Version: 2
    Management Type: manual

    n20959
        Public Key: 0372a7ee5e43a241fb0d622e02a53797507d1b4d289286577157b1ed72a82a6edd
        Vote: ACCEPT (implied as requester):
            03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
        Endpoints:
            tcp://127.0.0.1:18044
        Service (scabbard): a000
            admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
            version:
              2
            peer_services:
                b000

    n8198
        Public Key: 02bf74d9263327a571763c6557f50d7995bf3dec86387fc8e5f9f75a74b15919a4
        Vote: PENDING
        Endpoints:
            tcp://127.0.0.1:28044
        Service (scabbard): b000
            admin_keys:
              03f91f722329b99234be43f962e7ce33bbd4f2e72634a1a68f12ad908ca5693f03
              038684ef88607ca0e5175fe31b7d94f65b30dc27ef838845f0496eb9c1126c8c82
            version:
              2
            peer_services:
                a000
```