### PR TITLE
Verify proposal circuit version is supported for vote

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -2725,6 +2725,20 @@ impl AdminServiceShared {
         circuit_proposal: &StoreProposal,
         node_id: &str,
     ) -> Result<(), AdminSharedError> {
+        if circuit_proposal.proposal_type() == &ProposalType::Create {
+            let circuit = circuit_proposal.circuit();
+            // verify that the circuit version is supported
+            match circuit.circuit_version() {
+                1 | CIRCUIT_PROTOCOL_VERSION => (),
+                _ => {
+                    return Err(AdminSharedError::ValidationFailed(format!(
+                        "Proposed circuit's schema version is unsupported: {}",
+                        circuit.circuit_version()
+                    )));
+                }
+            }
+        };
+
         let circuit_hash = proposal_vote.get_circuit_hash();
 
         self.validate_key(signer_public_key)?;


### PR DESCRIPTION
Verify that the circuit version for the proposal that is being
voted on is still valid for the currently support circuit
versions. It is possible that due to an upgrade versions
may no longer be supported. In this case, the vote should
not be accepted.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>