### PR TITLE
Rename config value for scabbard storage

### DIFF
--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -29,7 +29,7 @@ version = "1"
 # "database" or "lmdb". When set to "database" scabbard state will be stored in
 # in the database specified by the database key above. When set to "lmdb", lmdb
 # files will be created in the Splinter state_dir.
-#scabbard_storage = "database"
+#scabbard_state = "database"
 
 # Identifier for this node. Must be unique on the network. This value will be
 # used to initialize a "node_id" file in the Splinter state directory. Once

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -426,11 +426,11 @@ impl ConfigBuilder {
                 .find_map(|p| p.verbosity().map(|v| (v, p.source())))
                 .ok_or_else(|| ConfigError::MissingValue("verbosity".to_string()))?,
             #[cfg(feature = "scabbard-database-support")]
-            scabbard_storage: self
+            scabbard_state: self
                 .partial_configs
                 .iter()
-                .find_map(|p| p.scabbard_storage().map(|v| (v, p.source())))
-                .ok_or_else(|| ConfigError::MissingValue("scabbard_storage".to_string()))?,
+                .find_map(|p| p.scabbard_state().map(|v| (v, p.source())))
+                .ok_or_else(|| ConfigError::MissingValue("scabbard_state".to_string()))?,
         })
     }
 }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -21,7 +21,7 @@ use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuild
 use clap::{ArgMatches, ErrorKind};
 
 #[cfg(feature = "scabbard-database-support")]
-use crate::config::scabbard_storage::ScabbardStorage;
+use crate::config::scabbard_state::ScabbardState;
 
 /// `PartialConfig` builder which holds command line arguments, represented as clap `ArgMatches`.
 pub struct ClapPartialConfigBuilder<'a> {
