### PR TITLE
Fix scabbard batch status deadlock

### DIFF
--- a/libsplinter/src/orchestrator/builder.rs
+++ b/libsplinter/src/orchestrator/builder.rs
@@ -15,10 +15,10 @@
 //! Builder for constructing new service orchestrators.
 
 use crate::error::InvalidStateError;
-use crate::service::ServiceFactory;
 use crate::transport::Connection;
 
 use super::runnable::RunnableServiceOrchestrator;
+use super::OrchestratableServiceFactory;
 
 const DEFAULT_INCOMING_CAPACITY: usize = 512;
 const DEFAULT_OUTGOING_CAPACITY: usize = 512;
@@ -31,7 +31,7 @@ pub struct ServiceOrchestratorBuilder {
     incoming_capacity: Option<usize>,
     outgoing_capacity: Option<usize>,
     channel_capacity: Option<usize>,
-    service_factories: Vec<Box<dyn ServiceFactory>>,
+    service_factories: Vec<Box<dyn OrchestratableServiceFactory>>,
 }
 
 impl ServiceOrchestratorBuilder {
@@ -78,7 +78,10 @@ impl ServiceOrchestratorBuilder {
     /// Adds a service factory which will be used to create service instances.
     ///
     /// This function may be called more than once to add additional service factories.
-    pub fn with_service_factory(mut self, service_factory: Box<dyn ServiceFactory>) -> Self {
+    pub fn with_service_factory(
+        mut self,
+        service_factory: Box<dyn OrchestratableServiceFactory>,
+    ) -> Self {
         self.service_factories.push(service_factory);
 
         self

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -71,6 +71,35 @@ impl std::fmt::Display for ServiceDefinition {
     }
 }
 
+/// A service that may be orchestratable.
+///
+/// This service has several stronger requirements, mainly required moving and sharing a service
+/// instance among threads.
+pub trait OrchestratableService: Service {
+    fn clone_box(&self) -> Box<dyn OrchestratableService>;
+
+    fn as_service(&self) -> &dyn Service;
+}
+
+impl Clone for Box<dyn OrchestratableService> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// A service factory that produces orchestratable services.
+pub trait OrchestratableServiceFactory: ServiceFactory {
+    /// Create a Service instance with the given ID, of the given type, the given circuit_id,
+    /// with the given arguments.
+    fn create_orchestratable_service(
+        &self,
+        service_id: String,
+        service_type: &str,
+        circuit_id: &str,
+        args: HashMap<String, String>,
+    ) -> Result<Box<dyn OrchestratableService>, FactoryCreateError>;
+}
+
 /// Stores a service and other structures that are used to manage it
 struct ManagedService {
     pub service: Box<dyn Service>,

--- a/libsplinter/src/orchestrator/rest_api.rs
+++ b/libsplinter/src/orchestrator/rest_api.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use crate::actix_web::HttpResponse;
+use crate::error::InternalError;
 use crate::futures::IntoFuture;
+use crate::orchestrator::OrchestratableService;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
 
-use super::ServiceOrchestrator;
+use super::{ManagedService, ServiceDefinition, ServiceOrchestrator};
 
 /// The `ServiceOrchestrator` exposes REST API resources provided by the
 /// [`ServiceFactory::get_rest_endpoints`] methods of its factories. Each factory defines the
@@ -66,35 +71,14 @@ impl RestResourceProvider for ServiceOrchestrator {
                                     .unwrap_or("")
                                     .to_string();
 
-                                let services = match services.lock() {
-                                    Ok(s) => s,
-                                    Err(err) => {
-                                        error!("Orchestrator's service lock is poisoned: {}", err);
-                                        return Box::new(
-                                            HttpResponse::InternalServerError()
-                                                .json(json!({
-                                                    "message": "An internal error occurred"
-                                                }))
-                                                .into_future(),
-                                        )
-                                        .into_future();
-                                    }
-                                };
-
-                                let service = match services.iter().find_map(
-                                    |(service_def, managed_service)| {
-                                        if service_def.service_type == service_type
-                                            && service_def.circuit == circuit
-                                            && service_def.service_id == service_id
-                                        {
-                                            Some(&*managed_service.service)
-                                        } else {
-                                            None
-                                        }
-                                    },
+                                let service = match lookup_service(
+                                    &*services,
+                                    &circuit,
+                                    &service_id,
+                                    &service_type,
                                 ) {
-                                    Some(s) => s,
-                                    None => {
+                                    Ok(Some(s)) => s,
+                                    Ok(None) => {
                                         return Box::new(
                                             HttpResponse::NotFound()
                                                 .json(json!({
@@ -103,6 +87,17 @@ impl RestResourceProvider for ServiceOrchestrator {
                                                             "{} service {} on circuit {} not found",
                                                             service_type, service_id, circuit
                                                         )
+                                                }))
+                                                .into_future(),
+                                        )
+                                        .into_future();
+                                    }
+                                    Err(err) => {
+                                        error!("{}", err);
+                                        return Box::new(
+                                            HttpResponse::InternalServerError()
+                                                .json(json!({
+                                                    "message": "An internal error occurred"
                                                 }))
                                                 .into_future(),
                                         )
@@ -120,4 +115,26 @@ impl RestResourceProvider for ServiceOrchestrator {
                 acc
             })
     }
+}
+
+fn lookup_service(
+    services: &Mutex<HashMap<ServiceDefinition, ManagedService>>,
+    circuit: &str,
+    service_id: &str,
+    service_type: &str,
+) -> Result<Option<Box<dyn OrchestratableService>>, InternalError> {
+    let services = services.lock().map_err(|_| {
+        InternalError::with_message("Orchestrator's service lock is poisoned".into())
+    })?;
+
+    Ok(services.iter().find_map(|(service_def, managed_service)| {
+        if service_def.service_type == service_type
+            && service_def.circuit == circuit
+            && service_def.service_id == service_id
+        {
+            Some(managed_service.service.clone())
+        } else {
+            None
+        }
+    }))
 }

--- a/libsplinter/src/orchestrator/rest_api.rs
+++ b/libsplinter/src/orchestrator/rest_api.rs
@@ -50,135 +50,69 @@ impl RestResourceProvider for ServiceOrchestrator {
 
                         let service_type = endpoint.service_type;
                         let handler = endpoint.handler;
-                        #[cfg(feature = "authorization")]
-                        {
-                            resource_builder.add_method(
-                                endpoint.method,
-                                endpoint.permission,
-                                move |request, payload| {
-                                    let circuit = request
-                                        .match_info()
-                                        .get("circuit")
-                                        .unwrap_or("")
-                                        .to_string();
-                                    let service_id = request
-                                        .match_info()
-                                        .get("service_id")
-                                        .unwrap_or("")
-                                        .to_string();
+                        resource_builder.add_method(
+                            endpoint.method,
+                            #[cfg(feature = "authorization")]
+                            endpoint.permission,
+                            move |request, payload| {
+                                let circuit = request
+                                    .match_info()
+                                    .get("circuit")
+                                    .unwrap_or("")
+                                    .to_string();
+                                let service_id = request
+                                    .match_info()
+                                    .get("service_id")
+                                    .unwrap_or("")
+                                    .to_string();
 
-                                    let services = match services.lock() {
-                                        Ok(s) => s,
-                                        Err(err) => {
-                                            error!("Orchestrator's service lock is poisoned: {}", err);
-                                            return Box::new(
-                                                HttpResponse::InternalServerError()
-                                                    .json(json!({
-                                                        "message": "An internal error occurred"
-                                                    }))
-                                                    .into_future(),
-                                            )
-                                            .into_future();
+                                let services = match services.lock() {
+                                    Ok(s) => s,
+                                    Err(err) => {
+                                        error!("Orchestrator's service lock is poisoned: {}", err);
+                                        return Box::new(
+                                            HttpResponse::InternalServerError()
+                                                .json(json!({
+                                                    "message": "An internal error occurred"
+                                                }))
+                                                .into_future(),
+                                        )
+                                        .into_future();
+                                    }
+                                };
+
+                                let service = match services.iter().find_map(
+                                    |(service_def, managed_service)| {
+                                        if service_def.service_type == service_type
+                                            && service_def.circuit == circuit
+                                            && service_def.service_id == service_id
+                                        {
+                                            Some(&*managed_service.service)
+                                        } else {
+                                            None
                                         }
-                                    };
+                                    },
+                                ) {
+                                    Some(s) => s,
+                                    None => {
+                                        return Box::new(
+                                            HttpResponse::NotFound()
+                                                .json(json!({
+                                                    "message":
+                                                        format!(
+                                                            "{} service {} on circuit {} not found",
+                                                            service_type, service_id, circuit
+                                                        )
+                                                }))
+                                                .into_future(),
+                                        )
+                                        .into_future();
+                                    }
+                                };
 
-                                    let service = match services.iter().find_map(
-                                        |(service_def, managed_service)| {
-                                            if service_def.service_type == service_type
-                                                && service_def.circuit == circuit
-                                                && service_def.service_id == service_id
-                                            {
-                                                Some(&*managed_service.service)
-                                            } else {
-                                                None
-                                            }
-                                        },
-                                    ) {
-                                        Some(s) => s,
-                                        None => {
-                                            return Box::new(
-                                                HttpResponse::NotFound()
-                                                    .json(json!({
-                                                        "message":
-                                                            format!(
-                                                                "{} service {} on circuit {} not found",
-                                                                service_type, service_id, circuit
-                                                            )
-                                                    }))
-                                                    .into_future(),
-                                            )
-                                            .into_future();
-                                        }
-                                    };
-
-                                    handler(request, payload, service)
-                                },
-                            )
-                        }
-                        #[cfg(not(feature = "authorization"))]
-                        {
-                            resource_builder.add_method(
-                                endpoint.method,
-                                move |request, payload| {
-                                    let circuit = request
-                                        .match_info()
-                                        .get("circuit")
-                                        .unwrap_or("")
-                                        .to_string();
-                                    let service_id = request
-                                        .match_info()
-                                        .get("service_id")
-                                        .unwrap_or("")
-                                        .to_string();
-
-                                    let services = match services.lock() {
-                                        Ok(s) => s,
-                                        Err(err) => {
-                                            error!("Orchestrator's service lock is poisoned: {}", err);
-                                            return Box::new(
-                                                HttpResponse::InternalServerError()
-                                                    .json(json!({
-                                                        "message": "An internal error occurred"
-                                                    }))
-                                                    .into_future(),
-                                            )
-                                            .into_future();
-                                        }
-                                    };
-
-                                    let service = match services.iter().find_map(
-                                        |(service_def, managed_service)| {
-                                            if service_def.service_type == service_type
-                                                && service_def.circuit == circuit
-                                                && service_def.service_id == service_id
-                                            {
-                                                Some(&*managed_service.service)
-                                            } else {
-                                                None
-                                            }
-                                        },
-                                    ) {
-                                        Some(s) => s,
-                                        None => {
-                                            return Box::new(
-                                                HttpResponse::NotFound()
-                                                    .json(json!({
-                                                        "message":
-                                                            format!(
-                                                                "{} service {} on circuit {} not found",
-                                                                service_type, service_id, circuit
-                                                            )
-                                                    }))
-                                                    .into_future(),
-                                            )
-                                            .into_future();
-                                        }
-                                    };
-
-                                    handler(request, payload, service)
-                                },
-                            )
-                        }
+                                handler(request, payload, service)
+                            },
+                        )
                     })
                     .collect::<Vec<_>>();
 

--- a/libsplinter/src/orchestrator/rest_api.rs
+++ b/libsplinter/src/orchestrator/rest_api.rs
@@ -110,7 +110,7 @@ impl RestResourceProvider for ServiceOrchestrator {
                                     }
                                 };
 
-                                handler(request, payload, service)
+                                handler(request, payload, service.as_service())
                             },
                         )
                     })

--- a/libsplinter/src/orchestrator/runnable.rs
+++ b/libsplinter/src/orchestrator/runnable.rs
@@ -24,10 +24,9 @@ use uuid::Uuid;
 use crate::error::InternalError;
 use crate::mesh::Mesh;
 use crate::network::reply::InboundRouter;
-use crate::service::ServiceFactory;
 use crate::transport::Connection;
 
-use super::{JoinHandles, ServiceOrchestrator};
+use super::{JoinHandles, OrchestratableServiceFactory, ServiceOrchestrator};
 
 /// A runnable service orchestrator is configured, but not started ServiceOrchestrator. It may only
 /// be used for operations that can be done during that state, such as starting the orchestrator.
@@ -36,7 +35,7 @@ pub struct RunnableServiceOrchestrator {
     pub(super) incoming_capacity: usize,
     pub(super) outgoing_capacity: usize,
     pub(super) channel_capacity: usize,
-    pub(super) service_factories: Vec<Box<dyn ServiceFactory>>,
+    pub(super) service_factories: Vec<Box<dyn OrchestratableServiceFactory>>,
     pub(super) supported_service_types: Vec<String>,
 }
 

--- a/services/scabbard/libscabbard/src/client/reqwest/mod.rs
+++ b/services/scabbard/libscabbard/src/client/reqwest/mod.rs
@@ -294,7 +294,7 @@ fn wait_for_batches(
 
         debug!("Checking batches via {}", url);
         let request = Client::new()
-            .get(url.clone())
+            .get(url_with_query.clone())
             .header("Authorization", auth.to_string());
         let response = perform_request(request)?;
 

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -35,6 +35,7 @@ use sawtooth::receipt::store::ReceiptStore;
 #[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]
 use splinter::error::InternalError;
 use splinter::error::{InvalidArgumentError, InvalidStateError};
+use splinter::orchestrator::{OrchestratableService, OrchestratableServiceFactory};
 use splinter::service::validation::ServiceArgValidator;
 use splinter::service::{FactoryCreateError, Service, ServiceFactory};
 #[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]
@@ -476,6 +477,96 @@ impl ServiceFactory for ScabbardFactory {
         circuit_id: &str,
         args: HashMap<String, String>,
     ) -> Result<Box<dyn Service>, FactoryCreateError> {
+        Ok(Box::new(
+            self.create_scabbard(service_id, circuit_id, args)?,
+        ))
+    }
+
+    #[cfg(not(any(feature = "postgres", feature = "sqlite")))]
+    fn create(
+        &self,
+        _service_id: String,
+        _service_type: &str,
+        _circuit_id: &str,
+        _args: HashMap<String, String>,
+    ) -> Result<Box<dyn Service>, FactoryCreateError> {
+        // As the factory cannot be created under these conditions, this function is not reachable.
+        unreachable!()
+    }
+
+    #[cfg(feature = "rest-api")]
+    /// The `Scabbard` services created by the `ScabbardFactory` provide the following REST API
+    /// endpoints as [`ServiceEndpoint`]s:
+    ///
+    /// * `POST /batches` - Add one or more batches to scabbard's queue
+    /// * `GET /batch_statuses` - Get the status of one or more batches
+    /// * `GET /ws/subscribe` - Subscribe to scabbard state-delta events
+    /// * `GET /state/{address}` - Get a value from scabbard's state
+    /// * `GET /state` - Get multiple scabbard state entries
+    /// * `GET /state_root` - Get the current state root hash of scabbard's state
+    ///
+    /// These endpoints are only available if the following REST API backend feature is enabled:
+    ///
+    /// * `rest-api-actix`
+    ///
+    /// [`ServiceEndpoint`]: ../rest_api/struct.ServiceEndpoint.html
+    fn get_rest_endpoints(&self) -> Vec<splinter::service::rest_api::ServiceEndpoint> {
+        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
+        // enabled
+        #[allow(unused_mut)]
+        let mut endpoints = vec![];
+
+        #[cfg(feature = "rest-api-actix")]
+        {
+            endpoints.append(&mut vec![
+                actix::batches::make_add_batches_to_queue_endpoint(),
+                actix::ws_subscribe::make_subscribe_endpoint(),
+                actix::batch_statuses::make_get_batch_status_endpoint(),
+                actix::state_address::make_get_state_at_address_endpoint(),
+                actix::state::make_get_state_with_prefix_endpoint(),
+                actix::state_root::make_get_state_root_endpoint(),
+            ])
+        }
+
+        endpoints
+    }
+}
+
+impl OrchestratableServiceFactory for ScabbardFactory {
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    fn create_orchestratable_service(
+        &self,
+        service_id: String,
+        _service_type: &str,
+        circuit_id: &str,
+        args: HashMap<String, String>,
+    ) -> Result<Box<dyn OrchestratableService>, FactoryCreateError> {
+        Ok(Box::new(
+            self.create_scabbard(service_id, circuit_id, args)?,
+        ))
+    }
+
+    #[cfg(not(any(feature = "postgres", feature = "sqlite")))]
+    fn create_orchestratable_service(
+        &self,
+        _service_id: String,
+        _service_type: &str,
+        _circuit_id: &str,
+        _args: HashMap<String, String>,
+    ) -> Result<Box<dyn OrchestratableService>, FactoryCreateError> {
+        // As the factory cannot be created under these conditions, this function is not reachable.
+        unreachable!()
+    }
+}
+
+impl ScabbardFactory {
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    fn create_scabbard(
+        &self,
+        service_id: String,
+        circuit_id: &str,
+        args: HashMap<String, String>,
+    ) -> Result<Scabbard, FactoryCreateError> {
         let peer_services_str = args.get("peer_services").ok_or_else(|| {
             FactoryCreateError::InvalidArguments("peer_services argument not provided".into())
         })?;
@@ -581,7 +672,7 @@ impl ServiceFactory for ScabbardFactory {
                 ),
             };
 
-        let service = Scabbard::new(
+        Scabbard::new(
             service_id,
             circuit_id,
             version,
@@ -599,62 +690,9 @@ impl ServiceFactory for ScabbardFactory {
             admin_keys,
             coordinator_timeout,
         )
-        .map_err(|err| FactoryCreateError::CreationFailed(Box::new(err)))?;
-
-        Ok(Box::new(service))
+        .map_err(|err| FactoryCreateError::CreationFailed(Box::new(err)))
     }
 
-    #[cfg(not(any(feature = "postgres", feature = "sqlite")))]
-    fn create(
-        &self,
-        _service_id: String,
-        _service_type: &str,
-        _circuit_id: &str,
-        _args: HashMap<String, String>,
-    ) -> Result<Box<dyn Service>, FactoryCreateError> {
-        // As the factory cannot be created under these conditions, this function is not reachable.
-        unreachable!()
-    }
-
-    #[cfg(feature = "rest-api")]
-    /// The `Scabbard` services created by the `ScabbardFactory` provide the following REST API
-    /// endpoints as [`ServiceEndpoint`]s:
-    ///
-    /// * `POST /batches` - Add one or more batches to scabbard's queue
-    /// * `GET /batch_statuses` - Get the status of one or more batches
-    /// * `GET /ws/subscribe` - Subscribe to scabbard state-delta events
-    /// * `GET /state/{address}` - Get a value from scabbard's state
-    /// * `GET /state` - Get multiple scabbard state entries
-    /// * `GET /state_root` - Get the current state root hash of scabbard's state
-    ///
-    /// These endpoints are only available if the following REST API backend feature is enabled:
-    ///
-    /// * `rest-api-actix`
-    ///
-    /// [`ServiceEndpoint`]: ../rest_api/struct.ServiceEndpoint.html
-    fn get_rest_endpoints(&self) -> Vec<splinter::service::rest_api::ServiceEndpoint> {
-        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
-        // enabled
-        #[allow(unused_mut)]
-        let mut endpoints = vec![];
-
-        #[cfg(feature = "rest-api-actix")]
-        {
-            endpoints.append(&mut vec![
-                actix::batches::make_add_batches_to_queue_endpoint(),
-                actix::ws_subscribe::make_subscribe_endpoint(),
-                actix::batch_statuses::make_get_batch_status_endpoint(),
-                actix::state_address::make_get_state_at_address_endpoint(),
-                actix::state::make_get_state_with_prefix_endpoint(),
-                actix::state_root::make_get_state_root_endpoint(),
-            ])
-        }
-
-        endpoints
-    }
-}
-
-impl ScabbardFactory {
     /// Check that the LMDB files doesn't exist for the given service.
     #[cfg(feature = "lmdb")]
     #[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -35,6 +35,7 @@ use protobuf::Message;
 use sawtooth::receipt::store::ReceiptStore;
 use splinter::{
     consensus::{Proposal, ProposalUpdate},
+    orchestrator::OrchestratableService,
     service::{
         Service, ServiceDestroyError, ServiceError, ServiceMessageContext, ServiceNetworkRegistry,
         ServiceStartError, ServiceStopError,
@@ -509,6 +510,16 @@ impl Service for Scabbard {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+impl OrchestratableService for Scabbard {
+    fn as_service(&self) -> &dyn Service {
+        self
+    }
+
+    fn clone_box(&self) -> Box<dyn OrchestratableService> {
+        Box::new(self.clone())
     }
 }
 


### PR DESCRIPTION
To test, create a scabbard service as normal, and submit a transaction with a wait time.  This should issue a single request to the node for batch status.