### PR TITLE
Consolidate scabbard migrations

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,6 @@ log = "0.4"
 openssl = "0.10"
 protobuf = "2.23"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
-sawtooth = { version = "0.6.7", features = ["diesel"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
@@ -51,13 +50,7 @@ features = ["admin-service", "registry", "node-id-store"]
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"
-features = ["postgres", "sqlite", "lmdb"]
-optional = true
-
-[dependencies.transact]
-version = "0.3.10"
-default-features = false
-features = ["postgres", "state-merkle-sql", "sqlite"]
+features = ["postgres", "sqlite", "lmdb", "database-support"]
 optional = true
 
 [dev-dependencies]
@@ -101,15 +94,13 @@ https-certs = []
 postgres = [
     "diesel/postgres",
     "splinter/postgres",
-    "sawtooth/postgres",
 ]
 registry = []
-scabbard-receipt-store = ["sawtooth/diesel"]
-scabbard-migrations = ["scabbard", "transact"]
+scabbard-receipt-store = []
+scabbard-migrations = ["scabbard"]
 sqlite = [
     "diesel/sqlite",
     "splinter/sqlite",
-    "sawtooth/sqlite",
 ]
 upgrade = [
     "database",

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.3.10", features = ["sawtooth-compat"] }
+transact = { version = "0.3.11", features = ["sawtooth-compat"] }
 
 [dependencies.sawtooth]
 version = "0.6.7"
@@ -49,7 +49,7 @@ features = ["lmdb-store", "receipt-store", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
-transact = { version = "0.3.10", features = ["family-command", "sawtooth-compat"] }
+transact = { version = "0.3.11", features = ["family-command", "sawtooth-compat"] }
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/mod.rs
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/mod.rs
@@ -20,7 +20,11 @@ use diesel::sqlite::SqliteConnection;
 use diesel::Connection;
 use diesel_migrations::MigrationConnection;
 
+#[cfg(feature = "receipt-store")]
+use sawtooth::migrations::run_sqlite_migrations as run_sawtooth_sqlite_migrations;
 use splinter::error::InternalError;
+#[cfg(feature = "database-support")]
+use transact::state::merkle::sql::migration::run_sqlite_migrations as run_transact_sqlite_migrations;
 
 /// Run all pending database migrations.
 ///
@@ -30,6 +34,14 @@ use splinter::error::InternalError;
 ///
 pub fn run_migrations(conn: &SqliteConnection) -> Result<(), InternalError> {
     embedded_migrations::run(conn).map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+    #[cfg(feature = "database-support")]
+    run_transact_sqlite_migrations(conn)
+        .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+    #[cfg(feature = "receipt-store")]
+    run_sawtooth_sqlite_migrations(conn)
+        .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
     debug!("Successfully applied Scabbard SQLite migrations");
 


### PR DESCRIPTION
This PR consolidates the execution of the migrations required to correctly setup a database for scabbard.  Previously, the consumer of libscabbard was required to also pull in transact and sawtooth for each library's migrations.  Missing any of them results in a mis-configured scabbard system.