### PR TITLE
Stabilize cli/scabbard-migrations by removing it

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -82,7 +82,6 @@ experimental = [
     "health",
     "https-certs",
     "registry",
-    "scabbard-migrations",
 ]
 
 authorization-handler-maintenance = []
@@ -97,9 +96,6 @@ postgres = [
     "scabbard/postgres"
 ]
 registry = []
-scabbard-migrations = [
-  "scabbard/lmdb"
-]
 sqlite = [
     "diesel/sqlite",
     "splinter/sqlite",
@@ -107,6 +103,7 @@ sqlite = [
 ]
 upgrade = [
     "database",
+    "scabbard/lmdb",
     "splinter/store-factory"
 ]
 user = []

--- a/cli/src/action/database/upgrade/mod.rs
+++ b/cli/src/action/database/upgrade/mod.rs
@@ -69,15 +69,14 @@ impl Action for UpgradeAction {
         let db_store = store_factory.get_admin_service_store();
         yaml::import_yaml_state_to_database(state_dir.as_path(), &*db_store)?;
 
-        {
-            scabbard::upgrade_scabbard_commit_hash_state(state_dir.as_path(), &database_uri)
-                .map_err(|err| {
-                    CliError::ActionError(format!(
-                        "failed to upgrade scabbard commit hash state: {}",
-                        err
-                    ))
-                })?;
-        }
+        scabbard::upgrade_scabbard_commit_hash_state(state_dir.as_path(), &database_uri).map_err(
+            |err| {
+                CliError::ActionError(format!(
+                    "failed to upgrade scabbard commit hash state: {}",
+                    err
+                ))
+            },
+        )?;
 
         receipt_store::upgrade_scabbard_receipt_store(state_dir.as_path(), &database_uri)?;
 

--- a/cli/src/action/database/upgrade/mod.rs
+++ b/cli/src/action/database/upgrade/mod.rs
@@ -14,11 +14,9 @@
 
 //! Provides database upgrade functionality
 
-#[cfg(feature = "scabbard-migrations")]
 mod error;
 mod node_id;
 mod receipt_store;
-#[cfg(feature = "scabbard-migrations")]
 mod scabbard;
 mod yaml;
 
@@ -71,7 +69,6 @@ impl Action for UpgradeAction {
         let db_store = store_factory.get_admin_service_store();
         yaml::import_yaml_state_to_database(state_dir.as_path(), &*db_store)?;
 
-        #[cfg(feature = "scabbard-migrations")]
         {
             scabbard::upgrade_scabbard_commit_hash_state(state_dir.as_path(), &database_uri)
                 .map_err(|err| {


### PR DESCRIPTION
This change stabilizes the CLI feature "scabbard-migrations" by removing the feature.  Its functionality is covered by the "upgrade" feature.