### PR TITLE
Implement `splinter state migrate` command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 whoami = "0.7.0"
 users = "0.11"
+transact = { version = "0.4", features = ["state-merkle-sql"] }
 
 [dependencies.sawtooth]
 version = "0.7"

--- a/cli/man/splinter-state-migrate.1.md
+++ b/cli/man/splinter-state-migrate.1.md
@@ -1,0 +1,130 @@
+% SPLINTER-STATE-MIGRATE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-state-migrate** — Move scabbard state to or from LMDB
+
+SYNOPSIS
+========
+| **command** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Move scabbard state to or from LMDB, deleting from the input database. This
+allows for reconfiguring Scabbard instances to switch between using
+LMDB files for merkle state or using SQL based databases. The SQL URI provided
+should be for the SQLite or PostgreSQL database that contains the rest of
+Splinter state.
+
+The command will prompt the user to make sure they wish to run the command as
+once the merkle state has been successfully moved to the out target for a
+service, the input data will be removed.
+
+This command should not be run when the associated splinterd is currently
+running.
+
+FLAGS
+=====
+`-f`, `--force`
+: Always attempt to move state, regardless of if there is existing data in the
+  out database
+
+`-h`, `--help`
+: Prints help information
+
+`-V`, `--version`
+: Prints version information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output
+
+`-y`, `--yes`
+:  Do not prompt for confirmation
+
+OPTIONS
+=======
+
+`--in` `IN_DATABASE`
+: Database URI that currently contains the scabbard state. If state is in
+  individual LMDB files, provide `lmdb`
+
+`--out` `OUT_DATABASE`
+: The database URI the scabbard state should end up in. If state should be put
+  into individual LMDB files, provide `lmdb`
+
+`--state-dir` `STATE-DIR`
+: Specifies the storage directory. (Defaults to `/var/lib/splinter`, unless
+  `SPLINTER_STATE_DIR` or `SPLINTER_HOME` is set.)
+
+
+EXAMPLES
+========
+
+The following example moves the LMDB files into the SQLite database for the
+splinter daemon:
+
+```
+$ splinter state migrate --in lmdb --out /var/lib/splinter/splinter_state.db
+Attempting to migrate scabbard state from lmdb to /var/lib/splinter/splinter_state.db
+Warning: This will purge the data from `--in` and only the current state root is stored, the rest are purged.
+Are you sure you wish to migrate scabbard state? [y/N]
+y
+Migrating state data for GkV3z-S1YpG::b000
+Scabbard state successfully migrated
+```
+
+To skip responding to the prompt, add `-y` or `--yes`:
+
+```
+$ splinter state migrate \
+    --in lmdb \
+    --out /var/lib/splinter/splinter_state.db \
+    --yes
+Attempting to migrate scabbard state from lmdb to /var/lib/splinter/splinter_state.db
+Migrating state data for GkV3z-S1YpG::b000
+Scabbard state successfully migrated
+```
+
+If the LMDB files are not in the configured state directory provide
+`--state-dir`:
+
+```
+$ splinter state migrate \
+    --in lmdb \
+    --out /var/lib/splinter/splinter_state.db \
+    --state-dir  home/node2/data/splinter_state.db \
+    -y
+Attempting to migrate scabbard state from lmdb to /var/lib/splinter/splinter_state.db
+Migrating state data for GkV3z-S1YpG::b000
+Scabbard state successfully migrated
+```
+
+ENVIRONMENT
+===========
+The following environment variables affect the execution of the command.
+
+**SPLINTER_STATE_DIR**
+
+: Defines the default state directory for YAML state and SQLite. This is
+overridden by the `--state-dir` flag
+
+**SPLINTER_HOME**
+
+: Defines the default splinter home directory, from which the state directory
+is derived as `$SPLINTER_HOME/data`. This environment variable is not used if
+either the `SPLINTER_STATE_DIR` environment variable or the `--state-dir` flag
+is set.
+
+SEE ALSO
+========
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/cli/man/splinter.1.md
+++ b/cli/man/splinter.1.md
@@ -67,6 +67,9 @@ SUBCOMMANDS
 `role`
 : Role-based authorization role-related commands
 
+`state`
+: Commands to manage scabbard state
+
 `upgrade`
 : Upgrades splinter YAML state to database state
 
@@ -134,6 +137,7 @@ SEE ALSO
 | `splinter-role-list(1)`
 | `splinter-role-show(1)`
 | `splinter-role-update(1)`
+| `splinter-state-migrate(1)`
 | `splinter-upgrade(1)`
 | `splinter-user(1)`
 |

--- a/cli/src/action/database/mod.rs
+++ b/cli/src/action/database/mod.rs
@@ -17,6 +17,7 @@ mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 
+mod stores;
 #[cfg(feature = "upgrade")]
 mod upgrade;
 
