### PR TITLE
Rename metrics arguments to be influx 

### DIFF
--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -148,7 +148,7 @@ OPTIONS
 `--metrics-password` `METRICS_PASSWORD`
 : The password used for authorization with the InfluxDB.
 
-`--metrics-url` `METRICS_URL`
+`--influx-url` `URL`
 : The URL to connect the InfluxDB database for metrics collection.
 
 `--metrics-username` `METRICS_USERNAME`

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -142,7 +142,7 @@ OPTIONS
   This heartbeat is used to check the health of connections to other Splinter
   nodes.
 
-`--metrics-db` `METRICS_DB`
+`--influx-db` `DB_NAME`
 : The name of the InfluxDB database for metrics Collection.
 
 `--metrics-password` `METRICS_PASSWORD`

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -145,7 +145,7 @@ OPTIONS
 `--influx-db` `DB_NAME`
 : The name of the InfluxDB database for metrics Collection.
 
-`--metrics-password` `METRICS_PASSWORD`
+`--influx-password` `PASSWORD`
 : The password used for authorization with the InfluxDB.
 
 `--influx-url` `URL`

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -151,7 +151,7 @@ OPTIONS
 `--influx-url` `URL`
 : The URL to connect the InfluxDB database for metrics collection.
 
-`--metrics-username` `METRICS_USERNAME`
+`--influx-username` `USERNAME`
 : The username used for authorization with the InfluxDB.
 
 `-n`, `--network-endpoints` `NETWORK-ENDPOINT`

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -152,7 +152,7 @@ version = "1"
 #metrics_url = ""
 
 # The target database for metrics.
-#metrics_db = ""
+#influx_db = ""
 
 # A username with write access to the database specified above.
 #metrics_username = ""

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -155,5 +155,5 @@ version = "1"
 #influx_db = ""
 
 # A username with write access to the database specified above.
-#metrics_username = ""
+#influx_username = ""
 #metrics_password = ""

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -149,7 +149,7 @@ version = "1"
 #
 
 # The HTTP or UDP URL for your InfluxDB instance.
-#metrics_url = ""
+#influx_url = ""
 
 # The target database for metrics.
 #influx_db = ""

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -156,4 +156,4 @@ version = "1"
 
 # A username with write access to the database specified above.
 #influx_username = ""
