### PR TITLE
Create Database file with 640 permissions

### DIFF
--- a/cli/src/action/database/sqlite.rs
+++ b/cli/src/action/database/sqlite.rs
@@ -15,7 +15,9 @@
 //! Provides sqlite migration support to the database action
 
 use std::fs::{self, OpenOptions};
-use std::path::PathBuf;
+#[cfg(target_family = "unix")]
+use std::os::unix::prelude::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 
 use diesel::{
     r2d2::{ConnectionManager, Pool},
@@ -36,6 +38,8 @@ pub fn sqlite_migrations(connection_string: String) -> Result<(), CliError> {
         if let Err(err) = OpenOptions::new()
             .read(true)
             .write(true)
+            .create(!Path::new(&connection_string).exists())
+            .mode(0o640)
             .open(&connection_string)
         {
             match err.kind() {


### PR DESCRIPTION
There are two related changes in the commit.

1. Creating the file if it does not exist already
2. Setting the mode to 640 for rw-r----- file permisssions

If the file does not exist when the filename gets passed to the
SQLiteConnection constructor the Rust library that handles the foreign
function interface code to the sqlite3 C++ library hard codes 644
(rw-r--r--) as the file permissions. To avoid that the file just has to
exist beforehand with the permissions we want.

Signed-off-by: Caleb Hill <hill@bitwise.io>