### PR TITLE
Fix `LmdbReceiptStore` file path

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
+++ b/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
@@ -502,11 +502,11 @@ impl ServiceFactory for ScabbardFactory {
                         )
                     })?;
 
-                let purge_db_path = receipt_db_path.clone();
+                let purge_db_path = receipt_db_path;
                 (
                     Arc::new(RwLock::new(
                         LmdbReceiptStore::new(
-                            &receipt_db_path,
+                            receipt_db_dir_path,
                             &[file.clone()],
                             file,
                             Some(*db_size),


### PR DESCRIPTION
Change the `dir_path` value that is given when creating a new `LmdbReceiptStore` to be the path of the directory that the LMDB file should be created in rather than the full file path of the database file.

Previously the LmdbReceiptStore would fail to create a new store because it was trying to create the LMDB file an additional directory that didn't exist.