### PR TITLE
Scabbard storage config

### DIFF
--- a/libsplinter/src/service/error.rs
+++ b/libsplinter/src/service/error.rs
@@ -270,6 +270,7 @@ impl From<ServiceSendError> for ServiceError {
 pub enum FactoryCreateError {
     CreationFailed(Box<dyn Error + Send>),
     InvalidArguments(String),
+    Internal(String),
 }
 
 impl Error for FactoryCreateError {
@@ -277,6 +278,7 @@ impl Error for FactoryCreateError {
         match self {
             FactoryCreateError::CreationFailed(err) => Some(&**err),
             FactoryCreateError::InvalidArguments(_) => None,
+            FactoryCreateError::Internal(_) => None,
         }
     }
 }
@@ -290,6 +292,7 @@ impl std::fmt::Display for FactoryCreateError {
             FactoryCreateError::InvalidArguments(err) => {
                 write!(f, "invalid arguments specified: {}", err)
             }
+            FactoryCreateError::Internal(msg) => f.write_str(msg),
         }
     }
 }

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -75,7 +75,6 @@ experimental = [
   # The following features are experimental:
   "commit-store",
   "diesel-receipt-store",
-  "factory-builder",
   "https",
   "metrics",
   "postgres",
@@ -88,7 +87,6 @@ client-reqwest = ["client", "reqwest"]
 commit-store = []
 diesel-receipt-store = ["diesel", "sawtooth/transaction-receipt-store-lmdb"]
 events = ["splinter/events"]
-factory-builder = []
 https = []
 lmdb = []
 postgres = ["diesel/postgres", "diesel_migrations", "sawtooth/postgres"]

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -45,7 +45,7 @@ transact = { version = "0.3", features = ["sawtooth-compat"] }
 [dependencies.sawtooth]
 version = "0.6.6"
 default-features = false
-features = ["diesel", "lmdb-store", "postgres", "receipt-store", "sqlite", "transaction-receipt-store"]
+features = ["lmdb-store", "receipt-store", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -86,13 +86,13 @@ authorization = ["splinter/authorization"]
 client = []
 client-reqwest = ["client", "reqwest"]
 commit-store = []
-diesel-receipt-store = ["diesel"]
+diesel-receipt-store = ["diesel", "sawtooth/transaction-receipt-store-lmdb"]
 events = ["splinter/events"]
 factory-builder = []
 https = []
 lmdb = []
-postgres = ["diesel/postgres", "diesel_migrations"]
+postgres = ["diesel/postgres", "diesel_migrations", "sawtooth/postgres"]
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
 service-arg-validation = ["splinter/service-arg-validation"]
-sqlite = ["diesel/sqlite", "diesel_migrations"]
+sqlite = ["diesel/sqlite", "diesel_migrations", "sawtooth/sqlite"]

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -22,7 +22,7 @@ extern crate log;
 #[cfg_attr(feature = "commit-store", macro_use)]
 extern crate diesel;
 #[cfg(feature = "diesel_migrations")]
-#[macro_use]
+#[cfg_attr(feature = "commit-store", macro_use)]
 extern crate diesel_migrations;
 #[macro_use]
 extern crate serde_derive;

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -140,28 +140,6 @@ pub struct ScabbardFactory {
     signature_verifier_factory: Arc<Mutex<Box<dyn VerifierFactory>>>,
 }
 
-impl ScabbardFactory {
-    pub fn new(
-        state_db_dir: Option<String>,
-        state_db_size: Option<usize>,
-        receipt_db_dir: Option<String>,
-        receipt_db_size: Option<usize>,
-        #[cfg(feature = "diesel-receipt-store")] receipt_db_url: String,
-        signature_verifier_factory: Arc<Mutex<Box<dyn VerifierFactory>>>,
-    ) -> Self {
-        ScabbardFactory {
-            service_types: vec![SERVICE_TYPE.into()],
-            state_db_dir: state_db_dir.unwrap_or_else(|| DEFAULT_STATE_DB_DIR.into()),
-            state_db_size: state_db_size.unwrap_or(DEFAULT_STATE_DB_SIZE),
-            receipt_db_dir: receipt_db_dir.unwrap_or_else(|| DEFAULT_RECEIPT_DB_DIR.into()),
-            receipt_db_size: receipt_db_size.unwrap_or(DEFAULT_RECEIPT_DB_SIZE),
-            #[cfg(feature = "diesel-receipt-store")]
-            receipt_db_url,
-            signature_verifier_factory,
-        }
-    }
-}
-
 #[cfg(feature = "service-arg-validation")]
 pub struct ScabbardArgValidator;
 

--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -34,7 +34,6 @@ const DEFAULT_STATE_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 const DEFAULT_RECEIPT_DB_DIR: &str = "/var/lib/splinter";
 const DEFAULT_RECEIPT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 
-#[cfg(feature = "factory-builder")]
 /// Builds new ScabbardFactory instances.
 #[derive(Default)]
 pub struct ScabbardFactoryBuilder {
@@ -47,7 +46,6 @@ pub struct ScabbardFactoryBuilder {
     signature_verifier_factory: Option<Arc<Mutex<Box<dyn VerifierFactory>>>>,
 }
 
-#[cfg(feature = "factory-builder")]
 impl ScabbardFactoryBuilder {
     /// Constructs a new builder.
     pub fn new() -> Self {

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -53,9 +53,7 @@ use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
 #[cfg(feature = "service-arg-validation")]
 pub use factory::ScabbardArgValidator;
-pub use factory::ScabbardFactory;
-#[cfg(feature = "factory-builder")]
-pub use factory::ScabbardFactoryBuilder;
+pub use factory::{ScabbardFactory, ScabbardFactoryBuilder};
 use shared::ScabbardShared;
 pub use state::{
     BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent, StateIter,

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -18,7 +18,7 @@
 
 mod consensus;
 mod error;
-mod factory;
+pub(crate) mod factory;
 #[cfg(feature = "rest-api")]
 mod rest_api;
 mod shared;
@@ -27,13 +27,16 @@ mod state;
 use std::any::Any;
 use std::collections::{HashSet, VecDeque};
 use std::convert::TryFrom;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::path::Path;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use cylinder::Verifier as SignatureVerifier;
-use openssl::hash::{hash, MessageDigest};
 use protobuf::Message;
+#[cfg(feature = "diesel-receipt-store")]
+use sawtooth::receipt::store::ReceiptStore;
+#[cfg(not(feature = "diesel-receipt-store"))]
+use sawtooth::store::receipt_store::TransactionReceiptStore;
 use splinter::{
     consensus::{Proposal, ProposalUpdate},
     service::{
@@ -46,14 +49,13 @@ use transact::{
     protos::{FromBytes, IntoBytes},
 };
 
-use super::hex::to_hex;
 use super::protos::scabbard::{ScabbardMessage, ScabbardMessage_Type};
 
 use consensus::ScabbardConsensusManager;
 use error::ScabbardError;
 #[cfg(feature = "service-arg-validation")]
 pub use factory::ScabbardArgValidator;
-pub use factory::{ScabbardFactory, ScabbardFactoryBuilder};
+pub use factory::{ScabbardFactory, ScabbardFactoryBuilder, ScabbardStorageConfiguration};
 use shared::ScabbardShared;
 pub use state::{
     BatchInfo, BatchInfoIter, BatchStatus, Events, StateChange, StateChangeEvent, StateIter,
@@ -84,6 +86,12 @@ impl TryFrom<Option<&str>> for ScabbardVersion {
     }
 }
 
+#[cfg(not(feature = "diesel-receipt-store"))]
+type ScabbardReceiptStore = Arc<RwLock<TransactionReceiptStore>>;
+
+#[cfg(feature = "diesel-receipt-store")]
+type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;
+
 /// A service for running Sawtooth Sabre smart contracts with two-phase commit consensus.
 #[derive(Clone)]
 pub struct Scabbard {
@@ -92,6 +100,7 @@ pub struct Scabbard {
     version: ScabbardVersion,
     shared: Arc<Mutex<ScabbardShared>>,
     state: Arc<Mutex<ScabbardState>>,
+    purge_fn: Arc<dyn Fn() -> Result<(), splinter::error::InternalError> + Send + Sync>,
     /// The coordinator timeout for the two-phase commit consensus engine
     coordinator_timeout: Duration,
     consensus: Arc<Mutex<Option<ScabbardConsensusManager>>>,
@@ -108,15 +117,11 @@ impl Scabbard {
         // List of other scabbard services on the same circuit that this service shares state with
         peer_services: HashSet<String>,
         // The directory in which to create sabre's LMDB database
-        state_db_dir: &Path,
+        state_db_path: &Path,
         // The size of sabre's LMDB database
         state_db_size: usize,
-        // The directory in which to create the transaction receipt store's LMDB database
-        receipt_db_dir: &Path,
-        // The size of the transaction receipt store's LMDB database
-        receipt_db_size: usize,
-        // The database connection url to use for the receipt store
-        #[cfg(feature = "diesel-receipt-store")] receipt_db_url: String,
+        receipt_store: ScabbardReceiptStore,
+        purge_fn: Box<dyn Fn() -> Result<(), splinter::error::InternalError> + Send + Sync>,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts
         admin_keys: Vec<String>,
@@ -135,18 +140,8 @@ impl Scabbard {
             version,
         );
 
-        let (state_db_path, receipt_db_path) =
-            compute_db_paths(&service_id, circuit_id, state_db_dir, receipt_db_dir)?;
-        let state = ScabbardState::new(
-            &state_db_path,
-            state_db_size,
-            &receipt_db_path,
-            receipt_db_size,
-            #[cfg(feature = "diesel-receipt-store")]
-            receipt_db_url,
-            admin_keys,
-        )
-        .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
+        let state = ScabbardState::new(state_db_path, state_db_size, receipt_store, admin_keys)
+            .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
 
         let coordinator_timeout =
             coordinator_timeout.unwrap_or_else(|| Duration::from_secs(DEFAULT_COORDINATOR_TIMEOUT));
@@ -157,6 +152,7 @@ impl Scabbard {
             version,
             shared: Arc::new(Mutex::new(shared)),
             state: Arc::new(Mutex::new(state)),
+            purge_fn: purge_fn.into(),
             coordinator_timeout,
             consensus: Arc::new(Mutex::new(None)),
         })
@@ -393,13 +389,7 @@ impl Service for Scabbard {
     }
 
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
-        self.state
-            .lock()
-            .map_err(|_| {
-                splinter::error::InternalError::with_message("consensus lock poisoned".into())
-            })?
-            .remove_db_files()
-            .map_err(|err| splinter::error::InternalError::from_source(Box::new(err)))
+        (*self.purge_fn)()
     }
 
     fn handle_message(
@@ -514,49 +504,52 @@ impl Service for Scabbard {
     }
 }
 
-fn compute_db_paths(
-    service_id: &str,
-    circuit_id: &str,
-    state_db_dir: &Path,
-    receipt_db_dir: &Path,
-) -> Result<(PathBuf, PathBuf), ScabbardError> {
-    let hash = hash(
-        MessageDigest::sha256(),
-        format!("{}::{}", service_id, circuit_id).as_bytes(),
-    )
-    .map(|digest| to_hex(&*digest))
-    .map_err(|err| ScabbardError::InitializationFailed(Box::new(err)))?;
-    let state_db_path = state_db_dir.join(format!("{}-state", hash));
-    let receipt_db_path = receipt_db_dir.join(format!("{}-receipts", hash));
-    Ok((state_db_path, receipt_db_path))
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
 
     use std::error::Error;
+    use std::path::PathBuf;
 
     use cylinder::{secp256k1::Secp256k1Context, VerifierFactory};
+    #[cfg(feature = "diesel-receipt-store")]
+    use sawtooth::receipt::store::{ReceiptIter, ReceiptStoreError};
+    #[cfg(not(feature = "diesel-receipt-store"))]
+    use sawtooth::store::lmdb::LmdbOrderedStore;
     use splinter::service::{
         ServiceConnectionError, ServiceDisconnectionError, ServiceMessageContext,
         ServiceNetworkSender, ServiceSendError,
     };
+    use tempdir::TempDir;
+    #[cfg(feature = "diesel-receipt-store")]
+    use transact::protocol::receipt::TransactionReceipt;
+
+    use crate::service::factory::compute_db_path;
+
+    const MOCK_CIRCUIT_ID: &str = "abcde-01234";
+    const MOCK_SERVICE_ID: &str = "ABCD";
+    const TEMP_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 
     /// Tests that a new scabbard service is properly instantiated.
     #[test]
     fn new_scabbard() {
+        let paths = StatePaths::new("new_scabbard");
+
         let service = Scabbard::new(
             "new_scabbard".into(),
             "test_circuit",
             ScabbardVersion::V1,
             HashSet::new(),
-            Path::new("/tmp"),
-            1024 * 1024,
-            Path::new("/tmp"),
-            1024 * 1024,
+            paths.state_db_path.as_path(),
+            TEMP_DB_SIZE,
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            Arc::new(RwLock::new(TransactionReceiptStore::new(Box::new(
+                LmdbOrderedStore::new(&paths.receipt_db_path, Some(TEMP_DB_SIZE))
+                    .expect("Unable to make lmdb store"),
+            )))),
             #[cfg(feature = "diesel-receipt-store")]
-            ":memory:".to_string(),
+            Arc::new(RwLock::new(MockReceiptStore)),
+            Box::new(|| Ok(())),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -570,17 +563,23 @@ pub mod tests {
     /// will hang if the thread does not get shutdown correctly.
     #[test]
     fn thread_cleanup() {
+        let paths = StatePaths::new("new_scabbard");
+
         let mut service = Scabbard::new(
             "thread_cleanup".into(),
             "test_circuit",
             ScabbardVersion::V1,
             HashSet::new(),
-            Path::new("/tmp"),
-            1024 * 1024,
-            Path::new("/tmp"),
-            1024 * 1024,
+            paths.state_db_path.as_path(),
+            TEMP_DB_SIZE,
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            Arc::new(RwLock::new(TransactionReceiptStore::new(Box::new(
+                LmdbOrderedStore::new(&paths.receipt_db_path, Some(TEMP_DB_SIZE))
+                    .expect("Unable to make lmdb store"),
+            )))),
             #[cfg(feature = "diesel-receipt-store")]
-            ":memory:".to_string(),
+            Arc::new(RwLock::new(MockReceiptStore)),
+            Box::new(|| Ok(())),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -594,23 +593,62 @@ pub mod tests {
     /// Tests that the service properly connects and disconnects using the network registry.
     #[test]
     fn connect_and_disconnect() {
+        let paths = StatePaths::new("new_scabbard");
+
         let mut service = Scabbard::new(
             "connect_and_disconnect".into(),
             "test_circuit",
             ScabbardVersion::V1,
             HashSet::new(),
-            Path::new("/tmp"),
-            1024 * 1024,
-            Path::new("/tmp"),
-            1024 * 1024,
+            paths.state_db_path.as_path(),
+            TEMP_DB_SIZE,
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            Arc::new(RwLock::new(TransactionReceiptStore::new(Box::new(
+                LmdbOrderedStore::new(&paths.receipt_db_path, Some(TEMP_DB_SIZE))
+                    .expect("Unable to make lmdb store"),
+            )))),
             #[cfg(feature = "diesel-receipt-store")]
-            ":memory:".to_string(),
+            Arc::new(RwLock::new(MockReceiptStore)),
+            Box::new(|| Ok(())),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
         )
         .expect("failed to create service");
         test_connect_and_disconnect(&mut service);
+    }
+
+    struct StatePaths {
+        // this is deleted when dropped
+        _temp_dir: TempDir,
+        pub state_db_path: PathBuf,
+        #[cfg(not(feature = "diesel-receipt-store"))]
+        pub receipt_db_path: PathBuf,
+    }
+
+    impl StatePaths {
+        fn new(prefix: &str) -> Self {
+            let temp_dir = TempDir::new(prefix).expect("Failed to create temp dir");
+            // This computes the paths such that they're the same ones that will be used by
+            // scabbard when it's initialized
+            let state_db_path =
+                compute_db_path(MOCK_SERVICE_ID, MOCK_CIRCUIT_ID, temp_dir.path(), "-state")
+                    .expect("Failed to compute DB paths");
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            let receipt_db_path = compute_db_path(
+                MOCK_SERVICE_ID,
+                MOCK_CIRCUIT_ID,
+                temp_dir.path(),
+                "-receipts",
+            )
+            .expect("Failed to compute DB paths");
+            Self {
+                _temp_dir: temp_dir,
+                state_db_path,
+                #[cfg(not(feature = "diesel-receipt-store"))]
+                receipt_db_path,
+            }
+        }
     }
 
     #[derive(Debug)]
@@ -745,6 +783,58 @@ pub mod tests {
             _sender: &str,
         ) -> Result<(), ServiceSendError> {
             Ok(())
+        }
+    }
+
+    #[cfg(feature = "diesel-receipt-store")]
+    struct MockReceiptStore;
+
+    #[cfg(feature = "diesel-receipt-store")]
+    impl ReceiptStore for MockReceiptStore {
+        fn get_txn_receipt_by_id(
+            &self,
+            _id: String,
+        ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn get_txn_receipt_by_index(
+            &self,
+            _index: u64,
+        ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn add_txn_receipts(
+            &self,
+            _receipts: Vec<TransactionReceipt>,
+        ) -> Result<(), ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn remove_txn_receipt_by_id(
+            &self,
+            _id: String,
+        ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn remove_txn_receipt_by_index(
+            &self,
+            _index: u64,
+        ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn count_txn_receipts(&self) -> Result<u64, ReceiptStoreError> {
+            unimplemented!()
+        }
+
+        fn list_receipts_since(
+            &self,
+            _id: Option<String>,
+        ) -> Result<ReceiptIter, ReceiptStoreError> {
+            unimplemented!()
         }
     }
 

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -100,17 +100,18 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex, RwLock};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
     #[cfg(feature = "diesel-receipt-store")]
-    use diesel::{
-        r2d2::{ConnectionManager, Pool},
-        sqlite::SqliteConnection,
-    };
+    use diesel::r2d2::{ConnectionManager, Pool};
     use reqwest::{blocking::Client, StatusCode, Url};
     #[cfg(feature = "diesel-receipt-store")]
     use sawtooth::migrations::run_sqlite_migrations;
+    #[cfg(feature = "diesel-receipt-store")]
+    use sawtooth::receipt::store::diesel::DieselReceiptStore;
+    #[cfg(not(feature = "diesel-receipt-store"))]
+    use sawtooth::store::{lmdb::LmdbOrderedStore, receipt_store::TransactionReceiptStore};
     use serde_json::{to_value, Value as JsonValue};
     use tempdir::TempDir;
     use transact::{
@@ -137,7 +138,9 @@ mod tests {
         service::Service,
     };
 
-    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard, ScabbardVersion};
+    use crate::service::{
+        factory::compute_db_path, state::ScabbardState, Scabbard, ScabbardVersion,
+    };
 
     const MOCK_CIRCUIT_ID: &str = "abcde-01234";
     const MOCK_SERVICE_ID: &str = "ABCD";
@@ -161,10 +164,18 @@ mod tests {
     fn state_with_prefix() {
         let paths = StatePaths::new("state_with_prefix");
 
+        #[cfg(not(feature = "diesel-receipt-store"))]
+        let receipt_store = Arc::new(RwLock::new(TransactionReceiptStore::new(Box::new(
+            LmdbOrderedStore::new(
+                &StatePaths::new("state_at_address").receipt_db_path,
+                Some(TEMP_DB_SIZE),
+            )
+            .expect("Failed to create LMDB store"),
+        ))));
         #[cfg(feature = "diesel-receipt-store")]
-        let receipt_db_uri = paths.temp_dir.path().join("sqlite_receipts.db");
-        #[cfg(feature = "diesel-receipt-store")]
-        create_connection_pool_and_migrate(receipt_db_uri.to_str().unwrap().to_string());
+        let receipt_store = Arc::new(RwLock::new(DieselReceiptStore::new(
+            create_connection_pool_and_migrate(":memory:".to_string()),
+        )));
 
         // Initialize a temporary scabbard state and set some values; this will pre-populate the DBs
         let prefix = "abcdef".to_string();
@@ -178,10 +189,7 @@ mod tests {
             let mut state = ScabbardState::new(
                 &paths.state_db_path,
                 TEMP_DB_SIZE,
-                &paths.receipt_db_path,
-                TEMP_DB_SIZE,
-                #[cfg(feature = "diesel-receipt-store")]
-                receipt_db_uri.to_str().unwrap().to_string(),
+                receipt_store.clone(),
                 vec![],
             )
             .expect("Failed to initialize state");
@@ -215,12 +223,10 @@ mod tests {
             MOCK_CIRCUIT_ID,
             ScabbardVersion::V1,
             Default::default(),
-            paths.temp_dir.path(),
+            paths.state_db_path.as_path(),
             TEMP_DB_SIZE,
-            paths.temp_dir.path(),
-            TEMP_DB_SIZE,
-            #[cfg(feature = "diesel-receipt-store")]
-            receipt_db_uri.to_str().unwrap().to_string(),
+            receipt_store,
+            Box::new(|| Ok(())),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -345,8 +351,10 @@ mod tests {
     }
 
     struct StatePaths {
-        pub temp_dir: TempDir,
+        // This is deleted when dropped
+        _temp_dir: TempDir,
         pub state_db_path: PathBuf,
+        #[cfg(not(feature = "diesel-receipt-store"))]
         pub receipt_db_path: PathBuf,
     }
 
@@ -355,16 +363,21 @@ mod tests {
             let temp_dir = TempDir::new(prefix).expect("Failed to create temp dir");
             // This computes the paths such that they're the same ones that will be used by
             // scabbard when it's initialized
-            let (state_db_path, receipt_db_path) = compute_db_paths(
+            let state_db_path =
+                compute_db_path(MOCK_SERVICE_ID, MOCK_CIRCUIT_ID, temp_dir.path(), "-state")
+                    .expect("Failed to compute DB paths");
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            let receipt_db_path = compute_db_path(
                 MOCK_SERVICE_ID,
                 MOCK_CIRCUIT_ID,
                 temp_dir.path(),
-                temp_dir.path(),
+                "-receipts",
             )
             .expect("Failed to compute DB paths");
             Self {
-                temp_dir,
+                _temp_dir: temp_dir,
                 state_db_path,
+                #[cfg(not(feature = "diesel-receipt-store"))]
                 receipt_db_path,
             }
         }
@@ -473,11 +486,12 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "diesel-receipt-store")]
+    #[cfg(all(feature = "diesel-receipt-store", feature = "sqlite"))]
     fn create_connection_pool_and_migrate(
         connection_string: String,
-    ) -> Pool<ConnectionManager<SqliteConnection>> {
-        let connection_manager = ConnectionManager::<SqliteConnection>::new(connection_string);
+    ) -> Pool<ConnectionManager<diesel::SqliteConnection>> {
+        let connection_manager =
+            ConnectionManager::<diesel::SqliteConnection>::new(connection_string);
         let pool = Pool::builder()
             .max_size(1)
             .build(connection_manager)

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex, RwLock};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
     #[cfg(feature = "diesel-receipt-store")]
@@ -79,6 +79,10 @@ mod tests {
     use reqwest::{blocking::Client, StatusCode, Url};
     #[cfg(feature = "diesel-receipt-store")]
     use sawtooth::migrations::run_sqlite_migrations;
+    #[cfg(feature = "diesel-receipt-store")]
+    use sawtooth::receipt::store::diesel::DieselReceiptStore;
+    #[cfg(not(feature = "diesel-receipt-store"))]
+    use sawtooth::store::{lmdb::LmdbOrderedStore, receipt_store::TransactionReceiptStore};
     use tempdir::TempDir;
     use transact::{
         families::command::make_command_transaction,
@@ -104,7 +108,9 @@ mod tests {
         service::Service,
     };
 
-    use crate::service::{compute_db_paths, state::ScabbardState, Scabbard, ScabbardVersion};
+    use crate::service::{
+        factory::compute_db_path, state::ScabbardState, Scabbard, ScabbardVersion,
+    };
 
     const MOCK_CIRCUIT_ID: &str = "abcde-01234";
     const MOCK_SERVICE_ID: &str = "ABCD";
@@ -123,10 +129,18 @@ mod tests {
     fn state_root() {
         let paths = StatePaths::new("state_root");
 
+        #[cfg(not(feature = "diesel-receipt-store"))]
+        let receipt_store = Arc::new(RwLock::new(TransactionReceiptStore::new(Box::new(
+            LmdbOrderedStore::new(
+                &StatePaths::new("state_at_address").receipt_db_path,
+                Some(TEMP_DB_SIZE),
+            )
+            .expect("Failed to create LMDB store"),
+        ))));
         #[cfg(feature = "diesel-receipt-store")]
-        let receipt_db_uri = paths.temp_dir.path().join("sqlite_receipts.db");
-        #[cfg(feature = "diesel-receipt-store")]
-        create_connection_pool_and_migrate(receipt_db_uri.to_str().unwrap().to_string());
+        let receipt_store = Arc::new(RwLock::new(DieselReceiptStore::new(
+            create_connection_pool_and_migrate(":memory:".to_string()),
+        )));
 
         // Initialize a temporary scabbard state and set some values to pre-populate the DBs, then
         // get the resulting state root hash.
@@ -134,10 +148,7 @@ mod tests {
             let mut state = ScabbardState::new(
                 &paths.state_db_path,
                 TEMP_DB_SIZE,
-                &paths.receipt_db_path,
-                TEMP_DB_SIZE,
-                #[cfg(feature = "diesel-receipt-store")]
-                receipt_db_uri.to_str().unwrap().to_string(),
+                receipt_store.clone(),
                 vec![],
             )
             .expect("Failed to initialize state");
@@ -171,12 +182,10 @@ mod tests {
             MOCK_CIRCUIT_ID,
             ScabbardVersion::V1,
             Default::default(),
-            paths.temp_dir.path(),
+            paths.state_db_path.as_path(),
             TEMP_DB_SIZE,
-            paths.temp_dir.path(),
-            TEMP_DB_SIZE,
-            #[cfg(feature = "diesel-receipt-store")]
-            receipt_db_uri.to_str().unwrap().to_string(),
+            receipt_store,
+            Box::new(|| Ok(())),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -213,8 +222,10 @@ mod tests {
     }
 
     struct StatePaths {
-        pub temp_dir: TempDir,
+        // This is deleted when dropped
+        _temp_dir: TempDir,
         pub state_db_path: PathBuf,
+        #[cfg(not(feature = "diesel-receipt-store"))]
         pub receipt_db_path: PathBuf,
     }
 
@@ -223,16 +234,21 @@ mod tests {
             let temp_dir = TempDir::new(prefix).expect("Failed to create temp dir");
             // This computes the paths such that they're the same ones that will be used by
             // scabbard when it's initialized
-            let (state_db_path, receipt_db_path) = compute_db_paths(
+            let state_db_path =
+                compute_db_path(MOCK_SERVICE_ID, MOCK_CIRCUIT_ID, temp_dir.path(), "-state")
+                    .expect("Failed to compute DB paths");
+            #[cfg(not(feature = "diesel-receipt-store"))]
+            let receipt_db_path = compute_db_path(
                 MOCK_SERVICE_ID,
                 MOCK_CIRCUIT_ID,
                 temp_dir.path(),
-                temp_dir.path(),
+                "-receipts",
             )
             .expect("Failed to compute DB paths");
             Self {
-                temp_dir,
+                _temp_dir: temp_dir,
                 state_db_path,
+                #[cfg(not(feature = "diesel-receipt-store"))]
                 receipt_db_path,
             }
         }

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -101,13 +101,15 @@ experimental = [
     # The following features are experimental:
     "authorization-handler-maintenance",
     "challenge-authorization",
-    "scabbard-receipt-store",
     "health-service",
     "https-bind",
     "log-config",
     "tap",
     "node",
     "node-file-block",
+    "scabbard-receipt-store",
+    "scabbard-receipt-store-postgres",
+    "scabbard-receipt-store-sqlite",
     "service-arg-validation",
     "service-endpoint",
     "ws-transport",
@@ -135,6 +137,8 @@ config-allow-keys = ["authorization-handler-allow-keys"]
 database-postgres = ["splinter/postgres"]
 database-sqlite = ["splinter/sqlite"]
 scabbard-receipt-store = ["scabbard/diesel-receipt-store"]
+scabbard-receipt-store-postgres = ["scabbard/postgres"]
+scabbard-receipt-store-sqlite = ["scabbard/sqlite"]
 health-service = ["health", "health/authorization"]
 https-bind = ["splinter/https-bind"]
 log-config = []

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -153,7 +153,6 @@ node = [
     "diesel",
     "sawtooth",
     "scabbard/client-reqwest",
-    "scabbard/factory-builder",
     "splinter/admin-service-client",
     "splinter/admin-service-event-client",
     "splinter/admin-service-event-client-actix-web-client",


### PR DESCRIPTION
This PR modifies the scabbard factory to create the required storage configuration (either the stores themselves or the exact lmdb files) at service-create time.

* It makes the ScabbardFactoryBuilder the only way to construct the factory (this is needed due to the changes in possibilities for storage configuration).
* It re-arranges many of the sawtooth feature dependencies, as several experimental features were being included with a stable feature.
* Adds two features for the specific db types in order to make use of the updated receipt store.