### PR TITLE
Positive REST API security test

### DIFF
--- a/splinterd/src/node/builder/biome.rs
+++ b/splinterd/src/node/builder/biome.rs
@@ -1,0 +1,48 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for the BiomeSubsystem
+
+use splinter::biome::UserProfileStore;
+use splinter::error::InternalError;
+
+use crate::node::runnable::biome::RunnableBiomeSubsystem;
+
+pub struct BiomeSubsystemBuilder {
+    profile_store: Option<Box<dyn UserProfileStore>>,
+}
+
+impl BiomeSubsystemBuilder {
+    pub fn new() -> Self {
+        Self {
+            profile_store: None,
+        }
+    }
+
+    /// Specifies the store factory to use with the node. Defaults to the MemoryStoreFactory.
+    pub fn with_profile_store(mut self, profile_store: Box<dyn UserProfileStore>) -> Self {
+        self.profile_store = Some(profile_store);
+        self
+    }
+
+    pub fn build(self) -> Result<RunnableBiomeSubsystem, InternalError> {
+        let profile_store = self.profile_store.ok_or_else(|| {
+            InternalError::with_message(
+                "Cannot build BiomeSubsystem without a store factory".to_string(),
+            )
+        })?;
+
+        Ok(RunnableBiomeSubsystem { profile_store })
+    }
+}

--- a/splinterd/src/node/runnable/biome.rs
+++ b/splinterd/src/node/runnable/biome.rs
@@ -19,13 +19,15 @@ use std::sync::Arc;
 use splinter::biome::{
     credentials::rest_api::BiomeCredentialsRestResourceProviderBuilder,
     key_management::rest_api::BiomeKeyManagementRestResourceProvider,
-    profile::rest_api::BiomeProfileRestResourceProvider,
+    profile::rest_api::BiomeProfileRestResourceProvider, UserProfileStore,
 };
 use splinter::error::InternalError;
 use splinter::rest_api::{
     actix_web_1::Resource as Actix1Resource, AuthConfig, RestResourceProvider,
 };
 use splinter::store::StoreFactory;
+
+use crate::node::running::biome::BiomeSubsystem;
 
 /// Biome resource provider
 pub struct BiomeResourceProvider {
@@ -79,5 +81,16 @@ impl BiomeResourceProvider {
         let mut replaced = vec![];
         std::mem::swap(&mut self.actix1_resources, &mut replaced);
         replaced
+    }
+}
+
+pub struct RunnableBiomeSubsystem {
+    pub profile_store: Box<dyn UserProfileStore>,
+}
+
+impl RunnableBiomeSubsystem {
+    pub fn run(self) -> Result<BiomeSubsystem, InternalError> {
+        let profile_store = self.profile_store;
+        Ok(BiomeSubsystem { profile_store })
     }
 }

--- a/splinterd/src/node/runnable/mod.rs
+++ b/splinterd/src/node/runnable/mod.rs
@@ -37,6 +37,7 @@ use splinter::rest_api::{
 };
 
 use super::builder::admin::AdminSubsystemBuilder;
+use super::builder::biome::BiomeSubsystemBuilder;
 use super::{BiomeResourceProvider, Node, NodeRestApiVariant};
 
 use self::network::RunnableNetworkSubsystem;
