### PR TITLE
Add scabbard_storage key to example toml file

### DIFF
--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -189,3 +189,6 @@ version = "1"
 # Filter defines the level of log the logger writes to appenders.
 # Valid filter options are, Trace, Debug, Info, Warn, and Error in decreasing order of verbosity.
 #filter = "Warn"
+
+# Where scabbard will store its internal state, valid options are "database" or "lmdb"
+#scabbard_storage = "database"


### PR DESCRIPTION
All keys should be documented/present in the example toml file. This
commit adds the key and some basic docs.

Signed-off-by: Caleb Hill <hill@bitwise.io>