### PR TITLE
Add platform/arch specific LDMB size defaults

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
+++ b/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
@@ -37,8 +37,15 @@ use crate::service::rest_api::actix;
 use crate::service::{error::ScabbardError, Scabbard, ScabbardVersion, SERVICE_TYPE};
 
 const DEFAULT_STATE_DB_DIR: &str = "/var/lib/splinter";
+// Linux, with a 64bit CPU supports sparse files of a large size
+#[cfg(target_os = "linux")]
+const DEFAULT_STATE_DB_SIZE: usize = 1 << 40; // 1024 ** 4
+#[cfg(any(target_arch = "x86", target_arch = "arm", not(target_os = "linux")))]
 const DEFAULT_STATE_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 const DEFAULT_RECEIPT_DB_DIR: &str = "/var/lib/splinter";
+#[cfg(target_os = "linux")]
+const DEFAULT_RECEIPT_DB_SIZE: usize = 1 << 40; // 1024 ** 4
+#[cfg(any(target_arch = "x86", target_arch = "arm", not(target_os = "linux")))]
 const DEFAULT_RECEIPT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 
 type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;

--- a/services/scabbard/libscabbard/src/store/transact/factory.rs
+++ b/services/scabbard/libscabbard/src/store/transact/factory.rs
@@ -29,6 +29,10 @@ use crate::hex::to_hex;
 
 use super::CURRENT_STATE_ROOT_INDEX;
 
+// Linux, with a 64bit CPU supports sparse files of a large size
+#[cfg(target_os = "linux")]
+const DEFAULT_DB_SIZE: usize = 1 << 40; // 1024 ** 4
+#[cfg(any(target_arch = "x86", target_arch = "arm", not(target_os = "linux")))]
 const DEFAULT_DB_SIZE: usize = 1 << 30; // 1024 ** 3
 
 #[derive(Clone)]


### PR DESCRIPTION
This change adds conditional compile-time values for the default LMDB database size. On 64-bit Linux, this value can be `1024^4`, due to 64-bit usize as well as support for sparse files.  On all other systems, the default value remains at the original default value.
