### PR TITLE
Detect incorrect state daemon

### DIFF
--- a/splinterd/src/daemon/mod.rs
+++ b/splinterd/src/daemon/mod.rs
@@ -497,9 +497,9 @@ impl SplinterDaemon {
                 .with_lmdb_state_enabled(self.enable_lmdb_state);
         }
 
-        let scabbard_factory = scabbard_factory_builder.build().map_err(|err| {
-            StartError::OrchestratorError(format!("failed to create new orchestrator: {}", err))
-        })?;
+        let scabbard_factory = scabbard_factory_builder
+            .build()
+            .map_err(|err| StartError::UserError(err.to_string()))?;
 
         let mut orchestrator = ServiceOrchestratorBuilder::new()
             .with_connection(orchestrator_connection)


### PR DESCRIPTION
This PR changes the ScabbardFactory builder to fail if LMDB state is not enabled, but there are any existing LMDB files in the state directory.

To test:

1. Start a pair of nodes, with at least one node providing the argument --scabbard-state lmdb
2. Create a circuit and execute a single transaction
3. Stop the node with the above --scabbard-state argument
4. Restart the node without that argument

You should see an error like:

```
[2021-10-28 10:10:27.114] T[main] ERROR [splinterd] Failed to start daemon, unable to start the Splinter daemon: there has been a user error: LMDB database files exist, but LMDB storage is not enabled
```