### PR TITLE
Fix type for admin service event id for postgres

### DIFF
--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-10-13-172200_fix-admin-event-id/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-10-13-172200_fix-admin-event-id/down.sql
@@ -1,0 +1,35 @@
+-- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_circuit_proposal
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_vote_record
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_proposed_circuit
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_proposed_node
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_proposed_node_endpoint
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_proposed_service
+ALTER COLUMN event_id TYPE INTEGER;
+
+ALTER TABLE admin_event_proposed_service_argument
+ALTER COLUMN event_id TYPE INTEGER;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2021-10-13-172200_fix-admin-event-id/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2021-10-13-172200_fix-admin-event-id/up.sql
@@ -1,0 +1,35 @@
+---- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE admin_event_circuit_proposal
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_vote_record
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_proposed_circuit
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_proposed_node
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_proposed_node_endpoint
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_proposed_service
+ALTER COLUMN event_id TYPE BIGINT;
+
+ALTER TABLE admin_event_proposed_service_argument
+ALTER COLUMN event_id TYPE BIGINT;


### PR DESCRIPTION
For postgres, there is a difference between Integer and
BigInt. Before the event Id's were being set to BigInt
(using BigSerial) in the admin_service_event but Integer
on all other tables. However, these types need to be the
same so this commit adds a migration that changes the type
from Integer to BigInt.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>