### PR TITLE
Stablize the `tap` features in splinterd to turn on metrics

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -65,6 +65,7 @@ stable = [
   "default",
   "events",
   "lmdb",
+  "metrics",
   "rest-api",
   "rest-api-actix",
 ]
@@ -77,7 +78,6 @@ experimental = [
   "diesel-receipt-store",
   "factory-builder",
   "https",
-  "metrics",
   "postgres",
   "sqlite",
 ]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -87,6 +87,7 @@ default = [
     "database-postgres",
     "database-sqlite",
     "oauth",
+    "tap",
     "trust-authorization",
 ]
 
@@ -105,7 +106,6 @@ experimental = [
     "health-service",
     "https-bind",
     "log-config",
-    "tap",
     "node",
     "node-file-block",
     "service-arg-validation",


### PR DESCRIPTION
This enables sending metrics to a influx db instance if the `influx_*`arguments are provided.