### PR TITLE
Add libscabbard to CLI docker file

### DIFF
--- a/cli/Dockerfile-installed-focal
+++ b/cli/Dockerfile-installed-focal
@@ -39,6 +39,7 @@ COPY examples/gameroom/database/Cargo.toml \
 
 # Copy over source files
 COPY libsplinter /build/libsplinter
+COPY services/scabbard/libscabbard /build/services/scabbard/libscabbard
 COPY cli /build/cli
 
 # Build the project


### PR DESCRIPTION
This change adds the libscabbard sources to the CLI docker file to support the addition of the scabbard migrations to the CLI.