### PR TITLE
Enable write-exclusivity with splinter stores

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -106,6 +106,7 @@ stable = [
     "rest-api-actix",
     "rest-api-cors",
     "sqlite",
+    "store",
     "store-factory",
     "tap",
     "trust-authorization",
@@ -163,7 +164,7 @@ https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
 node-id-store = []
 oauth = ["biome", "base64", "oauth2", "reqwest", "rest-api"]
-postgres = ["diesel/postgres", "diesel_migrations"]
+postgres = ["diesel/postgres", "diesel_migrations", "store"]
 registry = []
 registry-client = ["registry"]
 registry-client-reqwest = ["registry-client", "reqwest"]
@@ -181,8 +182,9 @@ rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
 service-network = []
-sqlite = ["diesel/sqlite", "diesel_migrations"]
-store-factory = []
+sqlite = ["diesel/sqlite", "diesel_migrations", "store"]
+store = []
+store-factory = ["store"]
 tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-1"]
 trust-authorization = []
 ws-transport = ["tungstenite"]

--- a/libsplinter/src/admin/store/error.rs
+++ b/libsplinter/src/admin/store/error.rs
@@ -98,3 +98,9 @@ impl From<diesel::result::Error> for AdminServiceStoreError {
         }
     }
 }
+
+impl From<InternalError> for AdminServiceStoreError {
+    fn from(err: InternalError) -> Self {
+        Self::InternalError(err)
+    }
+}

--- a/libsplinter/src/biome/key_management/store/error.rs
+++ b/libsplinter/src/biome/key_management/store/error.rs
@@ -15,6 +15,8 @@
 use std::error::Error;
 use std::fmt;
 
+use crate::error::InternalError;
+
 /// Represents KeyStore errors
 #[derive(Debug)]
 pub enum KeyStoreError {
@@ -41,6 +43,8 @@ pub enum KeyStoreError {
     DuplicateKeyError(String),
     /// Returned when a user is not found with the provided ID
     UserDoesNotExistError(String),
+    /// An internal error has occurred
+    InternalError(InternalError),
 }
 
 impl Error for KeyStoreError {
@@ -57,6 +61,7 @@ impl Error for KeyStoreError {
             KeyStoreError::NotFoundError(_) => None,
             KeyStoreError::DuplicateKeyError(_) => None,
             KeyStoreError::UserDoesNotExistError(_) => None,
+            KeyStoreError::InternalError(err) => Some(err),
         }
     }
 }
@@ -88,6 +93,7 @@ impl fmt::Display for KeyStoreError {
             KeyStoreError::NotFoundError(msg) => write!(f, "key not found: {}", msg),
             KeyStoreError::DuplicateKeyError(msg) => write!(f, "key already exists: {}", msg),
             KeyStoreError::UserDoesNotExistError(msg) => write!(f, "user does not exist: {}", msg),
+            KeyStoreError::InternalError(err) => f.write_str(&err.to_string()),
         }
     }
 }
@@ -96,5 +102,11 @@ impl fmt::Display for KeyStoreError {
 impl From<diesel::r2d2::PoolError> for KeyStoreError {
     fn from(err: diesel::r2d2::PoolError) -> KeyStoreError {
         KeyStoreError::ConnectionError(Box::new(err))
+    }
+}
+
+impl From<InternalError> for KeyStoreError {
+    fn from(err: InternalError) -> Self {
+        Self::InternalError(err)
     }
 }

--- a/libsplinter/src/biome/oauth/store/error.rs
+++ b/libsplinter/src/biome/oauth/store/error.rs
@@ -90,3 +90,9 @@ impl From<diesel::result::Error> for OAuthUserSessionStoreError {
         }
     }
 }
+
+impl From<InternalError> for OAuthUserSessionStoreError {
+    fn from(err: InternalError) -> Self {
+        Self::Internal(err)
+    }
+}

--- a/libsplinter/src/biome/profile/store/error.rs
+++ b/libsplinter/src/biome/profile/store/error.rs
@@ -86,3 +86,9 @@ impl From<diesel::result::Error> for UserProfileStoreError {
         }
     }
 }
+
+impl From<InternalError> for UserProfileStoreError {
+    fn from(err: InternalError) -> Self {
+        Self::Internal(err)
+    }
+}

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -98,7 +98,7 @@ pub mod registry;
 pub mod rest_api;
 pub mod service;
 pub mod sets;
