### PR TITLE
Add lmdb extension to state file path

### DIFF
--- a/services/scabbard/libscabbard/src/store/transact/factory.rs
+++ b/services/scabbard/libscabbard/src/store/transact/factory.rs
@@ -70,7 +70,7 @@ impl LmdbDatabaseFactory {
             return Ok(db.clone());
         }
 
-        let db_path = self.path_from_key(&key)?;
+        let db_path = self.path_from_key(&key)?.with_extension("lmdb");
 
         let db = LmdbDatabase::new(
             LmdbContext::new(&db_path, self.indexes.len(), Some(self.db_size))


### PR DESCRIPTION
Add the `lmdb` file extension to the state file path when it is created in `path_from_key` in the `LmdbDatabaseFactory`.

Bug found when attempting to run `splinter upgrade`, the missing extension caused the `get_database` function to create a new empty LMDB file with the same name minus the extension rather than open the existing file and retrieve the current commit hash.