### PR TITLE
Stabilize node-id-upgrade by removing it

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,7 +47,7 @@ whoami = "0.7.0"
 
 [dependencies.splinter]
 path = "../libsplinter"
-features = ["admin-service", "registry"]
+features = ["admin-service", "registry", "node-id-store"]
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"
@@ -88,7 +88,6 @@ experimental = [
     "challenge-authorization",
     "health",
     "https-certs",
-    "node-id-upgrade",
     "registry",
     "scabbard-receipt-store",
     "scabbard-migrations",
@@ -101,7 +100,6 @@ circuit-template = ["splinter/circuit-template"]
 database = ["diesel"]
 health = []
 https-certs = []
-node-id-upgrade = ["upgrade","splinter/node-id-store"]
 postgres = [
     "diesel/postgres",
     "splinter/postgres",

--- a/cli/src/action/database/upgrade/mod.rs
+++ b/cli/src/action/database/upgrade/mod.rs
@@ -16,7 +16,6 @@
 
 #[cfg(feature = "scabbard-migrations")]
 mod error;
-#[cfg(feature = "node-id-upgrade")]
 mod node_id;
 #[cfg(feature = "scabbard-migrations")]
 mod scabbard;
@@ -48,11 +47,12 @@ impl Action for UpgradeAction {
         })?;
         info!("Upgrading splinterd state");
 
-        #[cfg(feature = "node-id-upgrade")]
+        #[cfg(any(feature = "sqlite", feature = "postgres"))]
         {
             let db_store = store_factory.get_node_id_store();
             node_id::migrate_node_id_to_db(state_dir.clone(), &*db_store)?;
         }
+
         info!(
             "Source yaml state directory: {}",
             state_dir.to_string_lossy()


### PR DESCRIPTION
Removes the feature

Signed-off-by: Caleb Hill <hill@bitwise.io>