### PR TITLE
Check if `rest-api-endpoint` option contains protocol

### DIFF
--- a/examples/gameroom/tests/cypress/docker-compose.yaml
+++ b/examples/gameroom/tests/cypress/docker-compose.yaml
@@ -126,7 +126,7 @@ services:
               --database postgres://admin:admin@splinterd-db-node:5432/splinter \
               --service-endpoint 0.0.0.0:8043 \
               --network-endpoint 0.0.0.0:8044 \
-              --rest-api-endpoint 0.0.0.0:8085 \
+              --rest-api-endpoint http://0.0.0.0:8085 \
               --tls-insecure \
               --enable-biome-credentials
       "

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -131,8 +131,8 @@ impl std::fmt::Display for BindConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             #[cfg(feature = "https-bind")]
-            BindConfig::Https { bind, .. } => write!(f, "https://{}", bind),
-            BindConfig::Http(bind) => write!(f, "http://{}", bind),
+            BindConfig::Https { bind, .. } => write!(f, "{}", bind),
+            BindConfig::Http(bind) => write!(f, "{}", bind),
         }
     }
 }


### PR DESCRIPTION
Check that the value given for the `--rest-api-endpoint` splinterd CLI option contains 'http://' or 'https://' and exit with an error if it does not.

### Testing:

start splinterd without the `https-bind` feature enabled and give a value without `http://` for the `--rest-api-endpoint` option, splinterd should exit with an error:

`ERROR [splinterd] Failed to start daemon, unable to build the Splinter daemon: Invalid REST API endpoint provided, 'http://' protocol required`

start splinterd with the `https-bind` feature enabled and give a value without `https://` or `http://` for the `--rest-api-endpoint` option, splinterd should exit with an error:

`ERROR [splinterd] Failed to start daemon, unable to build the Splinter daemon: Invalid REST API endpoint provided, 'https://' protocol required`