### PR TITLE
Fix update_proposal so it does not remove incorrect nodes

### DIFF
--- a/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
+++ b/libsplinter/src/admin/store/diesel/operations/update_proposal.rs
@@ -87,18 +87,13 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 .execute(self.conn)?;
 
             // Delete existing data associated with the `CircuitProposal` and `ProposedCircuit`
-            let node_ids: Vec<String> = proposed_node::table
-                .filter(proposed_node::circuit_id.eq(proposal.circuit_id()))
-                .select(proposed_node::node_id)
-                .load(self.conn)?;
-
             delete(
                 proposed_node::table.filter(proposed_node::circuit_id.eq(proposal.circuit_id())),
             )
             .execute(self.conn)?;
             delete(
                 proposed_node_endpoint::table
-                    .filter(proposed_node_endpoint::node_id.eq_any(&node_ids)),
+                    .filter(proposed_node_endpoint::circuit_id.eq(proposal.circuit_id())),
             )
             .execute(self.conn)?;
             delete(
@@ -193,18 +188,13 @@ impl<'a> AdminServiceStoreUpdateProposalOperation
                 .execute(self.conn)?;
 
             // Delete existing data associated with the `CircuitProposal` and `ProposedCircuit`
-            let node_ids: Vec<String> = proposed_node::table
-                .filter(proposed_node::circuit_id.eq(proposal.circuit_id()))
-                .select(proposed_node::node_id)
-                .load(self.conn)?;
-
             delete(
                 proposed_node::table.filter(proposed_node::circuit_id.eq(proposal.circuit_id())),
             )
             .execute(self.conn)?;
             delete(
                 proposed_node_endpoint::table
-                    .filter(proposed_node_endpoint::node_id.eq_any(&node_ids)),
+                    .filter(proposed_node_endpoint::circuit_id.eq(proposal.circuit_id())),
             )
             .execute(self.conn)?;
             delete(


### PR DESCRIPTION
When updating a proposal, the command was removing on proposed
nodes with the same node id. This is incorrect because there maybe
several proposed nodes with different circuits. This commit
updates the command to remove the nodes by circuit id instead.

This was only seen when submitting multiple 3 party circuit
transactions and submitting only one vote for each proposal.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>