### PR TITLE
Log default adjustment

### DIFF
--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -273,14 +273,26 @@ version = "1"
 # Optional for non-root loggers, defaults to the root loggers level.
 #level = "Warn"
 #
-# By default there are two non-root loggers configured. 
+# By default there are six non-root loggers configured. 
 #
 #[loggers.splinter]
-#level = "Info"
+#level = "Trace"
 #
 #[loggers.splinterd]
-#level = "Info"
+#level = "Trace"
 #
-# These two loggers select for the logs related to Splinter operations. Their
+#[loggers.scabbard]
+#level = "Trace"
+#
+#[loggers.sawtooth]
+#level = "Trace"
+#
+#[loggers.cylinder]
+#level = "Trace"
+#
+#[loggers.transact]
+#level = "Trace"
+#
+# These five loggers select for the logs related to Splinter operations. Their
 # appenders fields are not set so they inherit their appenders from the root
 # logger.

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -127,14 +127,14 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 "splinter".to_string(),
                 UnnamedLoggerConfig {
                     appenders: None,
-                    level: Some(log::Level::Info),
+                    level: Some(log::Level::Trace),
                 },
             ),
             (
                 "splinterd".to_string(),
                 UnnamedLoggerConfig {
                     appenders: None,
-                    level: Some(log::Level::Info),
+                    level: Some(log::Level::Trace),
                 },
             ),
         ]

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -137,6 +137,34 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                     level: Some(log::Level::Trace),
                 },
             ),
+            (
+                "sawtooth".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
+            (
+                "scabbard".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
+            (
+                "cylinder".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
+            (
+                "transact".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
         ]
         .into_iter()
         .collect::<HashMap<String, UnnamedLoggerConfig>>();

--- a/splinterd/src/logging.rs
+++ b/splinterd/src/logging.rs
@@ -185,19 +185,6 @@ pub fn configure_logging(
     };
     let loggers = if let Some(loggers) = config.loggers() {
         loggers
-            .iter()
-            .map(|l| {
-                if l.name == "splinterd" {
-                    LoggerConfig {
-                        level: Some(config.verbosity()),
-                        name: l.name.to_owned(),
-                        appenders: l.appenders.to_owned(),
-                    }
-                } else {
-                    l.to_owned()
-                }
-            })
-            .collect()
     } else {
         vec![]
     };


### PR DESCRIPTION
Redo the -v verbosity flag logic and add `scabbard` and `cylinder` default loggers.