### PR TITLE
Use CircuitTemplate::load_from_file to use the file_path directly

### DIFF
--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -22,9 +22,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use super::{
-    find_template, CircuitTemplateError, DEFAULT_TEMPLATE_DIR, SPLINTER_CIRCUIT_TEMPLATE_PATH,
-};
+use super::CircuitTemplateError;
 
 /// Version guard for the template, referring to the version of the circuit definition being used.
 #[derive(Deserialize, Debug)]
@@ -47,18 +45,7 @@ impl CircuitTemplate {
     ///
     /// * `file_path` - Path to the template YAML file.
     pub fn load_from_file(file_path: &str) -> Result<Self, CircuitTemplateError> {
-        let mut paths = Vec::new();
-        if let Ok(template_paths) = std::env::var(SPLINTER_CIRCUIT_TEMPLATE_PATH) {
-            paths.extend(
-                template_paths
-                    .split(':')
-                    .map(ToOwned::to_owned)
-                    .collect::<Vec<String>>(),
-            );
-        }
-        paths.push(DEFAULT_TEMPLATE_DIR.to_string());
-        let template_path = find_template(file_path, &paths)?;
-        let custom_path = Path::new(&template_path);
+        let custom_path = Path::new(&file_path);
         if !custom_path.is_file() {
             return Err(CircuitTemplateError::new(&format!(
                 "File does not exist or is inaccessible: {:?}",


### PR DESCRIPTION
Every time this is used it is passed the entire file path. The file
path was found from the default and env variables previously.

Trying to find a file based on the full file path would cause the
file to not be found, and thus the show and argument CLI commands
would fail.
