### PR TITLE
Sqlite migrations check error type

### DIFF
--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -40,10 +40,15 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
             .write(true)
             .open(&connection_string)
         {
-            return Err(CliError::ActionError(format!(
-                "While opening: {} received {}",
-                &connection_string, err
-            )));
+            match err.kind() {
+                std::io::ErrorKind::NotFound => (),
+                _ => {
+                    return Err(CliError::ActionError(format!(
+                        "While opening: {} received {}",
+                        &connection_string, err
+                    )))
+                }
+            }
         }
     }
     let connection_manager = ConnectionManager::<SqliteConnection>::new(&connection_string);


### PR DESCRIPTION
The `sqlite_migrations` method has check that will return an error if
the file being used for the splinter state database does not exist.
However if the file does not exist it will be created later by sqlite
and therefore no error should be returned in this situation. This
commit adds a match statement to this check that will ensure an error
is not returned if the error type is `std::io::ErrorKind::NotFound`.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>