### PR TITLE
scabbard db upgrade

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ features = ["admin-service", "registry"]
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"
-features = ["commit-store", "postgres", "sqlite"]
+features = ["commit-store", "postgres", "sqlite", "lmdb"]
 optional = true
 
 [dependencies.transact]

--- a/cli/src/action/database/upgrade/error.rs
+++ b/cli/src/action/database/upgrade/error.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use splinter::error::{InternalError, InvalidStateError};
+
+#[derive(Debug)]
+pub enum UpgradeError {
+    Internal(InternalError),
+    InvalidState(InvalidStateError),
+}
+
+impl fmt::Display for UpgradeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Internal(e) => f.write_str(&e.to_string()),
+            Self::InvalidState(e) => f.write_str(&e.to_string()),
+        }
+    }
+}
+
+impl Error for UpgradeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Internal(e) => Some(e),
+            Self::InvalidState(e) => Some(e),
+        }
+    }
+}
+
+impl From<InternalError> for UpgradeError {
+    fn from(e: InternalError) -> Self {
+        UpgradeError::Internal(e)
+    }
+}
+
+impl From<InvalidStateError> for UpgradeError {
+    fn from(e: InvalidStateError) -> Self {
+        UpgradeError::InvalidState(e)
+    }
+}

--- a/cli/src/action/database/upgrade/mod.rs
+++ b/cli/src/action/database/upgrade/mod.rs
@@ -57,7 +57,7 @@ impl Action for UpgradeAction {
         info!("Destination database uri: {}", database_uri);
         info!("Loading YAML datastore... ");
         let db_store = store_factory.get_admin_service_store();
-        yaml::import_yaml_state_to_database(state_dir, &*db_store)?;
+        yaml::import_yaml_state_to_database(state_dir.as_path(), &*db_store)?;
         Ok(())
     }
 }

--- a/cli/src/action/database/upgrade/mod.rs
+++ b/cli/src/action/database/upgrade/mod.rs
@@ -14,8 +14,12 @@
 
 //! Provides database upgrade functionality
 
+#[cfg(feature = "scabbard-migrations")]
+mod error;
 #[cfg(feature = "node-id-upgrade")]
 mod node_id;
+#[cfg(feature = "scabbard-migrations")]
+mod scabbard;
 mod yaml;
 
 use std::path::PathBuf;
@@ -58,6 +62,18 @@ impl Action for UpgradeAction {
         info!("Loading YAML datastore... ");
         let db_store = store_factory.get_admin_service_store();
         yaml::import_yaml_state_to_database(state_dir.as_path(), &*db_store)?;
+
+        #[cfg(feature = "scabbard-migrations")]
+        {
+            scabbard::upgrade_scabbard_commit_hash_state(state_dir.as_path(), &database_uri)
+                .map_err(|err| {
+                    CliError::ActionError(format!(
+                        "failed to upgrade scabbard commit hash state: {}",
+                        err
+                    ))
+                })?;
+        }
+
         Ok(())
     }
 }

