### PR TITLE
Remove `ScabbardReceiptStore` types

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -735,14 +735,14 @@ impl ScabbardFactory {
             self.create_sql_merkle_state_purge_handle(circuit_id, &service_id),
         );
 
-        let (receipt_store, commit_hash_store): (Arc<RwLock<dyn ReceiptStore>>, Box<dyn CommitHashStore>) =
+        let (receipt_store, commit_hash_store): (Arc<dyn ReceiptStore>, Box<dyn CommitHashStore>) =
             match &self.store_factory_config {
                 #[cfg(feature = "postgres")]
                 ScabbardFactoryStorageConfig::Postgres { pool } => (
-                    Arc::new(RwLock::new(DieselReceiptStore::new(
+                    Arc::new(DieselReceiptStore::new(
                         pool.clone(),
                         Some(format!("{}::{}", circuit_id, service_id)),
-                    ))),
+                    )),
                     Box::new(DieselCommitHashStore::new(
                         pool.clone(),
                         circuit_id,
@@ -751,10 +751,10 @@ impl ScabbardFactory {
                 ),
                 #[cfg(feature = "sqlite")]
                 ScabbardFactoryStorageConfig::Sqlite { pool } => (
-                    Arc::new(RwLock::new(DieselReceiptStore::new(
+                    Arc::new(DieselReceiptStore::new(
                         pool.clone(),
                         Some(format!("{}::{}", circuit_id, service_id)),
-                    ))),
+                    )),
                     Box::new(DieselCommitHashStore::new(
                         pool.clone(),
                         circuit_id,
@@ -763,10 +763,10 @@ impl ScabbardFactory {
                 ),
                 #[cfg(feature = "sqlite")]
                 ScabbardFactoryStorageConfig::SqliteExclusiveWrites { pool } => (
-                    Arc::new(RwLock::new(DieselReceiptStore::new_with_write_exclusivity(
+                    Arc::new(DieselReceiptStore::new_with_write_exclusivity(
                         pool.clone(),
                         Some(format!("{}::{}", circuit_id, service_id)),
-                    ))),
+                    )),
                     Box::new(DieselCommitHashStore::new_with_write_exclusivity(
                         pool.clone(),
                         circuit_id,

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -64,9 +64,6 @@ use crate::store::CommitHashStore;
 #[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]
 const DEFAULT_LMDB_DIR: &str = "/var/lib/splinter";
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;
-
 /// A connection URI to a database instance.
 #[derive(Clone)]
 pub enum ConnectionUri {
@@ -738,7 +735,7 @@ impl ScabbardFactory {
             self.create_sql_merkle_state_purge_handle(circuit_id, &service_id),
         );
 
-        let (receipt_store, commit_hash_store): (ScabbardReceiptStore, Box<dyn CommitHashStore>) =
+        let (receipt_store, commit_hash_store): (Arc<RwLock<dyn ReceiptStore>>, Box<dyn CommitHashStore>) =
             match &self.store_factory_config {
                 #[cfg(feature = "postgres")]
                 ScabbardFactoryStorageConfig::Postgres { pool } => (

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -86,8 +86,6 @@ impl TryFrom<Option<&str>> for ScabbardVersion {
     }
 }
 
-type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;
-
 /// A handler for purging a scabbard instances state
 pub trait ScabbardStatePurgeHandler: Send + Sync {
     /// Purge the scabbard instances state.
@@ -120,7 +118,7 @@ impl Scabbard {
         peer_services: HashSet<String>,
         merkle_state: MerkleState,
         commit_hash_store: Box<dyn CommitHashStore>,
-        receipt_store: ScabbardReceiptStore,
+        receipt_store: Arc<RwLock<dyn ReceiptStore>>,
         purge_handler: Box<dyn ScabbardStatePurgeHandler>,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -27,7 +27,7 @@ mod state;
 use std::any::Any;
 use std::collections::{HashSet, VecDeque};
 use std::convert::TryFrom;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use cylinder::Verifier as SignatureVerifier;
@@ -118,7 +118,7 @@ impl Scabbard {
         peer_services: HashSet<String>,
         merkle_state: MerkleState,
         commit_hash_store: Box<dyn CommitHashStore>,
-        receipt_store: Arc<RwLock<dyn ReceiptStore>>,
+        receipt_store: Arc<dyn ReceiptStore>,
         purge_handler: Box<dyn ScabbardStatePurgeHandler>,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts
@@ -554,7 +554,7 @@ pub mod tests {
             HashSet::new(),
             merkle_state,
             commit_hash_store,
-            Arc::new(RwLock::new(MockReceiptStore)),
+            Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
@@ -578,7 +578,7 @@ pub mod tests {
             HashSet::new(),
             merkle_state,
             commit_hash_store,
-            Arc::new(RwLock::new(MockReceiptStore)),
+            Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
@@ -601,7 +601,7 @@ pub mod tests {
             HashSet::new(),
             merkle_state,
             commit_hash_store,
-            Arc::new(RwLock::new(MockReceiptStore)),
+            Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -100,7 +100,7 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
 mod tests {
     use super::*;
 
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, Mutex};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
     use diesel::r2d2::{ConnectionManager, Pool};
@@ -163,10 +163,10 @@ mod tests {
     fn state_with_prefix() {
         let (merkle_state, commit_hash_store) = create_merkle_state_and_commit_hash_store();
 
-        let receipt_store = Arc::new(RwLock::new(DieselReceiptStore::new(
+        let receipt_store = Arc::new(DieselReceiptStore::new(
             create_connection_pool_and_migrate(":memory:".to_string()),
             None,
-        )));
+        ));
 
         // Initialize a temporary scabbard state and set some values; this will pre-populate the DBs
         let prefix = "abcdef".to_string();

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -76,7 +76,7 @@ pub fn make_get_state_at_address_endpoint() -> ServiceEndpoint {
 mod tests {
     use super::*;
 
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, Mutex};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
     use diesel::{
@@ -137,10 +137,10 @@ mod tests {
     fn state_at_address() {
         let (merkle_state, commit_hash_store) = create_merkle_state_and_commit_hash_store();
 
-        let receipt_store = Arc::new(RwLock::new(DieselReceiptStore::new(
+        let receipt_store = Arc::new(DieselReceiptStore::new(
             create_connection_pool_and_migrate(":memory:".to_string()),
             None,
-        )));
+        ));
 
         // Initialize a temporary scabbard state and set a value; this will pre-populate the DBs
         let address = "abcdef".to_string();

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -68,7 +68,7 @@ pub fn make_get_state_root_endpoint() -> ServiceEndpoint {
 mod tests {
     use super::*;
 
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, Mutex};
 
     use cylinder::{secp256k1::Secp256k1Context, Context};
     use diesel::{
@@ -128,10 +128,10 @@ mod tests {
     fn state_root() {
         let (merkle_state, commit_hash_store) = create_merkle_state_and_commit_hash_store();
 
-        let receipt_store = Arc::new(RwLock::new(DieselReceiptStore::new(
+        let receipt_store = Arc::new(DieselReceiptStore::new(
             create_connection_pool_and_migrate(":memory:".to_string()),
             None,
-        )));
+        ));
 
         // Initialize a temporary scabbard state and set some values to pre-populate the DBs, then
         // get the resulting state root hash.

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -58,8 +58,6 @@ const ITER_CACHE_SIZE: usize = 64;
 const COMPLETED_BATCH_INFO_ITER_RETRY: Duration = Duration::from_millis(100);
 const DEFAULT_BATCH_HISTORY_SIZE: usize = 100;
 
-type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;
-
 /// Iterator over entries in a Scabbard service's state
 pub type StateIter = Box<dyn Iterator<Item = Result<(String, Vec<u8>), ScabbardStateError>>>;
 
@@ -69,7 +67,7 @@ pub struct ScabbardState {
     context_manager: ContextManager,
     executor: Executor,
     current_state_root: String,
-    receipt_store: ScabbardReceiptStore,
+    receipt_store: Arc<RwLock<dyn ReceiptStore>>,
     pending_changes: Option<(String, Vec<TransactionReceipt>)>,
     event_subscribers: Vec<Box<dyn StateSubscriber>>,
     #[cfg(feature = "metrics")]
@@ -83,7 +81,7 @@ impl ScabbardState {
     pub fn new(
         merkle_state: merkle_state::MerkleState,
         commit_hash_store: Box<dyn CommitHashStore>,
-        receipt_store: ScabbardReceiptStore,
+        receipt_store: Arc<RwLock<dyn ReceiptStore>>,
         #[cfg(feature = "metrics")] service_id: String,
         #[cfg(feature = "metrics")] circuit_id: String,
         admin_keys: Vec<String>,


### PR DESCRIPTION
Remove unnecessary `ScabbardReceiptStore` types. This type was initially
created so that the receipt store implementation used by scabbard could
change depending on whether or not the "receipt-store" experimental
feature was enabled. The "receipt-store" feature has been stabilized
and removed so the `ScabbardReceiptStore` type is no longer needed.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>