### PR TITLE
Adjust default loggers to exclude extra logs

### DIFF
--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -249,7 +249,7 @@ version = "1"
 #
 # Valid options are, Trace, Debug, Info, Warn, and Error in decreasing order of
 # verbosity.
-#level = "Trace"
+#level = "Warn"
 
 #
 # Logging Options (Advanced)
@@ -272,3 +272,15 @@ version = "1"
 # are, Trace, Debug, Info, Warn, and Error in decreasing order of verbosity.
 # Optional for non-root loggers, defaults to the root loggers level.
 #level = "Warn"
+#
+# By default there are two non-root loggers configured. 
+#
+#[loggers.splinter]
+#appenders = ["stdout"]
+#level = "Info"
+#
+#[loggers.splinterd]
+#appenders = ["stdout"]
+#level = "Info"
+#
+# These two loggers select for the logs related to Splinter operations.

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -113,7 +113,7 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
 
         let root_logger: Option<RootConfig> = Some(RootConfig {
             appenders: vec!["stdout".to_string()],
-            level: log::Level::Trace,
+            level: log::Level::Warn,
         });
         let stdout = UnnamedAppenderConfig {
             encoder: String::from(DEFAULT_LOGGING_PATTERN),
@@ -124,24 +124,17 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
         };
         let loggers = vec![
             (
-                "tokio".to_string(),
+                "splinter".to_string(),
                 UnnamedLoggerConfig {
                     appenders: Some(vec!["stdout".into()]),
-                    level: Some(log::Level::Warn),
+                    level: Some(log::Level::Info),
                 },
             ),
             (
-                "tokio_reactor".to_string(),
+                "splinterd".to_string(),
                 UnnamedLoggerConfig {
                     appenders: Some(vec!["stdout".into()]),
-                    level: Some(log::Level::Warn),
-                },
-            ),
-            (
-                "hyper".to_string(),
-                UnnamedLoggerConfig {
-                    appenders: Some(vec!["stdout".into()]),
-                    level: Some(log::Level::Warn),
+                    level: Some(log::Level::Info),
                 },
             ),
         ]


### PR DESCRIPTION
Set root logger level to `Warn` and add loggers for `splinter` and
`splinterd` with levels Info.

Signed-off-by: Caleb Hill <hill@bitwise.io>