### PR TITLE
Restore use of pool for receipt store

### DIFF
--- a/splinterd/src/daemon/mod.rs
+++ b/splinterd/src/daemon/mod.rs
@@ -463,8 +463,18 @@ impl SplinterDaemon {
             }
             #[cfg(any(feature = "database-postgres", feature = "database-sqlite"))]
             {
-                scabbard_factory_builder =
-                    scabbard_factory_builder.with_receipt_db_url(self.db_url.to_string());
+                match connection_pool {
+                    #[cfg(feature = "database-postgres")]
+                    store::ConnectionPool::Postgres { pool } => {
+                        scabbard_factory_builder =
+                            scabbard_factory_builder.with_receipt_postgres_connection_pool(pool);
+                    }
+                    #[cfg(feature = "database-sqlite")]
+                    store::ConnectionPool::Sqlite { pool } => {
+                        scabbard_factory_builder =
+                            scabbard_factory_builder.with_receipt_sqlite_connection_pool(pool);
+                    }
+                }
             }
         }
         #[cfg(feature = "scabbard-database-support")]


### PR DESCRIPTION
This change restores the use of the connection pool when configuring the scabbard factory receipt store.

This was removed due to a misapplied rebase.
