### PR TITLE
log-config bug fixes

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -41,7 +41,7 @@ cylinder = { version = "0.2.2", features = ["key-load"] }
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 health = { path = "../services/health", optional = true }
 log = "0.4"
-log4rs = "1"
+log4rs = { version = "1", features = ["threshold_filter"] }
 openssl = { version = "0.10", optional = true }
 protobuf = "2.23"
 rand = "0.7"

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -128,21 +128,21 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 (
                     "tokio".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["default".into()],
+                        appenders: vec!["stdout".into()],
                         level: log::Level::Warn,
                     },
                 ),
                 (
                     "tokio_reactor".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["default".into()],
+                        appenders: vec!["stdout".into()],
                         level: log::Level::Warn,
                     },
                 ),
                 (
                     "hyper".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["default".into()],
+                        appenders: vec!["stdout".into()],
                         level: log::Level::Warn,
                     },
                 ),

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -123,6 +123,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 kind: super::logging::RawLogTarget::Stdout,
                 size: None,
                 filename: None,
+                level: None,
             };
             let loggers = vec![
                 (

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -129,22 +129,22 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 (
                     "tokio".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["stdout".into()],
-                        level: log::Level::Warn,
+                        appenders: Some(vec!["stdout".into()]),
+                        level: Some(log::Level::Warn),
                     },
                 ),
                 (
                     "tokio_reactor".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["stdout".into()],
-                        level: log::Level::Warn,
+                        appenders: Some(vec!["stdout".into()]),
+                        level: Some(log::Level::Warn),
                     },
                 ),
                 (
                     "hyper".to_string(),
                     UnnamedLoggerConfig {
-                        appenders: vec!["stdout".into()],
-                        level: log::Level::Warn,
+                        appenders: Some(vec!["stdout".into()]),
+                        level: Some(log::Level::Warn),
                     },
                 ),
             ]

--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -62,6 +62,7 @@ pub struct AppenderConfig {
     pub name: String,
     pub encoder: String,
     pub kind: LogTarget,
+    pub level: Option<Level>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -72,6 +73,7 @@ pub struct UnnamedAppenderConfig {
     pub kind: RawLogTarget,
     pub filename: Option<String>,
     pub size: Option<u64>,
+    pub level: Option<Level>,
 }
 
 #[derive(Clone, Debug)]
@@ -143,6 +145,7 @@ impl TryFrom<(String, UnnamedAppenderConfig)> for AppenderConfig {
             name: value.0,
             encoder: value.1.encoder,
             kind,
+            level: value.1.level,
         })
     }
 }
@@ -162,6 +165,7 @@ impl From<TomlUnnamedAppenderConfig> for UnnamedAppenderConfig {
             kind: unnamed.kind.into(),
             filename: unnamed.filename,
             size: unnamed.size.map(|s| s.into()),
+            level: unnamed.level.map(|l| l.into()),
         }
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -829,8 +829,11 @@ mod tests {
             assert!(loggers.contains_key("splinter"));
             let splinter = loggers.get("splinter").unwrap();
             let splinter: LoggerConfig = ("splinter".to_string(), splinter.clone()).into();
-            assert!(matches!(splinter.level, Level::Warn));
-            assert_eq!(splinter.appenders, ["stdout", "rolling_file"]);
+            assert!(matches!(splinter.level,Some(level) if matches!(level, Level::Warn)));
+            assert!(splinter.appenders.is_some());
+            let appenders = splinter.appenders.unwrap();
+            assert!(matches!(appenders.get(0), Some(val) if val == "stdout"));
+            assert!(matches!(appenders.get(1), Some(val) if val == "rolling_file"));
         }
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -22,6 +22,8 @@ use log::Level;
 use serde_derive::Deserialize;
 #[cfg(feature = "log-config")]
 use std::collections::HashMap;
+#[cfg(feature = "log-config")]
+use std::convert::TryInto;
 
 #[cfg(feature = "log-config")]
 use super::bytes::ByteSize;
