### PR TITLE
Update node base image in some Dockerfiles

### DIFF
--- a/docker/lint-client.dockerfile
+++ b/docker/lint-client.dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk add --no-cache \
     curl \

--- a/examples/gameroom/gameroom-app/Dockerfile-installed
+++ b/examples/gameroom/gameroom-app/Dockerfile-installed
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk add --no-cache python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /app


### PR DESCRIPTION
node:lts-alpine was updated to be based on alpine 3.14 instead of 3.11
and use node v16 instead of v14. gameroom-app currentely is incompatible
with node v16.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>