### PR TITLE
Remove duplicate `-` from scabbard LMDB file names

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory.rs
+++ b/services/scabbard/libscabbard/src/service/factory.rs
@@ -436,7 +436,7 @@ impl ServiceFactory for ScabbardFactory {
         let version = ScabbardVersion::try_from(args.get("version").map(String::as_str))
             .map_err(FactoryCreateError::InvalidArguments)?;
 
-        let state_db_path = compute_db_path(&service_id, circuit_id, state_db_dir, "-state")?;
+        let state_db_path = compute_db_path(&service_id, circuit_id, state_db_dir, "state")?;
 
         let (receipt_store, receipt_purge): (ScabbardReceiptStore, _) = match &self
             .receipt_store_factory_config
@@ -465,7 +465,7 @@ impl ServiceFactory for ScabbardFactory {
                 let receipt_db_dir_path = Path::new(&db_dir);
 
                 let receipt_db_path =
-                    compute_db_path(&service_id, circuit_id, receipt_db_dir_path, "-receipts")?;
+                    compute_db_path(&service_id, circuit_id, receipt_db_dir_path, "receipts")?;
 
                 let file: String = receipt_db_path
                     .with_extension("lmdb")


### PR DESCRIPTION
This change removes an additional `-` from the generated file names given to the state and receipts LMDB files. This was added as the result of a refactor.

This `-` created a regression where old db files would not be found.