### PR TITLE
Add ca-certificates package to scabbard-cli Docker image

### DIFF
--- a/services/scabbard/cli/Dockerfile-installed-focal
+++ b/services/scabbard/cli/Dockerfile-installed-focal
@@ -67,6 +67,7 @@ COPY --from=BUILDER /commit-hash /commit-hash
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     man \
  && mandb \


### PR DESCRIPTION
This package is required to use curl to download files from sites
with TLS.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>