### PR TITLE
Backport: Update node base image in some Dockerfiles

### DIFF
--- a/docker/lint-client
+++ b/docker/lint-client
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 

--- a/examples/gameroom/gameroom-app/Dockerfile-installed
+++ b/examples/gameroom/gameroom-app/Dockerfile-installed
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:14.18.1-alpine3.11 as build-stage
 
 RUN apk update && apk add python g++ git make && rm -rf /var/cache/apk/*
 WORKDIR /app


### PR DESCRIPTION
node:lts-alpine was updated to be based on alpine 3.14 instead of 3.11
and use node v16 instead of v14. gameroom-app currentely is incompatible
with node v16.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>