### PR TITLE
Add circuit metric tag

### DIFF
--- a/libsplinter/src/tap/mod.rs
+++ b/libsplinter/src/tap/mod.rs
@@ -30,7 +30,7 @@ pub mod influx;
 #[macro_export]
 macro_rules! counter {
     ($t:tt, $v:expr) => {};
-    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr),* $(,)?) => {};
 }
 
 /// no-op `gauge` macro for when the `metrics` feature is not enabled
@@ -38,7 +38,7 @@ macro_rules! counter {
 #[macro_export]
 macro_rules! gauge {
     ($t:tt, $v:expr) => {};
-    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr),* $(,)?) => {};
 }
 
 /// no-op `histogram` macro for when the `metrics` feature is not enabled
@@ -46,5 +46,5 @@ macro_rules! gauge {
 #[macro_export]
 macro_rules! histogram {
     ($t:tt, $v:expr) => {};
-    ($t:tt, $v:expr, $($key:expr => $value:expr)*) => {};
+    ($t:tt, $v:expr, $($key:expr => $value:expr),* $(,)?) => {};
 }

--- a/services/scabbard/libscabbard/src/service/state/state_database/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/state_database/mod.rs
@@ -136,7 +136,10 @@ impl ScabbardState {
             .map_err(|err| ScabbardStateError(format!("failed to start executor: {}", err)))?;
 
         // initialize committed_batches metric
-        counter!("splinter.scabbard.committed_batches", 0, "service" => format!("{}::{}", &circuit_id, &service_id));
+        counter!("splinter.scabbard.committed_batches", 0,
+            "circuit" => circuit_id.clone(),
+            "service" => format!("{}::{}", &circuit_id, &service_id)
+        );
 
         Ok(ScabbardState {
             merkle_state,
@@ -313,7 +316,10 @@ impl ScabbardState {
                 }
 
                 self.batch_history.commit(&signature);
-                counter!("splinter.scabbard.committed_batches", 1, "service" => format!("{}::{}", self.circuit_id, self.service_id));
+                counter!("splinter.scabbard.committed_batches", 1,
+                    "circuit" => self.circuit_id.clone(),
+                    "service" => format!("{}::{}", &self.circuit_id, &self.service_id)
+                );
                 Ok(())
             }
             None => Err(ScabbardStateError("no pending changes to commit".into())),


### PR DESCRIPTION
This PR adds a "circuit" tag to the scabbard metric "committed_batches".

It also fixes the no-op tap macros properly can accept multiple tags.