@@ -70,6 +71,18 @@ pub enum ConnectionUri {
     Postgres(String),
     #[cfg(feature = "sqlite")]
     Sqlite(String),
+}
+
+impl std::fmt::Display for ConnectionUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            #[cfg(feature = "postgres")]
+            ConnectionUri::Postgres(pg) => pg,
+            #[cfg(feature = "sqlite")]
+            ConnectionUri::Sqlite(sqlite) => sqlite,
+        };
+        f.write_str(string)
+    }
 }
 
 impl FromStr for ConnectionUri {

--- a/cli/src/action/database/mod.rs
+++ b/cli/src/action/database/mod.rs
@@ -17,6 +17,7 @@ mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 
+mod state;
 mod stores;
 #[cfg(feature = "upgrade")]
 mod upgrade;
@@ -31,6 +32,7 @@ use clap::ArgMatches;
 use self::postgres::get_default_database;
 #[cfg(feature = "sqlite")]
 use self::sqlite::{get_default_database, sqlite_migrations};
+pub use self::state::StateMigrateAction;
 #[cfg(feature = "upgrade")]
 pub use self::upgrade::UpgradeAction;
 use crate::error::CliError;

--- a/cli/src/action/database/state/merkle.rs
+++ b/cli/src/action/database/state/merkle.rs
@@ -1,0 +1,218 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::collections::HashMap;
+
+use diesel::r2d2::{ConnectionManager, Pool};
+use scabbard::store::transact::factory::LmdbDatabaseFactory;
+use transact::state::{
+    merkle::{
+        kv::MerkleState as TransactMerkleState,
+        sql::{
+            backend,
+            store::{MerkleRadixStore, SqlMerkleRadixStore},
+            SqlMerkleState,
+        },
+        MerkleRadixLeafReadError, MerkleRadixLeafReader,
+    },
+    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
+};
+
+use super::CliError;
+
+#[derive(Clone)]
+pub enum MerkleState {
+    Lmdb {
+        state: TransactMerkleState,
+        merkle_root: String,
+        tree_id: (String, String),
+    },
+    /// Configure scabbard storage using a shared Postgres connection pool.
+    #[cfg(feature = "postgres")]
+    Postgres {
+        state: SqlMerkleState<backend::PostgresBackend>,
+    },
+    #[cfg(feature = "sqlite")]
+    Sqlite {
+        state: SqlMerkleState<backend::SqliteBackend>,
+    },
+}
+
+impl std::fmt::Debug for MerkleState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_tuple("MerkleState");
+        match self {
+            MerkleState::Lmdb { .. } => debug_struct.field(&"Lmdb".to_string()),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { .. } => debug_struct.field(&"Postgres".to_string()),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { .. } => debug_struct.field(&"Sqlite".to_string()),
+        };
+        debug_struct.finish()
+    }
+}
+
+impl MerkleState {
+    pub fn get_state_root(&self) -> Result<String, CliError> {
+        match self {
+            // lmdb provides current state root,
+            MerkleState::Lmdb { merkle_root, .. } => Ok(merkle_root.to_string()),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state
+                .initial_state_root_hash()
+                .map_err(|e| CliError::ActionError(format!("{}", e))),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state
+                .initial_state_root_hash()
+                .map_err(|e| CliError::ActionError(format!("{}", e))),
+        }
+    }
+
+    pub fn delete_tree(self, lmdb_db_factory: &LmdbDatabaseFactory) -> Result<(), CliError> {
+        match self {
+            MerkleState::Lmdb { tree_id, .. } => {
+                let (circuit_id, service_id) = tree_id;
+                lmdb_db_factory
+                    .get_database_purge_handle(&circuit_id, &service_id)
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))?
+                    .purge()
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))
+            }
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state
+                .delete_tree()
+                .map_err(|e| CliError::ActionError(format!("{}", e))),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state
+                .delete_tree()
+                .map_err(|e| CliError::ActionError(format!("{}", e))),
+        }
+    }
+}
+
+impl Write for MerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        match self {
+            MerkleState::Lmdb { state, .. } => state.commit(state_id, state_changes),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state.commit(state_id, state_changes),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state.commit(state_id, state_changes),
+        }
+    }
+
+    fn compute_state_id(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        match self {
+            MerkleState::Lmdb { state, .. } => state.compute_state_id(state_id, state_changes),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state.compute_state_id(state_id, state_changes),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state.compute_state_id(state_id, state_changes),
+        }
+    }
+}
+
+impl Read for MerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
+        match self {
+            MerkleState::Lmdb { state, .. } => state.get(state_id, keys),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state.get(state_id, keys),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state.get(state_id, keys),
+        }
+    }
+
+    fn clone_box(
+        &self,
+    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
+        Box::new(self.clone())
+    }
+}
+
+impl Prune for MerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StatePruneError> {
+        match self {
+            MerkleState::Lmdb { state, .. } => state.prune(state_ids),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state.prune(state_ids),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state.prune(state_ids),
+        }
+    }
+}
+
+// These types make the clippy happy
+type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
+type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
+
+impl MerkleRadixLeafReader for MerkleState {
+    fn leaves(
+        &self,
+        state_id: &Self::StateId,
+        subtree: Option<&str>,
+    ) -> IterResult<LeafIter<(Self::Key, Self::Value)>> {
+        match self {
+            MerkleState::Lmdb { state, .. } => state.leaves(state_id, subtree),
+            #[cfg(feature = "postgres")]
+            MerkleState::Postgres { state } => state.leaves(state_id, subtree),
+            #[cfg(feature = "sqlite")]
+            MerkleState::Sqlite { state } => state.leaves(state_id, subtree),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+pub fn sqlite_list_available_trees(
+    pool: &Pool<ConnectionManager<diesel::SqliteConnection>>,
+) -> Result<Vec<String>, CliError> {
+    let sqlite_backend = backend::SqliteBackend::from(pool.clone());
+    SqlMerkleRadixStore::new(&sqlite_backend)
+        .list_trees()
+        .and_then(|iter| iter.collect::<Result<Vec<_>, _>>())
+        .map_err(|e| CliError::ActionError(format!("{}", e)))
+}
+
+#[cfg(feature = "postgres")]
+pub fn postgres_list_available_trees(
+    pool: &Pool<ConnectionManager<diesel::pg::PgConnection>>,
+) -> Result<Vec<String>, CliError> {
+    let postgres_backend = backend::PostgresBackend::from(pool.clone());
+    SqlMerkleRadixStore::new(&postgres_backend)
+        .list_trees()
+        .and_then(|iter| iter.collect::<Result<Vec<_>, _>>())
+        .map_err(|e| CliError::ActionError(format!("{}", e)))
+}

--- a/cli/src/action/database/state/mod.rs
+++ b/cli/src/action/database/state/mod.rs
@@ -1,0 +1,519 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides scabbard state migration functionality
+
+mod merkle;
+
+use std::io;
+use std::io::prelude::*;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::ArgMatches;
+use scabbard::store::transact::factory::LmdbDatabaseFactory;
+use transact::state::{
+    merkle::{
+        kv::{MerkleRadixTree, MerkleState as TransactMerkleState},
+        sql::{backend, SqlMerkleStateBuilder},
+        MerkleRadixLeafReader,
+    },
+    Prune, StateChange, Write,
+};
+
+use crate::action::database::{
+    stores::{new_upgrade_stores, UpgradeStores},
+    ConnectionUri, SplinterEnvironment,
+};
+
+use super::{Action, CliError};
+
+use self::merkle::MerkleState;
+
+pub struct StateMigrateAction;
+
+impl Action for StateMigrateAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let state_dir =
+            get_state_dir(arg_matches).map_err(|e| CliError::ActionError(format!("{}", e)))?;
+        let lmdb_db_factory = LmdbDatabaseFactory::new_state_db_factory(&state_dir, None);
+
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+        let mut in_database = args
+            .value_of("in")
+            .ok_or_else(|| CliError::ActionError("'in' argument is required".to_string()))?;
+
+        let mut out_database = args
+            .value_of("out")
+            .ok_or_else(|| CliError::ActionError("'out' argument is required".to_string()))?;
+
+        info!(
+            "Attempting to migrate scabbard state from {} to {}",
+            in_database, out_database
+        );
+
+        if !args.is_present("yes") {
+            warn!(
+                "Warning: This will purge the data from `--in` and only the current state \
+                root is stored, the rest are purged."
+            );
+            warn!("Are you sure you wish to migrate scabbard state? [y/N]");
+            let stdin = io::stdin();
+            let line = stdin.lock().lines().next();
+            match line {
+                Some(Ok(input)) => match input.as_str() {
+                    "y" => (),
+                    _ => {
+                        info!("Migration cancelled");
+                        return Ok(());
+                    }
+                },
+                _ => {
+                    return Err(CliError::ActionError(
+                        "Unable to get prompt response".to_string(),
+                    ))
+                }
+            }
+        }
+
+        // used to check for LMDBM regardless of capitalization
+        let lower_in_database = in_database.to_string().to_lowercase();
+        let lower_out_database = out_database.to_string().to_lowercase();
+
+        // Get the database uri that wil be used for getting the circuit information. If lmdb
+        // is the target directory, we need to use the URI for the in database, otherwise the
+        // out database is used.
+        let database_uri = match (lower_in_database.as_str(), lower_out_database.as_str()) {
+            ("lmdb", "lmdb") => {
+                return Err(CliError::ActionError(
+                    "LMDB to LMDB is not supported".to_string(),
+                ))
+            }
+            (_, "lmdb") => {
+                out_database = lower_out_database.as_str();
+                in_database.to_string()
+            }
+            ("lmdb", _) => {
+                in_database = lower_in_database.as_str();
+                out_database.to_string()
+            }
+            (_, _) => {
+                return Err(CliError::ActionError(
+                    "Command only supports moving state to or from LMDB".to_string(),
+                ))
+            }
+        };
+
+        let in_upgrade_stores = match in_database {
+            "lmdb" => None,
+            _ => Some(
+                new_upgrade_stores(&ConnectionUri::from_str(in_database)?).map_err(|e| {
+                    CliError::ActionError(format!(
+                        "Unable to get stores for `--in` database {}: {}",
+                        in_database, e
+                    ))
+                })?,
+            ),
+        };
+
+        let out_upgrade_stores = match out_database {
+            "lmdb" => None,
+            _ => Some(
+                new_upgrade_stores(&ConnectionUri::from_str(out_database)?).map_err(|e| {
+                    CliError::ActionError(format!(
+                        "Unable to get stores for `--out` database {}: {}",
+                        out_database, e
+                    ))
+                })?,
+            ),
+        };
+
+        // Get the database that will be used to get circuit information
+        let upgrade_stores =
+            new_upgrade_stores(&ConnectionUri::from_str(&database_uri)?).map_err(|e| {
+                CliError::ActionError(format!(
+                    "Unable to get stores to fetch circuit information {}",
+                    e
+                ))
+            })?;
+
+        let node_id = if let Some(node_id) = upgrade_stores
+            .new_node_id_store()
+            .get_node_id()
+            .map_err(|e| CliError::ActionError(format!("{}", e)))?
+        {
+            node_id
+        } else {
+            // This node has not even set a node id, so it cannot have any circuits.
+            info!("Skipping scabbard state migrate, no local node ID found");
+            return Ok(());
+        };
+
+        let circuits = upgrade_stores
+            .new_admin_service_store()
+            .list_circuits(&[])
+            .map_err(|e| CliError::ActionError(format!("{}", e)))?;
+
+        if circuits.len() == 0 {
+            info!("Skipping scabbard state migrate, no circuits found");
+            Ok(())
+        } else {
+            let local_services = circuits
+                .into_iter()
+                .map(|circuit| {
+                    circuit
+                        .roster()
+                        .iter()
+                        .filter_map(|svc| {
+                            if svc.node_id() == node_id && svc.service_type() == "scabbard" {
+                                Some((
+                                    circuit.circuit_id().to_string(),
+                                    svc.service_id().to_string(),
+                                ))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .flatten();
+
+            for (circuit_id, service_id) in local_services {
+                info!("Migrating state data for {}::{}", circuit_id, service_id);
+                let commit_hash_store =
+                    upgrade_stores.new_commit_hash_store(&circuit_id, &service_id);
+                let commit_hash = commit_hash_store
+                    .get_current_commit_hash()
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))?
+                    .ok_or_else(|| {
+                        CliError::ActionError(format!(
+                            "No commit hash for service {}::{}",
+                            circuit_id, service_id,
+                        ))
+                    })?;
+
+                let state_reader = get_merkle_state(
+                    in_database,
+                    &circuit_id,
+                    &service_id,
+                    &in_upgrade_stores,
+                    &lmdb_db_factory,
+                    false,
+                )?;
+
+                // check if the tree already exists and error if so unless force is set
+                if !args.is_present("force")
+                    && database_exists(
+                        out_database,
+                        &circuit_id,
+                        &service_id,
+                        &out_upgrade_stores,
+                        &lmdb_db_factory,
+                    )?
+                {
+                    return Err(CliError::ActionError(format!(
+                        "Merkle Tree for {}::{} in {} already exists",
+                        circuit_id, service_id, out_database
+                    )));
+                }
+
+                let state_writer = get_merkle_state(
+                    out_database,
+                    &circuit_id,
+                    &service_id,
+                    &out_upgrade_stores,
+                    &lmdb_db_factory,
+                    true,
+                )?;
+
+                copy_state(&state_reader, commit_hash.to_string(), &state_writer)?;
+
+                // delete the existing scabbard state
+                state_reader.delete_tree(&lmdb_db_factory)?;
+            }
+            info!("Scabbard state successfully migrated to {}", out_database);
+            Ok(())
+        }
+    }
+}
+
+/// Gets the path of splinterd's state directory
+///
+///
+/// # Arguments
+///
+/// * `arg_matches` - an option of clap ['ArgMatches'](https://docs.rs/clap/2.33.3/clap/struct.ArgMatches.html).
+///
+/// # Returns
+///
+/// * PathBuf to state_dir if present in arg_matches, otherwise just the default from
+/// SplinterEnvironment
+fn get_state_dir(arg_matches: Option<&ArgMatches>) -> Result<PathBuf, CliError> {
+    if let Some(arg_matches) = arg_matches {
+        match arg_matches.value_of("state_dir") {
+            Some(state_dir) => {
+                let state_dir = PathBuf::from(state_dir.to_string());
+                Ok(
+                    std::fs::canonicalize(state_dir.as_path())
+                        .unwrap_or_else(|_| state_dir.clone()),
+                )
+            }
+            None => Ok(SplinterEnvironment::load().get_state_path()),
+        }
+    } else {
+        Ok(SplinterEnvironment::load().get_state_path())
+    }
+}
+
+/// Copy existing scabbard state for the current commit hash from state reader MerkleState to
+/// state writer MerkleState
+///
+/// # Arguments
+///
+/// * `state_reader` - The MerkleState that holds the state that should be moved
+/// * `current_commit_hash` - The current state root hash for the in database
+/// * `state_writer` - The MerkleState that the state should be moved to
+///
+/// # Returns
+///
+/// * Ok if the state was sucessfully copied and results in the correct state root hash, otherwise
+/// a CliError is returned
+fn copy_state(
+    state_reader: &MerkleState,
+    current_commit_hash: String,
+    state_writer: &MerkleState,
+) -> Result<(), CliError> {
+    let state_changes_iter = state_reader
+        .leaves(&current_commit_hash, None)
+        .map_err(|e| {
+            CliError::ActionError(format!("Unable to get leaves for commit hash: {}", e))
+        })?;
+
+    let mut count = 0;
+    let mut last_state_id = state_writer.get_state_root()?;
+    let mut state_changes = vec![];
+    let mut to_prune = vec![];
+    for state_change in state_changes_iter {
+        match state_change {
+            Ok((key, value)) => {
+                state_changes.push(StateChange::Set { key, value });
+                count += 1;
+
+                if count > 1000 {
+                    to_prune.push(last_state_id.to_string());
+                    last_state_id = state_writer
+                        .commit(&last_state_id, &state_changes)
+                        .map_err(|e| {
+                            CliError::ActionError(format!("Unable to commit state changes {}", e))
+                        })?;
+                    count = 0;
+                    state_changes.clear()
+                }
+            }
+            Err(err) => {
+                return Err(CliError::ActionError(format!(
+                    "Cannot get state change: {}",
+                    err
+                )))
+            }
+        }
+    }
+
+    to_prune.push(last_state_id.to_string());
+    last_state_id = state_writer
+        .commit(&last_state_id, &state_changes)
+        .map_err(|e| CliError::ActionError(format!("Unable to commit state changes {}", e)))?;
+
+    if last_state_id == current_commit_hash {
+        state_writer.prune(to_prune).map_err(|e| {
+            CliError::ActionError(format!("Unable to purge old commit hashes {}", e))
+        })?;
+    } else {
+        return Err(CliError::ActionError(format!(
+            "Ending commit hash did not match expected {} != {}",
+            last_state_id, current_commit_hash
+        )));
+    }
+
+    Ok(())
+}
+
+/// Get a the state for the provide
+///
+/// # Arguments
+///
+/// * `database` - The database URI for the MerkleState
+/// * `circuit_id` - The circuit the Scabbard state belongs too
+/// * `service_id` - The service the Scabbard state belongs too
+/// * `upgrade_stores` - The UpgradeStores struct that should be used to get Postgres or Sqlite
+/// *   pool
+/// * `lmdb_db_factory` - The factory to create LMDB databases
+/// * `create_tree` - Whether the tree should be created if it does not exist
+fn get_merkle_state(
+    database: &str,
+    circuit_id: &str,
+    service_id: &str,
+    upgrade_stores: &Option<Box<dyn UpgradeStores>>,
+    lmdb_db_factory: &LmdbDatabaseFactory,
+    create_tree: bool,
+) -> Result<MerkleState, CliError> {
+    match database {
+        "lmdb" => {
+            if !create_tree {
+                let path = lmdb_db_factory
+                    .compute_path(circuit_id, service_id)
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))?
+                    .with_extension("lmdb");
+
+                if !path.is_file() {
+                    return Err(CliError::ActionError(format!(
+                        "LMDB file for service {}::{} ({:?}) does not exist",
+                        circuit_id, service_id, path
+                    )));
+                }
+            }
+            let state = lmdb_db_factory
+                .get_database(circuit_id, service_id)
+                .map_err(|e| CliError::ActionError(format!("{}", e)))?;
+            let merkle_root = MerkleRadixTree::new(Box::new(state.clone()), None)
+                .map_err(|e| CliError::ActionError(format!("{}", e)))?
+                .get_merkle_root();
+            Ok(MerkleState::Lmdb {
+                state: TransactMerkleState::new(Box::new(state)),
+                merkle_root,
+                tree_id: (circuit_id.to_string(), service_id.to_string()),
+            })
+        }
+        _ => {
+            if let Some(upgrade_stores) = &upgrade_stores {
+                let connection_uri = ConnectionUri::from_str(database)
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))?;
+                match connection_uri {
+                    #[cfg(feature = "postgres")]
+                    ConnectionUri::Postgres(_) => {
+                        let pool = upgrade_stores.get_postgres_pool();
+                        let backend = backend::PostgresBackend::from(pool);
+                        let mut builder = SqlMerkleStateBuilder::new()
+                            .with_backend(backend)
+                            .with_tree(format!("{}::{}", circuit_id, service_id));
+
+                        if create_tree {
+                            builder = builder.create_tree_if_necessary();
+                        }
+
+                        let state = builder.build().map_err(|e| {
+                            CliError::ActionError(format!(
+                                "Unable to get database for Merkle tree {}::{}: {}",
+                                circuit_id, service_id, e
+                            ))
+                        })?;
+                        Ok(MerkleState::Postgres { state })
+                    }
+                    #[cfg(feature = "sqlite")]
+                    ConnectionUri::Sqlite(_) => {
+                        let pool = upgrade_stores.get_sqlite_pool();
+                        let backend = backend::SqliteBackend::from(pool);
+                        let mut builder = SqlMerkleStateBuilder::new()
+                            .with_backend(backend)
+                            .with_tree(format!("{}::{}", circuit_id, service_id));
+
+                        if create_tree {
+                            builder = builder.create_tree_if_necessary();
+                        }
+
+                        let state = builder.build().map_err(|e| {
+                            CliError::ActionError(format!(
+                                "Unable to get database for Merkle tree {}::{}: {}",
+                                circuit_id, service_id, e
+                            ))
+                        })?;
+                        Ok(MerkleState::Sqlite { state })
+                    }
+                }
+            } else {
+                // this should never happen
+                Err(CliError::ActionError(
+                    "Upgrade store for database type is not configured".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// Check if the database exists
+///
+/// # Arguments
+///
+/// * `database` - The database URI for the MerkleState
+/// * `circuit_id` - The circuit the Scabbard state belongs too
+/// * `service_id` - The service the Scabbard state belongs too
+/// * `upgrade_stores` - The UpgradeStores struct that should be used to get Postgres or Sqlite
+/// *   pool
+/// * `lmdb_db_factory` - The factory to check LMDB databases
+fn database_exists(
+    database: &str,
+    circuit_id: &str,
+    service_id: &str,
+    upgrade_stores: &Option<Box<dyn UpgradeStores>>,
+    lmdb_db_factory: &LmdbDatabaseFactory,
+) -> Result<bool, CliError> {
+    let tree_name = format!("{}::{}", circuit_id, service_id);
+    match database {
+        "lmdb" => {
+            let path = lmdb_db_factory
+                .compute_path(circuit_id, service_id)
+                .map_err(|e| CliError::ActionError(format!("{}", e)))?
+                .with_extension("lmdb");
+
+            Ok(path.is_file())
+        }
+        _ => {
+            if let Some(upgrade_stores) = &upgrade_stores {
+                let connection_uri = ConnectionUri::from_str(database)
+                    .map_err(|e| CliError::ActionError(format!("{}", e)))?;
+                match connection_uri {
+                    #[cfg(feature = "postgres")]
+                    ConnectionUri::Postgres(_) => {
+                        let pool = upgrade_stores.get_postgres_pool();
+                        merkle::postgres_list_available_trees(&pool)
+                            .map(|trees| Ok(trees.contains(&tree_name)))
+                            .map_err(|e| {
+                                CliError::ActionError(format!(
+                                    "Unable to read merkle state trees in postgres: {}",
+                                    e
+                                ))
+                            })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    ConnectionUri::Sqlite(_) => {
+                        let pool = upgrade_stores.get_sqlite_pool();
+                        merkle::sqlite_list_available_trees(&pool)
+                            .map(|trees| Ok(trees.contains(&tree_name)))
+                            .map_err(|e| {
+                                CliError::ActionError(format!(
+                                    "Unable to read merkle state trees in sqlite: {}",
+                                    e
+                                ))
+                            })?
+                    }
+                }
+            } else {
+                // this should never happen
+                Err(CliError::ActionError(
+                    "Upgrade store for database type is not configured".to_string(),
+                ))
+            }
+        }
+    }
+}

--- a/cli/src/action/database/stores.rs
+++ b/cli/src/action/database/stores.rs
@@ -1,0 +1,152 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use diesel::r2d2::{ConnectionManager, Pool};
+use sawtooth::receipt::store::{diesel::DieselReceiptStore, ReceiptStore};
+use scabbard::store::{diesel::DieselCommitHashStore, CommitHashStore};
+use splinter::{
+    admin::store::{diesel::DieselAdminServiceStore, AdminServiceStore},
+    error::InternalError,
+    node_id::store::{diesel::DieselNodeIdStore, NodeIdStore},
+};
+
+use super::ConnectionUri;
+
+pub trait UpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore>;
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore>;
+
+    fn new_commit_hash_store(&self, circuit_id: &str, service_id: &str)
+        -> Box<dyn CommitHashStore>;
+
+    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore>;
+}
+
+pub fn new_upgrade_stores(
+    database_uri: &ConnectionUri,
+) -> Result<Box<dyn UpgradeStores>, InternalError> {
+    match database_uri {
+        #[cfg(feature = "postgres")]
+        ConnectionUri::Postgres(url) => {
+            let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
+            let pool = Pool::builder().build(connection_manager).map_err(|err| {
+                InternalError::from_source_with_prefix(
+                    Box::new(err),
+                    "Failed to build connection pool".to_string(),
+                )
+            })?;
+            // Test the connection
+            let _conn = pool
+                .get()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            Ok(Box::new(PostgresUpgradeStores(pool)))
+        }
+        #[cfg(feature = "sqlite")]
+        ConnectionUri::Sqlite(conn_str) => {
+            if (conn_str != ":memory:") && !std::path::Path::new(&conn_str).exists() {
+                return Err(InternalError::with_message(format!(
+                    "Database file '{}' does not exist",
+                    conn_str
+                )));
+            }
+            let connection_manager =
+                ConnectionManager::<diesel::sqlite::SqliteConnection>::new(conn_str);
+            let mut pool_builder = Pool::builder();
+            // A new database is created for each connection to the in-memory SQLite
+            // implementation; to ensure that the resulting stores will operate on the same
+            // database, only one connection is allowed.
+            if conn_str == ":memory:" {
+                pool_builder = pool_builder.max_size(1);
+            }
+            let pool = pool_builder.build(connection_manager).map_err(|err| {
+                InternalError::from_source_with_prefix(
+                    Box::new(err),
+                    "Failed to build connection pool".to_string(),
+                )
+            })?;
+            // Test the connection
+            let _conn = pool
+                .get()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            Ok(Box::new(SqliteUpgradeStores(pool)))
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+struct PostgresUpgradeStores(Pool<ConnectionManager<diesel::pg::PgConnection>>);
+
+#[cfg(feature = "postgres")]
+impl UpgradeStores for PostgresUpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
+        Box::new(DieselAdminServiceStore::new(self.0.clone()))
+    }
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
+        Box::new(DieselNodeIdStore::new(self.0.clone()))
+    }
+
+    fn new_commit_hash_store(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+    ) -> Box<dyn CommitHashStore> {
+        Box::new(DieselCommitHashStore::new(
+            self.0.clone(),
+            circuit_id,
+            service_id,
+        ))
+    }
+
+    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore> {
+        Box::new(DieselReceiptStore::new(
+            self.0.clone(),
+            Some(format!("{}::{}", circuit_id, service_id)),
+        ))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+struct SqliteUpgradeStores(Pool<ConnectionManager<diesel::SqliteConnection>>);
+
+#[cfg(feature = "sqlite")]
+impl UpgradeStores for SqliteUpgradeStores {
+    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
+        Box::new(DieselAdminServiceStore::new(self.0.clone()))
+    }
+
+    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
+        Box::new(DieselNodeIdStore::new(self.0.clone()))
+    }
+
+    fn new_commit_hash_store(
+        &self,
+        circuit_id: &str,
+        service_id: &str,
+    ) -> Box<dyn CommitHashStore> {
+        Box::new(DieselCommitHashStore::new(
+            self.0.clone(),
+            circuit_id,
+            service_id,
+        ))
+    }
+
+    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore> {
+        Box::new(DieselReceiptStore::new(
+            self.0.clone(),
+            Some(format!("{}::{}", circuit_id, service_id)),
+        ))
+    }
+}

--- a/cli/src/action/database/stores.rs
+++ b/cli/src/action/database/stores.rs
@@ -32,6 +32,12 @@ pub trait UpgradeStores {
         -> Box<dyn CommitHashStore>;
 
     fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore>;
+
+    #[cfg(feature = "sqlite")]
+    fn get_sqlite_pool(&self) -> Pool<ConnectionManager<diesel::SqliteConnection>>;
+
+    #[cfg(feature = "postgres")]
+    fn get_postgres_pool(&self) -> Pool<ConnectionManager<diesel::PgConnection>>;
 }
 
 pub fn new_upgrade_stores(
@@ -116,6 +122,16 @@ impl UpgradeStores for PostgresUpgradeStores {
             Some(format!("{}::{}", circuit_id, service_id)),
         ))
     }
+
+    // should never be used if using postgres
+    #[cfg(feature = "sqlite")]
+    fn get_sqlite_pool(&self) -> Pool<ConnectionManager<diesel::SqliteConnection>> {
+        unimplemented!()
+    }
+
+    fn get_postgres_pool(&self) -> Pool<ConnectionManager<diesel::PgConnection>> {
+        self.0.clone()
+    }
 }
 
 #[cfg(feature = "sqlite")]
@@ -148,5 +164,15 @@ impl UpgradeStores for SqliteUpgradeStores {
             self.0.clone(),
             Some(format!("{}::{}", circuit_id, service_id)),
         ))
+    }
+
+    fn get_sqlite_pool(&self) -> Pool<ConnectionManager<diesel::SqliteConnection>> {
+        self.0.clone()
+    }
+
+    // should never be used if using sqlite
+    #[cfg(feature = "postgres")]
+    fn get_postgres_pool(&self) -> Pool<ConnectionManager<diesel::PgConnection>> {
+        unimplemented!()
     }
 }

--- a/cli/src/action/database/upgrade/receipt_store.rs
+++ b/cli/src/action/database/upgrade/receipt_store.rs
@@ -17,16 +17,10 @@
 use std::fmt::Write;
 use std::path::Path;
 
-use diesel::r2d2::{ConnectionManager, Pool};
 use openssl::hash::{hash, MessageDigest};
-use sawtooth::receipt::store::{diesel::DieselReceiptStore, lmdb::LmdbReceiptStore, ReceiptStore};
-use splinter::{
-    admin::store::{diesel::DieselAdminServiceStore, AdminServiceStore},
-    node_id::store::{diesel::DieselNodeIdStore, NodeIdStore},
-};
+use sawtooth::receipt::store::{lmdb::LmdbReceiptStore, ReceiptStore};
 
-use super::ConnectionUri;
-
+use crate::action::database::{stores::new_upgrade_stores, ConnectionUri};
 use crate::error::CliError;
 
 /// Migrate all of the transaction receipts to the `ReceiptStore`.
@@ -34,7 +28,8 @@ pub(super) fn upgrade_scabbard_receipt_store(
     receipt_db_dir: &Path,
     database_uri: &ConnectionUri,
 ) -> Result<(), CliError> {
-    let upgrade_stores = new_upgrade_stores(database_uri)?;
+    let upgrade_stores =
+        new_upgrade_stores(database_uri).map_err(|e| CliError::ActionError(format!("{}", e)))?;
 
     let node_id = if let Some(node_id) = upgrade_stores
         .new_node_id_store()
@@ -140,97 +135,4 @@ fn to_hex(bytes: &[u8]) -> String {
     }
 
     buf
-}
-
-trait UpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore>;
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore>;
-
-    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore>;
-}
-
-fn new_upgrade_stores(database_uri: &ConnectionUri) -> Result<Box<dyn UpgradeStores>, CliError> {
-    match database_uri {
-        #[cfg(feature = "postgres")]
-        ConnectionUri::Postgres(url) => {
-            let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-            let pool = Pool::builder().build(connection_manager).map_err(|err| {
-                CliError::ActionError(format!("Failed to build connection pool: {}", err))
-            })?;
-            // Test the connection
-            let _conn = pool
-                .get()
-                .map_err(|e| CliError::ActionError(format!("{}", e)))?;
-            Ok(Box::new(PostgresUpgradeStores(pool)))
-        }
-        #[cfg(feature = "sqlite")]
-        ConnectionUri::Sqlite(conn_str) => {
-            if (conn_str != ":memory:") && !std::path::Path::new(&conn_str).exists() {
-                return Err(CliError::ActionError(format!(
-                    "Database file '{}' does not exist",
-                    conn_str
-                )));
-            }
-            let connection_manager =
-                ConnectionManager::<diesel::sqlite::SqliteConnection>::new(conn_str);
-            let mut pool_builder = Pool::builder();
-            // A new database is created for each connection to the in-memory SQLite
-            // implementation; to ensure that the resulting stores will operate on the same
-            // database, only one connection is allowed.
-            if conn_str == ":memory:" {
-                pool_builder = pool_builder.max_size(1);
-            }
-            let pool = pool_builder.build(connection_manager).map_err(|err| {
-                CliError::ActionError(format!("Failed to build connection pool: {}", err))
-            })?;
-            // Test the connection
-            let _conn = pool
-                .get()
-                .map_err(|e| CliError::ActionError(format!("{}", e)))?;
-            Ok(Box::new(SqliteUpgradeStores(pool)))
-        }
-    }
-}
-
-#[cfg(feature = "postgres")]
-struct PostgresUpgradeStores(Pool<ConnectionManager<diesel::pg::PgConnection>>);
-
-#[cfg(feature = "postgres")]
-impl UpgradeStores for PostgresUpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
-        Box::new(DieselAdminServiceStore::new(self.0.clone()))
-    }
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
-        Box::new(DieselNodeIdStore::new(self.0.clone()))
-    }
-
-    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore> {
-        Box::new(DieselReceiptStore::new(
-            self.0.clone(),
-            Some(format!("{}::{}", circuit_id, service_id)),
-        ))
-    }
-}
-
-#[cfg(feature = "sqlite")]
-struct SqliteUpgradeStores(Pool<ConnectionManager<diesel::SqliteConnection>>);
-
-#[cfg(feature = "sqlite")]
-impl UpgradeStores for SqliteUpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
-        Box::new(DieselAdminServiceStore::new(self.0.clone()))
-    }
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
-        Box::new(DieselNodeIdStore::new(self.0.clone()))
-    }
-
-    fn new_receipt_store(&self, circuit_id: &str, service_id: &str) -> Box<dyn ReceiptStore> {
-        Box::new(DieselReceiptStore::new(
-            self.0.clone(),
-            Some(format!("{}::{}", circuit_id, service_id)),
-        ))
-    }
 }

