### PR TITLE
Fix issues that can happen when duplicate peer connections need to be resolved

### DIFF
--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -842,6 +842,7 @@ where
         endpoint: &str,
         connection_id: &str,
     ) -> Result<Option<ConnectionMetadata>, ConnectionManagerError> {
+        debug!("Remove connection {} ({})", endpoint, connection_id);
         let meta = if let Some(meta) = self.connections.get_mut(connection_id) {
             meta.clone()
         } else {

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -415,8 +415,9 @@ where
                 };
 
             trace!(
-                "Received message from {}: {:?}",
+                "Received message from {}({}): {:?}",
                 peer_id,
+                connection_id,
                 network_msg.get_message_type()
             );
             match dispatch_msg_sender.send(
@@ -593,8 +594,9 @@ fn run_pending_recv_loop(
                     };
 
                 trace!(
-                    "Received message from {}: {:?}",
+                    "Received message from {}({}): {:?}",
                     peer_id,
+                    connection_id,
                     network_msg.get_message_type()
                 );
                 match dispatch_msg_sender.send(

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -500,6 +500,10 @@ where
                         if let Err(err) = message_sender.send(new_connection_id, payload) {
                             error!("Unable to send message to {}: {}", recipient, err);
                         }
+                    } else {
+                        error!("Unable to send message to {}: {}", recipient, err);
+                        // remove cached connection id, peer has gone away
+                        peer_id_to_connection_id.remove(&recipient);
                     }
                 } else {
                     error!("Unable to send message to {}: {}", recipient, err);

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -634,6 +634,12 @@ fn add_peer(
             old_connection_ids,
         );
 
+        // Update peer for new state
+        let notification = PeerManagerNotification::Connected {
+            peer: peer_token_pair.clone(),
+        };
+        subscribers.broadcast(notification);
+
         let peer_ref = PeerRef::new(peer_token_pair.clone(), peer_remover.clone());
         return Ok(peer_ref);
     }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1162,7 +1162,7 @@ fn handle_inbound_connection(
         let old_connection_id = peer_metadata.connection_id;
         let starting_status = peer_metadata.status;
         peer_metadata.status = PeerStatus::Connected;
-        peer_metadata.connection_id = connection_id;
+        peer_metadata.connection_id = connection_id.clone();
         // reset retry settings
         peer_metadata.retry_frequency = retry_frequency;
         peer_metadata.last_connection_attempt = Instant::now();
@@ -1171,7 +1171,7 @@ fn handle_inbound_connection(
             peer: peer_token_pair.clone(),
         };
 
-        peer_metadata.active_endpoint = endpoint.to_string();
+        peer_metadata.active_endpoint = endpoint;
         if let Err(err) = peers.update_peer(peer_metadata) {
             error!("Unable to update peer: {}", err);
         }
@@ -1179,7 +1179,7 @@ fn handle_inbound_connection(
         subscribers.broadcast(notification);
 
         // if peer is pending there is no connection to remove
-        if endpoint != old_endpoint && starting_status != PeerStatus::Pending {
+        if connection_id != old_connection_id && starting_status != PeerStatus::Pending {
             if let Err(err) = connector.remove_connection(&old_endpoint, &old_connection_id) {
                 warn!("Unable to clean up old connection: {}", err);
             }
@@ -1303,9 +1303,9 @@ fn handle_connected(
         let starting_status = peer_metadata.status;
         let old_endpoint = peer_metadata.active_endpoint;
         let old_connection_id = peer_metadata.connection_id;
-        peer_metadata.active_endpoint = endpoint.to_string();
+        peer_metadata.active_endpoint = endpoint;
         peer_metadata.status = PeerStatus::Connected;
-        peer_metadata.connection_id = connection_id;
+        peer_metadata.connection_id = connection_id.clone();
         // reset retry settings
         peer_metadata.retry_frequency = retry_frequency;
         peer_metadata.last_connection_attempt = Instant::now();
@@ -1315,7 +1315,7 @@ fn handle_connected(
         }
 
         // remove old connection
-        if endpoint != old_endpoint && starting_status != PeerStatus::Pending {
+        if connection_id != old_connection_id && starting_status != PeerStatus::Pending {
             if let Err(err) = connector.remove_connection(&old_endpoint, &old_connection_id) {
                 error!("Unable to clean up old connection: {}", err);
             }

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1326,8 +1326,6 @@ fn handle_connected(
     } else {
         // if this endpoint has been requested, add this connection to peers with the provided
         // endpoint
-        // allow unused-variables, variable required if challenge-authorization is enabled
-        #[allow(unused_variables)]
         if let Some(requested_endpoint) = unreferenced_peers.requested_endpoints.get(&endpoint) {
             debug!(
                 "Adding peer {} by endpoint {} ({})",

--- a/libsplinter/src/peer/unreferenced.rs
+++ b/libsplinter/src/peer/unreferenced.rs
@@ -27,6 +27,7 @@ pub struct UnreferencedPeer {
     pub endpoint: String,
     pub connection_id: String,
     pub local_authorization: PeerAuthorizationToken,
+    pub old_connection_ids: Vec<String>,
 }
 
 /// An entry for a peer that was only requested by endpoint.
@@ -62,7 +63,10 @@ impl UnreferencedPeerState {
     ) -> Option<(PeerTokenPair, UnreferencedPeer)> {
         self.peers
             .iter()
-            .find(|(_, peer)| peer.connection_id == connection_id)
+            .find(|(_, peer)| {
+                peer.connection_id == connection_id
+                    || peer.old_connection_ids.contains(&connection_id.to_string())
+            })
             .map(|(id, peer)| (id.clone(), peer.clone()))
     }
 }

--- a/splinterd/tests/admin/circuit_create.rs
+++ b/splinterd/tests/admin/circuit_create.rs
@@ -2048,7 +2048,6 @@ pub fn test_3_party_circuit_proposal_rejected_stop() {
 ///    created, where one needs to be closed
 /// 3. Wait for the circuit to be created sucessfully
 #[test]
-#[ignore]
 pub fn test_2_party_circuit_duplicate_connection() {
     // Start a 2-node network
     let mut network = Network::new()


### PR DESCRIPTION
This PR includes several fixes for the peer manager and interconnect:
1. Save replaced connection ids for peers so that old messages can still be routed.
2. Check for inbound unreferenced peer when upgrading an outbound unreferenced peer to peers. If one is found, check whether the outbound or inbound connection should be used.
3. Improves logs around peering

This PR also enables test_2_party_circuit_duplicate_connection