### PR TITLE
Fail if SQL trees exist if scabbard-state=lmdb is enabled

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -39,7 +39,7 @@ sawtooth-sabre = "0.7.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.3.13", features = ["sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.3.14", features = ["sawtooth-compat", "state-merkle-sql"] }
 
 [dependencies.sawtooth]
 version = "0.6.7"
@@ -48,7 +48,7 @@ features = ["lmdb", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
-transact = { version = "0.3.13", features = ["family-command", "sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.3.14", features = ["family-command", "sawtooth-compat", "state-merkle-sql"] }
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -50,7 +50,7 @@ use crate::service::ScabbardStatePurgeHandler;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 use crate::service::{
     error::ScabbardError,
-    state::merkle_state::{MerkleState, MerkleStateConfig},
+    state::merkle_state::{self, MerkleState, MerkleStateConfig},
     Scabbard, ScabbardVersion, SERVICE_TYPE,
 };
 #[cfg(feature = "diesel")]
@@ -280,6 +280,8 @@ impl ScabbardFactoryBuilder {
         #[cfg(feature = "lmdb")]
         if !state_storage_configuration.enable_lmdb {
             check_for_lmdb_files(lmdb_path)?;
+        } else {
+            check_for_sql_trees(&store_factory_config)?;
         }
 
         #[cfg(feature = "lmdb")]
@@ -362,6 +364,52 @@ fn check_for_lmdb_files(lmdb_path: &Path) -> Result<(), InvalidStateError> {
             lmdb_path.display(),
             err
         ))),
+    }
+}
+
+#[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]
+fn check_for_sql_trees(
+    store_factory_config: &ScabbardFactoryStorageConfig,
+) -> Result<(), InvalidStateError> {
+    match store_factory_config {
+        #[cfg(feature = "postgres")]
+        ScabbardFactoryStorageConfig::Postgres { pool } => {
+            merkle_state::postgres_list_available_trees(pool)
+                .map_err(|e| {
+                    InvalidStateError::with_message(format!(
+                        "Unable to read merkle state trees in postgres: {}",
+                        e
+                    ))
+                })
+                .and_then(|trees| {
+                    if trees.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(InvalidStateError::with_message(
+                            "SQL Merkle Radix trees exist, but LMDB storage is enabled".into(),
+                        ))
+                    }
+                })
+        }
+        #[cfg(feature = "sqlite")]
+        ScabbardFactoryStorageConfig::Sqlite { pool } => {
+            merkle_state::sqlite_list_available_trees(pool)
+                .map_err(|e| {
+                    InvalidStateError::with_message(format!(
+                        "Unable to read merkle state trees in sqlite: {}",
+                        e
+                    ))
+                })
+                .and_then(|trees| {
+                    if trees.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(InvalidStateError::with_message(
+                            "SQL Merkle Radix trees exist, but LMDB storage is enabled".into(),
+                        ))
+                    }
+                })
+        }
     }
 }
 


### PR DESCRIPTION
To test: 

Setup two nodes with the default database settings (i.e. sqlite).  Create a scabbard circuit and commit at least one transaction.

Restart one of the nodes with the added argument of `--scabbard-state lmdb`.  This should fail to start with an error about the invalid state configuration.