--- a/cli/src/action/database/upgrade/scabbard.rs
+++ b/cli/src/action/database/upgrade/scabbard.rs
@@ -16,19 +16,15 @@
 
 use std::path::Path;
 
-use diesel::r2d2::{ConnectionManager, Pool};
 use scabbard::store::{
-    diesel::DieselCommitHashStore,
     transact::{factory::LmdbDatabaseFactory, TransactCommitHashStore},
     CommitHashStore,
 };
-use splinter::{
-    admin::store::{diesel::DieselAdminServiceStore, AdminServiceStore},
-    error::InternalError,
-    node_id::store::{diesel::DieselNodeIdStore, NodeIdStore},
-};
+use splinter::error::InternalError;
 
-use super::{error::UpgradeError, ConnectionUri};
+use super::error::UpgradeError;
+
+use crate::action::database::{stores::new_upgrade_stores, ConnectionUri};
 
 /// Migrate all of the service state's current commit hashes to the [`CommitHashStore`].
 pub(super) fn upgrade_scabbard_commit_hash_state(
@@ -97,115 +93,4 @@ pub(super) fn upgrade_scabbard_commit_hash_state(
     }
 
     Ok(())
-}
-
-trait UpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore>;
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore>;
-
-    fn new_commit_hash_store(&self, circuit_id: &str, service_id: &str)
-        -> Box<dyn CommitHashStore>;
-}
-
-fn new_upgrade_stores(
-    database_uri: &ConnectionUri,
-) -> Result<Box<dyn UpgradeStores>, UpgradeError> {
-    match database_uri {
-        #[cfg(feature = "postgres")]
-        ConnectionUri::Postgres(url) => {
-            let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
-            let pool = Pool::builder().build(connection_manager).map_err(|err| {
-                InternalError::from_source_with_prefix(
-                    Box::new(err),
-                    "Failed to build connection pool".to_string(),
-                )
-            })?;
-            // Test the connection
-            let _conn = pool
-                .get()
-                .map_err(|err| InternalError::from_source(Box::new(err)))?;
-            Ok(Box::new(PostgresUpgradeStores(pool)))
-        }
-        #[cfg(feature = "sqlite")]
-        ConnectionUri::Sqlite(conn_str) => {
-            if (conn_str != ":memory:") && !std::path::Path::new(&conn_str).exists() {
-                return Err(UpgradeError::Internal(InternalError::with_message(
-                    format!("Database file '{}' does not exist", conn_str),
-                )));
-            }
-            let connection_manager =
-                ConnectionManager::<diesel::sqlite::SqliteConnection>::new(conn_str);
-            let mut pool_builder = Pool::builder();
-            // A new database is created for each connection to the in-memory SQLite
-            // implementation; to ensure that the resulting stores will operate on the same
-            // database, only one connection is allowed.
-            if conn_str == ":memory:" {
-                pool_builder = pool_builder.max_size(1);
-            }
-            let pool = pool_builder.build(connection_manager).map_err(|err| {
-                InternalError::from_source_with_prefix(
-                    Box::new(err),
-                    "Failed to build connection pool".to_string(),
-                )
-            })?;
-            // Test the connection
-            let _conn = pool
-                .get()
-                .map_err(|err| InternalError::from_source(Box::new(err)))?;
-            Ok(Box::new(SqliteUpgradeStores(pool)))
-        }
-    }
-}
-
-#[cfg(feature = "postgres")]
-struct PostgresUpgradeStores(Pool<ConnectionManager<diesel::pg::PgConnection>>);
-
-#[cfg(feature = "postgres")]
-impl UpgradeStores for PostgresUpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
-        Box::new(DieselAdminServiceStore::new(self.0.clone()))
-    }
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
-        Box::new(DieselNodeIdStore::new(self.0.clone()))
-    }
-
-    fn new_commit_hash_store(
-        &self,
-        circuit_id: &str,
-        service_id: &str,
-    ) -> Box<dyn CommitHashStore> {
-        Box::new(DieselCommitHashStore::new(
-            self.0.clone(),
-            circuit_id,
-            service_id,
-        ))
-    }
-}
-
-#[cfg(feature = "sqlite")]
-struct SqliteUpgradeStores(Pool<ConnectionManager<diesel::SqliteConnection>>);
-
-#[cfg(feature = "sqlite")]
-impl UpgradeStores for SqliteUpgradeStores {
-    fn new_admin_service_store(&self) -> Box<dyn AdminServiceStore> {
-        Box::new(DieselAdminServiceStore::new(self.0.clone()))
-    }
-
-    fn new_node_id_store(&self) -> Box<dyn NodeIdStore> {
-        Box::new(DieselNodeIdStore::new(self.0.clone()))
-    }
-
-    fn new_commit_hash_store(
-        &self,
-        circuit_id: &str,
-        service_id: &str,
-    ) -> Box<dyn CommitHashStore> {
-        Box::new(DieselCommitHashStore::new(
-            self.0.clone(),
-            circuit_id,
-            service_id,
-        ))
-    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -947,7 +947,60 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .help("Database connection URI"),
                         ),
                 ),
