### PR TITLE
Add JUSTX_CARGO_TEST_ARGS and JUSTX_TEST_BINARY_ARGS

### DIFF
--- a/justfile
+++ b/justfile
@@ -223,7 +223,7 @@ test:
     do
         for crate in $(echo {{crates}})
         do
-            cmd="cargo test --manifest-path=$crate/Cargo.toml $TEST_MODE $feature"
+            cmd="cargo test --manifest-path=$crate/Cargo.toml $TEST_MODE $feature $JUSTX_CARGO_TEST_ARGS -- $JUSTX_TEST_BINARY_ARGS"
             echo "\033[1m$cmd\033[0m"
             $cmd
         done


### PR DESCRIPTION
These allow setting arguments on cargo test when running 'just test'.
The prefix JUSTX_ was chosen because we want this to be cross-project,
but the prefix JUST_ is used by the just command itself.

JUSTX_CARGO_TEST_ARGS allows setting arguments on cargo test itself.

JUSTX_TEST_BINARY_ARGS allows setting arguments on the test binary; this
is passed after the "--" to cargo test.

Examples:

  JUSTX_CARGO_TEST_ARGS="-j 6" just test
  JUSTX_TEST_BINARY_ARGS="--test-threads=6" just test
  JUSTX_TEST_BINARY_ARGS="admin::service --test-threads=6" just test
