### PR TITLE
Splinter keygen group option

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,6 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 whoami = "0.7.0"
+users = "0.11"
 
 [dependencies.splinter]
 path = "../libsplinter"

--- a/cli/src/action/keygen.rs
+++ b/cli/src/action/keygen.rs
@@ -38,6 +38,13 @@ const DEFAULT_SYSTEM_KEY_NAME: &str = "splinterd";
 
 pub struct KeyGenAction;
 
+#[derive(Debug)]
+pub enum GroupOptions {
+    Auto,
+    Named(String),
+    GroupID(u32),
+}
+
 impl Action for KeyGenAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -123,7 +123,11 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 Arg::with_name("system")
                     .long("system")
                     .help("Generate system keys in /etc/splinter/keys"),
-            ),
+            )
+            .arg(Arg::with_name("group").long("group").help(
+                "Key file owning group, options are none|auto|<name_of_group>|<gid_of_group>",
+            )
+            .takes_value(true)),
     );
 
     let propose_circuit = SubCommand::with_name("propose")


### PR DESCRIPTION
This adds the `--group` flag to the splinter keygen command.
