### PR TITLE
Break apart scabbard-migration features

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,6 @@ features = ["admin-service", "registry", "node-id-store"]
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"
-features = ["postgres", "sqlite", "lmdb", "database-support"]
 optional = true
 
 [dev-dependencies]
@@ -93,12 +92,17 @@ https-certs = []
 postgres = [
     "diesel/postgres",
     "splinter/postgres",
+    "scabbard/postgres"
 ]
 registry = []
-scabbard-migrations = ["scabbard"]
+scabbard-migrations = [
+  "scabbard/database-support",
+  "scabbard/lmdb"
+]
 sqlite = [
     "diesel/sqlite",
     "splinter/sqlite",
+    "scabbard/sqlite"
 ]
 upgrade = [
     "database",

--- a/cli/src/action/database/postgres.rs
+++ b/cli/src/action/database/postgres.rs
@@ -30,15 +30,12 @@ pub fn postgres_migrations(url: &str) -> Result<(), CliError> {
         CliError::ActionError(format!("Unable to run Postgres migrations: {}", err))
     })?;
 
-    #[cfg(feature = "scabbard-migrations")]
-    {
-        scabbard::migrations::run_postgres_migrations(&connection).map_err(|err| {
-            CliError::ActionError(format!(
-                "Unable to run Postgres migrations for scabbard: {}",
-                err
-            ))
-        })?;
-    }
+    scabbard::migrations::run_postgres_migrations(&connection).map_err(|err| {
+        CliError::ActionError(format!(
+            "Unable to run Postgres migrations for scabbard: {}",
+            err
+        ))
+    })?;
 
     Ok(())
 }

--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -82,18 +82,15 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
     })?)
     .map_err(|err| CliError::ActionError(format!("Unable to run Sqlite migrations: {}", err)))?;
 
-    #[cfg(feature = "scabbard-migrations")]
-    {
-        scabbard::migrations::run_sqlite_migrations(&*pool.get().map_err(|_| {
-            CliError::ActionError("Failed to get connection for migrations".to_string())
-        })?)
-        .map_err(|err| {
-            CliError::ActionError(format!(
-                "Unable to run Sqlite migrations for scabbard: {}",
-                err
-            ))
-        })?;
-    }
+    scabbard::migrations::run_sqlite_migrations(&*pool.get().map_err(|_| {
+        CliError::ActionError("Failed to get connection for migrations".to_string())
+    })?)
+    .map_err(|err| {
+        CliError::ActionError(format!(
+            "Unable to run Sqlite migrations for scabbard: {}",
+            err
+        ))
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
The scabbard migrations were only being run if the scabbard-migrations
feature was enabled which was experimental. This means the transaction
receipt migrations were not being run on stable.

This commit fixes the issues by moving pulling in scabbard/postgres
and scabbard/sqlite with the associated postgres and sqlite features.

And scabbard/database-support and scabbard/lmdb are now pulled in
by scabbard-migrations.

The migrations from scabbard will always be run.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>