-        )
+        );
+
+        app = app.subcommand(
+            SubCommand::with_name("state")
+                .about("Commands to manage scabbard state")
+                .setting(AppSettings::SubcommandRequiredElseHelp)
+                .subcommand(
+                    SubCommand::with_name("migrate")
+                        .about(
+                            "Move scabbard state to or from LMDB, deleting from the \
+                            input database",
+                        )
+                        .arg(
+                            Arg::with_name("in")
+                                .long("in")
+                                .help(
+                                    "Database URI that currently contains the scabbard state. If \
+                                    state is in individual LMDB files, provide `lmdb`",
+                                )
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("out")
+                                .long("out")
+                                .help(
+                                    "The database URI the scabbard state should end up in. \
+                                    If state should be put into individual LMDB files, provide \
+                                    `lmdb`",
+                                )
+                                .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("state_dir")
+                                .long("state-dir")
+                                .long_help(
+                                    "The location of the state directory for the LMDB files. \
+                                    Defaults to /var/lib/splinter. This location can also be \
+                                    changed with the SPLINTER_STATE_DIR or SPLINTER_HOME \
+                                    environment variables",
+                                )
+                                .takes_value(true),
+                        )
+                        .arg(Arg::with_name("force").short("f").long("force").help(
+                            "Always attempt to move state, regardless of if there is \
+                                    existing data in the out database",
+                        ))
+                        .arg(
+                            Arg::with_name("yes")
+                                .short("y")
+                                .long("yes")
+                                .help("Do not prompt for confirmation"),
+                        ),
+                ),
+        );
     }
 
     #[cfg(feature = "upgrade")]
