### PR TITLE
Remove unnecessary log messages

### DIFF
--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -73,13 +73,8 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
             "Running migrations against SQLite database: {}",
             full_path.display()
         );
-        info!(
-            "Running migrations against SQLite database for receipt store: {}",
-            full_path.display()
-        );
     } else {
         info!("Running migrations against SQLite database: :memory: ");
-        info!("Running migrations against SQLite database: :memory: for receipt store");
     };
 
     run_sqlite_migrations(&*pool.get().map_err(|_| {


### PR DESCRIPTION
Receipt store migrations are handled in scabbard, the log messages at
this level are not needed.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>