### PR TITLE
Replace scabbard purge fn with trait

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory/factory_database.rs
+++ b/services/scabbard/libscabbard/src/service/factory/factory_database.rs
@@ -36,10 +36,12 @@ use crate::service::rest_api::actix;
 use crate::service::{
     error::ScabbardError,
     state::merkle_state::{MerkleState, MerkleStateConfig},
-    Scabbard, ScabbardVersion, SERVICE_TYPE,
+    Scabbard, ScabbardStatePurgeHandler, ScabbardVersion, SERVICE_TYPE,
 };
 use crate::store::{
-    diesel::DieselCommitHashStore, transact::factory::LmdbDatabaseFactory, CommitHashStore,
+    diesel::DieselCommitHashStore,
+    transact::factory::{LmdbDatabaseFactory, LmdbDatabasePurgeHandle},
+    CommitHashStore,
 };
 
 const DEFAULT_LMDB_DIR: &str = "/var/lib/splinter";
@@ -439,38 +441,36 @@ impl ServiceFactory for ScabbardFactory {
         let version = ScabbardVersion::try_from(args.get("version").map(String::as_str))
             .map_err(FactoryCreateError::InvalidArguments)?;
 
-        let (merkle_state, state_purge) = if self.enable_lmdb_state {
-            self.sql_state_check(circuit_id, &service_id)?;
+        let (merkle_state, state_purge): (_, Box<dyn ScabbardStatePurgeHandler>) =
+            if self.enable_lmdb_state {
+                self.sql_state_check(circuit_id, &service_id)?;
 
-            let db = self
-                .state_store_factory
-                .get_database(circuit_id, &service_id)
-                .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
+                let db = self
+                    .state_store_factory
+                    .get_database(circuit_id, &service_id)
+                    .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
 
-            let db_purge_handle = self
-                .state_store_factory
-                .get_database_purge_handle(circuit_id, &service_id)
-                .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
+                let db_purge_handle = self
+                    .state_store_factory
+                    .get_database_purge_handle(circuit_id, &service_id)
+                    .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
 
-            let merkle_state = MerkleState::new(MerkleStateConfig::key_value(db.clone_box()))
-                .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
+                let merkle_state = MerkleState::new(MerkleStateConfig::key_value(db.clone_box()))
+                    .map_err(|e| FactoryCreateError::Internal(e.to_string()))?;
 
-            (
-                merkle_state,
-                Box::new(move || {
-                    db_purge_handle.purge()?;
-                    Ok(())
-                }) as Box<dyn Fn() -> Result<(), InternalError> + Sync + Send>,
-            )
-        } else {
-            self.lmdb_state_check(circuit_id, &service_id)?;
+                (
+                    merkle_state,
+                    Box::new(LmdbScabbardPurgeHandler { db_purge_handle }),
+                )
+            } else {
+                self.lmdb_state_check(circuit_id, &service_id)?;
 
-            (
-                MerkleState::new(self.create_sql_merkle_state_config(circuit_id, &service_id))
-                    .map_err(|e| FactoryCreateError::Internal(e.to_string()))?,
-                Box::new(|| Ok(())) as Box<dyn Fn() -> Result<(), InternalError> + Sync + Send>,
-            )
-        };
+                (
+                    MerkleState::new(self.create_sql_merkle_state_config(circuit_id, &service_id))
+                        .map_err(|e| FactoryCreateError::Internal(e.to_string()))?,
+                    Box::new(NoOpScabbardStatePurgeHandler),
+                )
+            };
 
         let (receipt_store, commit_hash_store): (ScabbardReceiptStore, Box<dyn CommitHashStore>) =
             match &self.store_factory_config {
@@ -500,8 +500,6 @@ impl ServiceFactory for ScabbardFactory {
                 ),
             };
 
-        let purge_fn = state_purge as Box<dyn Fn() -> Result<(), InternalError> + Sync + Send>;
-
         let service = Scabbard::new(
             service_id,
             circuit_id,
@@ -510,7 +508,7 @@ impl ServiceFactory for ScabbardFactory {
             merkle_state,
             commit_hash_store,
             receipt_store,
-            purge_fn,
+            state_purge,
             self.signature_verifier_factory
                 .lock()
                 .map_err(|_| {
@@ -664,6 +662,24 @@ fn get_sqlite_pool(
     pool_builder.build(connection_manager).map_err(|err| {
         InvalidStateError::with_message(format!("Failed to build connection pool: {}", err))
     })
+}
+
+struct LmdbScabbardPurgeHandler {
+    db_purge_handle: LmdbDatabasePurgeHandle,
+}
+
+impl ScabbardStatePurgeHandler for LmdbScabbardPurgeHandler {
+    fn purge_state(&self) -> Result<(), InternalError> {
+        self.db_purge_handle.purge()
+    }
+}
+
+struct NoOpScabbardStatePurgeHandler;
+
+impl ScabbardStatePurgeHandler for NoOpScabbardStatePurgeHandler {
+    fn purge_state(&self) -> Result<(), InternalError> {
+        Ok(())
+    }
 }
 
 #[cfg(feature = "sqlite")]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -88,6 +88,12 @@ impl TryFrom<Option<&str>> for ScabbardVersion {
 
 type ScabbardReceiptStore = Arc<RwLock<dyn ReceiptStore>>;
 
+/// A handler for purging a scabbard instances state
+pub trait ScabbardStatePurgeHandler: Send + Sync {
+    /// Purge the scabbard instances state.
+    fn purge_state(&self) -> Result<(), splinter::error::InternalError>;
+}
+
 /// A service for running Sawtooth Sabre smart contracts with two-phase commit consensus.
 #[derive(Clone)]
 pub struct Scabbard {
@@ -96,7 +102,7 @@ pub struct Scabbard {
     version: ScabbardVersion,
     shared: Arc<Mutex<ScabbardShared>>,
     state: Arc<Mutex<ScabbardState>>,
-    purge_fn: Arc<dyn Fn() -> Result<(), splinter::error::InternalError> + Send + Sync>,
+    purge_handler: Arc<dyn ScabbardStatePurgeHandler>,
     /// The coordinator timeout for the two-phase commit consensus engine
     coordinator_timeout: Duration,
     consensus: Arc<Mutex<Option<ScabbardConsensusManager>>>,
@@ -121,7 +127,7 @@ impl Scabbard {
         #[cfg(feature = "database-support")] merkle_state: MerkleState,
         #[cfg(feature = "database-support")] commit_hash_store: Box<dyn CommitHashStore>,
         receipt_store: ScabbardReceiptStore,
-        purge_fn: Box<dyn Fn() -> Result<(), splinter::error::InternalError> + Send + Sync>,
+        purge_handler: Box<dyn ScabbardStatePurgeHandler>,
         signature_verifier: Box<dyn SignatureVerifier>,
         // The public keys that are authorized to create and manage sabre contracts
         admin_keys: Vec<String>,
@@ -175,7 +181,7 @@ impl Scabbard {
             version,
             shared: Arc::new(Mutex::new(shared)),
             state: Arc::new(Mutex::new(state)),
-            purge_fn: purge_fn.into(),
+            purge_handler: purge_handler.into(),
             coordinator_timeout,
             consensus: Arc::new(Mutex::new(None)),
         })
@@ -412,7 +418,7 @@ impl Service for Scabbard {
     }
 
     fn purge(&mut self) -> Result<(), splinter::error::InternalError> {
-        (*self.purge_fn)()
+        self.purge_handler.purge_state()
     }
 
     fn handle_message(
@@ -585,7 +591,7 @@ pub mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             Arc::new(RwLock::new(MockReceiptStore)),
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -618,7 +624,7 @@ pub mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             Arc::new(RwLock::new(MockReceiptStore)),
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -651,7 +657,7 @@ pub mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             Arc::new(RwLock::new(MockReceiptStore)),
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -876,6 +882,14 @@ pub mod tests {
             _id: Option<String>,
         ) -> Result<ReceiptIter, ReceiptStoreError> {
             unimplemented!()
+        }
+    }
+
+    struct NoOpScabbardStatePurgeHandler;
+
+    impl ScabbardStatePurgeHandler for NoOpScabbardStatePurgeHandler {
+        fn purge_state(&self) -> Result<(), splinter::error::InternalError> {
+            Ok(())
         }
     }
 

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -143,7 +143,9 @@ mod tests {
     use crate::service::factory::compute_db_path;
     #[cfg(feature = "database-support")]
     use crate::service::state::merkle_state::{MerkleState, MerkleStateConfig};
-    use crate::service::{state::ScabbardState, Scabbard, ScabbardVersion};
+    use crate::service::{
+        state::ScabbardState, Scabbard, ScabbardStatePurgeHandler, ScabbardVersion,
+    };
     #[cfg(feature = "database-support")]
     use crate::store::{
         transact::{TransactCommitHashStore, CURRENT_STATE_ROOT_INDEX},
@@ -255,7 +257,7 @@ mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             receipt_store,
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandlerHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -377,6 +379,14 @@ mod tests {
             .shutdown()
             .expect("Unable to shutdown rest api");
         join_handle.join().expect("Unable to join rest api thread");
+    }
+
+    struct NoOpScabbardStatePurgeHandlerHandler;
+
+    impl ScabbardStatePurgeHandler for NoOpScabbardStatePurgeHandlerHandler {
+        fn purge_state(&self) -> Result<(), InternalError> {
+            Ok(())
+        }
     }
 
     #[cfg(not(feature = "database-support"))]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -121,7 +121,9 @@ mod tests {
     use crate::service::factory::compute_db_path;
     #[cfg(feature = "database-support")]
     use crate::service::state::merkle_state::{MerkleState, MerkleStateConfig};
-    use crate::service::{state::ScabbardState, Scabbard, ScabbardVersion};
+    use crate::service::{
+        state::ScabbardState, Scabbard, ScabbardStatePurgeHandler, ScabbardVersion,
+    };
     #[cfg(feature = "database-support")]
     use crate::store::{
         transact::{TransactCommitHashStore, CURRENT_STATE_ROOT_INDEX},
@@ -222,7 +224,7 @@ mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             receipt_store,
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandlerHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -359,6 +361,14 @@ mod tests {
                 }
             })
             .expect("No port available")
+    }
+
+    struct NoOpScabbardStatePurgeHandlerHandler;
+
+    impl ScabbardStatePurgeHandler for NoOpScabbardStatePurgeHandlerHandler {
+        fn purge_state(&self) -> Result<(), InternalError> {
+            Ok(())
+        }
     }
 
     /// An identity provider that always returns `Ok(Some(_))`

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -113,7 +113,9 @@ mod tests {
     use crate::service::factory::compute_db_path;
     #[cfg(feature = "database-support")]
     use crate::service::state::merkle_state::{MerkleState, MerkleStateConfig};
-    use crate::service::{state::ScabbardState, Scabbard, ScabbardVersion};
+    use crate::service::{
+        state::ScabbardState, Scabbard, ScabbardStatePurgeHandler, ScabbardVersion,
+    };
     #[cfg(feature = "database-support")]
     use crate::store::{
         transact::{TransactCommitHashStore, CURRENT_STATE_ROOT_INDEX},
@@ -213,7 +215,7 @@ mod tests {
             #[cfg(feature = "database-support")]
             commit_hash_store,
             receipt_store,
-            Box::new(|| Ok(())),
+            Box::new(NoOpScabbardStatePurgeHandlerHandler),
             Secp256k1Context::new().new_verifier(),
             vec![],
             None,
@@ -336,6 +338,14 @@ mod tests {
                 }
             })
             .expect("No port available")
+    }
+
+    struct NoOpScabbardStatePurgeHandlerHandler;
+
+    impl ScabbardStatePurgeHandler for NoOpScabbardStatePurgeHandlerHandler {
+        fn purge_state(&self) -> Result<(), InternalError> {
+            Ok(())
+        }
     }
 
     /// An identity provider that always returns `Ok(Some(_))`


### PR DESCRIPTION
This change replaces the boxed function for handling state purge with a trait for the specific operation.  This gives a more concrete name for the operation.
