### PR TITLE
Add missing toml keys

### DIFF
--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -148,6 +148,7 @@ struct TomlConfig {
     #[cfg(feature = "scabbard-database-support")]
     scabbard_storage: Option<ScabbardStorageToml>,
     config_dir: Option<String>,
+    state_dir: Option<String>,
 
     // Deprecated values
     cert_dir: Option<String>,
@@ -229,7 +230,8 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_heartbeat(self.toml_config.heartbeat)
             .with_admin_timeout(self.toml_config.admin_timeout)
             .with_peering_key(self.toml_config.peering_key)
-            .with_config_dir(self.toml_config.config_dir);
+            .with_config_dir(self.toml_config.config_dir)
+            .with_state_dir(self.toml_config.state_dir);
 
         #[cfg(feature = "https-bind")]
         {


### PR DESCRIPTION
state_dir and config_dir were present in `splinterd.toml.example` but not in the code that deserializes that file. These commits add them to the struct.