-#metrics_password = ""
+#influx_password = ""

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -339,10 +339,10 @@ impl ConfigBuilder {
                 .find_map(|p| p.strict_ref_counts().map(|v| (v, p.source())))
                 .ok_or_else(|| ConfigError::MissingValue("strict_ref_counts".to_string()))?,
             #[cfg(feature = "tap")]
-            metrics_db: self
+            influx_db: self
                 .partial_configs
                 .iter()
-                .find_map(|p| p.metrics_db().map(|v| (v, p.source()))),
+                .find_map(|p| p.influx_db().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
             metrics_url: self
                 .partial_configs

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -344,10 +344,10 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.influx_db().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
-            metrics_url: self
+            influx_url: self
                 .partial_configs
                 .iter()
-                .find_map(|p| p.metrics_url().map(|v| (v, p.source()))),
+                .find_map(|p| p.influx_url().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
             metrics_username: self
                 .partial_configs

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -349,10 +349,10 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.influx_url().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
-            metrics_username: self
+            influx_username: self
                 .partial_configs
                 .iter()
-                .find_map(|p| p.metrics_username().map(|v| (v, p.source()))),
+                .find_map(|p| p.influx_username().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
             metrics_password: self
                 .partial_configs

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -354,10 +354,10 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.influx_username().map(|v| (v, p.source()))),
             #[cfg(feature = "tap")]
-            metrics_password: self
+            influx_password: self
                 .partial_configs
                 .iter()
-                .find_map(|p| p.metrics_password().map(|v| (v, p.source()))),
+                .find_map(|p| p.influx_password().map(|v| (v, p.source()))),
             #[cfg(feature = "challenge-authorization")]
             peering_key: self
                 .partial_configs

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -176,7 +176,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 .with_influx_db(self.matches.value_of("influx_db").map(String::from))
                 .with_influx_url(self.matches.value_of("influx_url").map(String::from))
                 .with_influx_username(self.matches.value_of("influx_username").map(String::from))
-                .with_metrics_password(self.matches.value_of("metrics_password").map(String::from))
+                .with_influx_password(self.matches.value_of("influx_password").map(String::from))
         }
         #[cfg(feature = "log-config")]
         {

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -173,7 +173,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
         #[cfg(feature = "tap")]
         {
             partial_config = partial_config
-                .with_metrics_db(self.matches.value_of("metrics_db").map(String::from))
+                .with_influx_db(self.matches.value_of("influx_db").map(String::from))
                 .with_metrics_url(self.matches.value_of("metrics_url").map(String::from))
                 .with_metrics_username(self.matches.value_of("metrics_username").map(String::from))
                 .with_metrics_password(self.matches.value_of("metrics_password").map(String::from))

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -175,7 +175,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
             partial_config = partial_config
                 .with_influx_db(self.matches.value_of("influx_db").map(String::from))
                 .with_influx_url(self.matches.value_of("influx_url").map(String::from))
-                .with_metrics_username(self.matches.value_of("metrics_username").map(String::from))
+                .with_influx_username(self.matches.value_of("influx_username").map(String::from))
                 .with_metrics_password(self.matches.value_of("metrics_password").map(String::from))
         }
         #[cfg(feature = "log-config")]

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -174,7 +174,7 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
         {
             partial_config = partial_config
                 .with_influx_db(self.matches.value_of("influx_db").map(String::from))
-                .with_metrics_url(self.matches.value_of("metrics_url").map(String::from))
+                .with_influx_url(self.matches.value_of("influx_url").map(String::from))
                 .with_metrics_username(self.matches.value_of("metrics_username").map(String::from))
                 .with_metrics_password(self.matches.value_of("metrics_password").map(String::from))
         }

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -38,7 +38,7 @@ const OAUTH_OPENID_URL_ENV: &str = "OAUTH_OPENID_URL";
 #[cfg(feature = "tap")]
 const METRICS_DB_ENV: &str = "SPLINTER_INFLUX_DB";
 #[cfg(feature = "tap")]
-const METRICS_URL_ENV: &str = "SPLINTER_METRICS_URL";
+const METRICS_URL_ENV: &str = "SPLINTER_INFLUX_URL";
 #[cfg(feature = "tap")]
 const METRICS_USERNAME_ENV: &str = "SPLINTER_METRICS_USERNAME";
 #[cfg(feature = "tap")]
@@ -129,7 +129,7 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
         {
             config = config
                 .with_influx_db(env::var(METRICS_DB_ENV).ok())
-                .with_metrics_url(env::var(METRICS_URL_ENV).ok())
+                .with_influx_url(env::var(METRICS_URL_ENV).ok())
                 .with_metrics_username(env::var(METRICS_USERNAME_ENV).ok())
                 .with_metrics_password(env::var(METRICS_PASSWORD_ENV).ok())
         }

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -42,7 +42,7 @@ const METRICS_URL_ENV: &str = "SPLINTER_INFLUX_URL";
 #[cfg(feature = "tap")]
 const METRICS_USERNAME_ENV: &str = "SPLINTER_INFLUX_USERNAME";
 #[cfg(feature = "tap")]
-const METRICS_PASSWORD_ENV: &str = "SPLINTER_METRICS_PASSWORD";
+const METRICS_PASSWORD_ENV: &str = "SPLINTER_INFLUX_PASSWORD";
 
 pub struct EnvPartialConfigBuilder;
 
@@ -131,7 +131,7 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
                 .with_influx_db(env::var(METRICS_DB_ENV).ok())
                 .with_influx_url(env::var(METRICS_URL_ENV).ok())
                 .with_influx_username(env::var(METRICS_USERNAME_ENV).ok())
-                .with_metrics_password(env::var(METRICS_PASSWORD_ENV).ok())
+                .with_influx_password(env::var(METRICS_PASSWORD_ENV).ok())
         }
 
         Ok(config)

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -36,7 +36,7 @@ const OAUTH_REDIRECT_URL_ENV: &str = "OAUTH_REDIRECT_URL";
 #[cfg(feature = "oauth")]
 const OAUTH_OPENID_URL_ENV: &str = "OAUTH_OPENID_URL";
 #[cfg(feature = "tap")]
-const METRICS_DB_ENV: &str = "SPLINTER_METRICS_DB";
+const METRICS_DB_ENV: &str = "SPLINTER_INFLUX_DB";
 #[cfg(feature = "tap")]
 const METRICS_URL_ENV: &str = "SPLINTER_METRICS_URL";
 #[cfg(feature = "tap")]
@@ -128,7 +128,7 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
         #[cfg(feature = "tap")]
         {
             config = config
-                .with_metrics_db(env::var(METRICS_DB_ENV).ok())
+                .with_influx_db(env::var(METRICS_DB_ENV).ok())
                 .with_metrics_url(env::var(METRICS_URL_ENV).ok())
                 .with_metrics_username(env::var(METRICS_USERNAME_ENV).ok())
                 .with_metrics_password(env::var(METRICS_PASSWORD_ENV).ok())

--- a/splinterd/src/config/env.rs
+++ b/splinterd/src/config/env.rs
@@ -40,7 +40,7 @@ const METRICS_DB_ENV: &str = "SPLINTER_INFLUX_DB";
 #[cfg(feature = "tap")]
 const METRICS_URL_ENV: &str = "SPLINTER_INFLUX_URL";
 #[cfg(feature = "tap")]
-const METRICS_USERNAME_ENV: &str = "SPLINTER_METRICS_USERNAME";
+const METRICS_USERNAME_ENV: &str = "SPLINTER_INFLUX_USERNAME";
 #[cfg(feature = "tap")]
 const METRICS_PASSWORD_ENV: &str = "SPLINTER_METRICS_PASSWORD";
 
@@ -130,7 +130,7 @@ impl PartialConfigBuilder for EnvPartialConfigBuilder {
             config = config
                 .with_influx_db(env::var(METRICS_DB_ENV).ok())
                 .with_influx_url(env::var(METRICS_URL_ENV).ok())
-                .with_metrics_username(env::var(METRICS_USERNAME_ENV).ok())
+                .with_influx_username(env::var(METRICS_USERNAME_ENV).ok())
                 .with_metrics_password(env::var(METRICS_PASSWORD_ENV).ok())
         }
 

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -96,7 +96,7 @@ pub struct Config {
     #[cfg(feature = "tap")]
     influx_username: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
-    metrics_password: Option<(String, ConfigSource)>,
+    influx_password: Option<(String, ConfigSource)>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: (String, ConfigSource),
     #[cfg(feature = "log-config")]
@@ -332,8 +332,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_password(&self) -> Option<&str> {
-        if let Some((password, _)) = &self.metrics_password {
+    pub fn influx_password(&self) -> Option<&str> {
+        if let Some((password, _)) = &self.influx_password {
             Some(password)
         } else {
             None
@@ -565,8 +565,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_password_source(&self) -> Option<&ConfigSource> {
-        if let Some((_, source)) = &self.metrics_password {
+    pub fn influx_password_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.influx_password {
             Some(source)
         } else {
             None
@@ -847,10 +847,9 @@ impl Config {
                 );
             }
 
-            if let (Some(_), Some(source)) =
-                (self.metrics_password(), self.metrics_password_source())
+            if let (Some(_), Some(source)) = (self.influx_password(), self.influx_password_source())
             {
-                debug!("Config: metrics_password: <HIDDEN> (source: {:?})", source,);
+                debug!("Config: influx_password: <HIDDEN> (source: {:?})", source,);
             }
         }
         #[cfg(feature = "log-config")]

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -90,7 +90,7 @@ pub struct Config {
     oauth_openid_scopes: Option<(Vec<String>, ConfigSource)>,
     strict_ref_counts: (bool, ConfigSource),
     #[cfg(feature = "tap")]
-    metrics_db: Option<(String, ConfigSource)>,
+    influx_db: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
     metrics_url: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
@@ -305,8 +305,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_db(&self) -> Option<&str> {
-        if let Some((db, _)) = &self.metrics_db {
+    pub fn influx_db(&self) -> Option<&str> {
+        if let Some((db, _)) = &self.influx_db {
             Some(db)
         } else {
             None
@@ -538,8 +538,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_db_source(&self) -> Option<&ConfigSource> {
-        if let Some((_, source)) = &self.metrics_db {
+    pub fn influx_db_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.influx_db {
             Some(source)
         } else {
             None
@@ -830,8 +830,8 @@ impl Config {
         );
         #[cfg(feature = "tap")]
         {
-            if let (Some(db), Some(source)) = (self.metrics_db(), self.metrics_db_source()) {
-                debug!("Config: metrics_db: {:?} (source: {:?})", db, source,);
+            if let (Some(db), Some(source)) = (self.influx_db(), self.influx_db_source()) {
+                debug!("Config: influx_db: {:?} (source: {:?})", db, source,);
             }
 
             if let (Some(url), Some(source)) = (self.metrics_url(), self.metrics_url_source()) {

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -92,7 +92,7 @@ pub struct Config {
     #[cfg(feature = "tap")]
     influx_db: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
-    metrics_url: Option<(String, ConfigSource)>,
+    influx_url: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
     metrics_username: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
@@ -314,8 +314,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_url(&self) -> Option<&str> {
-        if let Some((url, _)) = &self.metrics_url {
+    pub fn influx_url(&self) -> Option<&str> {
+        if let Some((url, _)) = &self.influx_url {
             Some(url)
         } else {
             None
@@ -547,8 +547,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_url_source(&self) -> Option<&ConfigSource> {
-        if let Some((_, source)) = &self.metrics_url {
+    pub fn influx_url_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.influx_url {
             Some(source)
         } else {
             None
@@ -834,8 +834,8 @@ impl Config {
                 debug!("Config: influx_db: {:?} (source: {:?})", db, source,);
             }
 
-            if let (Some(url), Some(source)) = (self.metrics_url(), self.metrics_url_source()) {
-                debug!("Config: metrics_url: {:?} (source: {:?})", url, source,);
+            if let (Some(url), Some(source)) = (self.influx_url(), self.influx_url_source()) {
+                debug!("Config: influx_url: {:?} (source: {:?})", url, source,);
             }
 
             if let (Some(username), Some(source)) =

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -94,7 +94,7 @@ pub struct Config {
     #[cfg(feature = "tap")]
     influx_url: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
-    metrics_username: Option<(String, ConfigSource)>,
+    influx_username: Option<(String, ConfigSource)>,
     #[cfg(feature = "tap")]
     metrics_password: Option<(String, ConfigSource)>,
     #[cfg(feature = "challenge-authorization")]
@@ -323,8 +323,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_username(&self) -> Option<&str> {
-        if let Some((username, _)) = &self.metrics_username {
+    pub fn influx_username(&self) -> Option<&str> {
+        if let Some((username, _)) = &self.influx_username {
             Some(username)
         } else {
             None
@@ -556,8 +556,8 @@ impl Config {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_username_source(&self) -> Option<&ConfigSource> {
-        if let Some((_, source)) = &self.metrics_username {
+    pub fn influx_username_source(&self) -> Option<&ConfigSource> {
+        if let Some((_, source)) = &self.influx_username {
             Some(source)
         } else {
             None
@@ -839,10 +839,10 @@ impl Config {
             }
 
             if let (Some(username), Some(source)) =
-                (self.metrics_username(), self.metrics_username_source())
+                (self.influx_username(), self.influx_username_source())
             {
                 debug!(
-                    "Config: metrics_username: {:?} (source: {:?})",
+                    "Config: influx_username: {:?} (source: {:?})",
                     username, source,
                 );
             }

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -86,7 +86,7 @@ pub struct PartialConfig {
     oauth_openid_scopes: Option<Vec<String>>,
     strict_ref_counts: Option<bool>,
     #[cfg(feature = "tap")]
-    metrics_db: Option<String>,
+    influx_db: Option<String>,
     #[cfg(feature = "tap")]
     metrics_url: Option<String>,
     #[cfg(feature = "tap")]
@@ -160,7 +160,7 @@ impl PartialConfig {
             oauth_openid_scopes: None,
             strict_ref_counts: None,
             #[cfg(feature = "tap")]
-            metrics_db: None,
+            influx_db: None,
             #[cfg(feature = "tap")]
             metrics_url: None,
             #[cfg(feature = "tap")]
@@ -339,8 +339,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_db(&self) -> Option<String> {
-        self.metrics_db.clone()
+    pub fn influx_db(&self) -> Option<String> {
+        self.influx_db.clone()
     }
 
     #[cfg(feature = "tap")]
@@ -793,14 +793,14 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    /// Adds an `metrics_db` value to the `PartialConfig` object.
+    /// Adds an `influx_db` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
-    /// * `metrics_db` - Add the name of the InfluxDB database used for metrics
+    /// * `influx_db` - Add the name of the InfluxDB database used for metrics
     ///
-    pub fn with_metrics_db(mut self, metrics_db: Option<String>) -> Self {
-        self.metrics_db = metrics_db;
+    pub fn with_influx_db(mut self, influx_db: Option<String>) -> Self {
+        self.influx_db = influx_db;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -92,7 +92,7 @@ pub struct PartialConfig {
     #[cfg(feature = "tap")]
     influx_username: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_password: Option<String>,
+    influx_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: Option<String>,
     #[cfg(feature = "log-config")]
@@ -166,7 +166,7 @@ impl PartialConfig {
             #[cfg(feature = "tap")]
             influx_username: None,
             #[cfg(feature = "tap")]
-            metrics_password: None,
+            influx_password: None,
             #[cfg(feature = "challenge-authorization")]
             peering_key: None,
             #[cfg(feature = "log-config")]
@@ -354,8 +354,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_password(&self) -> Option<String> {
-        self.metrics_password.clone()
+    pub fn influx_password(&self) -> Option<String> {
+        self.influx_password.clone()
     }
 
     #[cfg(feature = "challenge-authorization")]
@@ -830,15 +830,15 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    /// Adds an `metrics_password` value to the `PartialConfig` object.
+    /// Adds an `influx_password` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
-    /// * `metrics_password` - Add the password for authorization with the InfluxDB database used
+    /// * `influx_password` - Add the password for authorization with the InfluxDB database used
     ///    for metrics
     ///
-    pub fn with_metrics_password(mut self, metrics_password: Option<String>) -> Self {
-        self.metrics_password = metrics_password;
+    pub fn with_influx_password(mut self, influx_password: Option<String>) -> Self {
+        self.influx_password = influx_password;
         self
     }
     #[cfg(feature = "challenge-authorization")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -88,7 +88,7 @@ pub struct PartialConfig {
     #[cfg(feature = "tap")]
     influx_db: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_url: Option<String>,
+    influx_url: Option<String>,
     #[cfg(feature = "tap")]
     metrics_username: Option<String>,
     #[cfg(feature = "tap")]
@@ -162,7 +162,7 @@ impl PartialConfig {
             #[cfg(feature = "tap")]
             influx_db: None,
             #[cfg(feature = "tap")]
-            metrics_url: None,
+            influx_url: None,
             #[cfg(feature = "tap")]
             metrics_username: None,
             #[cfg(feature = "tap")]
@@ -344,8 +344,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_url(&self) -> Option<String> {
-        self.metrics_url.clone()
+    pub fn influx_url(&self) -> Option<String> {
+        self.influx_url.clone()
     }
 
     #[cfg(feature = "tap")]
@@ -805,14 +805,14 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    /// Adds an `metrics_url` value to the `PartialConfig` object.
+    /// Adds an `influx_url` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
-    /// * `metrics_url` - Add the URL of the InfluxDB database used for metrics
+    /// * `influx_url` - Add the URL of the InfluxDB database used for metrics
     ///
-    pub fn with_metrics_url(mut self, metrics_url: Option<String>) -> Self {
-        self.metrics_url = metrics_url;
+    pub fn with_influx_url(mut self, influx_url: Option<String>) -> Self {
+        self.influx_url = influx_url;
         self
     }
 

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -90,7 +90,7 @@ pub struct PartialConfig {
     #[cfg(feature = "tap")]
     influx_url: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_username: Option<String>,
+    influx_username: Option<String>,
     #[cfg(feature = "tap")]
     metrics_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
@@ -164,7 +164,7 @@ impl PartialConfig {
             #[cfg(feature = "tap")]
             influx_url: None,
             #[cfg(feature = "tap")]
-            metrics_username: None,
+            influx_username: None,
             #[cfg(feature = "tap")]
             metrics_password: None,
             #[cfg(feature = "challenge-authorization")]
@@ -349,8 +349,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    pub fn metrics_username(&self) -> Option<String> {
-        self.metrics_username.clone()
+    pub fn influx_username(&self) -> Option<String> {
+        self.influx_username.clone()
     }
 
     #[cfg(feature = "tap")]
@@ -817,15 +817,15 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "tap")]
-    /// Adds an `metrics_username` value to the `PartialConfig` object.
+    /// Adds an `influx_username` value to the `PartialConfig` object.
     ///
     /// # Arguments
     ///
-    /// * `metrics_username` - Add the username for authorization with the InfluxDB database used
+    /// * `influx_username` - Add the username for authorization with the InfluxDB database used
     ///    for metrics
     ///
-    pub fn with_metrics_username(mut self, metrics_username: Option<String>) -> Self {
-        self.metrics_username = metrics_username;
+    pub fn with_influx_username(mut self, influx_username: Option<String>) -> Self {
+        self.influx_username = influx_username;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -78,7 +78,7 @@ struct TomlConfig {
     #[cfg(feature = "tap")]
     influx_url: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_username: Option<String>,
+    influx_username: Option<String>,
     #[cfg(feature = "tap")]
     metrics_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
@@ -202,7 +202,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             partial_config = partial_config
                 .with_influx_db(self.toml_config.influx_db)
                 .with_influx_url(self.toml_config.influx_url)
-                .with_metrics_username(self.toml_config.metrics_username)
+                .with_influx_username(self.toml_config.influx_username)
                 .with_metrics_password(self.toml_config.metrics_password)
         }
         #[cfg(feature = "log-config")]

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -76,7 +76,7 @@ struct TomlConfig {
     #[cfg(feature = "tap")]
     influx_db: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_url: Option<String>,
+    influx_url: Option<String>,
     #[cfg(feature = "tap")]
     metrics_username: Option<String>,
     #[cfg(feature = "tap")]
@@ -201,7 +201,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         {
             partial_config = partial_config
                 .with_influx_db(self.toml_config.influx_db)
-                .with_metrics_url(self.toml_config.metrics_url)
+                .with_influx_url(self.toml_config.influx_url)
                 .with_metrics_username(self.toml_config.metrics_username)
                 .with_metrics_password(self.toml_config.metrics_password)
         }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -74,7 +74,7 @@ struct TomlConfig {
     #[cfg(feature = "oauth")]
     oauth_openid_scopes: Option<Vec<String>>,
     #[cfg(feature = "tap")]
-    metrics_db: Option<String>,
+    influx_db: Option<String>,
     #[cfg(feature = "tap")]
     metrics_url: Option<String>,
     #[cfg(feature = "tap")]
@@ -200,7 +200,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         #[cfg(feature = "tap")]
         {
             partial_config = partial_config
-                .with_metrics_db(self.toml_config.metrics_db)
+                .with_influx_db(self.toml_config.influx_db)
                 .with_metrics_url(self.toml_config.metrics_url)
                 .with_metrics_username(self.toml_config.metrics_username)
                 .with_metrics_password(self.toml_config.metrics_password)

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -80,7 +80,7 @@ struct TomlConfig {
     #[cfg(feature = "tap")]
     influx_username: Option<String>,
     #[cfg(feature = "tap")]
-    metrics_password: Option<String>,
+    influx_password: Option<String>,
     #[cfg(feature = "challenge-authorization")]
     peering_key: Option<String>,
     #[cfg(feature = "log-config")]
@@ -203,7 +203,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_influx_db(self.toml_config.influx_db)
                 .with_influx_url(self.toml_config.influx_url)
                 .with_influx_username(self.toml_config.influx_username)
-                .with_metrics_password(self.toml_config.metrics_password)
+                .with_influx_password(self.toml_config.influx_password)
         }
         #[cfg(feature = "log-config")]
         {

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -585,8 +585,9 @@ fn main() {
     #[cfg(feature = "tap")]
     let app = app
         .arg(
-            Arg::with_name("metrics_db")
-                .long("metrics-db")
+            Arg::with_name("influx_db")
+                .long("influx-db")
+                .value_name("db_name")
                 .long_help("The name of the InfluxDB database for metrics collection")
                 .takes_value(true),
         )
@@ -679,13 +680,13 @@ fn main() {
 
 #[cfg(feature = "tap")]
 fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
-    let metrics_configured = config.metrics_db().is_some()
+    let metrics_configured = config.influx_db().is_some()
         || config.metrics_url().is_some()
         || config.metrics_username().is_some()
         || config.metrics_password().is_some();
 
     if metrics_configured {
-        let metrics_db = config.metrics_db().ok_or_else(|| {
+        let influx_db = config.influx_db().ok_or_else(|| {
             UserError::MissingArgument("missing metrics db provider configuration".into())
         })?;
 
@@ -701,7 +702,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics password provider configuration".into())
         })?;
 
-        InfluxRecorder::init(metrics_url, metrics_db, metrics_username, metrics_password)
+        InfluxRecorder::init(metrics_url, influx_db, metrics_username, metrics_password)
             .map_err(UserError::InternalError)?
     }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -599,8 +599,9 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("metrics_username")
-                .long("metrics-username")
+            Arg::with_name("influx_username")
+                .long("influx-username")
+                .value_name("username")
                 .long_help("The username used for authorization with the InfluxDB")
                 .takes_value(true),
         )
@@ -683,7 +684,7 @@ fn main() {
 fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
     let metrics_configured = config.influx_db().is_some()
         || config.influx_url().is_some()
-        || config.metrics_username().is_some()
+        || config.influx_username().is_some()
         || config.metrics_password().is_some();
 
     if metrics_configured {
@@ -695,7 +696,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics url provider configuration".into())
         })?;
 
-        let metrics_username = config.metrics_username().ok_or_else(|| {
+        let influx_username = config.influx_username().ok_or_else(|| {
             UserError::MissingArgument("missing metrics username provider configuration".into())
         })?;
 
@@ -703,7 +704,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics password provider configuration".into())
         })?;
 
-        InfluxRecorder::init(influx_url, influx_db, metrics_username, metrics_password)
+        InfluxRecorder::init(influx_url, influx_db, influx_username, metrics_password)
             .map_err(UserError::InternalError)?
     }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -592,8 +592,9 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("metrics_url")
-                .long("metrics-url")
+            Arg::with_name("influx_url")
+                .long("influx-url")
+                .value_name("url")
                 .long_help("The URL to connect the InfluxDB database for metrics collection")
                 .takes_value(true),
         )
@@ -681,7 +682,7 @@ fn main() {
 #[cfg(feature = "tap")]
 fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
     let metrics_configured = config.influx_db().is_some()
-        || config.metrics_url().is_some()
+        || config.influx_url().is_some()
         || config.metrics_username().is_some()
         || config.metrics_password().is_some();
 
@@ -690,7 +691,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics db provider configuration".into())
         })?;
 
-        let metrics_url = config.metrics_url().ok_or_else(|| {
+        let influx_url = config.influx_url().ok_or_else(|| {
             UserError::MissingArgument("missing metrics url provider configuration".into())
         })?;
 
@@ -702,7 +703,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics password provider configuration".into())
         })?;
 
-        InfluxRecorder::init(metrics_url, influx_db, metrics_username, metrics_password)
+        InfluxRecorder::init(influx_url, influx_db, metrics_username, metrics_password)
             .map_err(UserError::InternalError)?
     }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -606,8 +606,9 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("metrics_password")
-                .long("metrics-password")
+            Arg::with_name("influx_password")
+                .long("influx-password")
+                .value_name("password")
                 .long_help("The password used for authorization with the InfluxDB")
                 .takes_value(true),
         );
@@ -685,7 +686,7 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
     let metrics_configured = config.influx_db().is_some()
         || config.influx_url().is_some()
         || config.influx_username().is_some()
-        || config.metrics_password().is_some();
+        || config.influx_password().is_some();
 
     if metrics_configured {
         let influx_db = config.influx_db().ok_or_else(|| {
@@ -700,11 +701,11 @@ fn setup_metrics_recorder(config: &Config) -> Result<(), UserError> {
             UserError::MissingArgument("missing metrics username provider configuration".into())
         })?;
 
-        let metrics_password = config.metrics_password().ok_or_else(|| {
+        let influx_password = config.influx_password().ok_or_else(|| {
             UserError::MissingArgument("missing metrics password provider configuration".into())
         })?;
 
-        InfluxRecorder::init(influx_url, influx_db, influx_username, metrics_password)
+        InfluxRecorder::init(influx_url, influx_db, influx_username, influx_password)
             .map_err(UserError::InternalError)?
     }
 


### PR DESCRIPTION
The arguments required for configuring metrics are now 
```
        --influx-db <db_name>                                       The name of the InfluxDB database for metrics
                                                                    collection
        --influx-password <password>                                The password used for authorization with the
                                                                    InfluxDB
        --influx-url <url>                                          The URL to connect the InfluxDB database for metrics
                                                                    collection
        --influx-username <username>                                The username used for authorization with the
                                                                    InfluxDB

```

Also updates the environment variable to be `SPLINTER_METRICS_*` to be `SPLINTER_INFLUX_*` 