@@ -62,8 +64,8 @@ pub struct TomlUnnamedAppenderConfig {
 #[cfg(feature = "log-config")]
 #[derive(Deserialize, Clone, Debug)]
 pub struct TomlUnnamedLoggerConfig {
-    pub appenders: Vec<String>,
-    pub level: TomlLogLevel,
+    pub appenders: Option<Vec<String>>,
+    pub level: Option<TomlLogLevel>,
 }
 
 #[cfg(feature = "log-config")]
@@ -278,7 +280,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             if let Some(mut loggers) = self.toml_config.loggers {
                 if let Some(unnamed) = loggers.remove("root") {
                     partial_config = partial_config
-                        .with_root_logger(Some(unnamed.into()))
+                        .with_root_logger(Some(unnamed.try_into()?))
                         .with_loggers(Some(
                             loggers
                                 .drain()

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -56,6 +56,7 @@ pub struct TomlUnnamedAppenderConfig {
     pub kind: TomlRawLogTarget,
     pub filename: Option<String>,
     pub size: Option<ByteSize>,
+    pub level: Option<TomlLogLevel>,
 }
 
 #[cfg(feature = "log-config")]

--- a/splinterd/src/logging.rs
+++ b/splinterd/src/logging.rs
@@ -14,7 +14,6 @@
 
 use std::convert::{From, Into, TryInto};
 
-use log::Level;
 use log4rs::{
     append::{
         console::{ConsoleAppender, Target},
@@ -96,12 +95,6 @@ impl From<RootConfig> for Root {
     }
 }
 
-impl RootConfig {
-    fn set_level(self, level: Level) -> Self {
-        Self { level, ..self }
-    }
-}
-
 impl TryInto<Config> for LogConfig {
     type Error = ConfigErrors;
     fn try_into(self) -> Result<Config, Self::Error> {
@@ -114,14 +107,5 @@ impl TryInto<Config> for LogConfig {
             )
             .loggers(self.loggers.iter().map(|lc| lc.to_owned().into()))
             .build(root)
-    }
-}
-
-impl LogConfig {
-    pub fn set_root_level(self, level: Level) -> Self {
-        Self {
-            root: self.root.set_level(level),
-            ..self
-        }
     }
 }

--- a/splinterd/src/logging.rs
+++ b/splinterd/src/logging.rs
@@ -32,6 +32,7 @@ use log4rs::{
     },
     config::{runtime::ConfigErrors, Appender, Logger, Root},
     encode::{pattern::PatternEncoder, Encode},
+    filter::threshold::ThresholdFilter,
     Config,
 };
 
@@ -69,7 +70,11 @@ impl TryInto<Appender> for AppenderConfig {
                 )
             }
         };
-        Ok(Appender::builder().build(&self.name, boxed))
+        let mut builder = Appender::builder();
+        if let Some(level) = self.level {
+            builder = builder.filter(Box::new(ThresholdFilter::new(level.to_level_filter())))
+        }
+        Ok(builder.build(&self.name, boxed))
     }
 }
 

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -694,8 +694,21 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
                         check_file_readability(path)
                     }
                 })?;
-
             appenders
+                .iter()
+                .map(|a| {
+                    if a.name == "stdout" {
+                        AppenderConfig {
+                            level: Some(config.verbosity()),
+                            name: a.name.to_owned(),
+                            encoder: a.encoder.to_owned(),
+                            kind: a.kind.to_owned(),
+                        }
+                    } else {
+                        a.to_owned()
+                    }
+                })
+                .collect()
         } else {
             vec![]
         };
@@ -708,8 +721,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
             root: config.root_logger().to_owned(),
             appenders,
             loggers,
-        }
-        .set_root_level(config.verbosity().to_owned());
+        };
         if let Ok(log_config) = log_config.try_into() {
             _log_handle.set_config(log_config);
         }

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -634,7 +634,11 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
 
     #[cfg(feature = "log-config")]
     {
-        configure_logging(&config, _log_handle)?;
+        if let Err(e) = configure_logging(&config, &_log_handle) {
+            _log_handle.set_config(default_log_settings());
+            config.log_as_debug();
+            return Err(e);
+        }
     }
 
     let state_dir = config.state_dir();