--- a/cli/src/action/database/upgrade/scabbard.rs
+++ b/cli/src/action/database/upgrade/scabbard.rs
@@ -1,0 +1,216 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides scabbard state upgrade functionality
+
+use std::path::Path;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+use scabbard::store::{
+    diesel::DieselCommitHashStore,
+    transact::{factory::LmdbDatabaseFactory, TransactCommitHashStore},
+    CommitHashStore,
+};
+use splinter::{
+    admin::store::{diesel::DieselAdminServiceStore, AdminServiceStore},
+    error::InternalError,
+    node_id::store::{diesel::DieselNodeIdStore, NodeIdStore},
+    store::ConnectionUri,
+};
+
+use super::error::UpgradeError;
+
+/// Migrate all of the service state's current commit hashes to the [`CommitHashStore`].
+pub fn upgrade_scabbard_commit_hash_state(
+    state_dir: &Path,
+    database_uri: &ConnectionUri,
+) -> Result<(), UpgradeError> {
+    let lmdb_db_factory = LmdbDatabaseFactory::new_state_db_factory(state_dir, None);
+    let upgrade_stores = new_upgrade_stores(database_uri)?;
+
+    let node_id = if let Some(node_id) = upgrade_stores
+        .new_node_id_store()
+        .get_node_id()
+        .map_err(|e| InternalError::from_source(Box::new(e)))?
+    {
+        node_id
+    } else {
+        // This node has not even set a node id, so it cannot have any circuits.
+        info!("Skipping scabbard commit hash store upgrade, no local node ID found");
+        return Ok(());
+    };
+
+    let circuits = upgrade_stores
+        .new_admin_service_store()
+        .list_circuits(&[])
+        .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+    let local_services = circuits
+        .into_iter()
+        .map(|circuit| {
+            circuit
+                .roster()
+                .iter()
+                .filter_map(|svc| {
+                    if svc.node_id() == node_id && svc.service_type() == "scabbard" {
+                        Some((
+                            circuit.circuit_id().to_string(),
+                            svc.service_id().to_string(),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .flatten();
+
+    for (circuit_id, service_id) in local_services {
+        let lmdb_commit_hash_store =
+            TransactCommitHashStore::new(lmdb_db_factory.get_database(&circuit_id, &service_id)?);
+        let db_commit_hash_store = upgrade_stores.new_commit_hash_store(&circuit_id, &service_id);
+
+        if let Some(current_commit_hash) = lmdb_commit_hash_store
+            .get_current_commit_hash()
+            .map_err(|e| InternalError::from_source(Box::new(e)))?
+        {
+            db_commit_hash_store
+                .set_current_commit_hash(&current_commit_hash)
+                .map_err(|e| InternalError::from_source(Box::new(e)))?;
+            info!("Upgraded scabbard service {}::{}", circuit_id, service_id);
+        } else {
+            debug!(
+                "No commit hash found for service {}::{}",
+                circuit_id, service_id
+            );
+        }
+    }
+
+    Ok(())
+}
+
+trait UpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore>;
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore>;
+
+    fn new_commit_hash_store(&self, circuit_id: &str, service_id: &str)
+        -> Box<dyn CommitHashStore>;
+}
+
+fn new_upgrade_stores(
+    database_uri: &ConnectionUri,
+) -> Result<Box<dyn UpgradeStores>, UpgradeError> {
+    match database_uri {
+        #[cfg(feature = "postgres")]
+        ConnectionUri::Postgres(url) => {
+            let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
+            let pool = Pool::builder().build(connection_manager).map_err(|err| {
+                InternalError::from_source_with_prefix(
+                    Box::new(err),
+                    "Failed to build connection pool".to_string(),
+                )
+            })?;
+            // Test the connection
+            let _conn = pool
+                .get()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            Ok(Box::new(PostgresUpgradeStores(pool)))
+        }
+        #[cfg(feature = "sqlite")]
+        ConnectionUri::Sqlite(conn_str) => {
+            if (conn_str != ":memory:") && !std::path::Path::new(&conn_str).exists() {
+                return Err(UpgradeError::Internal(InternalError::with_message(
+                    format!("Database file '{}' does not exist", conn_str),
+                )));
+            }
+            let connection_manager =
+                ConnectionManager::<diesel::sqlite::SqliteConnection>::new(conn_str);
+            let mut pool_builder = Pool::builder();
+            // A new database is created for each connection to the in-memory SQLite
+            // implementation; to ensure that the resulting stores will operate on the same
+            // database, only one connection is allowed.
+            if conn_str == ":memory:" {
+                pool_builder = pool_builder.max_size(1);
+            }
+            let pool = pool_builder.build(connection_manager).map_err(|err| {
+                InternalError::from_source_with_prefix(
+                    Box::new(err),
+                    "Failed to build connection pool".to_string(),
+                )
+            })?;
+            // Test the connection
+            let _conn = pool
+                .get()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            Ok(Box::new(SqliteUpgradeStores(pool)))
+        }
+        #[cfg(feature = "memory")]
+        _ => Err(UpgradeError::InvalidState(InvalidStateError::with_message(
+            format!("Unsupported database: {}", database_uri),
+        ))),
+    }
+}
+
+#[cfg(feature = "postgres")]
+struct PostgresUpgradeStores(Pool<ConnectionManager<diesel::pg::PgConnection>>);
+
+#[cfg(feature = "postgres")]
+impl UpgradeStores for PostgresUpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
+        Box::new(DieselAdminServiceStore::new(self.0.clone()))
+    }
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
+        Box::new(DieselNodeIdStore::new(self.0.clone()))
+    }
+
+    fn new_commit_hash_store(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+    ) -> Box<dyn CommitHashStore> {
+        Box::new(DieselCommitHashStore::new(
+            self.0.clone(),
+            circuit_id,
+            service_id,
+        ))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+struct SqliteUpgradeStores(Pool<ConnectionManager<diesel::SqliteConnection>>);
+
+#[cfg(feature = "sqlite")]
+impl UpgradeStores for SqliteUpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
+        Box::new(DieselAdminServiceStore::new(self.0.clone()))
+    }
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
+        Box::new(DieselNodeIdStore::new(self.0.clone()))
+    }
+
+    fn new_commit_hash_store(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+    ) -> Box<dyn CommitHashStore> {
+        Box::new(DieselCommitHashStore::new(
+            self.0.clone(),
+            circuit_id,
+            service_id,
+        ))
+    }
+}

--- a/cli/src/action/database/upgrade/yaml.rs
+++ b/cli/src/action/database/upgrade/yaml.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{fmt, fs};
 
 use splinter::admin::store::error::AdminServiceStoreError;
@@ -88,8 +88,8 @@ fn import_store(
 }
 
 /// Import yaml state from the specified directory to a database
-pub fn import_yaml_state_to_database<P: Into<PathBuf>>(
-    state_dir: P,
+pub fn import_yaml_state_to_database(
+    state_dir: &Path,
     db_store: &'_ dyn AdminServiceStore,
 ) -> Result<(), CliError> {
     fn invalid_utf8() -> CliError {

--- a/services/scabbard/libscabbard/src/store/transact/factory.rs
+++ b/services/scabbard/libscabbard/src/store/transact/factory.rs
@@ -1,0 +1,92 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides a factory to produce LMDB database instances.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use openssl::hash::{hash, MessageDigest};
+use splinter::error::InternalError;
+use transact::{
+    database::lmdb::{LmdbContext, LmdbDatabase},
+    state::merkle::INDEXES,
+};
+
+use crate::hex::to_hex;
+
+use super::CURRENT_STATE_ROOT_INDEX;
+
+const DEFAULT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
+
+#[derive(Clone)]
+pub struct LmdbDatabaseFactory {
+    db_dir: Arc<Path>,
+    db_size: usize,
+    db_suffix: Arc<str>,
+
+    indexes: Arc<[&'static str]>,
+
+    databases: Arc<Mutex<HashMap<Box<str>, LmdbDatabase>>>,
+}
+
+impl LmdbDatabaseFactory {
+    pub fn new_state_db_factory(db_dir: &Path, db_size: Option<usize>) -> Self {
+        let mut indexes = INDEXES.to_vec();
+        indexes.push(CURRENT_STATE_ROOT_INDEX);
+        Self {
+            db_dir: db_dir.into(),
+            db_size: db_size.unwrap_or(DEFAULT_DB_SIZE),
+            db_suffix: "state".into(),
+            indexes: indexes.into(),
+            databases: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn get_database(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+    ) -> Result<LmdbDatabase, InternalError> {
+        let mut databases = self
+            .databases
+            .lock()
+            .map_err(|_| InternalError::with_message("databases lock has been poisoned".into()))?;
+
+        let key = format!("{}::{}", service_id, circuit_id);
+        if let Some(db) = databases.get(&*key) {
+            return Ok(db.clone());
+        }
+
+        let hash = hash(MessageDigest::sha256(), key.as_bytes())
+            .map(|digest| to_hex(&*digest))
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+        let db_path = Path::new(&*self.db_dir)
+            .to_path_buf()
+            .join(format!("{}-{}", hash, self.db_suffix))
+            .with_extension("lmdb");
+
+        let db = LmdbDatabase::new(
+            LmdbContext::new(&db_path, self.indexes.len(), Some(self.db_size))
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
+            &*self.indexes,
+        )
+        .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        databases.insert(key.into(), db.clone());
+
+        Ok(db)
+    }
+}

--- a/services/scabbard/libscabbard/src/store/transact/mod.rs
+++ b/services/scabbard/libscabbard/src/store/transact/mod.rs
@@ -14,6 +14,8 @@
 
 //! Transact-backed CommitHashStore implementations.
 
+pub mod factory;
+
 use splinter::error::{InternalError, InvalidArgumentError, InvalidStateError};
 use transact::database::{lmdb::LmdbDatabase, Database, DatabaseError};
 


### PR DESCRIPTION
To test:

Create a scabbard circuit between two nodes.

Apply one transaction against the circuit:

```
$ scabbard cr create smallbank --owners $(cat ~/.cylinder/keys/$USER.pub) --service-id $CIRCUIT_ID::a000 --url $SPLINTER_URL
```

Run 

```
$ splinter upgrade -vv
...
Upgraded scabbard service CIRCUIT_ID::a000
```
where `CIRCUIT_ID` is the circuit created above.

This can be verified by using the sqlite client:

```
$ sqlite3 -header $SPLINTER_HOME/data/splinter_state.db
> select * from scabbard_commit_log;
circuit_id|service_id|commit_hash
CIRCUIT_ID|a000|859ac1f96d790dd660cfee2e788eeb4b8f46c12a5ff49504ad88d05fff412cfa
```