### PR TITLE
Bump the version of jsonwebtoken to 7

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -48,7 +48,7 @@ futures = { version = "0.1", optional = true }
 futures-0-3 = { package = "futures", version = "0.3", optional = true }
 glob = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
-jsonwebtoken = { version = "6.0", optional = true }
+jsonwebtoken = { version = "7.0", optional = true }
 influxdb = { version = "0.4.0", features = ["derive"], optional = true }
 log = "0.3.0"
 metrics = {version = "0.17", features = ["std"], optional = true}

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/authorize.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/authorize.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 #[cfg(feature = "biome-credentials")]
-use jsonwebtoken::{decode, Validation};
+use jsonwebtoken::{decode, DecodingKey, Validation};
 
 use crate::actix_web::HttpRequest;
 #[cfg(feature = "biome-credentials")]
@@ -62,7 +62,11 @@ pub(crate) fn validate_claims(
         }
     };
 
-    match decode::<Claims>(token, secret.as_ref(), validation) {
+    match decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(secret.as_ref()),
+        validation,
+    ) {
         Ok(claims) => AuthorizationResult::Authorized(claims.claims),
         Err(err) => {
             debug!("Invalid token: {}", err);

--- a/libsplinter/src/rest_api/auth/identity/biome.rs
+++ b/libsplinter/src/rest_api/auth/identity/biome.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use jsonwebtoken::{decode, Validation};
+use jsonwebtoken::{decode, DecodingKey, Validation};
 
 use crate::error::InternalError;
 use crate::rest_api::{
@@ -62,9 +62,13 @@ impl IdentityProvider for BiomeUserIdentityProvider {
             .secret()
             .map_err(|err| InternalError::from_source(err.into()))?;
 
-        Ok(decode::<Claims>(token, secret.as_ref(), &self.validation)
-            .map(|token_data| Identity::User(token_data.claims.user_id()))
-            .ok())
+        Ok(decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(secret.as_ref()),
+            &self.validation,
+        )
+        .map(|token_data| Identity::User(token_data.claims.user_id()))
+        .ok())
     }
 
     fn clone_box(&self) -> Box<dyn IdentityProvider> {

--- a/libsplinter/src/rest_api/sessions/mod.rs
+++ b/libsplinter/src/rest_api/sessions/mod.rs
@@ -27,7 +27,7 @@ pub use error::{ClaimsBuildError, TokenIssuerError, TokenValidationError};
 pub use token_issuer::AccessTokenIssuer;
 
 #[cfg(feature = "biome-credentials")]
-const DEFAULT_LEEWAY: i64 = 10; // default leeway in seconds.
+const DEFAULT_LEEWAY: u64 = 10; // default leeway in seconds.
 
 /// Implementers can issue JWT tokens
 pub trait TokenIssuer<T: Serialize> {

--- a/libsplinter/src/rest_api/sessions/token_issuer.rs
+++ b/libsplinter/src/rest_api/sessions/token_issuer.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use jsonwebtoken::{encode, Header};
+use jsonwebtoken::{encode, EncodingKey, Header};
 
 use super::{Claims, TokenIssuer, TokenIssuerError};
 use crate::rest_api::secrets::SecretManager;
@@ -47,7 +47,7 @@ impl TokenIssuer<Claims> for AccessTokenIssuer {
         let token = encode(
             &Header::default(),
             &claims,
-            self.secret_manager.secret()?.as_ref(),
+            &EncodingKey::from_secret(self.secret_manager.secret()?.as_ref()),
         )?;
         Ok(token)
     }
@@ -57,7 +57,7 @@ impl TokenIssuer<Claims> for AccessTokenIssuer {
         let token = encode(
             &Header::default(),
             &claims,
-            self.refresh_secret_manager.secret()?.as_ref(),
+            &EncodingKey::from_secret(self.refresh_secret_manager.secret()?.as_ref()),
         )?;
         Ok(token)
     }


### PR DESCRIPTION
Bump the version of jsonwebtoken to 7 to resolve a build issue with the dependent ring crate.

The prior version of the ring crate did not include pregenerated
assembler source for Apple M1 silicon.

Signed-off-by: James Mitchell <mitchell@bitwise.io>