@@ -198,10 +198,10 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
 
         #[cfg(feature = "scabbard-database-support")]
         {
-            partial_config = partial_config.with_scabbard_storage(
+            partial_config = partial_config.with_scabbard_state(
                 self.matches
-                    .value_of("scabbard-state")
-                    .map(ScabbardStorage::from_str)
+                    .value_of("scabbard_state")
+                    .map(ScabbardState::from_str)
                     .transpose()?,
             )
         }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -24,7 +24,7 @@ use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuild
 #[cfg(feature = "log-config")]
 use super::logging::{RootConfig, UnnamedAppenderConfig, DEFAULT_LOGGING_PATTERN};
 #[cfg(feature = "scabbard-database-support")]
-use super::ScabbardStorage;
+use super::ScabbardState;
 
 const CONFIG_DIR: &str = "/etc/splinter";
 const TLS_CERT_DIR: &str = "/etc/splinter/certs";
@@ -166,7 +166,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
 
         #[cfg(feature = "scabbard-database-support")]
         {
-            partial_config = partial_config.with_scabbard_storage(Some(ScabbardStorage::Database));
+            partial_config = partial_config.with_scabbard_state(Some(ScabbardState::Database));
         }
 
         Ok(partial_config)

--- a/splinterd/src/config/error.rs
+++ b/splinterd/src/config/error.rs
@@ -19,7 +19,7 @@ use std::io;
 use toml::de::Error as TomlError;
 
 #[cfg(feature = "scabbard-database-support")]
-use super::scabbard_storage::ScabbardStorageError;
+use super::scabbard_state::ScabbardStateError;
 
 #[derive(Debug)]
 /// General error type used during `Config` contruction.
@@ -45,10 +45,10 @@ impl From<clap::Error> for ConfigError {
 }
 
 #[cfg(feature = "scabbard-database-support")]
-impl From<ScabbardStorageError> for ConfigError {
-    fn from(err: ScabbardStorageError) -> Self {
+impl From<ScabbardStateError> for ConfigError {
+    fn from(err: ScabbardStateError) -> Self {
         match err {
-            ScabbardStorageError::ParseError(msg) => ConfigError::InvalidArgument(msg),
+            ScabbardStateError::ParseError(msg) => ConfigError::InvalidArgument(msg),
         }
     }
 }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -29,7 +29,7 @@ mod error;
 mod logging;
 mod partial;
 #[cfg(feature = "scabbard-database-support")]
-mod scabbard_storage;
+mod scabbard_state;
 mod toml;
 
 use std::time::Duration;
@@ -42,7 +42,7 @@ pub use builder::{ConfigBuilder, PartialConfigBuilder};
 pub use error::ConfigError;
 pub use partial::{ConfigSource, PartialConfig};
 #[cfg(feature = "scabbard-database-support")]
-pub use scabbard_storage::ScabbardStorage;
+pub use scabbard_state::ScabbardState;
 
 #[cfg(feature = "log-config")]
 pub use logging::{
@@ -121,7 +121,7 @@ pub struct Config {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: (String, ConfigSource),
     #[cfg(feature = "scabbard-database-support")]
-    scabbard_storage: (ScabbardStorage, ConfigSource),
+    scabbard_state: (ScabbardState, ConfigSource),
 }
 
 impl Config {
@@ -634,13 +634,13 @@ impl Config {
     }
 
     #[cfg(feature = "scabbard-database-support")]
-    pub fn scabbard_storage(&self) -> &ScabbardStorage {
-        &self.scabbard_storage.0
+    pub fn scabbard_state(&self) -> &ScabbardState {
+        &self.scabbard_state.0
     }
 
     #[cfg(feature = "scabbard-database-support")]
-    pub fn scabbard_storage_source(&self) -> &ConfigSource {
-        &self.scabbard_storage.1
+    pub fn scabbard_state_source(&self) -> &ConfigSource {
+        &self.scabbard_state.1
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -907,9 +907,9 @@ impl Config {
         #[cfg(feature = "scabbard-database-support")]
         {
             debug!(
-                "Config: scabbard_storage: {:?}, (source: {:?})",
-                self.scabbard_storage(),
-                self.scabbard_storage_source()
+                "Config: scabbard_state: {:?}, (source: {:?})",
+                self.scabbard_state(),
+                self.scabbard_state_source()
             );
         }
     }

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 #[cfg(feature = "log-config")]
 use super::logging::{RootConfig, UnnamedAppenderConfig, UnnamedLoggerConfig};
 #[cfg(feature = "scabbard-database-support")]
-use super::ScabbardStorage;
+use super::ScabbardState;
 
 /// `ConfigSource` displays the source of configuration values, used to identify which of the various
 /// config modules were used to create a particular `PartialConfig` object.
@@ -107,7 +107,7 @@ pub struct PartialConfig {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: Option<String>,
     #[cfg(feature = "scabbard-database-support")]
-    scabbard_storage: Option<ScabbardStorage>,
+    scabbard_state: Option<ScabbardState>,
 }
 
 impl PartialConfig {
@@ -182,7 +182,7 @@ impl PartialConfig {
             #[cfg(feature = "config-allow-keys")]
             allow_keys_file: None,
             #[cfg(feature = "scabbard-database-support")]
-            scabbard_storage: None,
+            scabbard_state: None,
         }
     }
 
@@ -389,8 +389,8 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "scabbard-database-support")]
-    pub fn scabbard_storage(&self) -> Option<ScabbardStorage> {
-        self.scabbard_storage
+    pub fn scabbard_state(&self) -> Option<ScabbardState> {
+        self.scabbard_state
     }
 
     /// Adds a `config_dir` value to the `PartialConfig` object.
@@ -922,14 +922,14 @@ impl PartialConfig {
     }
 
     #[cfg(feature = "scabbard-database-support")]
-    /// Adds a `scabbard_storage` value to the  `PartialConfig` object.
+    /// Adds a `scabbard_state` value to the  `PartialConfig` object.
     ///
     /// # Arguments
     ///
-    /// * `scabbard_storage` - Option of ScabbardStorage value for where to store state
+    /// * `scabbard_state` - Option of ScabbardState value for where to store state
     ///
-    pub fn with_scabbard_storage(mut self, scabbard_storage: Option<ScabbardStorage>) -> Self {
-        self.scabbard_storage = scabbard_storage;
+    pub fn with_scabbard_state(mut self, scabbard_state: Option<ScabbardState>) -> Self {
+        self.scabbard_state = scabbard_state;
         self
     }
 }

--- a/splinterd/src/config/scabbard_state.rs
+++ b/splinterd/src/config/scabbard_state.rs
@@ -16,44 +16,44 @@ use std::convert::From;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use super::toml::ScabbardStorageToml;
+use super::toml::ScabbardStateToml;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum ScabbardStorage {
+pub enum ScabbardState {
     Database,
     Lmdb,
 }
 
-pub enum ScabbardStorageError {
+pub enum ScabbardStateError {
     ParseError(String),
 }
 
-impl Display for ScabbardStorageError {
+impl Display for ScabbardStateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ScabbardStorageError::ParseError(msg) => {
+            ScabbardStateError::ParseError(msg) => {
                 write!(f, "got {}, expected 'lmdb' or 'database'", msg)
             }
         }
     }
 }
 
-impl FromStr for ScabbardStorage {
-    type Err = ScabbardStorageError;
+impl FromStr for ScabbardState {
+    type Err = ScabbardStateError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "database" => Ok(Self::Database),
             "lmdb" => Ok(Self::Lmdb),
-            _ => Err(ScabbardStorageError::ParseError(s.to_string())),
+            _ => Err(ScabbardStateError::ParseError(s.to_string())),
         }
     }
 }
 
-impl From<ScabbardStorageToml> for ScabbardStorage {
-    fn from(other: ScabbardStorageToml) -> Self {
+impl From<ScabbardStateToml> for ScabbardState {
+    fn from(other: ScabbardStateToml) -> Self {
         match other {
-            ScabbardStorageToml::Lmdb => ScabbardStorage::Lmdb,
-            ScabbardStorageToml::Database => ScabbardStorage::Database,
+            ScabbardStateToml::Lmdb => ScabbardState::Lmdb,
+            ScabbardStateToml::Database => ScabbardState::Database,
         }
     }
 }

--- a/splinterd/src/config/scabbard_state.rs
+++ b/splinterd/src/config/scabbard_state.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::From;
 use std::fmt::Display;
 use std::str::FromStr;
-
-use super::toml::ScabbardStateToml;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ScabbardState {
@@ -45,15 +42,6 @@ impl FromStr for ScabbardState {
             "database" => Ok(Self::Database),
             "lmdb" => Ok(Self::Lmdb),
             _ => Err(ScabbardStateError::ParseError(s.to_string())),
-        }
-    }
-}
-
-impl From<ScabbardStateToml> for ScabbardState {
-    fn from(other: ScabbardStateToml) -> Self {
-        match other {
-            ScabbardStateToml::Lmdb => ScabbardState::Lmdb,
-            ScabbardStateToml::Database => ScabbardState::Database,
         }
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -146,7 +146,7 @@ struct TomlConfig {
     #[cfg(feature = "log-config")]
     loggers: Option<HashMap<String, TomlUnnamedLoggerConfig>>,
     #[cfg(feature = "scabbard-database-support")]
-    scabbard_storage: Option<ScabbardStorageToml>,
+    scabbard_state: Option<ScabbardStateToml>,
     config_dir: Option<String>,
     state_dir: Option<String>,
 
@@ -306,7 +306,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
         #[cfg(feature = "scabbard-database-support")]
         {
             partial_config = partial_config
-                .with_scabbard_storage(self.toml_config.scabbard_storage.map(|inner| inner.into()));
+                .with_scabbard_state(self.toml_config.scabbard_state.map(|inner| inner.into()));
         }
 
         // deprecated values, only set if the current value was not set
@@ -353,7 +353,7 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
 
 #[cfg(feature = "scabbard-database-support")]
 #[derive(Deserialize, Debug)]
-pub enum ScabbardStorageToml {
+pub enum ScabbardStateToml {
     #[serde(rename = "database")]
     Database,
     #[serde(rename = "lmdb")]

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -27,6 +27,8 @@ use std::collections::HashMap;
 use super::bytes::ByteSize;
 #[cfg(feature = "log-config")]
 use super::logging::{default_pattern, UnnamedAppenderConfig, UnnamedLoggerConfig};
+#[cfg(feature = "scabbard-database-support")]
+use super::scabbard_state::ScabbardState;
 
 /// `TOML_VERSION` represents the version of the toml config file.
 /// The version determines the most current valid toml config entries.
@@ -358,6 +360,16 @@ pub enum ScabbardStateToml {
     Database,
     #[serde(rename = "lmdb")]
     Lmdb,
+}
+
+#[cfg(feature = "scabbard-database-support")]
+impl From<ScabbardStateToml> for ScabbardState {
+    fn from(other: ScabbardStateToml) -> Self {
+        match other {
+            ScabbardStateToml::Lmdb => ScabbardState::Lmdb,
+            ScabbardStateToml::Database => ScabbardState::Database,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -499,7 +499,7 @@ fn main() {
 
     #[cfg(feature = "scabbard-database-support")]
     let app = app.arg(
-        Arg::with_name("scabbard-state")
+        Arg::with_name("scabbard_state")
             .long("scabbard-state")
             .possible_values(&["lmdb", "database"])
             .long_help("Specifies where scabbard stores its internal state")
@@ -817,7 +817,7 @@ fn start_daemon(matches: ArgMatches, _log_handle: Handle) -> Result<(), UserErro
     }
     #[cfg(feature = "scabbard-database-support")]
     {
-        if config.scabbard_storage() == &config::ScabbardStorage::Lmdb {
+        if config.scabbard_state() == &config::ScabbardState::Lmdb {
             daemon_builder = daemon_builder.with_lmdb_state_enabled();
         }
     }


### PR DESCRIPTION
This change renames the config value for scabbard storage to scabbard state. This makes it consistent across the board and more accurate, as the setting is just changing state storage, not all of scabbard storage.
