### PR TITLE
Update admin routes to error if protocol version is too high

### DIFF
--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -205,8 +205,8 @@ fn query_list_circuits(
                     }),
                 ),
 
-                // Handles 2 (and catch all)
-                _ => Ok(
+                // Handles 2
+                "2" => Ok(
                     HttpResponse::Ok().json(resources::v2::circuits::ListCircuitsResponse {
                         data: circuits
                             .iter()
@@ -214,6 +214,12 @@ fn query_list_circuits(
                             .collect(),
                         paging: get_response_paging_info(limit, offset, &link, total_count),
                     }),
+                ),
+                _ => Ok(
+                    HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                        "Unsupported SplinterProtocolVersion: {}",
+                        protocol_version
+                    ))),
                 ),
             }
         }

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -87,10 +87,16 @@ fn fetch_circuit(
                 "1" => Ok(HttpResponse::Ok().json(
                     resources::v1::circuits_circuit_id::CircuitResponse::from(&circuit),
                 )),
-                // Handles 2 (and catch all)
-                _ => Ok(HttpResponse::Ok().json(
+                // Handles 2
+                "2" => Ok(HttpResponse::Ok().json(
                     resources::v2::circuits_circuit_id::CircuitResponse::from(&circuit),
                 )),
+                _ => Ok(
+                    HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                        "Unsupported SplinterProtocolVersion: {}",
+                        protocol_version
+                    ))),
+                ),
             },
             Err(err) => match err {
                 BlockingError::Error(err) => match err {

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -189,8 +189,8 @@ fn query_list_proposals<PS: ProposalStore + 'static>(
                         paging: get_response_paging_info(limit, offset, &link, total_count),
                     },
                 )),
-                // Handles 2 (and catch all)
-                _ => {
+                // Handles 2
+                "2" => {
                     let proposal_responses = match proposals
                         .iter()
                         .map(resources::v2::proposals::ProposalResponse::try_from)
@@ -210,6 +210,12 @@ fn query_list_proposals<PS: ProposalStore + 'static>(
                         }),
                     )
                 }
+                _ => Ok(
+                    HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                        "Unsupported SplinterProtocolVersion: {}",
+                        protocol_version
+                    ))),
+                ),
             }
         }
         Err(err) => match err {

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -90,8 +90,8 @@ fn fetch_proposal<PS: ProposalStore + 'static>(
                 "1" => Ok(HttpResponse::Ok().json(
                     resources::v1::proposals_circuit_id::ProposalResponse::from(&proposal),
                 )),
-                // Handles 2 (and catch all)
-                _ => {
+                // Handles 2
+                "2" => {
                     match resources::v2::proposals_circuit_id::ProposalResponse::try_from(&proposal)
                     {
                         Ok(proposal_response) => Ok(HttpResponse::Ok().json(proposal_response)),
@@ -102,6 +102,12 @@ fn fetch_proposal<PS: ProposalStore + 'static>(
                         }
                     }
                 }
+                _ => Ok(
+                    HttpResponse::BadRequest().json(ErrorResponse::bad_request(&format!(
+                        "Unsupported SplinterProtocolVersion: {}",
+                        protocol_version
+                    ))),
+                ),
             },
             Err(err) => match err {
                 BlockingError::Error(err) => match err {

--- a/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
+++ b/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
@@ -363,13 +363,17 @@ impl JsonAdminEvent {
                 })?),
                 event_id: Some(*event.event_id()),
             }),
-            // Handles 2 (and catch all)
-            _ => Ok(Self {
+            // Handles 2
+            2 => Ok(Self {
                 timestamp: time::SystemTime::now(),
                 event: Some(AdminServiceEvent::from(event)),
                 event_v1: None,
                 event_id: Some(*event.event_id()),
             }),
+            _ => Err(InvalidStateError::with_message(format!(
+                "Unsupported SplinterProtocolVersion: {}",
+                protocol_version
+            ))),
         }
     }
 }


### PR DESCRIPTION
Before the protocol version check had a catch all that would
default to the current protocol version. While this is safe
because there is already a guard around the route that would
reject a protocol that is too high, this commit adds an
explicit check in case the guard fails.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>