### PR TITLE
Update influxdb dependency

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -49,7 +49,7 @@ futures-0-3 = { package = "futures", version = "0.3", optional = true }
 glob = { version = "0.3", optional = true }
 hyper = { version = "0.12", optional = true }
 jsonwebtoken = { version = "7.0", optional = true }
-influxdb = { version = "0.4.0", features = ["derive"], optional = true }
+influxdb = { version = "0.5", features = ["derive"], optional = true }
 log = "0.4"
 metrics = {version = "0.17", features = ["std"], optional = true}
 mio = { version = "0.6", default-features = false }
@@ -65,7 +65,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 tokio = { version = "0.1.22", optional = true }
-tokio-0-2 = { package = "tokio", version = "0.2", optional = true }
+tokio-1 = { package = "tokio", version = "1", optional = true, features = ["rt", "sync"] }
 tungstenite = { version = "0.10", optional = true }
 url = "1.7.1"
 uuid = { version = "0.8", features = ["v4", "v5"] }
@@ -183,7 +183,7 @@ rest-api-cors = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations"]
 store-factory = []
-tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-0-2"]
+tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-1"]
 trust-authorization = []
 ws-transport = ["tungstenite"]
 

--- a/libsplinter/src/tap/influx.rs
+++ b/libsplinter/src/tap/influx.rs
@@ -24,9 +24,9 @@ use chrono::{DateTime, Utc};
 use influxdb::Client;
 use influxdb::InfluxDbWriteable;
 use metrics::{GaugeValue, Key, Label, Recorder, SharedString, Unit};
-use tokio_0_2::runtime::Runtime;
-use tokio_0_2::sync::mpsc::{unbounded_channel, UnboundedSender};
-use tokio_0_2::task::JoinHandle;
+use tokio_1::runtime::Runtime;
+use tokio_1::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio_1::task::JoinHandle;
 
 use crate::error::InternalError;
 use crate::threading::lifecycle::ShutdownHandle;
@@ -260,7 +260,7 @@ impl ShutdownHandle for InfluxRecorder {
         }
     }
 
-    fn wait_for_shutdown(mut self) -> Result<(), InternalError> {
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
         self.rt.block_on(self.join_handle).map_err(|err| {
             InternalError::with_message(format!("Unable to join InfluxRecorder thread: {:?}", err))
         })


### PR DESCRIPTION
This change updates the influxdb dependency to 0.5, as well as the specific tokio instance used for influxdb communication from 0.2 to 1.x.

This fixes the metrics not correctly writing to influxdb as well.