@@ -74,6 +75,7 @@ impl RunnableNodeRestApiVariant {
 pub struct RunnableNode {
     pub(super) admin_signer: Box<dyn cylinder::Signer>,
     pub(super) admin_subsystem_builder: AdminSubsystemBuilder,
+    pub(super) biome_subsystem_builder: BiomeSubsystemBuilder,
     pub(super) rest_api_variant: RunnableNodeRestApiVariant,
     pub(super) runnable_network_subsystem: RunnableNetworkSubsystem,
     pub(super) node_id: String,
@@ -94,6 +96,10 @@ impl RunnableNode {
             .build()?;
 
         let mut admin_subsystem = runnable_admin_subsystem.run()?;
+
+        let runnable_biome_subsystem = self.biome_subsystem_builder.build()?;
+
+        let biome_subsystem = runnable_biome_subsystem.run()?;
 
         let node_id = self.node_id;
 
@@ -216,6 +222,7 @@ impl RunnableNode {
         Ok(Node {
             admin_signer: self.admin_signer,
             admin_subsystem,
+            biome_subsystem,
             network_subsystem,
             rest_api_variant,
             rest_api_port,

--- a/splinterd/src/node/running/biome.rs
+++ b/splinterd/src/node/running/biome.rs
@@ -1,0 +1,27 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module defines the running biome subsystem.
+
+use splinter::biome::UserProfileStore;
+
+pub struct BiomeSubsystem {
+    pub(crate) profile_store: Box<dyn UserProfileStore>,
+}
+
+impl BiomeSubsystem {
+    pub fn user_profile_store(&self) -> &dyn UserProfileStore {
+        &*self.profile_store
+    }
+}

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -27,6 +27,7 @@ use splinter::admin::client::event::{
 };
 use splinter::admin::client::{AdminServiceClient, ReqwestAdminServiceClient};
 use splinter::biome::client::{BiomeClient, ReqwestBiomeClient};
+use splinter::biome::UserProfileStore;
 use splinter::error::InternalError;
 use splinter::peer::PeerManagerConnector;
 use splinter::registry::{
@@ -159,6 +160,10 @@ impl Node {
             format!("http://localhost:{}", self.rest_api_port),
             "foo".to_string(),
         ))
+    }
+
+    pub fn user_profile_store(&self) -> &dyn UserProfileStore {
+        self.biome_subsystem.user_profile_store()
     }
 
     pub fn stop(mut self) -> Result<RunnableNode, InternalError> {

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -139,6 +139,19 @@ impl Node {
         ))
     }
 
+    pub fn scabbard_client_with_auth(
+        &self,
+        auth: &str,
+    ) -> Result<Box<dyn ScabbardClient>, InternalError> {
+        Ok(Box::new(
+            ReqwestScabbardClientBuilder::new()
+                .with_url(&format!("http://localhost:{}", self.rest_api_port))
+                .with_auth(auth)
+                .build()
+                .map_err(|e| InternalError::from_source(Box::new(e)))?,
+        ))
+    }
+
     pub fn registry_client(self: &Node) -> Box<dyn RegistryClient> {
         Box::new(ReqwestRegistryClient::new(
             format!("http://localhost:{}", self.rest_api_port),

--- a/splinterd/src/node/running/mod.rs
+++ b/splinterd/src/node/running/mod.rs
@@ -15,6 +15,7 @@
 //! Contains the implementation of `Node`.
 
 pub mod admin;
+pub mod biome;
 pub mod network;
 
 use std::thread::JoinHandle;
@@ -48,6 +49,7 @@ pub(super) enum NodeRestApiVariant {
 pub struct Node {
     pub(super) admin_signer: Box<dyn Signer>,
     pub(super) admin_subsystem: admin::AdminSubsystem,
+    pub(super) biome_subsystem: biome::BiomeSubsystem,
     pub(super) rest_api_variant: NodeRestApiVariant,
     pub(super) rest_api_port: u16,
     pub(super) network_subsystem: network::NetworkSubsystem,
@@ -165,6 +167,7 @@ impl Node {
         let Node {
             admin_signer,
             admin_subsystem,
+            biome_subsystem: _,
             rest_api_variant,
             node_id,
             rest_api_port,

--- a/splinterd/tests/admin/rest_api.rs
+++ b/splinterd/tests/admin/rest_api.rs
@@ -180,7 +180,7 @@ fn create_endpoint_permission_map() -> HashMap<String, Vec<(String, PermissionCo
         )],
     );
     endpoints.insert(
-        "/admin/proposals/ABCDE-01234".into(),
+        "/admin/proposals/ABCDE-56789".into(),
         vec![(
             "get".into(),
             PermissionConfig::new(vec!["circuit.read".into()], new_signer()),
@@ -292,7 +292,7 @@ fn create_endpoint_permission_map() -> HashMap<String, Vec<(String, PermissionCo
         )],
     );
     endpoints.insert(
-        "/scabbard/ABCDE-01234/SERVICE_ID/batch_statuses".into(),
+        "/scabbard/ABCDE-01234/SERVICE_ID/batch_statuses?ids=6ff35474a572087e08fd6a54d563bd8172951b363e5c9731f1a40a855e14bba45dac515364a08d8403f4fb5d4a206174b7f63c29e4f4e425dc71b95494b8a798".into(),
         vec![(
             "get".into(),
             PermissionConfig::new(vec!["scabbard.read".into()], new_signer()),
@@ -306,7 +306,7 @@ fn create_endpoint_permission_map() -> HashMap<String, Vec<(String, PermissionCo
         )],
     );
     endpoints.insert(
-        "/scabbard/ABCDE-01234/SERVICE_ID/state/address".into(),
+        "/scabbard/ABCDE-01234/SERVICE_ID/state/00ec01b114f311db0e009ca2a88a9b97b1d7b362ddb27dc3dd214c6d20327a1fc3add8".into(),
         vec![(
             "get".into(),
             PermissionConfig::new(vec!["scabbard.read".into()], new_signer()),
@@ -320,7 +320,7 @@ fn create_endpoint_permission_map() -> HashMap<String, Vec<(String, PermissionCo
         )],
     );
     endpoints.insert(
-        "/biome/users/test-id".into(),
+        "/biome/users/USER_ID".into(),
         vec![
             (
                 "get".into(),

--- a/splinterd/tests/admin/rest_api.rs
+++ b/splinterd/tests/admin/rest_api.rs
@@ -18,7 +18,9 @@ use cylinder::{jwt::JsonWebTokenBuilder, secp256k1::Secp256k1Context, Context, S
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use splinter::admin::messages::AuthorizationType;
+use splinter::biome::profile::store::ProfileBuilder;
 use splinter::error::InternalError;
+use splinterd::node::Node;
 use splinterd::node::PermissionConfig;
 use splinterd::node::RestApiVariant;
 
@@ -357,4 +359,19 @@ fn new_signer() -> Box<dyn Signer> {
 #[derive(Deserialize)]
 pub struct ServerError {
     pub message: String,
+}
+
+// Adds a test profile to the user profile store
+fn add_profile(node: &Node) -> Result<(), InternalError> {
+    let profile = ProfileBuilder::new()
+        .with_user_id("test_user_id".into())
+        .with_subject("subject".into())
+        .with_name(Some("name".into()))
+        .build()
+        .expect("Unable to build profile");
+
+    let profile_store = node.user_profile_store();
+    Ok(profile_store
+        .add_profile(profile)
+        .map_err(|err| InternalError::from_source(Box::new(err)))?)
 }


### PR DESCRIPTION
- Add a `scabbard_client_with_auth` function that has the same functionality as `scabbard_client` but takes an auth string as an arg and passes it to the `ReqwestScabbardClientBuilder`.
- Add a method to `Network` that allows for the admin signer to be set when creating the network. This is necessary for the positive REST API tests because specific permissions need to be configured for the admin signer so that it can perform the necessary actions like creating a circuit and submitting scabbard batches.
- Add helper functions to the `tests::admin::rest_api` module to add a profile to the user profile store and submit a circuit proposal as part of the setup for the positive tests.
- Add a test that sets the necessary permissions for each endpoint for different signers and then uses those signers to attempt to access each REST API endpoint and check that a response is received that indicates the endpoint was able to be reached with the appropriate permissions set.