### PR TITLE
Update flexi-logger dependency to v0.20

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = "2"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 dirs = "4"
-flexi_logger = "0.14"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 libc = "0.2"
 log = "0.4"
 openssl = "0.10"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1611,7 +1611,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
 
     match Logger::with(log_spec_builder.build())
         .format(log_format)
-        .log_target(flexi_logger::LogTarget::StdOut)
+        .log_to_stdout()
         .start()
     {
         Ok(_) => {}

--- a/examples/gameroom/cli/Cargo.toml
+++ b/examples/gameroom/cli/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/main.rs"
 clap = "2"
 diesel = { version = "1.0", features = ["postgres"] }
 diesel_migrations = "1.4"
-flexi_logger = "0.14"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 log = "0.4"
 
 [features]

--- a/examples/gameroom/cli/src/main.rs
+++ b/examples/gameroom/cli/src/main.rs
@@ -68,7 +68,7 @@ fn setup_logging(log_level: log::LevelFilter) {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
-        .log_target(flexi_logger::LogTarget::StdOut)
+        .log_to_stdout()
         .start()
         .expect("Failed to create logger");
 }

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -40,7 +40,7 @@ ctrlc = "3.0"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
-flexi_logger = "0.14"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 futures = "0.1"
 gameroom-database = { path = "../database" }
 hyper = "0.12"

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 clap = "2"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 dirs = "4"
-flexi_logger = "0.14"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 log = "0.4"
 sabre-sdk = "0.7"
 transact = { version = "0.3", features = ["contract-archive"] }

--- a/services/scabbard/cli/src/main.rs
+++ b/services/scabbard/cli/src/main.rs
@@ -1193,7 +1193,7 @@ fn setup_logging(log_level: log::LevelFilter) -> Result<(), CliError> {
 
     Logger::with(log_spec_builder.build())
         .format(log_format)
-        .log_target(flexi_logger::LogTarget::StdOut)
+        .log_to_stdout()
         .start()?;
 
     Ok(())


### PR DESCRIPTION
In addition to updating the dependency version, this commit also changes
the gameroom daemon logging to use flexi-logger's built-in with_thread
formatter. This prevents needing to pull in the 'time' crate with the
new flexi-logger API.