### PR TITLE
Backport 0-6: Move authorization-handler-rbac feature to default

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -67,6 +67,7 @@ tempdir = "0.3"
 
 [features]
 default = [
+    "authorization-handler-rbac",
     "circuit-template",
     "database",
     "postgres",
@@ -76,7 +77,6 @@ default = [
 ]
 
 stable = [
-    "authorization-handler-rbac",
     "default",
 ]
 


### PR DESCRIPTION
The associated feature in splinterd is default and the CLI
should match. These features were stabilized and then moved
to default in libsplinter/splinterd but was missed in the CLI.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>