### PR TITLE
Stabilize scabbard-receipt-store in CLI

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,6 @@ experimental = [
     "health",
     "https-certs",
     "registry",
-    "scabbard-receipt-store",
     "scabbard-migrations",
 ]
 
@@ -96,7 +95,6 @@ postgres = [
     "splinter/postgres",
 ]
 registry = []
-scabbard-receipt-store = []
 scabbard-migrations = ["scabbard"]
 sqlite = [
     "diesel/sqlite",

--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -73,14 +73,12 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
             "Running migrations against SQLite database: {}",
             full_path.display()
         );
-        #[cfg(feature = "scabbard-receipt-store")]
         info!(
             "Running migrations against SQLite database for receipt store: {}",
             full_path.display()
         );
     } else {
         info!("Running migrations against SQLite database: :memory: ");
-        #[cfg(feature = "scabbard-receipt-store")]
         info!("Running migrations against SQLite database: :memory: for receipt store");
     };
 


### PR DESCRIPTION
Stabilize the "scabbard-receipt-store" feature in splinter CLI by removing it