### PR TITLE
Move pattern default value setting

### DIFF
--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -18,9 +18,7 @@ use std::collections::HashMap;
 
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 
-use super::logging::{
-    RootConfig, UnnamedAppenderConfig, UnnamedLoggerConfig, DEFAULT_LOGGING_PATTERN,
-};
+use super::logging::{LogEncoder, RootConfig, UnnamedAppenderConfig, UnnamedLoggerConfig};
 use super::ScabbardState;
 
 const CONFIG_DIR: &str = "/etc/splinter";
@@ -123,7 +121,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             level: log::Level::Warn,
         });
         let stdout = UnnamedAppenderConfig {
-            encoder: String::from(DEFAULT_LOGGING_PATTERN),
+            encoder: LogEncoder::default(),
             kind: super::logging::RawLogTarget::Stdout,
             size: None,
             filename: None,

--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -15,6 +15,7 @@
 use std::convert::From;
 use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::ops::Deref;
 
 use log::Level;
 
@@ -81,6 +82,32 @@ pub enum RawLogTarget {
     Stderr,
     File,
     RollingFile,
+}
+
+#[derive(Clone, Debug)]
+pub struct LogEncoder {
+    value: String,
+}
+
+impl From<String> for LogEncoder {
+    fn from(value: String) -> Self {
+        LogEncoder { value }
+    }
+}
+
+impl Default for LogEncoder {
+    fn default() -> Self {
+        Self {
+            value: DEFAULT_LOGGING_PATTERN.to_string(),
+        }
+    }
+}
+
+impl Deref for LogEncoder {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
 }
 
 impl AppenderConfig {

--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -24,10 +24,6 @@ use super::toml::{TomlRawLogTarget, TomlUnnamedAppenderConfig, TomlUnnamedLogger
 pub const DEFAULT_LOGGING_PATTERN: &str = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n";
 const DEFAULT_LOG_SIZE: u64 = 100_000_000;
 
-pub(super) fn default_pattern() -> String {
-    String::from(DEFAULT_LOGGING_PATTERN)
-}
-
 #[derive(Clone, Debug)]
 pub struct LogConfig {
     pub root: RootConfig,
@@ -155,7 +151,9 @@ impl TryFrom<(String, TomlUnnamedAppenderConfig)> for AppenderConfig {
 impl From<TomlUnnamedAppenderConfig> for UnnamedAppenderConfig {
     fn from(unnamed: TomlUnnamedAppenderConfig) -> Self {
         Self {
-            encoder: unnamed.encoder,
+            encoder: unnamed
+                .encoder
+                .unwrap_or_else(|| DEFAULT_LOGGING_PATTERN.to_string()),
             kind: unnamed.kind.into(),
             filename: unnamed.filename,
             size: unnamed.size.map(|s| s.into()),

--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -22,7 +22,7 @@ use log::Level;
 use super::error::ConfigError;
 use super::toml::{TomlRawLogTarget, TomlUnnamedAppenderConfig, TomlUnnamedLoggerConfig};
 
-pub const DEFAULT_LOGGING_PATTERN: &str = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n";
+const DEFAULT_LOGGING_PATTERN: &str = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n";
 const DEFAULT_LOG_SIZE: u64 = 100_000_000;
 
 #[derive(Clone, Debug)]
@@ -54,14 +54,14 @@ pub struct RootConfig {
 #[derive(Clone, Debug)]
 pub struct AppenderConfig {
     pub name: String,
-    pub encoder: String,
+    pub encoder: LogEncoder,
     pub kind: LogTarget,
     pub level: Option<Level>,
 }
 
 #[derive(Clone, Debug)]
 pub struct UnnamedAppenderConfig {
-    pub encoder: String,
+    pub encoder: LogEncoder,
     pub kind: RawLogTarget,
     pub filename: Option<String>,
     pub size: Option<u64>,
@@ -180,7 +180,7 @@ impl From<TomlUnnamedAppenderConfig> for UnnamedAppenderConfig {
         Self {
             encoder: unnamed
                 .encoder
-                .unwrap_or_else(|| DEFAULT_LOGGING_PATTERN.to_string()),
+                .map_or_else(LogEncoder::default, |f| f.into()),
             kind: unnamed.kind.into(),
             filename: unnamed.filename,
             size: unnamed.size.map(|s| s.into()),

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -38,8 +38,7 @@ pub use error::ConfigError;
 pub use partial::{ConfigSource, PartialConfig};
 
 pub use logging::{
-    AppenderConfig, LogConfig, LogTarget, LoggerConfig, RawLogTarget, RootConfig,
-    DEFAULT_LOGGING_PATTERN,
+    AppenderConfig, LogConfig, LogEncoder, LogTarget, LoggerConfig, RawLogTarget, RootConfig,
 };
 
 /// `Config` is the final representation of configuration values. This final config object assembles

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -461,7 +461,7 @@ impl From<ScabbardStateToml> for ScabbardState {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::LoggerConfig;
+    use crate::config::{LogEncoder, LoggerConfig};
 
     use super::*;
 
@@ -886,7 +886,7 @@ mod tests {
         assert!(matches!(stdout.kind, crate::config::RawLogTarget::Stdout));
         assert!(stdout.size.is_none());
         assert!(stdout.filename.is_none());
-        assert_eq!(stdout.encoder, default_pattern());
+        assert_eq!(&*stdout.encoder, &*LogEncoder::default());
 
         assert!(appenders.contains_key("rolling_file"));
         assert!(appenders.get("rolling_file").is_some());
@@ -902,7 +902,7 @@ mod tests {
             rolling_file.filename.as_ref().unwrap(),
             "/var/log/splinter/splinterd.log"
         );
-        assert_eq!(rolling_file.encoder, default_pattern());
+        assert_eq!(&*rolling_file.encoder, &*LogEncoder::default());
 
         let loggers = toml.loggers();
         assert!(loggers.is_some());

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -25,7 +25,7 @@ use std::convert::TryInto;
 #[cfg(feature = "service2")]
 use std::time::Duration;
 
-use super::logging::{default_pattern, UnnamedAppenderConfig, UnnamedLoggerConfig};
+use super::logging::{UnnamedAppenderConfig, UnnamedLoggerConfig};
 use super::ScabbardState;
 
 /// `TOML_VERSION` represents the version of the toml config file.
@@ -46,9 +46,8 @@ pub enum TomlRawLogTarget {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct TomlUnnamedAppenderConfig {
-    #[serde(default = "default_pattern")]
     #[serde(alias = "pattern")]
-    pub encoder: String,
+    pub encoder: Option<String>,
     pub kind: TomlRawLogTarget,
     pub filename: Option<String>,
     pub size: Option<TomlLogFileSize>,

--- a/splinterd/src/logging.rs
+++ b/splinterd/src/logging.rs
@@ -47,7 +47,7 @@ use crate::error::UserError;
 impl TryInto<Appender> for AppenderConfig {
     type Error = std::io::Error;
     fn try_into(self) -> Result<Appender, Self::Error> {
-        let encoder: Box<dyn Encode> = Box::new(PatternEncoder::new(&self.encoder));
+        let encoder: Box<dyn Encode> = self.encoder.into();
         let boxed: Box<dyn Append> = match &self.kind {
             LogTarget::Stdout => Box::new(
                 ConsoleAppender::builder()
@@ -201,6 +201,12 @@ pub fn configure_logging(
         Err(e) => Err(UserError::InternalError(InternalError::from_source(
             Box::new(e),
         ))),
+    }
+}
+
+impl From<LogEncoder> for Box<dyn log4rs::encode::Encode> {
+    fn from(log_encoder: LogEncoder) -> Self {
+        Box::new(PatternEncoder::new(&*log_encoder))
     }
 }
 

--- a/splinterd/src/logging.rs
+++ b/splinterd/src/logging.rs
@@ -39,8 +39,8 @@ use log4rs::{
 use splinter::error::InternalError;
 
 use crate::config::{
-    AppenderConfig, Config as InternalConfig, LogConfig, LogTarget, LoggerConfig, RootConfig,
-    DEFAULT_LOGGING_PATTERN,
+    AppenderConfig, Config as InternalConfig, LogConfig, LogEncoder, LogTarget, LoggerConfig,
+    RootConfig,
 };
 use crate::error::UserError;
 
@@ -212,7 +212,7 @@ pub fn default_log_settings() -> Config {
         },
         appenders: vec![AppenderConfig {
             name: String::from("default"),
-            encoder: String::from(DEFAULT_LOGGING_PATTERN),
+            encoder: LogEncoder::default(),
             kind: LogTarget::Stdout,
             level: None,
         }],


### PR DESCRIPTION
Moves the default value out of the toml code and cleans up the String -> log4rs::Encoder conversion.