### PR TITLE
Add "scabbard-service" default feature

### DIFF
--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -36,7 +36,7 @@ flexi_logger = "0.14"
 log = "0.4"
 sabre-sdk = "0.7"
 transact = { version = "0.3", features = ["contract-archive"] }
-scabbard = { path = "../libscabbard", features = ["client-reqwest"] }
+scabbard = { path = "../libscabbard", features = ["client-reqwest"], default-features=false }
 
 [dev-dependencies]
 serial_test = "0.3"

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -55,7 +55,7 @@ protoc-rust = "2.14"
 glob = "0.2"
 
 [features]
-default = []
+default = ["splinter-service"]
 
 stable = [
   "authorization",
@@ -89,4 +89,5 @@ lmdb = []
 postgres = ["diesel/postgres", "diesel_migrations", "sawtooth/postgres", "transact/postgres"]
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
+splinter-service = []
 sqlite = ["diesel/sqlite", "diesel_migrations", "sawtooth/sqlite", "transact/sqlite"]

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -30,7 +30,7 @@ cylinder = "0.2"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }
 futures = { version = "0.1", optional = true }
-log = "0.3.0"
+log = { version = "0.3.0", optional = true }
 metrics = { version = "0.17", optional = true}
 openssl = "0.10"
 protobuf = "2.23"