@@ -1676,7 +1729,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         subcommands = subcommands.with_command(
             "database",
             SubcommandActions::new().with_command("migrate", database::MigrateAction),
-        )
+        );
+
+        subcommands = subcommands.with_command(
+            "state",
+            SubcommandActions::new().with_command("migrate", database::StateMigrateAction),
+        );
     }
 
     #[cfg(feature = "upgrade")]


### PR DESCRIPTION
Implement command to move scabbard state to or from LMDB, deleting from the input database.

```
splinter state migrate -h
splinter-state-migrate 
Move scabbard state to or from LMDB, deleting from the input database

USAGE:
    splinter state migrate [FLAGS] [OPTIONS]

FLAGS:
    -f, --force      Always attempt to move state, regardless of if there is existing data in the out database
    -h, --help       Prints help information
    -q, --quiet      Do not display output
    -V, --version    Prints version information
    -v               Log verbosely
    -y, --yes        Do not prompt for confirmation

OPTIONS:
        --in <in>                  Database URI that currently contains the scabbard state. If state is in individual
                                   LMDB files, provide `lmdb`
        --out <out>                The database URI the scabbard state should end up in. If state should be put into
                                   individual LMDB files, provide `lmdb`
        --state-dir <state_dir>    The location of the state directory for the LMDB files
```

To test, start up to splinterd with lmdb scabbard state configured and create circuit and submit some txn. 

Then run the following command to move the migrate the scabbard data for on of the splinter daemons
```
splinter state migrate --in lmdb --out SQLITE_OR_POSTGRES_SPLINTER_DATABASE 
```

And then restart the splinter daemons, without lmdb configured for the daemon whose state was migrated. In the data directory, there should be no LMDB files remaining. You can do the reverse to move the scabbard state out into LMDB files as well.