### PR TITLE
Add default for rolling_file size

### DIFF
--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -24,6 +24,7 @@ use super::toml::TomlUnnamedAppenderConfig;
 use super::toml::TomlUnnamedLoggerConfig;
 
 pub const DEFAULT_LOGGING_PATTERN: &str = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n";
+const DEFAULT_LOG_SIZE: u64 = 100_000_000;
 
 pub(super) fn default_pattern() -> String {
     String::from(DEFAULT_LOGGING_PATTERN)
@@ -126,10 +127,13 @@ impl TryFrom<(String, UnnamedAppenderConfig)> for AppenderConfig {
                 }
             }
             RawLogTarget::RollingFile => {
-                if let (Some(filename), Some(size)) = (value.1.filename, value.1.size) {
-                    Ok(LogTarget::RollingFile { filename, size })
+                if let Some(filename) = value.1.filename {
+                    Ok(LogTarget::RollingFile {
+                        filename,
+                        size: value.1.size.unwrap_or(DEFAULT_LOG_SIZE),
+                    })
                 } else {
-                    Err(ConfigError::MissingValue("filename|size".to_string()))
+                    Err(ConfigError::MissingValue("filename".to_string()))
                 }
             }
         }?;


### PR DESCRIPTION
The default is set at 100Mb. The default value is set in the
config::logger module as opposed to config::toml because config::toml is
only concerned with deserialization and not providing defaults.  While
config::logger deals with all the details of converting a deserialized
struct to one we can actually use.

Signed-off-by: Caleb Hill <hill@bitwise.io>