### PR TITLE
Add check for io errors opening sqlite database

### DIFF
--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -30,10 +30,11 @@ use super::SplinterEnvironment;
 use crate::error::CliError;
 
 const DEFAULT_SQLITE: &str = "splinter_state.db";
+const MEMORY: &str = ":memory:";
 
 /// Run the sqlite migrations against the provided connection string
 pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
-    if connection_string != ":memory:" {
+    if connection_string != MEMORY {
         if let Err(err) = OpenOptions::new()
             .read(true)
             .write(true)
@@ -48,7 +49,7 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
     let connection_manager = ConnectionManager::<SqliteConnection>::new(&connection_string);
     let mut pool_builder = Pool::builder();
 
-    if connection_string == ":memory:" {
+    if connection_string == MEMORY {
         pool_builder = pool_builder.max_size(1)
     }
 
@@ -56,7 +57,7 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
         .build(connection_manager)
         .map_err(|_| CliError::ActionError("Failed to build connection pool".to_string()))?;
 
-    if connection_string != ":memory:" {
+    if connection_string != MEMORY {
         let path = PathBuf::from(&connection_string);
         let full_path = fs::canonicalize(&path).map_err(|err| {
             CliError::ActionError(format!(

--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -14,7 +14,7 @@
 
 //! Provides sqlite migration support to the database action
 
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
 
 use diesel::{
@@ -33,6 +33,18 @@ const DEFAULT_SQLITE: &str = "splinter_state.db";
 
 /// Run the sqlite migrations against the provided connection string
 pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
+    if connection_string != ":memory:" {
+        if let Err(err) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&connection_string)
+        {
+            return Err(CliError::ActionError(format!(
+                "While opening: {} received {}",
+                &connection_string, err
+            )));
+        }
+    }
     let connection_manager = ConnectionManager::<SqliteConnection>::new(&connection_string);
     let mut pool_builder = Pool::builder();
 


### PR DESCRIPTION
Sqlite connection pool initialization fails clumsily if the database
file can't be opened. This commit will force an early return with both
the filename and Error in the message.

Signed-off-by: Caleb Hill <hill@bitwise.io>