### PR TITLE
Update the root logger to allow levels below info

### DIFF
--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -116,7 +116,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
         {
             let root_logger: Option<RootConfig> = Some(RootConfig {
                 appenders: vec!["stdout".to_string()],
-                level: log::Level::Info,
+                level: log::Level::Trace,
             });
             let stdout = UnnamedAppenderConfig {
                 encoder: String::from(DEFAULT_LOGGING_PATTERN),


### PR DESCRIPTION
The default root logger had a preset level filter of info, which conflicted
with `-vv` and `-vvv` verbosity flags if the root logger wasn't
overridden in splinterd.toml. The value is now trace so all logs will
get forwarded to appenders.

Signed-off-by: Caleb Hill <hill@bitwise.io>