### PR TITLE
Add feature guard for testing import

### DIFF
--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -925,6 +925,7 @@ mod tests {
 
     use ::clap::ArgMatches;
     use ::toml::{map::Map, to_string, Value};
+    #[cfg(feature = "log-config")]
     use log::Level;
 
     use crate::config::{


### PR DESCRIPTION
log::Level is used by one test that is feature guarded. When you run
`just build` it will output warnings that theres an unused import for
stable and default feature builds. This commit just add the guard to
avoid the warning.

Signed-off-by: Caleb Hill <hill@bitwise.io>