### PR TITLE
Scabbard feature improvements

### DIFF
--- a/services/scabbard/libscabbard/src/service/state/state_database/merkle_state.rs
+++ b/services/scabbard/libscabbard/src/service/state/state_database/merkle_state.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 #[cfg(feature = "diesel")]
 use diesel::r2d2::{ConnectionManager, Pool};
 use splinter::error::InternalError;
-#[cfg(any(feature = "postgres", feature = "sql"))]
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
 use transact::state::merkle::sql;
 use transact::{
     database::Database,


### PR DESCRIPTION
This PR updates the feature guards such that the `"database-support"` feature can be compiled without databases (a necessary detail when the feature is removed during stabilization).