### PR TITLE
Enfroce protocol version is valid for proposal during vote

### DIFF
--- a/libsplinter/src/admin/service/consensus.rs
+++ b/libsplinter/src/admin/service/consensus.rs
@@ -253,6 +253,7 @@ impl ProposalManager for AdminProposalManager {
         } else {
             self.proposal_update_sender
                 .send(ProposalUpdate::ProposalCreated(None))?;
+            shared.cleanup_held_peer_refs();
         }
 
         Ok(())

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -17,6 +17,7 @@ use std::convert::{TryFrom, TryInto};
 use std::iter::ExactSizeIterator;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use cylinder::{PublicKey, Signature, Verifier as SignatureVerifier};
 use protobuf::{Message, RepeatedField};
@@ -64,6 +65,7 @@ static VOTER_ROLE: &str = "voter";
 static PROPOSER_ROLE: &str = "proposer";
 #[cfg(feature = "challenge-authorization")]
 const ADMIN_SERVICE_PUBLIC_KEY_PREFIX: &str = "public_key";
+const DEFAULT_HOLD_PEER_SECS: u64 = 10;
 
 pub enum PayloadType {
     Circuit(CircuitManagementPayload),
@@ -159,6 +161,9 @@ pub struct AdminServiceShared {
     #[cfg(feature = "challenge-authorization")]
     public_keys: Vec<public_key::PublicKey>,
     token_to_peer: HashMap<PeerTokenPair, PeerNodePair>,
+    // Temporarily hold on to peers that should be removed. This helps avoid dropping messages
+    // when removing a proposal.
+    peers_to_be_removed: Vec<(Instant, Vec<PeerTokenPair>)>,
 }
 
 impl AdminServiceShared {
@@ -207,6 +212,7 @@ impl AdminServiceShared {
             #[cfg(feature = "challenge-authorization")]
             public_keys,
             token_to_peer: HashMap::new(),
+            peers_to_be_removed: Vec::new(),
         }
     }
 
@@ -316,6 +322,23 @@ impl AdminServiceShared {
                     self.service_protocols.remove(&peer_id);
                 }
             }
+        }
+    }
+
+    /// Remove the peers who have been held onto for the default holding time. In some cases
+    /// peers should not be removed when a proposal is removed because it can cause messages to be
+    /// dropped. Instead, the will be dropped after 10 seconds or when the cleanlup_help_peer_refs
+    /// function is called.
+    pub fn cleanup_held_peer_refs(&mut self) {
+        let peers_to_be_removed = std::mem::take(&mut self.peers_to_be_removed);
+        let (to_clean, pending) = peers_to_be_removed
+            .into_iter()
+            .partition(|(instant, _)| instant.elapsed().as_secs() > DEFAULT_HOLD_PEER_SECS);
+
+        self.peers_to_be_removed = pending;
+
+        for (_, peers) in to_clean {
+            self.remove_peer_refs(peers);
         }
     }
 
@@ -615,7 +638,8 @@ impl AdminServiceShared {
                         let proposal = self.remove_proposal(circuit_id)?;
                         self.update_metrics()?;
                         if let Some(proposal) = proposal {
-                            self.remove_peer_refs(
+                            self.peers_to_be_removed.push((
+                                Instant::now(),
                                 proposal
                                     .circuit()
                                     .list_tokens(
@@ -629,7 +653,7 @@ impl AdminServiceShared {
                                             err
                                         ))
                                     })?,
-                            );
+                            ));
                         }
                         let circuit_proposal_proto =
                             messages::CircuitProposal::from_proto(circuit_proposal.clone())
@@ -665,6 +689,7 @@ impl AdminServiceShared {
         &mut self,
         mut circuit_payload: CircuitManagementPayload,
     ) -> Result<(String, CircuitProposal), AdminSharedError> {
+        self.cleanup_held_peer_refs();
         let header = Message::parse_from_bytes(circuit_payload.get_header())
             .map_err(MarshallingError::from)?;
         self.validate_circuit_management_payload(&circuit_payload, &header)?;

--- a/splinterd/tests/admin/circuit_disband.rs
+++ b/splinterd/tests/admin/circuit_disband.rs
@@ -195,7 +195,6 @@ pub fn test_2_party_circuit_lifecycle() {
 /// 8. Validate the active circuit is still available to each node, using `list_circuits` which
 ///    only returns active circuits
 #[test]
-#[ignore]
 pub fn test_2_party_circuit_disband_proposal_rejected() {
     // Start a 2-node network
     let mut network = Network::new()
@@ -539,7 +538,6 @@ pub fn test_3_party_circuit_lifecycle() {
 /// 11. Validate the circuit is still active for each node, using `list_circuits` which only returns
 ///     active circuits
 #[test]
-#[ignore]
 pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
     // Start a 3-node network
     let mut network = Network::new()
@@ -553,7 +551,7 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
     let node_b_admin_pubkey = admin_pubkey(node_b);
     // Get the third node in the network
     let node_c = network.node(2).expect("Unable to get third node");
-    let node_c_admin_pubkey = admin_pubkey(node_b);
+    let node_c_admin_pubkey = admin_pubkey(node_c);
 
     let circuit_id = "ABCDE-01234";
     commit_3_party_circuit(circuit_id, node_a, node_b, node_c, AuthorizationType::Trust);
@@ -596,7 +594,7 @@ pub fn test_3_party_circuit_lifecycle_proposal_rejected() {
     // Wait for the proposal event from each node.
     let proposal_a_event = node_a_events.next().expect("Unable to get next event");
     let proposal_b_event = node_b_events.next().expect("Unable to get next event");
-    let proposal_c_event = node_b_events.next().expect("Unable to get next event");
+    let proposal_c_event = node_c_events.next().expect("Unable to get next event");
 
     assert_eq!(&EventType::ProposalSubmitted, proposal_a_event.event_type());
     assert_eq!(&EventType::ProposalSubmitted, proposal_b_event.event_type());


### PR DESCRIPTION
It is possible that a proposal could have been stored in state
and when a vote has been received the agreed upon protocol
version has changed. This is possible due to node restarts/upgrades.

If the agreed upon protocol no longer supports the proposal,
the vote is rejected. The proposal is also rejected. 

To support rejecting the proposal , the peers are moved into a temporary vec,
that includes an Instant for when they are added to the list.
After 10 seconds, the peers can be dropped. This is triggered by
either propose_change or create_proposal, both functions being
called by consensus. This ensures that the peers are not
dropped until the proposal has been handled. This also enables
the integration test that test rejecting a proposal.