@@ -81,7 +81,7 @@ experimental = [
 
 authorization = ["splinter/authorization"]
 client = []
-client-reqwest = ["client", "reqwest"]
+client-reqwest = ["client", "log", "reqwest"]
 database-support = ["transact/state-merkle-sql"]
 events = ["splinter/events"]
 https = []
@@ -89,5 +89,5 @@ lmdb = []
 postgres = ["diesel/postgres", "diesel_migrations", "sawtooth/postgres", "transact/postgres"]
 rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
-splinter-service = []
+splinter-service = ["log"]
 sqlite = ["diesel/sqlite", "diesel_migrations", "sawtooth/sqlite", "transact/sqlite"]

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -36,8 +36,7 @@ openssl = "0.10"
 protobuf = "2.23"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth-sabre = "0.7.2"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
 transact = { version = "0.3.13", features = ["sawtooth-compat"] }

--- a/services/scabbard/libscabbard/src/client/reqwest/mod.rs
+++ b/services/scabbard/libscabbard/src/client/reqwest/mod.rs
@@ -22,6 +22,7 @@ use reqwest::{
     blocking::{Client, RequestBuilder, Response},
     Url,
 };
+use serde::{Deserialize, Serialize};
 use transact::{protocol::batch::Batch, protos::IntoBytes};
 
 use crate::hex::parse_hex;

--- a/services/scabbard/libscabbard/src/hex.rs
+++ b/services/scabbard/libscabbard/src/hex.rs
@@ -13,16 +13,7 @@
 // limitations under the License.
 
 use std::error::Error;
-use std::fmt::{self, Write};
-
-pub fn to_hex(bytes: &[u8]) -> String {
-    let mut buf = String::new();
-    for b in bytes {
-        write!(&mut buf, "{:02x}", b).expect("Unable to write to string");
-    }
-
-    buf
-}
+use std::fmt;
 
 pub fn parse_hex(hex: &str) -> Result<Vec<u8>, HexError> {
     if hex.len() % 2 != 0 {
@@ -93,16 +84,6 @@ mod tests {
 
         // check that invalid digits fails
         assert!(parse_hex("0G").is_err());
-
-        // check round trip
-        assert_eq!(
-            "abcdef",
-            &to_hex(&parse_hex("abcdef").expect("unable to parse hex for round trip"))
-        );
-        assert_eq!(
-            "012345",
-            &to_hex(&parse_hex("012345").expect("unable to parse hex for round trip"))
-        );
 
         // check empty parses
         let empty: Vec<u8> = Vec::with_capacity(0);

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -30,16 +30,17 @@ extern crate diesel_migrations;
 extern crate metrics;
 
 // pull in `no-op` metric macros if `metrics` is not enabled
-#[cfg(not(feature = "metrics"))]
-#[macro_use]
+#[cfg_attr(all(not(feature = "metrics"), feature = "splinter-service"), macro_use)]
 extern crate splinter;
 
 #[cfg(feature = "client")]
 pub mod client;
+#[cfg(any(feature = "client-reqwest", feature = "splinter-service"))]
 mod hex;
 #[cfg(feature = "diesel_migrations")]
 pub mod migrations;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "splinter-service")]
 pub mod service;
 pub mod store;

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -24,8 +24,6 @@ extern crate diesel;
 #[cfg(feature = "diesel_migrations")]
 #[macro_use]
 extern crate diesel_migrations;
-#[macro_use]
-extern crate serde_derive;
 
 #[cfg(feature = "metrics")]
 #[macro_use]

--- a/services/scabbard/libscabbard/src/lib.rs
+++ b/services/scabbard/libscabbard/src/lib.rs
@@ -16,6 +16,7 @@
 //! Hyperledger Transact for state management. Scabbard uses two-phase consensus to reach agreement
 //! on transactions.
 
+#[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
 #[cfg(feature = "diesel")]

--- a/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
+++ b/services/scabbard/libscabbard/src/service/factory/factory_static_configuration.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
@@ -31,7 +32,6 @@ use splinter::service::validation::ServiceArgValidator;
 use splinter::service::{FactoryCreateError, Service, ServiceFactory};
 
 use crate::hex::parse_hex;
-use crate::hex::to_hex;
 #[cfg(feature = "rest-api-actix")]
 use crate::service::rest_api::actix;
 use crate::service::{
@@ -675,6 +675,15 @@ fn purge_paths(lmdb_path: &Path) -> Result<(), InternalError> {
         .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
     Ok(())
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut buf = String::new();
+    for b in bytes {
+        write!(&mut buf, "{:02x}", b).expect("Unable to write to string");
+    }
+
+    buf
 }
 
 #[cfg(test)]

--- a/services/scabbard/libscabbard/src/service/rest_api/resources/batch_statuses.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/resources/batch_statuses.rs
@@ -14,6 +14,8 @@
 
 use std::time::SystemTime;
 
+use serde::Serialize;
+
 use crate::service::state::{BatchInfo, BatchStatus, InvalidTransaction, ValidTransaction};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/services/scabbard/libscabbard/src/service/rest_api/resources/batches.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/resources/batches.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::Serialize;
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct BatchLinkResponse<'a> {
     link: &'a str,

--- a/services/scabbard/libscabbard/src/service/rest_api/resources/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/resources/state.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::Serialize;
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct StateEntryResponse<'a> {
     pub address: &'a str,

--- a/services/scabbard/libscabbard/src/service/state/state_database/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/state_database/mod.rs
@@ -28,6 +28,7 @@ use sawtooth::receipt::store::ReceiptStore;
 use sawtooth_sabre::{
     handler::SabreTransactionHandler, ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY,
 };
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "events")]
 use splinter::events::{ParseBytes, ParseError};
 #[cfg(test)]

--- a/services/scabbard/libscabbard/src/service/state/state_static_configuration.rs
+++ b/services/scabbard/libscabbard/src/service/state/state_static_configuration.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
-use std::fmt;
+use std::fmt::{self, Write as _};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::{
@@ -168,7 +168,7 @@ impl ScabbardState {
     fn read_current_state_root(db: &dyn Database) -> Result<Option<String>, ScabbardStateError> {
         db.get_reader()
             .and_then(|reader| reader.index_get(CURRENT_STATE_ROOT_INDEX, b"HEAD"))
-            .map(|head| head.map(|bytes| hex::to_hex(&bytes)))
+            .map(|head| head.map(|bytes| to_hex(&bytes)))
             .map_err(|e| ScabbardStateError(format!("Unable to read HEAD entry: {}", e)))
     }
 
@@ -880,6 +880,15 @@ impl Iterator for ChannelBatchInfoIter {
             }
         }
     }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut buf = String::new();
+    for b in bytes {
+        write!(&mut buf, "{:02x}", b).expect("Unable to write to string");
+    }
+
+    buf
 }
 
 #[cfg(feature = "sqlite")]

--- a/services/scabbard/libscabbard/src/service/state/state_static_configuration.rs
+++ b/services/scabbard/libscabbard/src/service/state/state_static_configuration.rs
@@ -28,6 +28,7 @@ use sawtooth::receipt::store::ReceiptStore;
 use sawtooth_sabre::{
     handler::SabreTransactionHandler, ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY,
 };
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "events")]
 use splinter::events::{ParseBytes, ParseError};
 #[cfg(test)]

--- a/services/scabbard/libscabbard/src/store/transact/factory.rs
+++ b/services/scabbard/libscabbard/src/store/transact/factory.rs
@@ -25,8 +25,7 @@ use transact::{
     state::merkle::INDEXES,
 };
 
-use crate::hex::to_hex;
-
+use super::to_hex;
 use super::CURRENT_STATE_ROOT_INDEX;
 
 // Linux, with a 64bit CPU supports sparse files of a large size


### PR DESCRIPTION
This PR creates a `"scabbard-service"` default feature, around the grandfathered-in "stable" service code.  This will allow the CLI to only depend on the client, which will remove some very tricky feature guards when `"scabbard/database-support"` is stabilized.