### PR TITLE
Backport: Correct scar path environment variable in scabbard man page

### DIFF
--- a/services/scabbard/cli/man/scabbard-contract-upload.1.md
+++ b/services/scabbard/cli/man/scabbard-contract-upload.1.md
@@ -70,7 +70,7 @@ ARGUMENTS
 
 ENVIRONMENT VARIABLES
 =====================
-**SCAR_PATH_ENV_VAR**
+**SCAR_PATH**
 : List of directories to use when searching for the scar file to upload. (See
   `-p`, `--path`.)
 


### PR DESCRIPTION
The man page said the variable was SCAR_PATH_ENV_VAR but it
is actually SCAR_PATH

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>