@@ -666,7 +670,6 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
 
     let admin_timeout = config.admin_timeout();
 
-    #[cfg(not(feature = "log-config"))]
     config.log_as_debug();
 
     let node_id = find_node_id(&config)?;

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -28,27 +28,20 @@ pub mod node_id;
 mod routes;
 mod transport;
 
-#[cfg(feature = "log-config")]
-use std::fs::OpenOptions;
-
-#[cfg(feature = "log-config")]
-use config::AppenderConfig;
 use cylinder::{load_key_from_path, secp256k1::Secp256k1Context, Context, Signer};
 #[cfg(not(feature = "log-config"))]
 use log4rs::config::{Appender, Logger, Root};
 #[cfg(not(feature = "log-config"))]
 use log4rs::encode::pattern::PatternEncoder;
-use log4rs::Handle;
+use log4rs::{Config as LogConfig, Handle};
 #[cfg(feature = "log-config")]
-use std::convert::TryInto;
+use logging::{configure_logging, default_log_settings};
 
 use splinter::error::InternalError;
 use splinter::peer::PeerAuthorizationToken;
 #[cfg(feature = "tap")]
 use splinter::tap::influx::InfluxRecorder;
 
-#[cfg(feature = "log-config")]
-use crate::config::LogConfig;
 use crate::config::{
     ClapPartialConfigBuilder, Config, ConfigBuilder, ConfigError, DefaultPartialConfigBuilder,
     EnvPartialConfigBuilder, PartialConfigBuilder, TomlPartialConfigBuilder,
@@ -508,59 +501,7 @@ fn main() {
 
     let matches = app.get_matches();
 
-    let log_handle = {
-        #[cfg(feature = "log-config")]
-        {
-            use crate::config::{LogTarget, RootConfig, DEFAULT_LOGGING_PATTERN};
-            let default_config: LogConfig = LogConfig {
-                root: RootConfig {
-                    appenders: vec![String::from("default")],
-                    level: log::Level::Info,
-                },
-                appenders: vec![AppenderConfig {
-                    name: String::from("default"),
-                    encoder: String::from(DEFAULT_LOGGING_PATTERN),
-                    kind: LogTarget::Stdout,
-                    level: None,
-                }],
-                loggers: vec![],
-            };
-            log4rs::init_config(
-                //Always produces a valid config try_into just returns a Result
-                if let Ok(log_config) = default_config.try_into() {
-                    log_config
-                } else {
-                    unreachable!()
-                },
-            )
-        }
-        #[cfg(not(feature = "log-config"))]
-        {
-            let encoder =
-                PatternEncoder::new("[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n");
-            let stdout = log4rs::append::console::ConsoleAppender::builder()
-                .encoder(Box::new(encoder))
-                .build();
-            let config = log4rs::Config::builder()
-                .appender(Appender::builder().build("stdout", Box::new(stdout)))
-                .logger(Logger::builder().build("hyper", log::LevelFilter::Warn))
-                .logger(Logger::builder().build("tokio", log::LevelFilter::Warn));
-            #[cfg(feature = "https-bind")]
-            let config = config.logger(Logger::builder().build("h2", log::LevelFilter::Warn));
-            let conf = config.build(
-                Root::builder()
-                    .appender("stdout")
-                    .build(get_log_filter_level(&matches)),
-            );
-
-            if let Ok(lc) = conf {
-                log4rs::init_config(lc)
-            } else {
-                unreachable!();
-                //the basic config should always be valid
-            }
-        }
-    };
+    let log_handle = log4rs::init_config(default_log_config(&matches));
     let log_handle = match log_handle {
         Err(e) => {
             eprintln!("Could not start logging, {}", e);
@@ -647,6 +588,38 @@ fn get_log_filter_level(matches: &ArgMatches) -> log::LevelFilter {
     }
 }
 
+fn default_log_config(_matches: &ArgMatches) -> LogConfig {
+    #[cfg(feature = "log-config")]
+    {
+        default_log_settings()
+    }
+    #[cfg(not(feature = "log-config"))]
+    {
+        let encoder = PatternEncoder::new("[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n");
+        let stdout = log4rs::append::console::ConsoleAppender::builder()
+            .encoder(Box::new(encoder))
+            .build();
+        let config = log4rs::Config::builder()
+            .appender(Appender::builder().build("stdout", Box::new(stdout)))
+            .logger(Logger::builder().build("hyper", log::LevelFilter::Warn))
+            .logger(Logger::builder().build("tokio", log::LevelFilter::Warn));
+        #[cfg(feature = "https-bind")]
+        let config = config.logger(Logger::builder().build("h2", log::LevelFilter::Warn));
+        let conf = config.build(
+            Root::builder()
+                .appender("stdout")
+                .build(get_log_filter_level(_matches)),
+        );
+
+        if let Ok(lc) = conf {
+            lc
+        } else {
+            unreachable!();
+            //the basic config should always be valid
+        }
+    }
+}
+
 fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserError> {
     // get provided config file or search default location
     let config_file = get_config_file(&matches)?;
@@ -661,71 +634,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
 
     #[cfg(feature = "log-config")]
     {
-        let appenders = if let Some(appenders) = config.appenders() {
-            let check_file_readability = |path: &Path| {
-                OpenOptions::new()
-                    .write(true)
-                    .create(!path.exists())
-                    .open(path)
-                    .map(|_| ())
-                    .map_err(|err| UserError::IoError {
-                        context: format!("logfile is not writeable: {}", path.display()),
-                        source: Some(Box::new(err)),
-                    })
-            };
-            appenders
-                .iter()
-                .filter_map(AppenderConfig::get_filename)
-                .try_for_each(|filename| {
-                    let path = Path::new(filename);
-                    if let Some(parent) = path.parent() {
-                        if !parent.exists() {
-                            Err(UserError::IoError {
-                                context: format!(
-                                    "logfile directory does not exist: {}",
-                                    parent.display()
-                                ),
-                                source: None,
-                            })
-                        } else {
-                            check_file_readability(path)
-                        }
-                    } else {
-                        check_file_readability(path)
-                    }
-                })?;
-            appenders
-                .iter()
-                .map(|a| {
-                    if a.name == "stdout" {
-                        AppenderConfig {
-                            level: Some(config.verbosity()),
-                            name: a.name.to_owned(),
-                            encoder: a.encoder.to_owned(),
-                            kind: a.kind.to_owned(),
-                        }
-                    } else {
-                        a.to_owned()
-                    }
-                })
-                .collect()
-        } else {
-            vec![]
-        };
-        let loggers = if let Some(loggers) = config.loggers() {
-            loggers
-        } else {
-            vec![]
-        };
-        let log_config = LogConfig {
-            root: config.root_logger().to_owned(),
-            appenders,
-            loggers,
-        };
-        if let Ok(log_config) = log_config.try_into() {
-            _log_handle.set_config(log_config);
-        }
-        config.log_as_debug();
+        configure_logging(&config, _log_handle)?;
     }
 
     let state_dir = config.state_dir();

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -521,6 +521,7 @@ fn main() {
                     name: String::from("default"),
                     encoder: String::from(DEFAULT_LOGGING_PATTERN),
                     kind: LogTarget::Stdout,
+                    level: None,
                 }],
                 loggers: vec![],
             };

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -712,6 +712,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
         if let Ok(log_config) = log_config.try_into() {
             _log_handle.set_config(log_config);
         }
+        config.log_as_debug();
     }
 
     let state_dir = config.state_dir();
@@ -743,6 +744,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
 
     let admin_timeout = config.admin_timeout();
 
+    #[cfg(not(feature = "log-config"))]
     config.log_as_debug();
 
     let node_id = find_node_id(&config)?;


### PR DESCRIPTION
There are several bug fixes in this pr.
1. Default loggers expecting an apender that did not exist.
2. Logging all config values after logging configuration so they get recorded in log files.
3. Enabling Appender log level filtering.
4. Verbosity flag altering the stdout appenders level not the root loggers.

Signed-off-by: Caleb Hill <hill@bitwise.io>