### PR TITLE
Stabilize challenge-authorization API by removing guard

### DIFF
--- a/examples/gameroom/daemon/src/authorization_handler/mod.rs
+++ b/examples/gameroom/daemon/src/authorization_handler/mod.rs
@@ -1287,6 +1287,7 @@ mod test {
             members: vec![SplinterNode {
                 node_id: "Node-123".to_string(),
                 endpoints: vec!["127.0.0.1:8282".to_string()],
+                public_key: None,
             }],
             authorization_type: AuthorizationType::Trust,
             persistence: PersistenceType::Any,

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -131,12 +131,14 @@ pub async fn propose_gameroom(
         .map(|node| SplinterNode {
             node_id: node.identity.to_string(),
             endpoints: node.endpoints.to_vec(),
+            public_key: None,
         })
         .collect::<Vec<SplinterNode>>();
 
     members.push(SplinterNode {
         node_id: node_info.identity.to_string(),
         endpoints: node_info.endpoints.to_vec(),
+        public_key: None,
     });
 
     let node_ids = nodes

--- a/libsplinter/src/admin/client/event/ws/actix_web_client.rs
+++ b/libsplinter/src/admin/client/event/ws/actix_web_client.rs
@@ -415,7 +415,6 @@ impl From<messages::SplinterNode> for CircuitMembers {
         Self {
             node_id: splinter_node.node_id,
             endpoints: splinter_node.endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: splinter_node
                 .public_key
                 .as_ref()

--- a/libsplinter/src/admin/client/mod.rs
+++ b/libsplinter/src/admin/client/mod.rs
@@ -68,7 +68,6 @@ pub struct CircuitListSlice {
 pub struct CircuitMembers {
     pub node_id: String,
     pub endpoints: Vec<String>,
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -758,7 +758,6 @@ mod tests {
                 members: vec![SplinterNode {
                     node_id: "node_id".into(),
                     endpoints: vec!["".into()],
-                    #[cfg(feature = "challenge-authorization")]
                     public_key: None,
                 }],
                 authorization_type: AuthorizationType::Trust,
@@ -815,7 +814,6 @@ mod tests {
                 members: vec![SplinterNode {
                     node_id: "node_id".into(),
                     endpoints: vec!["".into()],
-                    #[cfg(feature = "challenge-authorization")]
                     public_key: None,
                 }],
                 authorization_type: AuthorizationType::Trust,

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits.rs
@@ -15,7 +15,6 @@
 use std::collections::BTreeMap;
 
 use crate::admin::store::{Circuit, CircuitNode, CircuitStatus, Service};
-#[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 use crate::rest_api::paging::Paging;
 
@@ -91,7 +90,6 @@ impl From<String> for CircuitStatus {
 pub(crate) struct CircuitNodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
@@ -100,7 +98,6 @@ impl<'a> From<&'a CircuitNode> for CircuitNodeResponse<'a> {
         Self {
             node_id: node_def.node_id(),
             endpoints: node_def.endpoints(),
-            #[cfg(feature = "challenge-authorization")]
             public_key: node_def
                 .public_key()
                 .as_ref()

--- a/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/circuits_circuit_id.rs
@@ -15,7 +15,6 @@
 use std::collections::BTreeMap;
 
 use crate::admin::store::{Circuit, CircuitNode, CircuitStatus, Service};
-#[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -74,7 +73,6 @@ impl<'a> From<&'a Service> for ServiceResponse<'a> {
 pub(crate) struct CircuitNodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
@@ -83,7 +81,6 @@ impl<'a> From<&'a CircuitNode> for CircuitNodeResponse<'a> {
         Self {
             node_id: node_def.node_id(),
             endpoints: node_def.endpoints(),
-            #[cfg(feature = "challenge-authorization")]
             public_key: node_def
                 .public_key()
                 .as_ref()

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals.rs
@@ -18,7 +18,6 @@ use crate::admin::messages::{
     Vote, VoteRecord,
 };
 use crate::hex::as_hex;
-#[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 use crate::rest_api::paging::Paging;
 
@@ -126,7 +125,6 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
@@ -135,7 +133,6 @@ impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
         Self {
             node_id: &node.node_id,
             endpoints: &node.endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: node
                 .public_key
                 .as_ref()

--- a/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/resources/v2/proposals_circuit_id.rs
@@ -19,7 +19,6 @@ use crate::admin::messages::{
     Vote, VoteRecord,
 };
 use crate::hex::as_hex;
-#[cfg(feature = "challenge-authorization")]
 use crate::hex::to_hex;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -121,7 +120,6 @@ impl<'a> TryFrom<&'a CreateCircuit> for CircuitResponse<'a> {
 pub(crate) struct NodeResponse<'a> {
     pub node_id: &'a str,
     pub endpoints: &'a [String],
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<String>,
 }
 
@@ -130,7 +128,6 @@ impl<'a> From<&'a SplinterNode> for NodeResponse<'a> {
         Self {
             node_id: &node.node_id,
             endpoints: &node.endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: node
                 .public_key
                 .as_ref()

--- a/libsplinter/src/admin/service/builder.rs
+++ b/libsplinter/src/admin/service/builder.rs
@@ -27,7 +27,6 @@ use crate::error::InvalidStateError;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::ServiceOrchestrator;
 use crate::peer::PeerManagerConnector;
-#[cfg(feature = "challenge-authorization")]
 use crate::public_key::PublicKey;
 #[cfg(feature = "service-arg-validation")]
 use crate::service::validation::ServiceArgValidator;
@@ -56,7 +55,6 @@ pub struct AdminServiceBuilder {
     coordinator_timeout: Option<Duration>,
     routing_table_writer: Option<Box<dyn RoutingTableWriter>>,
     event_store: Option<Box<dyn AdminServiceStore>>,
-    #[cfg(feature = "challenge-authorization")]
     public_keys: Option<Vec<PublicKey>>,
 }
 
@@ -155,7 +153,6 @@ impl AdminServiceBuilder {
     }
 
     /// Sets the public keys
-    #[cfg(feature = "challenge-authorization")]
     pub fn with_public_keys(mut self, public_keys: Vec<PublicKey>) -> Self {
         self.public_keys = Some(public_keys);
 
@@ -225,7 +222,6 @@ impl AdminServiceBuilder {
 
         let service_id = admin_service_id(&node_id);
 
-        #[cfg(feature = "challenge-authorization")]
         let public_keys = self.public_keys.unwrap_or_default();
 
         let admin_service_shared = Arc::new(Mutex::new(AdminServiceShared::new(
@@ -240,7 +236,6 @@ impl AdminServiceBuilder {
             key_permission_manager,
             routing_table_writer,
             admin_event_store,
-            #[cfg(feature = "challenge-authorization")]
             public_keys,
         )));
 

--- a/libsplinter/src/admin/service/consensus.rs
+++ b/libsplinter/src/admin/service/consensus.rs
@@ -29,7 +29,6 @@ use crate::consensus::{
     ProposalUpdate,
 };
 use crate::consensus::{ConsensusEngine, StartupState};
-#[cfg(feature = "challenge-authorization")]
 use crate::error::InvalidStateError;
 use crate::hex::to_hex;
 use crate::peer::PeerTokenPair;
@@ -216,7 +215,6 @@ impl ProposalManager for AdminProposalManager {
                 .list_nodes()
                 .map_err(|err| ProposalManagerError::Internal(Box::new(err)))?;
 
-            #[cfg(feature = "challenge-authorization")]
             let local_node = circuit_proposal
                 .get_circuit_proposal()
                 .get_node_token(shared.node_id())
@@ -235,12 +233,8 @@ impl ProposalManager for AdminProposalManager {
                     network_sender
                         .send(
                             &admin_service_id(
-                                &PeerTokenPair::new(
-                                    node.token.clone(),
-                                    #[cfg(feature = "challenge-authorization")]
-                                    local_node.clone(),
-                                )
-                                .id_as_string(),
+                                &PeerTokenPair::new(node.token.clone(), local_node.clone())
+                                    .id_as_string(),
                             ),
                             &envelope_bytes,
                         )

--- a/libsplinter/src/admin/service/messages/builders.rs
+++ b/libsplinter/src/admin/service/messages/builders.rs
@@ -191,16 +191,6 @@ impl CreateCircuitBuilder {
             .members
             .ok_or_else(|| BuilderError::MissingField("members".to_string()))?;
 
-        #[cfg(not(feature = "challenge-authorization"))]
-        let authorization_type = self.authorization_type.unwrap_or_else(|| {
-            debug!(
-                "Building circuit create request with default authorization_type: {:?}",
-                AuthorizationType::Trust
-            );
-            AuthorizationType::Trust
-        });
-
-        #[cfg(feature = "challenge-authorization")]
         let authorization_type = self.authorization_type.unwrap_or_else(|| {
             debug!(
                 "Building circuit create request with default authorization_type: {:?}",
@@ -353,7 +343,6 @@ impl SplinterServiceBuilder {
 pub struct SplinterNodeBuilder {
     node_id: Option<String>,
     endpoints: Option<Vec<String>>,
-    #[cfg(feature = "challenge-authorization")]
     public_key: Option<Vec<u8>>,
 }
 
@@ -370,7 +359,6 @@ impl SplinterNodeBuilder {
         self.endpoints.clone()
     }
 
-    #[cfg(feature = "challenge-authorization")]
     pub fn public_key(&self) -> Option<Vec<u8>> {
         self.public_key.clone()
     }
@@ -385,7 +373,6 @@ impl SplinterNodeBuilder {
         self
     }
 
-    #[cfg(feature = "challenge-authorization")]
     pub fn with_public_key(mut self, public_key: &[u8]) -> SplinterNodeBuilder {
         self.public_key = Some(public_key.into());
         self
@@ -403,7 +390,6 @@ impl SplinterNodeBuilder {
         let node = SplinterNode {
             node_id,
             endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: self.public_key,
         };
 
@@ -525,9 +511,6 @@ mod tests {
             .all(|c| c.is_ascii_alphanumeric()));
         assert_eq!(circuit.roster, vec![service]);
         assert_eq!(circuit.members, vec![node]);
-        #[cfg(not(feature = "challenge-authorization"))]
-        assert_eq!(circuit.authorization_type, AuthorizationType::Trust);
-        #[cfg(feature = "challenge-authorization")]
         assert_eq!(circuit.authorization_type, AuthorizationType::Challenge);
         assert_eq!(circuit.persistence, PersistenceType::Any);
         assert_eq!(circuit.durability, DurabilityType::NoDurability);

--- a/libsplinter/src/admin/service/messages/mod.rs
+++ b/libsplinter/src/admin/service/messages/mod.rs
@@ -54,7 +54,6 @@ impl CreateCircuit {
     pub fn from_proto(mut proto: admin::Circuit) -> Result<Self, MarshallingError> {
         let authorization_type = match proto.get_authorization_type() {
             admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION => AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                 AuthorizationType::Challenge
             }
@@ -180,7 +179,6 @@ impl CreateCircuit {
                 circuit
                     .set_authorization_type(admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION);
             }
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => {
                 circuit.set_authorization_type(
                     admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION,
@@ -264,7 +262,6 @@ impl TryInto<admin::Circuit> for CreateCircuit {
                 circuit
                     .set_authorization_type(admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION);
             }
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => {
                 circuit.set_authorization_type(
                     admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION,
@@ -319,7 +316,6 @@ pub fn is_valid_circuit_id(circuit_id: &str) -> bool {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum AuthorizationType {
     Trust,
-    #[cfg(feature = "challenge-authorization")]
     Challenge,
 }
 
@@ -327,7 +323,6 @@ impl From<&store::AuthorizationType> for AuthorizationType {
     fn from(store_enum: &store::AuthorizationType) -> Self {
         match *store_enum {
             store::AuthorizationType::Trust => AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             store::AuthorizationType::Challenge => AuthorizationType::Challenge,
         }
     }
@@ -421,7 +416,6 @@ impl std::fmt::Display for CircuitStatus {
 pub struct SplinterNode {
     pub node_id: String,
     pub endpoints: Vec<String>,
-    #[cfg(feature = "challenge-authorization")]
     pub public_key: Option<Vec<u8>>,
 }
 
@@ -432,7 +426,6 @@ impl SplinterNode {
         proto.set_node_id(self.node_id);
         proto.set_endpoints(self.endpoints.into());
 
-        #[cfg(feature = "challenge-authorization")]
         if let Some(public_key) = self.public_key {
             proto.set_public_key(public_key);
         }
@@ -441,7 +434,6 @@ impl SplinterNode {
     }
 
     pub fn from_proto(mut proto: admin::SplinterNode) -> Result<Self, MarshallingError> {
-        #[cfg(feature = "challenge-authorization")]
         let public_key = {
             let public_key = proto.take_public_key();
             if public_key.is_empty() {
@@ -454,7 +446,6 @@ impl SplinterNode {
         Ok(Self {
             node_id: proto.take_node_id(),
             endpoints: proto.take_endpoints().into(),
-            #[cfg(feature = "challenge-authorization")]
             public_key,
         })
     }
@@ -624,7 +615,6 @@ impl From<store::CircuitProposal> for CircuitProposal {
                 .map(|node| SplinterNode {
                     node_id: node.node_id().to_string(),
                     endpoints: node.endpoints().to_vec(),
-                    #[cfg(feature = "challenge-authorization")]
                     public_key: node.public_key().clone(),
                 })
                 .collect::<Vec<SplinterNode>>(),

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -300,7 +300,6 @@ impl AdminService {
                     let peer_ref = self.peer_connector.add_peer_ref(
                         member.token.clone(),
                         member.endpoints.to_vec(),
-                        #[cfg(feature = "challenge-authorization")]
                         local_required_auth.clone(),
                     );
                     if let Ok(peer_ref) = peer_ref {
@@ -310,11 +309,7 @@ impl AdminService {
                     }
 
                     token_to_peer.insert(
-                        PeerTokenPair::new(
-                            member.token.clone(),
-                            #[cfg(feature = "challenge-authorization")]
-                            local_required_auth.clone(),
-                        ),
+                        PeerTokenPair::new(member.token.clone(), local_required_auth.clone()),
                         PeerNodePair {
                             peer_node: member.clone(),
                             local_peer_token: local_required_auth.clone(),
@@ -356,7 +351,6 @@ impl AdminService {
                     routing::CircuitNode::new(
                         node.node_id().to_string(),
                         node.endpoints().to_vec(),
-                        #[cfg(feature = "challenge-authorization")]
                         node.public_key().clone(),
                     )
                 })
@@ -373,7 +367,6 @@ impl AdminService {
                             .iter()
                             .map(|node| node.node_id().to_string())
                             .collect(),
-                        #[cfg(feature = "challenge-authorization")]
                         circuit.authorization_type().into(),
                     ),
                     routing_members,
@@ -498,7 +491,6 @@ impl AdminService {
                     let peer_ref = self.peer_connector.add_peer_ref(
                         member.token.clone(),
                         member.endpoints.to_vec(),
-                        #[cfg(feature = "challenge-authorization")]
                         local_required_auth.clone(),
                     );
 
@@ -509,11 +501,7 @@ impl AdminService {
                     }
 
                     token_to_peer.insert(
-                        PeerTokenPair::new(
-                            member.token.clone(),
-                            #[cfg(feature = "challenge-authorization")]
-                            local_required_auth.clone(),
-                        ),
+                        PeerTokenPair::new(member.token.clone(), local_required_auth.clone()),
                         PeerNodePair {
                             peer_node: member.clone(),
                             local_peer_token: local_required_auth.clone(),
@@ -1039,7 +1027,6 @@ mod tests {
                     "other-node".to_string(),
                 ),
             ],
-            #[cfg(feature = "challenge-authorization")]
             "test-node".to_string(),
         );
 
@@ -1325,7 +1312,6 @@ mod tests {
             Box::new(self.clone())
         }
 
-        #[cfg(feature = "challenge-authorization")]
         fn send_with_sender(
             &mut self,
             recipient: &str,

--- a/libsplinter/src/admin/store/circuit.rs
+++ b/libsplinter/src/admin/store/circuit.rs
@@ -155,7 +155,6 @@ impl TryFrom<&admin::Circuit> for Circuit {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthorizationType {
     Trust,
-    #[cfg(feature = "challenge-authorization")]
     Challenge,
 }
 
@@ -163,7 +162,6 @@ impl From<&messages::AuthorizationType> for AuthorizationType {
     fn from(message_enum: &messages::AuthorizationType) -> Self {
         match *message_enum {
             messages::AuthorizationType::Trust => AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             messages::AuthorizationType::Challenge => AuthorizationType::Challenge,
         }
     }
@@ -175,7 +173,6 @@ impl TryFrom<&admin::Circuit_AuthorizationType> for AuthorizationType {
     fn try_from(proto: &admin::Circuit_AuthorizationType) -> Result<Self, Self::Error> {
         match *proto {
             admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION => Ok(AuthorizationType::Trust),
-            #[cfg(feature = "challenge-authorization")]
             admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                 Ok(AuthorizationType::Challenge)
             }
@@ -190,7 +187,6 @@ impl From<&AuthorizationType> for admin::Circuit_AuthorizationType {
     fn from(auth: &AuthorizationType) -> Self {
         match *auth {
             AuthorizationType::Trust => admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION,
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => {
                 admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION
             }
@@ -646,7 +642,6 @@ impl From<&AuthorizationType> for routing::AuthorizationType {
     fn from(auth_type: &AuthorizationType) -> Self {
         match auth_type {
             AuthorizationType::Trust => routing::AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => routing::AuthorizationType::Challenge,
         }
     }

--- a/libsplinter/src/admin/store/circuit_node.rs
+++ b/libsplinter/src/admin/store/circuit_node.rs
@@ -22,7 +22,6 @@ use super::ProposedNode;
 pub struct CircuitNode {
     id: String,
     endpoints: Vec<String>,
-    #[cfg(feature = "challenge-authorization")]
     public_key: Option<Vec<u8>>,
 }
 
@@ -38,7 +37,6 @@ impl CircuitNode {
     }
 
     /// Returns the public key that belongs to the node
-    #[cfg(feature = "challenge-authorization")]
     pub fn public_key(&self) -> &Option<Vec<u8>> {
         &self.public_key
     }
@@ -49,7 +47,6 @@ impl From<&ProposedNode> for CircuitNode {
         CircuitNode {
             id: proposed_node.node_id().into(),
             endpoints: proposed_node.endpoints().to_vec(),
-            #[cfg(feature = "challenge-authorization")]
             public_key: proposed_node.public_key().clone(),
         }
     }
@@ -60,7 +57,6 @@ impl From<ProposedNode> for CircuitNode {
         CircuitNode {
             id: node.node_id().into(),
             endpoints: node.endpoints().to_vec(),
-            #[cfg(feature = "challenge-authorization")]
             public_key: node.public_key().clone(),
         }
     }
@@ -71,7 +67,6 @@ impl From<ProposedNode> for CircuitNode {
 pub struct CircuitNodeBuilder {
     node_id: Option<String>,
     endpoints: Option<Vec<String>>,
-    #[cfg(feature = "challenge-authorization")]
     public_key: Option<Vec<u8>>,
 }
 
@@ -92,7 +87,6 @@ impl CircuitNodeBuilder {
     }
 
     /// Returns the public key for the node
-    #[cfg(feature = "challenge-authorization")]
     pub fn public_key(&self) -> Option<Vec<u8>> {
         self.public_key.clone()
     }
@@ -122,7 +116,6 @@ impl CircuitNodeBuilder {
     /// # Arguments
     ///
     ///  * `public_key` - The bytes of the node's public key
-    #[cfg(feature = "challenge-authorization")]
     pub fn with_public_key(mut self, public_key: &[u8]) -> CircuitNodeBuilder {
         self.public_key = Some(public_key.into());
         self
@@ -147,7 +140,6 @@ impl CircuitNodeBuilder {
         let node = CircuitNode {
             id: node_id,
             endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: self.public_key,
         };
 

--- a/libsplinter/src/admin/store/diesel/models.rs
+++ b/libsplinter/src/admin/store/diesel/models.rs
@@ -187,10 +187,7 @@ impl TryFrom<&ProposedCircuit> for Vec<ProposedNodeModel> {
                             "Unable to convert index into i32".to_string(),
                         ))
                     })?,
-                    #[cfg(feature = "challenge-authorization")]
                     public_key: node.public_key().clone(),
-                    #[cfg(not(feature = "challenge-authorization"))]
-                    public_key: None,
                 })
             })
             .collect::<Result<Vec<ProposedNodeModel>, AdminServiceStoreError>>()
@@ -464,10 +461,7 @@ impl TryFrom<&Circuit> for Vec<CircuitMemberModel> {
                             "Unable to convert index into i32".to_string(),
                         ))
                     })?,
-                    #[cfg(feature = "challenge-authorization")]
                     public_key: node.public_key().clone(),
-                    #[cfg(not(feature = "challenge-authorization"))]
-                    public_key: None,
                 })
             })
             .collect::<Result<Vec<CircuitMemberModel>, AdminServiceStoreError>>()
@@ -980,7 +974,6 @@ impl TryFrom<String> for AuthorizationType {
     fn try_from(variant: String) -> Result<Self, Self::Error> {
         match variant.as_ref() {
             "Trust" => Ok(AuthorizationType::Trust),
-            #[cfg(feature = "challenge-authorization")]
             "Challenge" => Ok(AuthorizationType::Challenge),
             _ => Err(AdminServiceStoreError::InvalidStateError(
                 InvalidStateError::with_message(
@@ -995,7 +988,6 @@ impl From<&AuthorizationType> for String {
     fn from(variant: &AuthorizationType) -> Self {
         match variant {
             AuthorizationType::Trust => String::from("Trust"),
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => String::from("Challenge"),
         }
     }
@@ -1005,7 +997,6 @@ impl From<&messages::AuthorizationType> for String {
     fn from(variant: &messages::AuthorizationType) -> Self {
         match variant {
             messages::AuthorizationType::Trust => String::from("Trust"),
-            #[cfg(feature = "challenge-authorization")]
             messages::AuthorizationType::Challenge => String::from("Challenge"),
         }
     }

--- a/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/add_circuit.rs
@@ -84,10 +84,7 @@ impl<'a> AdminServiceStoreAddCircuitOperation
                                 "Unable to convert index into i32".to_string(),
                             ))
                         })?,
-                        #[cfg(feature = "challenge-authorization")]
                         public_key: node.public_key().clone(),
-                        #[cfg(not(feature = "challenge-authorization"))]
-                        public_key: None,
                     })
                 })
                 .collect::<Result<Vec<CircuitMemberModel>, AdminServiceStoreError>>()?;
@@ -183,10 +180,7 @@ impl<'a> AdminServiceStoreAddCircuitOperation
                                 "Unable to convert index into i32".to_string(),
                             ))
                         })?,
-                        #[cfg(feature = "challenge-authorization")]
                         public_key: node.public_key().clone(),
-                        #[cfg(not(feature = "challenge-authorization"))]
-                        public_key: None,
                     })
                 })
                 .collect::<Result<Vec<CircuitMemberModel>, AdminServiceStoreError>>()?;

--- a/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_circuit.rs
@@ -104,11 +104,8 @@ where
                         builder = builder.with_endpoints(endpoints);
                     }
 
-                    #[cfg(feature = "challenge-authorization")]
-                    {
-                        if let Some(public_key) = &member.public_key {
-                            builder = builder.with_public_key(public_key);
-                        }
+                    if let Some(public_key) = &member.public_key {
+                        builder = builder.with_public_key(public_key);
                     }
 
                     builder.build()

--- a/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/get_proposal.rs
@@ -142,7 +142,6 @@ where
                         builder = builder.with_endpoints(&endpoints);
                     }
 
-                    #[cfg(feature = "challenge-authorization")]
                     if let Some(public_key) = &node.public_key {
                         builder = builder.with_public_key(public_key)
                     }

--- a/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_circuits.rs
@@ -270,11 +270,8 @@ where
                                     builder = builder.with_endpoints(endpoints);
                                 }
 
-                                #[cfg(feature = "challenge-authorization")]
-                                {
-                                    if let Some(public_key) = &member.public_key {
-                                        builder = builder.with_public_key(public_key);
-                                    }
+                                if let Some(public_key) = &member.public_key {
+                                    builder = builder.with_public_key(public_key);
                                 }
 
                                 builder.build()

--- a/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_nodes.rs
@@ -87,11 +87,8 @@ where
             .map(|node| {
                 let mut builder = CircuitNodeBuilder::new().with_node_id(&node.node_id);
 
-                #[cfg(feature = "challenge-authorization")]
-                {
-                    if let Some(public_key) = &node.public_key {
-                        builder = builder.with_public_key(public_key);
-                    }
+                if let Some(public_key) = &node.public_key {
+                    builder = builder.with_public_key(public_key);
                 }
 
                 if let Some(endpoints) = node_map.get(&node.node_id) {

--- a/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
+++ b/libsplinter/src/admin/store/diesel/operations/list_proposals.rs
@@ -307,11 +307,9 @@ where
                     {
                         proposed_node.endpoints.push(endpoint);
                     } else {
-                        #[allow(unused_mut)]
                         let mut proposed_node =
                             ProposedNodeBuilder::new().with_node_id(&node.node_id);
 
-                        #[cfg(feature = "challenge-authorization")]
                         if let Some(public_key) = &node.public_key {
                             proposed_node = proposed_node.with_public_key(public_key)
                         }

--- a/libsplinter/src/admin/store/proposed_circuit.rs
+++ b/libsplinter/src/admin/store/proposed_circuit.rs
@@ -111,7 +111,6 @@ impl ProposedCircuit {
     pub fn from_proto(mut proto: admin::Circuit) -> Result<Self, InvalidStateError> {
         let authorization_type = match proto.get_authorization_type() {
             admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION => AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                 AuthorizationType::Challenge
             }
@@ -249,7 +248,6 @@ impl ProposedCircuit {
                 circuit
                     .set_authorization_type(admin::Circuit_AuthorizationType::TRUST_AUTHORIZATION);
             }
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => {
                 circuit.set_authorization_type(
                     admin::Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION,

--- a/libsplinter/src/admin/store/proposed_node.rs
+++ b/libsplinter/src/admin/store/proposed_node.rs
@@ -23,7 +23,6 @@ use crate::protos::admin;
 pub struct ProposedNode {
     node_id: String,
     endpoints: Vec<String>,
-    #[cfg(feature = "challenge-authorization")]
     public_key: Option<Vec<u8>>,
 }
 
@@ -39,7 +38,6 @@ impl ProposedNode {
     }
 
     /// Returns the public key that belongs to the proposed node
-    #[cfg(feature = "challenge-authorization")]
     pub fn public_key(&self) -> &Option<Vec<u8>> {
         &self.public_key
     }
@@ -50,7 +48,6 @@ impl ProposedNode {
         proto.set_node_id(self.node_id);
         proto.set_endpoints(self.endpoints.into());
 
-        #[cfg(feature = "challenge-authorization")]
         if let Some(public_key) = self.public_key {
             proto.set_public_key(public_key);
         }
@@ -59,7 +56,6 @@ impl ProposedNode {
     }
 
     pub fn from_proto(mut proto: admin::SplinterNode) -> Self {
-        #[cfg(feature = "challenge-authorization")]
         let public_key = {
             let public_key = proto.take_public_key();
             if public_key.is_empty() {
@@ -72,7 +68,6 @@ impl ProposedNode {
         Self {
             node_id: proto.take_node_id(),
             endpoints: proto.take_endpoints().into(),
-            #[cfg(feature = "challenge-authorization")]
             public_key,
         }
     }
@@ -83,7 +78,6 @@ impl ProposedNode {
 pub struct ProposedNodeBuilder {
     node_id: Option<String>,
     endpoints: Option<Vec<String>>,
-    #[cfg(feature = "challenge-authorization")]
     public_key: Option<Vec<u8>>,
 }
 
@@ -104,7 +98,6 @@ impl ProposedNodeBuilder {
     }
 
     /// Returns the publice key for the node
-    #[cfg(feature = "challenge-authorization")]
     pub fn public_key(&self) -> Option<Vec<u8>> {
         self.public_key.clone()
     }
@@ -134,7 +127,6 @@ impl ProposedNodeBuilder {
     /// # Arguments
     ///
     ///  * `public_key` - The bytes of the node's public key
-    #[cfg(feature = "challenge-authorization")]
     pub fn with_public_key(mut self, public_key: &[u8]) -> ProposedNodeBuilder {
         self.public_key = Some(public_key.into());
         self
@@ -157,7 +149,6 @@ impl ProposedNodeBuilder {
         let node = ProposedNode {
             node_id,
             endpoints,
-            #[cfg(feature = "challenge-authorization")]
             public_key: self.public_key,
         };
 
@@ -170,7 +161,6 @@ impl From<&messages::SplinterNode> for ProposedNode {
         ProposedNode {
             node_id: admin_node.node_id.to_string(),
             endpoints: admin_node.endpoints.to_vec(),
-            #[cfg(feature = "challenge-authorization")]
             public_key: admin_node.public_key.clone(),
         }
     }

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1644,7 +1644,6 @@ impl From<ProposedNode> for YamlProposedNode {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum YamlAuthorizationType {
     Trust,
-    #[cfg(feature = "challenge-authorization")]
     Challenge,
 }
 
@@ -1652,7 +1651,6 @@ impl From<AuthorizationType> for YamlAuthorizationType {
     fn from(authorization_type: AuthorizationType) -> Self {
         match authorization_type {
             AuthorizationType::Trust => YamlAuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Challenge => YamlAuthorizationType::Challenge,
         }
     }
@@ -1662,7 +1660,6 @@ impl From<YamlAuthorizationType> for AuthorizationType {
     fn from(yaml_authorization_type: YamlAuthorizationType) -> Self {
         match yaml_authorization_type {
             YamlAuthorizationType::Trust => AuthorizationType::Trust,
-            #[cfg(feature = "challenge-authorization")]
             YamlAuthorizationType::Challenge => AuthorizationType::Challenge,
         }
     }

--- a/libsplinter/src/admin/token/mod.rs
+++ b/libsplinter/src/admin/token/mod.rs
@@ -32,10 +32,7 @@ pub struct PeerNode {
 }
 
 pub trait PeerAuthorizationTokenReader {
-    fn list_tokens(
-        &self,
-        #[cfg(feature = "challenge-authorization")] local_node: &str,
-    ) -> Result<Vec<PeerTokenPair>, InvalidStateError>;
+    fn list_tokens(&self, local_node: &str) -> Result<Vec<PeerTokenPair>, InvalidStateError>;
 
     fn list_nodes(&self) -> Result<Vec<PeerNode>, InvalidStateError>;
 

--- a/libsplinter/src/admin/token/token_protobuf.rs
+++ b/libsplinter/src/admin/token/token_protobuf.rs
@@ -19,11 +19,7 @@ use crate::protos::admin::{Circuit, Circuit_AuthorizationType};
 use super::{admin_service_id, PeerAuthorizationTokenReader, PeerNode};
 
 impl PeerAuthorizationTokenReader for Circuit {
-    fn list_tokens(
-        &self,
-        #[cfg(feature = "challenge-authorization")] local_node: &str,
-    ) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
-        #[cfg(feature = "challenge-authorization")]
+    fn list_tokens(&self, local_node: &str) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
         let local_required_auth = self.get_node_token(local_node)?.ok_or_else(|| {
             InvalidStateError::with_message(format!(
                 "Requested local node {} does not exist in the circuit",
@@ -36,10 +32,8 @@ impl PeerAuthorizationTokenReader for Circuit {
             .map(|member| match self.get_authorization_type() {
                 Circuit_AuthorizationType::TRUST_AUTHORIZATION => Ok(PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id(member.get_node_id()),
-                    #[cfg(feature = "challenge-authorization")]
                     local_required_auth.clone(),
                 )),
-                #[cfg(feature = "challenge-authorization")]
                 Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                     if !member.get_public_key().is_empty() {
                         Ok(PeerTokenPair::new(
@@ -72,7 +66,6 @@ impl PeerAuthorizationTokenReader for Circuit {
                     endpoints: member.get_endpoints().to_vec(),
                     admin_service: admin_service_id(member.get_node_id()),
                 }),
-                #[cfg(feature = "challenge-authorization")]
                 Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                     if !member.get_public_key().is_empty() {
                         Ok(PeerNode {
@@ -110,7 +103,6 @@ impl PeerAuthorizationTokenReader for Circuit {
                 Circuit_AuthorizationType::TRUST_AUTHORIZATION => Ok(Some(
                     PeerAuthorizationToken::from_peer_id(member.get_node_id()),
                 )),
-                #[cfg(feature = "challenge-authorization")]
                 Circuit_AuthorizationType::CHALLENGE_AUTHORIZATION => {
                     if !member.get_public_key().is_empty() {
                         Ok(Some(PeerAuthorizationToken::from_public_key(

--- a/libsplinter/src/admin/token/token_protocol.rs
+++ b/libsplinter/src/admin/token/token_protocol.rs
@@ -19,11 +19,7 @@ use crate::peer::{PeerAuthorizationToken, PeerTokenPair};
 use super::{admin_service_id, PeerAuthorizationTokenReader, PeerNode};
 
 impl PeerAuthorizationTokenReader for ProposedCircuit {
-    fn list_tokens(
-        &self,
-        #[cfg(feature = "challenge-authorization")] local_node: &str,
-    ) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
-        #[cfg(feature = "challenge-authorization")]
+    fn list_tokens(&self, local_node: &str) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
         let local_required_auth = self.get_node_token(local_node)?.ok_or_else(|| {
             InvalidStateError::with_message(format!(
                 "Requested local node {} does not exist in the circuit",
@@ -36,10 +32,8 @@ impl PeerAuthorizationTokenReader for ProposedCircuit {
             .map(|member| match self.authorization_type() {
                 AuthorizationType::Trust => Ok(PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id(member.node_id()),
-                    #[cfg(feature = "challenge-authorization")]
                     local_required_auth.clone(),
                 )),
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(PeerTokenPair::new(
@@ -68,7 +62,6 @@ impl PeerAuthorizationTokenReader for ProposedCircuit {
                     endpoints: member.endpoints().to_vec(),
                     admin_service: admin_service_id(member.node_id()),
                 }),
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(PeerNode {
@@ -102,7 +95,6 @@ impl PeerAuthorizationTokenReader for ProposedCircuit {
                 AuthorizationType::Trust => {
                     Ok(Some(PeerAuthorizationToken::from_peer_id(member.node_id())))
                 }
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(Some(PeerAuthorizationToken::from_public_key(public_key)))
@@ -119,11 +111,7 @@ impl PeerAuthorizationTokenReader for ProposedCircuit {
 }
 
 impl PeerAuthorizationTokenReader for Circuit {
-    fn list_tokens(
-        &self,
-        #[cfg(feature = "challenge-authorization")] local_node: &str,
-    ) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
-        #[cfg(feature = "challenge-authorization")]
+    fn list_tokens(&self, local_node: &str) -> Result<Vec<PeerTokenPair>, InvalidStateError> {
         let local_required_auth = self.get_node_token(local_node)?.ok_or_else(|| {
             InvalidStateError::with_message(format!(
                 "Requested local node {} does not exist in the circuit",
@@ -136,10 +124,8 @@ impl PeerAuthorizationTokenReader for Circuit {
             .map(|member| match self.authorization_type() {
                 AuthorizationType::Trust => Ok(PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id(member.node_id()),
-                    #[cfg(feature = "challenge-authorization")]
                     local_required_auth.clone(),
                 )),
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(PeerTokenPair::new(
@@ -168,7 +154,6 @@ impl PeerAuthorizationTokenReader for Circuit {
                     endpoints: member.endpoints().to_vec(),
                     admin_service: admin_service_id(member.node_id()),
                 }),
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(PeerNode {
@@ -202,7 +187,6 @@ impl PeerAuthorizationTokenReader for Circuit {
                 AuthorizationType::Trust => {
                     Ok(Some(PeerAuthorizationToken::from_peer_id(member.node_id())))
                 }
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Challenge => {
                     if let Some(public_key) = member.public_key() {
                         Ok(Some(PeerAuthorizationToken::from_public_key(public_key)))

--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -105,7 +105,6 @@ impl ServiceInstances for RoutingTableServiceInstances {
 
         service.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id(&component_id),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id(&self.node_id),
         ));
 
@@ -153,7 +152,6 @@ impl ServiceInstances for RoutingTableServiceInstances {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "challenge-authorization")]
     use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
@@ -226,7 +224,6 @@ mod tests {
             .expect("Missing service");
         service.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
 
@@ -277,7 +274,6 @@ mod tests {
                 .peer_id(),
             &Some(PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("my_component"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ))
         );
@@ -330,7 +326,6 @@ mod tests {
             .expect("Missing service");
         service.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
 
@@ -354,18 +349,8 @@ mod tests {
     }
 
     fn build_circuit() -> (Circuit, Vec<CircuitNode>) {
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -385,7 +370,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -90,7 +90,6 @@ impl Handler for CircuitErrorHandler {
                         .get_peer_auth_token(circuit.authorization_type())
                         .map_err(|err| DispatchError::HandleError(err.to_string()))?;
 
-                    #[cfg(feature = "challenge-authorization")]
                     let local_peer_id = self
                         .routing_table
                         .get_node(&self.node_id)
@@ -104,11 +103,7 @@ impl Handler for CircuitErrorHandler {
                         .get_peer_auth_token(circuit.authorization_type())
                         .map_err(|err| DispatchError::HandleError(err.to_string()))?;
 
-                    PeerTokenPair::new(
-                        peer_id,
-                        #[cfg(feature = "challenge-authorization")]
-                        local_peer_id,
-                    )
+                    PeerTokenPair::new(peer_id, local_peer_id)
                 }
             }
             None => {
@@ -155,7 +150,6 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
-    #[cfg(feature = "challenge-authorization")]
     use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
@@ -177,18 +171,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -208,7 +192,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -224,12 +207,10 @@ mod tests {
         let def_id = ServiceId::new("alpha".into(), "def".into());
         service_abc.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
         service_def.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("345"),
         ));
         writer.add_service(abc_id, service_abc).unwrap();
@@ -253,7 +234,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("345"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -268,7 +248,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
@@ -297,18 +276,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -328,7 +297,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -344,12 +312,10 @@ mod tests {
         let def_id = ServiceId::new("alpha".into(), "def".into());
         service_abc.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
         service_def.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("345"),
         ));
 
@@ -374,7 +340,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("568"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -389,7 +354,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("345"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
@@ -434,7 +398,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -452,7 +415,6 @@ mod tests {
             .send(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),

--- a/libsplinter/src/circuit/handlers/circuit_message.rs
+++ b/libsplinter/src/circuit/handlers/circuit_message.rs
@@ -116,7 +116,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("PEER"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -128,7 +128,6 @@ impl Handler for CircuitDirectMessageHandler {
                                     .get_peer_auth_token(circuit.authorization_type())
                                     .map_err(|err| DispatchError::HandleError(err.to_string()))?;
 
-                                #[cfg(feature = "challenge-authorization")]
                                 let local_peer_id = self
                                     .routing_table
                                     .get_node(&self.node_id)
@@ -142,11 +141,7 @@ impl Handler for CircuitDirectMessageHandler {
                                     .get_peer_auth_token(circuit.authorization_type())
                                     .map_err(|err| DispatchError::HandleError(err.to_string()))?;
 
-                                PeerTokenPair::new(
-                                    peer_id,
-                                    #[cfg(feature = "challenge-authorization")]
-                                    local_peer_id,
-                                )
+                                PeerTokenPair::new(peer_id, local_peer_id)
                             }
                             .into();
 
@@ -243,7 +238,6 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
-    #[cfg(feature = "challenge-authorization")]
     use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
@@ -265,18 +259,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -293,12 +277,10 @@ mod tests {
 
         service_abc.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
         service_def.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("345"),
         ));
 
@@ -307,7 +289,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -337,7 +318,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -352,7 +332,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
@@ -378,18 +357,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -406,12 +375,10 @@ mod tests {
 
         service_abc.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
         service_def.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("345"),
         ));
 
@@ -420,7 +387,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -451,7 +417,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -466,7 +431,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("123"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("345"),
             ),
             CircuitMessageType::CIRCUIT_DIRECT_MESSAGE,
@@ -491,18 +455,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_abc = Service::new(
             "abc".to_string(),
@@ -513,7 +467,6 @@ mod tests {
 
         service_abc.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("123"),
         ));
 
@@ -522,7 +475,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -553,7 +505,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -568,7 +519,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("def"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("345"),
             ),
             CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
@@ -594,18 +544,8 @@ mod tests {
         let reader: Box<dyn RoutingTableReader> = Box::new(table.clone());
         let mut writer: Box<dyn RoutingTableWriter> = Box::new(table.clone());
 
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let mut service_def = Service::new(
             "def".to_string(),
@@ -616,7 +556,6 @@ mod tests {
 
         service_def.set_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
-            #[cfg(feature = "challenge-authorization")]
             PeerAuthorizationToken::from_peer_id("345"),
         ));
 
@@ -625,7 +564,6 @@ mod tests {
             "alpha".into(),
             vec![service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 
@@ -655,7 +593,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -670,7 +607,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("def"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("345"),
             ),
             CircuitMessageType::CIRCUIT_ERROR_MESSAGE,
@@ -713,7 +649,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("def"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("345"),
                 )
                 .into(),
@@ -728,7 +663,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("def"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("345"),
             ),
             CircuitMessageType::CIRCUIT_ERROR_MESSAGE,

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -286,7 +286,6 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
-    #[cfg(feature = "challenge-authorization")]
     use crate::circuit::routing::AuthorizationType;
     use crate::circuit::routing::{
         memory::RoutingTable, Circuit, CircuitNode, RoutingTableWriter, Service,
@@ -320,7 +319,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -335,7 +333,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
@@ -379,7 +376,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("BAD"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -394,7 +390,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("BAD"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
@@ -437,7 +432,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -455,7 +449,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
@@ -492,7 +485,6 @@ mod tests {
         service.set_peer_id(
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             )
             .into(),
@@ -513,7 +505,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -528,7 +519,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_CONNECT_RESPONSE,
@@ -566,7 +556,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -581,7 +570,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
@@ -626,7 +614,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("BAD"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -641,7 +628,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("BAD"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
@@ -681,7 +667,6 @@ mod tests {
         service.set_peer_id(
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             )
             .into(),
@@ -702,7 +687,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -717,7 +701,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
@@ -758,7 +741,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("abc"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("123"),
                 )
                 .into(),
@@ -773,7 +755,6 @@ mod tests {
             id.into(),
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("123"),
             ),
             CircuitMessageType::SERVICE_DISCONNECT_RESPONSE,
@@ -789,18 +770,8 @@ mod tests {
     }
 
     fn build_circuit() -> (Circuit, Vec<CircuitNode>) {
-        let node_123 = CircuitNode::new(
-            "123".to_string(),
-            vec!["123.0.0.1:0".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
-        let node_345 = CircuitNode::new(
-            "345".to_string(),
-            vec!["123.0.0.1:1".to_string()],
-            #[cfg(feature = "challenge-authorization")]
-            None,
-        );
+        let node_123 = CircuitNode::new("123".to_string(), vec!["123.0.0.1:0".to_string()], None);
+        let node_345 = CircuitNode::new("345".to_string(), vec!["123.0.0.1:1".to_string()], None);
 
         let service_abc = Service::new(
             "abc".to_string(),
@@ -820,7 +791,6 @@ mod tests {
             "alpha".into(),
             vec![service_abc.clone(), service_def.clone()],
             vec!["123".into(), "345".into()],
-            #[cfg(feature = "challenge-authorization")]
             AuthorizationType::Trust,
         );
 

--- a/libsplinter/src/circuit/routing/memory/mod.rs
+++ b/libsplinter/src/circuit/routing/memory/mod.rs
@@ -26,7 +26,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
 use super::error::RoutingTableReaderError;
-#[cfg(feature = "challenge-authorization")]
 use super::AuthorizationType;
 use super::{
     Circuit, CircuitIter, CircuitNode, CircuitNodeIter, RoutingTableReader, RoutingTableWriter,
@@ -179,7 +178,6 @@ impl RoutingTableReader for RoutingTable {
                 ADMIN_CIRCUIT_ID.to_string(),
                 vec![],
                 vec![],
-                #[cfg(feature = "challenge-authorization")]
                 AuthorizationType::Trust,
             )))
         } else {

--- a/libsplinter/src/hex.rs
+++ b/libsplinter/src/hex.rs
@@ -29,7 +29,6 @@ pub fn to_hex(bytes: &[u8]) -> String {
     buf
 }
 
-#[cfg(any(feature = "admin-service", feature = "challenge-authorization"))]
 pub fn parse_hex(hex: &str) -> Result<Vec<u8>, HexError> {
     if hex.len() % 2 != 0 {
         return Err(HexError {

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -91,7 +91,6 @@ pub mod orchestrator;
 pub mod peer;
 pub mod protocol;
 pub mod protos;
-#[cfg(feature = "challenge-authorization")]
 pub mod public_key;
 #[cfg(feature = "registry")]
 pub mod registry;

--- a/libsplinter/src/network/auth/connection_manager.rs
+++ b/libsplinter/src/network/auth/connection_manager.rs
@@ -17,7 +17,6 @@ use crate::network::connection_manager::{
 };
 use crate::transport::Connection;
 
-#[cfg(feature = "challenge-authorization")]
 use super::ConnectionAuthorizationType;
 use super::{AuthorizationConnector, AuthorizationManagerError, ConnectionAuthorizationState};
 
@@ -27,19 +26,13 @@ impl Authorizer for AuthorizationConnector {
         connection_id: String,
         connection: Box<dyn Connection>,
         callback: AuthorizerCallback,
-        #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
-            ConnectionAuthorizationType,
-        >,
-        #[cfg(feature = "challenge-authorization")] local_authorization: Option<
-            ConnectionAuthorizationType,
-        >,
+        expected_authorization: Option<ConnectionAuthorizationType>,
+        local_authorization: Option<ConnectionAuthorizationType>,
     ) -> Result<(), AuthorizerError> {
         self.add_connection(
             connection_id,
             connection,
-            #[cfg(feature = "challenge-authorization")]
             expected_authorization,
-            #[cfg(feature = "challenge-authorization")]
             local_authorization,
             Box::new(move |state| (*callback)(state.into())),
         )
@@ -54,17 +47,13 @@ impl From<ConnectionAuthorizationState> for AuthorizationResult {
                 connection_id,
                 connection,
                 identity,
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization,
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization,
             } => AuthorizationResult::Authorized {
                 connection_id,
                 connection,
                 identity,
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization,
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization,
             },
 

--- a/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
@@ -516,7 +516,10 @@ mod tests {
     use cylinder::{PublicKey, Signature, VerificationError, Verifier};
     use protobuf::Message;
 
-    use crate::network::auth::{AuthorizationDispatchBuilder, Identity, ManagedAuthorizationState};
+    use crate::network::auth::AuthorizationDispatchBuilder;
+    #[cfg(feature = "challenge-authorization")]
+    use crate::network::auth::Identity;
+    use crate::network::auth::ManagedAuthorizationState;
     use crate::protocol::authorization::AuthComplete;
     use crate::protos::network::NetworkMessageType;
     use crate::protos::{authorization, network};

--- a/libsplinter/src/network/connection_manager/builder.rs
+++ b/libsplinter/src/network/connection_manager/builder.rs
@@ -222,17 +222,13 @@ fn handle_request<T: ConnectionMatrixLifeCycle, U: ConnectionMatrixSender>(
             endpoint,
             sender,
             connection_id,
-            #[cfg(feature = "challenge-authorization")]
             expected_authorization,
-            #[cfg(feature = "challenge-authorization")]
             local_authorization,
         } => state.add_outbound_connection(
             OutboundConnection {
                 endpoint,
                 connection_id,
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization,
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization,
             },
             sender,

--- a/libsplinter/src/network/connection_manager/notification.rs
+++ b/libsplinter/src/network/connection_manager/notification.rs
@@ -23,7 +23,6 @@ pub enum ConnectionManagerNotification {
         endpoint: String,
         connection_id: String,
         identity: ConnectionAuthorizationType,
-        #[cfg(feature = "challenge-authorization")]
         local_identity: ConnectionAuthorizationType,
     },
     FatalConnectionError {
@@ -35,7 +34,6 @@ pub enum ConnectionManagerNotification {
         endpoint: String,
         connection_id: String,
         identity: ConnectionAuthorizationType,
-        #[cfg(feature = "challenge-authorization")]
         local_identity: ConnectionAuthorizationType,
     },
     Disconnected {

--- a/libsplinter/src/network/dispatch/mod.rs
+++ b/libsplinter/src/network/dispatch/mod.rs
@@ -430,7 +430,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("TestPeer").into(),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("MyID").into(),
                 )
                 .into(),
@@ -472,7 +471,6 @@ mod tests {
                 .dispatch(
                     PeerTokenPair::new(
                         PeerAuthorizationToken::from_peer_id("TestPeer"),
-                        #[cfg(feature = "challenge-authorization")]
                         PeerAuthorizationToken::from_peer_id("MyID"),
                     )
                     .into(),

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -50,7 +50,6 @@ impl Handler for NetworkEchoHandler {
                 // authorization
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id(&echo_message.recipient),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id(&self.node_id),
                 )
                 .into()
@@ -150,7 +149,6 @@ mod tests {
             .dispatch(
                 PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("OTHER_PEER").into(),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("TestPeer").into(),
                 )
                 .into(),

--- a/libsplinter/src/peer/connector.rs
+++ b/libsplinter/src/peer/connector.rs
@@ -82,14 +82,13 @@ impl PeerManagerConnector {
         &self,
         peer_id: PeerAuthorizationToken,
         endpoints: Vec<String>,
-        #[cfg(feature = "challenge-authorization")] required_local_auth: PeerAuthorizationToken,
+        required_local_auth: PeerAuthorizationToken,
     ) -> Result<PeerRef, PeerRefAddError> {
         let (sender, recv) = channel();
 
         let message = PeerManagerMessage::Request(PeerManagerRequest::AddPeer {
             peer_id,
             endpoints,
-            #[cfg(feature = "challenge-authorization")]
             required_local_auth,
             sender,
         });
@@ -120,13 +119,12 @@ impl PeerManagerConnector {
     pub fn add_unidentified_peer(
         &self,
         endpoint: String,
-        #[cfg(feature = "challenge-authorization")] local_authorization: PeerAuthorizationToken,
+        local_authorization: PeerAuthorizationToken,
     ) -> Result<EndpointPeerRef, PeerUnknownAddError> {
         let (sender, recv) = channel();
 
         let message = PeerManagerMessage::Request(PeerManagerRequest::AddUnidentified {
             endpoint,
-            #[cfg(feature = "challenge-authorization")]
             local_authorization,
             sender,
         });

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -793,7 +793,6 @@ pub mod tests {
             .add_peer_ref(
                 PeerAuthorizationToken::from_peer_id("test_peer"),
                 vec!["test".to_string()],
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("my_id"),
             )
             .expect("Unable to add peer");
@@ -802,7 +801,6 @@ pub mod tests {
             peer_ref.peer_id(),
             &PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("test_peer"),
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::from_peer_id("my_id"),
             )
         );
@@ -817,7 +815,6 @@ pub mod tests {
             PeerManagerNotification::Connected {
                 peer: PeerTokenPair::new(
                     PeerAuthorizationToken::from_peer_id("test_peer"),
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::from_peer_id("my_id"),
                 )
             }
@@ -940,7 +937,6 @@ pub mod tests {
                     message_context.source_peer_id(),
                     &PeerTokenPair::new(
                         PeerAuthorizationToken::from_peer_id("test_peer"),
-                        #[cfg(feature = "challenge-authorization")]
                         PeerAuthorizationToken::from_peer_id("my_id"),
                     )
                     .into()
@@ -992,12 +988,8 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
-            #[cfg(feature = "challenge-authorization")] expected_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
-            #[cfg(feature = "challenge-authorization")] local_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
+            expected_authorization: Option<ConnectionAuthorizationType>,
+            local_authorization: Option<ConnectionAuthorizationType>,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -1005,9 +997,7 @@ pub mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization: expected_authorization.unwrap(),
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization: local_authorization.unwrap(),
             })
             .map_err(|err| AuthorizerError(format!("Unable to return result: {}", err)))

--- a/libsplinter/src/peer/notification.rs
+++ b/libsplinter/src/peer/notification.rs
@@ -184,7 +184,6 @@ pub mod tests {
                         PeerAuthorizationToken::Trust {
                             peer_id: format!("test_peer{}", i),
                         },
-                        #[cfg(feature = "challenge-authorization")]
                         PeerAuthorizationToken::Trust {
                             peer_id: "local".into(),
                         },
@@ -203,7 +202,6 @@ pub mod tests {
                         PeerAuthorizationToken::Trust {
                             peer_id: format!("test_peer{}", notifications_sent),
                         },
-                        #[cfg(feature = "challenge-authorization")]
                         PeerAuthorizationToken::Trust {
                             peer_id: "local".into(),
                         },
@@ -240,7 +238,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: format!("test_peer_{}", i),
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into(),
                     },
@@ -260,7 +257,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_0".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -274,7 +270,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_1".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -288,7 +283,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_2".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -311,7 +305,6 @@ pub mod tests {
                 PeerAuthorizationToken::Trust {
                     peer_id: "test_peer_3".into(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::Trust {
                     peer_id: "local".into(),
                 },
@@ -325,7 +318,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_3".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -339,7 +331,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_3".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -369,7 +360,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: format!("test_peer_{}", i),
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into(),
                     },
@@ -389,7 +379,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_2".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -406,7 +395,6 @@ pub mod tests {
                 PeerAuthorizationToken::Trust {
                     peer_id: "test_peer_3".into(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::Trust {
                     peer_id: "local".into(),
                 },
@@ -417,7 +405,6 @@ pub mod tests {
                 PeerAuthorizationToken::Trust {
                     peer_id: "test_peer_4".into(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 PeerAuthorizationToken::Trust {
                     peer_id: "local".into(),
                 },
@@ -431,7 +418,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_3".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },
@@ -445,7 +431,6 @@ pub mod tests {
                     PeerAuthorizationToken::Trust {
                         peer_id: "test_peer_4".into()
                     },
-                    #[cfg(feature = "challenge-authorization")]
                     PeerAuthorizationToken::Trust {
                         peer_id: "local".into()
                     },

--- a/libsplinter/src/peer/unreferenced.rs
+++ b/libsplinter/src/peer/unreferenced.rs
@@ -17,7 +17,6 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
-#[cfg(feature = "challenge-authorization")]
 use super::PeerAuthorizationToken;
 use super::PeerTokenPair;
 
@@ -27,7 +26,6 @@ use super::PeerTokenPair;
 pub struct UnreferencedPeer {
     pub endpoint: String,
     pub connection_id: String,
-    #[cfg(feature = "challenge-authorization")]
     pub local_authorization: PeerAuthorizationToken,
 }
 
@@ -35,7 +33,6 @@ pub struct UnreferencedPeer {
 #[derive(Debug)]
 pub struct RequestedEndpoint {
     pub endpoint: String,
-    #[cfg(feature = "challenge-authorization")]
     pub local_authorization: PeerAuthorizationToken,
 }
 

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -102,7 +102,6 @@ pub trait ServiceNetworkSender: Send {
 
     /// Send the message bytes to the given recipient (another service) with a configurable
     /// message sender
-    #[cfg(feature = "challenge-authorization")]
     fn send_with_sender(
         &mut self,
         recipient: &str,

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -738,12 +738,8 @@ pub mod tests {
             callback: Box<
                 dyn Fn(AuthorizationResult) -> Result<(), Box<dyn std::error::Error>> + Send,
             >,
-            #[cfg(feature = "challenge-authorization")] _expected_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
-            #[cfg(feature = "challenge-authorization")] _local_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
+            _expected_authorization: Option<ConnectionAuthorizationType>,
+            _local_authorization: Option<ConnectionAuthorizationType>,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -751,11 +747,9 @@ pub mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization: ConnectionAuthorizationType::Trust {
                     identity: "local_id".into(),
                 },

--- a/libsplinter/src/service/network/mod.rs
+++ b/libsplinter/src/service/network/mod.rs
@@ -778,12 +778,8 @@ mod tests {
             connection_id: String,
             connection: Box<dyn Connection>,
             callback: AuthorizerCallback,
-            #[cfg(feature = "challenge-authorization")] _expected_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
-            #[cfg(feature = "challenge-authorization")] _local_authorization: Option<
-                ConnectionAuthorizationType,
-            >,
+            _expected_authorization: Option<ConnectionAuthorizationType>,
+            _local_authorization: Option<ConnectionAuthorizationType>,
         ) -> Result<(), AuthorizerError> {
             (*callback)(AuthorizationResult::Authorized {
                 connection_id,
@@ -791,11 +787,9 @@ mod tests {
                 identity: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 expected_authorization: ConnectionAuthorizationType::Trust {
                     identity: self.authorized_id.clone(),
                 },
-                #[cfg(feature = "challenge-authorization")]
                 local_authorization: ConnectionAuthorizationType::Trust {
                     identity: "local_id".into(),
                 },

--- a/libsplinter/src/service/processor/sender.rs
+++ b/libsplinter/src/service/processor/sender.rs
@@ -147,7 +147,6 @@ impl ServiceNetworkSender for AdminServiceNetworkSender {
 
     /// Send the message bytes to the given recipient (another service) with a configurable
     /// message sender
-    #[cfg(feature = "challenge-authorization")]
     fn send_with_sender(
         &mut self,
         recipient: &str,
@@ -288,7 +287,6 @@ impl ServiceNetworkSender for StandardServiceNetworkSender {
 
     /// Send the message bytes to the given recipient (another service) with a configurable
     /// message sender
-    #[cfg(feature = "challenge-authorization")]
     fn send_with_sender(
         &mut self,
         recipient: &str,

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -559,7 +559,6 @@ mod tests {
             Box::new(self.clone())
         }
 
-        #[cfg(feature = "challenge-authorization")]
         fn send_with_sender(
             &mut self,
             _recipient: &str,

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -775,7 +775,6 @@ pub mod tests {
             Box::new(self.clone())
         }
 
-        #[cfg(feature = "challenge-authorization")]
         fn send_with_sender(
             &mut self,
             _recipient: &str,

--- a/services/scabbard/libscabbard/src/service/shared.rs
+++ b/services/scabbard/libscabbard/src/service/shared.rs
@@ -412,7 +412,6 @@ mod tests {
             Box::new(self.clone())
         }
 
-        #[cfg(feature = "challenge-authorization")]
         fn send_with_sender(
             &mut self,
             _recipient: &str,


### PR DESCRIPTION
This commit does not change the Cargo.toml and
challenge-authorization still guards the authorization
code for challenge authorization.

The guards around the API changes are removed, making them
a part of the public API. Includes some changes to deal with
the feature removal.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>