### PR TITLE
Fix logging use statements in config

### DIFF
--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -24,8 +24,7 @@ use std::path::Path;
 use crate::config::error::ConfigError;
 use crate::config::{Config, ConfigSource, PartialConfig};
 
-use super::logging::AppenderConfig;
-use super::LoggerConfig;
+use super::{AppenderConfig, LoggerConfig};
 
 pub trait PartialConfigBuilder {
     /// Takes all values set in a config object to create a `PartialConfig` object.

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -16,10 +16,11 @@
 
 use std::collections::HashMap;
 
-use crate::config::logging::UnnamedLoggerConfig;
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 
-use super::logging::{RootConfig, UnnamedAppenderConfig, DEFAULT_LOGGING_PATTERN};
+use super::logging::{
+    RootConfig, UnnamedAppenderConfig, UnnamedLoggerConfig, DEFAULT_LOGGING_PATTERN,
+};
 use super::ScabbardState;
 
 const CONFIG_DIR: &str = "/etc/splinter";

--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -19,9 +19,7 @@ use std::convert::TryInto;
 use log::Level;
 
 use super::error::ConfigError;
-use super::toml::TomlRawLogTarget;
-use super::toml::TomlUnnamedAppenderConfig;
-use super::toml::TomlUnnamedLoggerConfig;
+use super::toml::{TomlRawLogTarget, TomlUnnamedAppenderConfig, TomlUnnamedLoggerConfig};
 
 pub const DEFAULT_LOGGING_PATTERN: &str = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n";
 


### PR DESCRIPTION
Logging struct imports were inconsistently imported, this commit
condenses use statments and changes `crate` based uses to `super` uses
with in the config module.

Signed-off-by: Caleb Hill <hill@bitwise.io>