-#[cfg(feature = "store-factory")]
+#[cfg(feature = "store")]
 pub mod store;
 pub mod threading;
 pub mod transport;

--- a/libsplinter/src/node_id/store/error.rs
+++ b/libsplinter/src/node_id/store/error.rs
@@ -72,3 +72,9 @@ impl From<std::io::Error> for NodeIdStoreError {
         Self::InternalError(InternalError::from_source(Box::new(err)))
     }
 }
+
+impl From<InternalError> for NodeIdStoreError {
+    fn from(err: InternalError) -> Self {
+        Self::InternalError(err)
+    }
+}

--- a/libsplinter/src/registry/error.rs
+++ b/libsplinter/src/registry/error.rs
@@ -68,6 +68,12 @@ impl From<diesel::r2d2::PoolError> for RegistryError {
     }
 }
 
+impl From<InternalError> for RegistryError {
+    fn from(err: InternalError) -> Self {
+        Self::InternalError(err)
+    }
+}
+
 /// Represents the reason that a node was found to be invalid
 #[derive(Debug)]
 pub enum InvalidNodeError {

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -14,14 +14,17 @@
 
 //! Contains a `StoreFactory` trait, which is an abstract factory for building stores
 //! backed by a single storage mechanism (e.g. database)
-#[cfg(feature = "memory")]
+#[cfg(all(feature = "store-factory", feature = "memory"))]
 pub mod memory;
-#[cfg(feature = "postgres")]
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) mod pool;
+#[cfg(all(feature = "store-factory", feature = "postgres"))]
 pub mod postgres;
-#[cfg(feature = "sqlite")]
+#[cfg(all(feature = "store-factory", feature = "sqlite"))]
 pub mod sqlite;
 
 /// An abstract factory for creating Splinter stores backed by the same storage
+#[cfg(feature = "store-factory")]
 pub trait StoreFactory {
     /// Get a new `CredentialsStore`
     #[cfg(feature = "biome-credentials")]

--- a/libsplinter/src/store/pool.rs
+++ b/libsplinter/src/store/pool.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::error::InternalError;
+
+pub enum ConnectionPool<C: diesel::Connection + 'static> {
+    Normal(Pool<ConnectionManager<C>>),
+    WriteExclusive(Arc<RwLock<Pool<ConnectionManager<C>>>>),
+}
+
+macro_rules! conn {
+    ($pool:ident) => {
+        $pool
+            .get()
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    };
+}
+
+impl<C: diesel::Connection> ConnectionPool<C> {
+    pub fn execute_write<F, T, E>(&self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(&C) -> Result<T, E>,
+        E: From<InternalError>,
+    {
+        match self {
+            Self::Normal(pool) => f(&*conn!(pool)?),
+            Self::WriteExclusive(locked_pool) => locked_pool
+                .write()
+                .map_err(|_| {
+                    InternalError::with_message("Connection pool rwlock is poisoned".into()).into()
+                })
+                .and_then(|pool| f(&*conn!(pool)?)),
+        }
+    }
+
+    pub fn execute_read<F, T, E>(&self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(&C) -> Result<T, E>,
+        E: From<InternalError>,
+    {
+        match self {
+            Self::Normal(pool) => f(&*conn!(pool)?),
+            Self::WriteExclusive(locked_pool) => locked_pool
+                .read()
+                .map_err(|_| {
+                    InternalError::with_message("Connection pool rwlock is poisoned".into()).into()
+                })
+                .and_then(|pool| f(&*conn!(pool)?)),
+        }
+    }
+}
+
+impl<C: diesel::Connection> Clone for ConnectionPool<C> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Normal(pool) => Self::Normal(pool.clone()),
+            Self::WriteExclusive(locked_pool) => Self::WriteExclusive(locked_pool.clone()),
+        }
+    }
+}
+
+impl<C: diesel::Connection> From<Pool<ConnectionManager<C>>> for ConnectionPool<C> {
+    fn from(pool: Pool<ConnectionManager<C>>) -> Self {
+        Self::Normal(pool)
+    }
+}
+
+impl<C: diesel::Connection> From<Arc<RwLock<Pool<ConnectionManager<C>>>>> for ConnectionPool<C> {
+    fn from(pool: Arc<RwLock<Pool<ConnectionManager<C>>>>) -> Self {
+        Self::WriteExclusive(pool)
+    }
+}


### PR DESCRIPTION
This PR updates the splinter stores to support an optional write-exclusive mode. The SqliteStoreFactory has been updated to make use of this configuration.