### PR TITLE
 0-4: Use Message::parse_from_bytes instead of protobuf::parse_from_bytes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ flexi_logger = "0.14"
 libc = "0.2"
 log = "0.4"
 openssl = "0.10"
-protobuf = "~2.18"
+protobuf = "2.19"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 sawtooth-sdk = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ description = """\
 [dependencies]
 log = "0.3.8"
 openssl = "0.10"
-protobuf = "~2.18"
+protobuf = "2.19"
 splinter = { path = "../libsplinter" }
 url = "1.7.1"
 

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -46,7 +46,7 @@ hyper = "0.12"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2.0"
-protobuf = "~2.18"
+protobuf = "2.19"
 sabre-sdk = "0.5"
 sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
 scabbard = { path = "../../../services/scabbard/libscabbard", features = ["events"] }

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -46,7 +46,7 @@ mio = "0.6"
 mio-extras = "2"
 openssl = "0.10"
 percent-encoding = { version = "2.0", optional = true }
-protobuf = "~2.18"
+protobuf = "2.19"
 rand = "0.7"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth-sdk = { version = "0.4", optional = true }

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -499,7 +499,7 @@ impl Service for AdminService {
         message_bytes: &[u8],
         message_context: &ServiceMessageContext,
     ) -> Result<(), ServiceError> {
-        let admin_message: AdminMessage = protobuf::parse_from_bytes(message_bytes)
+        let admin_message: AdminMessage = Message::parse_from_bytes(message_bytes)
             .map_err(|err| ServiceError::InvalidMessageFormat(Box::new(err)))?;
 
         debug!("received admin message {:?}", admin_message);
@@ -899,7 +899,7 @@ mod tests {
         }
 
         let admin_envelope: admin::AdminMessage =
-            protobuf::parse_from_bytes(&message).expect("The message could not be parsed");
+            Message::parse_from_bytes(&message).expect("The message could not be parsed");
 
         assert_eq!(
             admin::AdminMessage_Type::SERVICE_PROTOCOL_VERSION_REQUEST,
@@ -933,7 +933,7 @@ mod tests {
         assert_eq!("admin::other-node".to_string(), recipient);
 
         let mut admin_envelope: admin::AdminMessage =
-            protobuf::parse_from_bytes(&message).expect("The message could not be parsed");
+            Message::parse_from_bytes(&message).expect("The message could not be parsed");
 
         assert_eq!(
             admin::AdminMessage_Type::PROPOSED_CIRCUIT,
@@ -945,7 +945,7 @@ mod tests {
             .take_circuit_payload();
 
         let header: admin::CircuitManagementPayload_Header =
-            protobuf::parse_from_bytes(envelope.get_header()).unwrap();
+            Message::parse_from_bytes(envelope.get_header()).unwrap();
         assert_eq!(
             admin::CircuitManagementPayload_Action::CIRCUIT_CREATE_REQUEST,
             header.get_action()

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -488,10 +488,9 @@ impl AdminServiceShared {
         &mut self,
         mut circuit_payload: CircuitManagementPayload,
     ) -> Result<(String, CircuitProposal), AdminSharedError> {
-        let header = protobuf::parse_from_bytes::<CircuitManagementPayload_Header>(
-            circuit_payload.get_header(),
-        )
-        .map_err(MarshallingError::from)?;
+        let header: CircuitManagementPayload_Header =
+            Message::parse_from_bytes(circuit_payload.get_header())
+                .map_err(MarshallingError::from)?;
         self.validate_circuit_management_payload(&circuit_payload, &header)?;
         self.verify_signature(&circuit_payload).map_err(|_| {
             AdminSharedError::ValidationFailed(String::from("Unable to verify signature"))
@@ -812,8 +811,8 @@ impl AdminServiceShared {
     pub fn submit(&mut self, payload: CircuitManagementPayload) -> Result<(), ServiceError> {
         debug!("Payload submitted: {:?}", payload);
 
-        let header =
-            protobuf::parse_from_bytes::<CircuitManagementPayload_Header>(payload.get_header())?;
+        let header: CircuitManagementPayload_Header =
+            Message::parse_from_bytes(payload.get_header())?;
         self.validate_circuit_management_payload(&payload, &header)
             .map_err(|err| ServiceError::UnableToHandleMessage(Box::new(err)))?;
         self.verify_signature(&payload)?;
@@ -1904,8 +1903,8 @@ impl AdminServiceShared {
     }
 
     fn verify_signature(&self, payload: &CircuitManagementPayload) -> Result<bool, ServiceError> {
-        let header =
-            protobuf::parse_from_bytes::<CircuitManagementPayload_Header>(payload.get_header())?;
+        let header: CircuitManagementPayload_Header =
+            Message::parse_from_bytes(payload.get_header())?;
 
         let signature = payload.get_signature();
         let public_key = header.get_requester();

--- a/libsplinter/src/circuit/handlers/admin_message.rs
+++ b/libsplinter/src/circuit/handlers/admin_message.rs
@@ -475,11 +475,11 @@ mod tests {
     ) {
         assert_eq!(expected_recipient, &recipient);
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&message).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&message).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
-        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+        let circuit_msg: M = Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         detail_assertions(circuit_msg);
     }

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -324,7 +324,7 @@ mod tests {
         let (_, message) = mock_sender.next_outbound().expect("No message was sent");
 
         // verify that the message returned was an NetworkEcho, not a CircuitError
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&message).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&message).unwrap();
 
         assert_eq!(
             network_msg.get_message_type(),
@@ -341,11 +341,11 @@ mod tests {
     ) {
         assert_eq!(expected_recipient, &recipient);
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&message).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&message).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
-        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+        let circuit_msg: M = Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         detail_assertions(circuit_msg);
     }

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -725,11 +725,11 @@ mod tests {
     ) {
         assert_eq!(expected_recipient, &recipient);
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&message).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&message).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
-        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+        let circuit_msg: M = Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         detail_assertions(circuit_msg);
     }

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -707,11 +707,11 @@ mod tests {
     ) {
         assert_eq!(expected_recipient, &recipient);
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&message).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&message).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         assert_eq!(expected_circuit_msg_type, circuit_msg.get_message_type(),);
-        let circuit_msg: M = protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+        let circuit_msg: M = Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         detail_assertions(circuit_msg);
     }

--- a/libsplinter/src/consensus/mod.rs
+++ b/libsplinter/src/consensus/mod.rs
@@ -126,7 +126,7 @@ impl From<Proposal> for ProposalProto {
 impl TryFrom<&[u8]> for Proposal {
     type Error = ProtobufError;
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let proto: ProposalProto = protobuf::parse_from_bytes(bytes)?;
+        let proto: ProposalProto = Message::parse_from_bytes(bytes)?;
         Ok(Proposal::from(proto))
     }
 }
@@ -235,7 +235,7 @@ impl From<ConsensusMessage> for ConsensusMessageProto {
 impl TryFrom<&[u8]> for ConsensusMessage {
     type Error = ProtobufError;
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let proto: ConsensusMessageProto = protobuf::parse_from_bytes(bytes)?;
+        let proto: ConsensusMessageProto = Message::parse_from_bytes(bytes)?;
         Ok(ConsensusMessage::from(proto))
     }
 }

--- a/libsplinter/src/consensus/two_phase/mod.rs
+++ b/libsplinter/src/consensus/two_phase/mod.rs
@@ -139,7 +139,7 @@ impl TwoPhaseEngine {
         network_sender: &dyn ConsensusNetworkSender,
         proposal_manager: &dyn ProposalManager,
     ) -> Result<(), ConsensusEngineError> {
-        let two_phase_msg: TwoPhaseMessage = protobuf::parse_from_bytes(&consensus_msg.message)?;
+        let two_phase_msg: TwoPhaseMessage = Message::parse_from_bytes(&consensus_msg.message)?;
         let proposal_id = ProposalId::from(two_phase_msg.get_proposal_id());
 
         match two_phase_msg.get_message_type() {
@@ -472,7 +472,7 @@ impl TwoPhaseEngine {
         // the list will be all peers.
         let verifiers = if !proposal.consensus_data.is_empty() {
             let required_verifiers: RequiredVerifiers =
-                protobuf::parse_from_bytes(&proposal.consensus_data)?;
+                Message::parse_from_bytes(&proposal.consensus_data)?;
             required_verifiers
                 .verifiers
                 .into_iter()
@@ -793,7 +793,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(0) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_VERIFICATION_REQUEST
@@ -825,7 +825,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(1) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_RESULT
@@ -851,7 +851,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(2) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_VERIFICATION_REQUEST
@@ -894,7 +894,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(3) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_RESULT
@@ -968,7 +968,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(0) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_VERIFICATION_REQUEST
@@ -1000,7 +1000,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(1) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_RESULT
@@ -1026,7 +1026,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(2) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_VERIFICATION_REQUEST
@@ -1069,7 +1069,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(3) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_RESULT
@@ -1150,7 +1150,7 @@ pub mod tests {
         loop {
             if let Some((msg, peer_id)) = network.sent_messages().get(0) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(peer_id, &vec![0].into());
                 assert_eq!(
                     msg.get_message_type(),
@@ -1211,7 +1211,7 @@ pub mod tests {
         loop {
             if let Some((msg, peer_id)) = network.sent_messages().get(1) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(peer_id, &vec![0].into());
                 assert_eq!(
                     msg.get_message_type(),
@@ -1288,7 +1288,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(0) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_VERIFICATION_REQUEST
@@ -1302,7 +1302,7 @@ pub mod tests {
         loop {
             if let Some(msg) = network.broadcast_messages().get(1) {
                 let msg: TwoPhaseMessage =
-                    protobuf::parse_from_bytes(msg).expect("failed to parse message");
+                    Message::parse_from_bytes(msg).expect("failed to parse message");
                 assert_eq!(
                     msg.get_message_type(),
                     TwoPhaseMessage_Type::PROPOSAL_RESULT

--- a/libsplinter/src/network/auth/handlers.rs
+++ b/libsplinter/src/network/auth/handlers.rs
@@ -618,16 +618,16 @@ mod tests {
         msg_bytes: &[u8],
     ) -> M {
         let network_msg: NetworkMessage =
-            protobuf::parse_from_bytes(msg_bytes).expect("Unable to parse network message");
+            Message::parse_from_bytes(msg_bytes).expect("Unable to parse network message");
         assert_eq!(NetworkMessageType::AUTHORIZATION, network_msg.message_type);
 
         let auth_msg: authorization::AuthorizationMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload())
+            Message::parse_from_bytes(network_msg.get_payload())
                 .expect("Unable to parse auth message");
 
         assert_eq!(message_type, auth_msg.message_type);
 
-        match protobuf::parse_from_bytes(auth_msg.get_payload()) {
+        match Message::parse_from_bytes(auth_msg.get_payload()) {
             Ok(msg) => msg,
             Err(err) => panic!(
                 "unable to parse message for type {:?}: {:?}",

--- a/libsplinter/src/network/auth/mod.rs
+++ b/libsplinter/src/network/auth/mod.rs
@@ -214,7 +214,7 @@ impl AuthorizationConnector {
             let authed_identity = 'main: loop {
                 match connection.recv() {
                     Ok(bytes) => {
-                        let mut msg: NetworkMessage = match protobuf::parse_from_bytes(&bytes) {
+                        let mut msg: NetworkMessage = match Message::parse_from_bytes(&bytes) {
                             Ok(msg) => msg,
                             Err(err) => {
                                 warn!("Received invalid network message: {}", err);
@@ -567,7 +567,7 @@ pub(in crate::network) mod tests {
 
     fn read_auth_message(bytes: &[u8]) -> AuthorizationMessage {
         let msg: NetworkMessage =
-            protobuf::parse_from_bytes(bytes).expect("Cannot parse network message");
+            Message::parse_from_bytes(bytes).expect("Cannot parse network message");
 
         assert_eq!(NetworkMessageType::AUTHORIZATION, msg.get_message_type());
 

--- a/libsplinter/src/network/connection_manager/mod.rs
+++ b/libsplinter/src/network/connection_manager/mod.rs
@@ -895,6 +895,8 @@ mod tests {
 
     use std::sync::mpsc;
 
+    use protobuf::Message;
+
     use crate::mesh::Mesh;
     use crate::network::auth::tests::negotiation_connection_auth;
     use crate::network::auth::AuthorizationManager;
@@ -1011,7 +1013,7 @@ mod tests {
         // Verify mesh received heartbeat
 
         let envelope = mesh.recv().unwrap();
-        let heartbeat: NetworkMessage = protobuf::parse_from_bytes(&envelope.payload()).unwrap();
+        let heartbeat: NetworkMessage = Message::parse_from_bytes(&envelope.payload()).unwrap();
         assert_eq!(
             heartbeat.get_message_type(),
             NetworkMessageType::NETWORK_HEARTBEAT
@@ -1041,8 +1043,7 @@ mod tests {
             // Verify mesh received heartbeat
 
             let envelope = mesh.recv().unwrap();
-            let heartbeat: NetworkMessage =
-                protobuf::parse_from_bytes(&envelope.payload()).unwrap();
+            let heartbeat: NetworkMessage = Message::parse_from_bytes(&envelope.payload()).unwrap();
             assert_eq!(
                 heartbeat.get_message_type(),
                 NetworkMessageType::NETWORK_HEARTBEAT
@@ -1221,7 +1222,7 @@ mod tests {
 
             // Verify mesh received heartbeat
             let envelope = mesh2.recv().expect("Cannot receive message");
-            let heartbeat: NetworkMessage = protobuf::parse_from_bytes(&envelope.payload())
+            let heartbeat: NetworkMessage = Message::parse_from_bytes(&envelope.payload())
                 .expect("Cannot parse NetworkMessage");
             assert_eq!(
                 heartbeat.get_message_type(),

--- a/libsplinter/src/network/dispatch/proto.rs
+++ b/libsplinter/src/network/dispatch/proto.rs
@@ -23,7 +23,7 @@ where
     M: Message + Sized,
 {
     fn from_message_bytes(message_bytes: &[u8]) -> Result<Self, DispatchError> {
-        protobuf::parse_from_bytes(message_bytes)
+        Message::parse_from_bytes(message_bytes)
             .map_err(|err| DispatchError::DeserializationError(err.to_string()))
     }
 }

--- a/libsplinter/src/network/handlers.rs
+++ b/libsplinter/src/network/handlers.rs
@@ -149,8 +149,8 @@ mod tests {
             .next_outbound()
             .expect("Unable to get expected message");
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&network_message).unwrap();
-        let echo: NetworkEcho = protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&network_message).unwrap();
+        let echo: NetworkEcho = Message::parse_from_bytes(network_msg.get_payload()).unwrap();
 
         assert_eq!(echo.get_recipient(), "TestPeer");
         assert_eq!(echo.get_time_to_live(), 2);

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -23,6 +23,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crossbeam_channel::{Receiver, Sender};
+use protobuf::Message;
 use uuid::Uuid;
 
 use crate::channel;
@@ -353,7 +354,7 @@ pub fn run_incoming_loop(
             }
         };
 
-        let msg: NetworkMessage = protobuf::parse_from_bytes(&message_bytes)
+        let msg: NetworkMessage = Message::parse_from_bytes(&message_bytes)
             .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
 
         // if a service is waiting on a reply the inbound router will
@@ -361,13 +362,13 @@ pub fn run_incoming_loop(
         // the message, otherwise it will be sent to the inbound thread
         match msg.get_message_type() {
             NetworkMessageType::CIRCUIT => {
-                let mut circuit_msg: CircuitMessage = protobuf::parse_from_bytes(msg.get_payload())
+                let mut circuit_msg: CircuitMessage = Message::parse_from_bytes(msg.get_payload())
                     .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
 
                 match circuit_msg.get_message_type() {
                     CircuitMessageType::ADMIN_DIRECT_MESSAGE => {
                         let admin_direct_message: AdminDirectMessage =
-                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                            Message::parse_from_bytes(circuit_msg.get_payload())
                                 .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
                         inbound_router
                             .route(
@@ -381,7 +382,7 @@ pub fn run_incoming_loop(
                     }
                     CircuitMessageType::CIRCUIT_DIRECT_MESSAGE => {
                         let direct_message: CircuitDirectMessage =
-                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                            Message::parse_from_bytes(circuit_msg.get_payload())
                                 .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
                         inbound_router
                             .route(
@@ -395,7 +396,7 @@ pub fn run_incoming_loop(
                     }
                     CircuitMessageType::SERVICE_CONNECT_RESPONSE => {
                         let response: ServiceConnectResponse =
-                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                            Message::parse_from_bytes(circuit_msg.get_payload())
                                 .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
                         inbound_router
                             .route(
@@ -409,7 +410,7 @@ pub fn run_incoming_loop(
                     }
                     CircuitMessageType::SERVICE_DISCONNECT_RESPONSE => {
                         let response: ServiceDisconnectResponse =
-                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                            Message::parse_from_bytes(circuit_msg.get_payload())
                                 .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
                         inbound_router
                             .route(
@@ -423,7 +424,7 @@ pub fn run_incoming_loop(
                     }
                     CircuitMessageType::CIRCUIT_ERROR_MESSAGE => {
                         let response: CircuitError =
-                            protobuf::parse_from_bytes(circuit_msg.get_payload())
+                            Message::parse_from_bytes(circuit_msg.get_payload())
                                 .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
                         warn!("Received circuit error message {:?}", response);
                     }
@@ -457,7 +458,7 @@ fn run_inbound_loop(
 
         match service_message {
             (CircuitMessageType::ADMIN_DIRECT_MESSAGE, msg) => {
-                let mut admin_direct_message: AdminDirectMessage = protobuf::parse_from_bytes(&msg)
+                let mut admin_direct_message: AdminDirectMessage = Message::parse_from_bytes(&msg)
                     .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
 
                 let services = services
@@ -495,7 +496,7 @@ fn run_inbound_loop(
             }
             (CircuitMessageType::CIRCUIT_DIRECT_MESSAGE, msg) => {
                 let mut circuit_direct_message: CircuitDirectMessage =
-                    protobuf::parse_from_bytes(&msg)
+                    Message::parse_from_bytes(&msg)
                         .map_err(|err| OrchestratorError::Internal(Box::new(err)))?;
 
                 let services = services

--- a/libsplinter/src/peer/interconnect.rs
+++ b/libsplinter/src/peer/interconnect.rs
@@ -26,6 +26,8 @@ use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 
+use protobuf::Message;
+
 use crate::network::dispatch::DispatchMessageSender;
 use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::transport::matrix::{
@@ -330,7 +332,7 @@ where
         // If we have the peer, pass message to dispatcher, else print error
         if let Some(peer_id) = peer_id {
             let mut network_msg: NetworkMessage =
-                match protobuf::parse_from_bytes(envelope.payload()) {
+                match Message::parse_from_bytes(envelope.payload()) {
                     Ok(msg) => msg,
                     Err(err) => {
                         error!("Unable to dispatch message: {}", err);
@@ -554,14 +556,14 @@ pub mod tests {
             mesh2.send(envelope).expect("Unable to send message");
             // Verify mesh received the same network echo back
             let envelope = mesh2.recv().expect("Cannot receive message");
-            let network_msg: NetworkMessage = protobuf::parse_from_bytes(&envelope.payload())
+            let network_msg: NetworkMessage = Message::parse_from_bytes(&envelope.payload())
                 .expect("Cannot parse NetworkMessage");
             assert_eq!(
                 network_msg.get_message_type(),
                 NetworkMessageType::NETWORK_ECHO
             );
 
-            let echo: NetworkEcho = protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            let echo: NetworkEcho = Message::parse_from_bytes(network_msg.get_payload()).unwrap();
             assert_eq!(echo.get_payload().to_vec(), b"test_retrieve".to_vec());
 
             // Send a message back to PeerInterconnect that will shutdown the test

--- a/libsplinter/src/peer/mod.rs
+++ b/libsplinter/src/peer/mod.rs
@@ -1470,6 +1470,8 @@ pub mod tests {
     use std::sync::mpsc;
     use std::time::Duration;
 
+    use protobuf::Message;
+
     use crate::mesh::Mesh;
     use crate::network::connection_manager::{
         AuthorizationResult, Authorizer, AuthorizerError, ConnectionManager,
@@ -2179,7 +2181,7 @@ pub mod tests {
                 .expect("Cannot add connection to mesh");
             // Verify mesh received heartbeat
             let envelope = mesh2.recv().expect("Cannot receive message");
-            let heartbeat: NetworkMessage = protobuf::parse_from_bytes(&envelope.payload())
+            let heartbeat: NetworkMessage = Message::parse_from_bytes(&envelope.payload())
                 .expect("Cannot parse NetworkMessage");
             assert_eq!(
                 heartbeat.get_message_type(),

--- a/libsplinter/src/protos/mod.rs
+++ b/libsplinter/src/protos/mod.rs
@@ -59,7 +59,7 @@ where
     N: FromProto<P>,
 {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        let p: P = protobuf::parse_from_bytes(bytes)
+        let p: P = protobuf::Message::parse_from_bytes(bytes)
             .map_err(|err| ProtoConversionError::DeserializationError(err.to_string()))?;
         N::from_proto(p)
     }

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -616,7 +616,7 @@ pub fn into_protobuf<M: Message>(
             body.extend_from_slice(&chunk);
             Ok::<_, ActixError>(body)
         })
-        .and_then(|body| match protobuf::parse_from_bytes::<M>(&body) {
+        .and_then(|body| match Message::parse_from_bytes(&body) {
             Ok(proto) => Ok(proto),
             Err(err) => Err(ErrorBadRequest(json!({ "message": format!("{}", err) }))),
         })

--- a/libsplinter/src/service/network/handlers.rs
+++ b/libsplinter/src/service/network/handlers.rs
@@ -991,11 +991,11 @@ mod tests {
         detail_assertions: F,
     ) {
         let component_message: component::ComponentMessage =
-            protobuf::parse_from_bytes(msg_bytes).unwrap();
+            Message::parse_from_bytes(msg_bytes).unwrap();
         let service_msg: service::ServiceMessage =
-            protobuf::parse_from_bytes(component_message.get_payload()).unwrap();
+            Message::parse_from_bytes(component_message.get_payload()).unwrap();
         assert_eq!(expected_service_msg_type, service_msg.get_message_type(),);
-        let service_msg_paylaod: M = protobuf::parse_from_bytes(service_msg.get_payload()).unwrap();
+        let service_msg_paylaod: M = Message::parse_from_bytes(service_msg.get_payload()).unwrap();
 
         detail_assertions(service_msg_paylaod);
     }

--- a/libsplinter/src/service/network/interconnect/mod.rs
+++ b/libsplinter/src/service/network/interconnect/mod.rs
@@ -22,6 +22,8 @@ use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 
+use protobuf::Message;
+
 use crate::network::dispatch::{ConnectionId, DispatchMessageSender, MessageSender};
 use crate::protos::component::{ComponentMessage, ComponentMessageType};
 use crate::transport::matrix::{
@@ -298,7 +300,7 @@ where
         // If we have the service, pass message to dispatcher, else print error
         if let Some(service_id) = service_id {
             let mut component_msg: ComponentMessage =
-                match protobuf::parse_from_bytes(envelope.payload()) {
+                match Message::parse_from_bytes(envelope.payload()) {
                     Ok(msg) => msg,
                     Err(err) => {
                         error!("Unable to dispatch message: {}", err);
@@ -522,13 +524,13 @@ pub mod tests {
 
             // Verify mesh received the same network echo back
             let envelope = mesh2.recv().expect("Cannot receive message");
-            let mut network_msg: ComponentMessage = protobuf::parse_from_bytes(&envelope.payload())
+            let mut network_msg: ComponentMessage = Message::parse_from_bytes(&envelope.payload())
                 .expect("Cannot parse ComponentMessage");
 
             if network_msg.get_message_type() == ComponentMessageType::COMPONENT_HEARTBEAT {
                 // try to get the service message
                 let envelope = mesh2.recv().expect("Cannot receive message");
-                network_msg = protobuf::parse_from_bytes(&envelope.payload())
+                network_msg = Message::parse_from_bytes(&envelope.payload())
                     .expect("Cannot parse ComponentMessage");
             }
 
@@ -538,7 +540,7 @@ pub mod tests {
             );
 
             let echo: service::ServiceProcessorMessage =
-                protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+                Message::parse_from_bytes(network_msg.get_payload()).unwrap();
 
             assert_eq!(echo.get_payload().to_vec(), b"test_retrieve".to_vec());
 
@@ -673,7 +675,7 @@ pub mod tests {
             );
 
             let service_processor_msg: service::ServiceProcessorMessage =
-                protobuf::parse_from_bytes(message.get_payload()).unwrap();
+                Message::parse_from_bytes(message.get_payload()).unwrap();
 
             let expected_msg = self
                 .expected_messages

--- a/libsplinter/src/service/processor.rs
+++ b/libsplinter/src/service/processor.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crossbeam_channel::{Receiver, Sender};
+use protobuf::Message;
 use uuid::Uuid;
 
 use std::collections::HashMap;
@@ -318,7 +319,7 @@ fn process_incoming_msg(
     message_bytes: &[u8],
     inbound_router: &mut InboundRouter<CircuitMessageType>,
 ) -> Result<(), ServiceProcessorError> {
-    let msg: NetworkMessage = protobuf::parse_from_bytes(message_bytes)
+    let msg: NetworkMessage = Message::parse_from_bytes(message_bytes)
         .map_err(to_process_err!("unable parse network message"))?;
 
     // if a service is waiting on a reply the inbound router will
@@ -326,13 +327,13 @@ fn process_incoming_msg(
     // the message, otherwise it will be sent to the inbound thread
     match msg.get_message_type() {
         NetworkMessageType::CIRCUIT => {
-            let mut circuit_msg: CircuitMessage = protobuf::parse_from_bytes(msg.get_payload())
+            let mut circuit_msg: CircuitMessage = Message::parse_from_bytes(msg.get_payload())
                 .map_err(to_process_err!("unable to parse circuit message"))?;
 
             match circuit_msg.get_message_type() {
                 CircuitMessageType::ADMIN_DIRECT_MESSAGE => {
                     let admin_direct_message: AdminDirectMessage =
-                        protobuf::parse_from_bytes(circuit_msg.get_payload())
+                        Message::parse_from_bytes(circuit_msg.get_payload())
                             .map_err(to_process_err!("unable to parse admin direct message"))?;
                     inbound_router
                         .route(
@@ -346,7 +347,7 @@ fn process_incoming_msg(
                 }
                 CircuitMessageType::CIRCUIT_DIRECT_MESSAGE => {
                     let direct_message: CircuitDirectMessage =
-                        protobuf::parse_from_bytes(circuit_msg.get_payload())
+                        Message::parse_from_bytes(circuit_msg.get_payload())
                             .map_err(to_process_err!("unable to parse circuit direct message"))?;
                     inbound_router
                         .route(
@@ -360,7 +361,7 @@ fn process_incoming_msg(
                 }
                 CircuitMessageType::SERVICE_CONNECT_RESPONSE => {
                     let response: ServiceConnectResponse =
-                        protobuf::parse_from_bytes(circuit_msg.get_payload())
+                        Message::parse_from_bytes(circuit_msg.get_payload())
                             .map_err(to_process_err!("unable to parse service connect response"))?;
                     inbound_router
                         .route(
@@ -374,7 +375,7 @@ fn process_incoming_msg(
                 }
                 CircuitMessageType::SERVICE_DISCONNECT_RESPONSE => {
                     let response: ServiceDisconnectResponse =
-                        protobuf::parse_from_bytes(circuit_msg.get_payload()).map_err(|err| {
+                        Message::parse_from_bytes(circuit_msg.get_payload()).map_err(|err| {
                             process_err!(err, "unable to parse service disconnect response")
                         })?;
                     inbound_router
@@ -403,7 +404,7 @@ fn process_inbound_msg_with_correlation_id(
 ) -> Result<(), ServiceProcessorError> {
     match service_message {
         (CircuitMessageType::ADMIN_DIRECT_MESSAGE, msg) => {
-            let admin_direct_message: AdminDirectMessage = protobuf::parse_from_bytes(&msg)
+            let admin_direct_message: AdminDirectMessage = Message::parse_from_bytes(&msg)
                 .map_err(to_process_err!(
                     "unable to parse inbound admin direct message"
                 ))?;
@@ -413,7 +414,7 @@ fn process_inbound_msg_with_correlation_id(
             )?;
         }
         (CircuitMessageType::CIRCUIT_DIRECT_MESSAGE, msg) => {
-            let circuit_direct_message: CircuitDirectMessage = protobuf::parse_from_bytes(&msg)
+            let circuit_direct_message: CircuitDirectMessage = Message::parse_from_bytes(&msg)
                 .map_err(to_process_err!(
                     "unable to parse inbound circuit direct message"
                 ))?;
@@ -423,7 +424,7 @@ fn process_inbound_msg_with_correlation_id(
             )?;
         }
         (CircuitMessageType::CIRCUIT_ERROR_MESSAGE, msg) => {
-            let response: CircuitError = protobuf::parse_from_bytes(&msg)
+            let response: CircuitError = Message::parse_from_bytes(&msg)
                 .map_err(to_process_err!("unable to parse circuit error message"))?;
             warn!("Received circuit error message {:?}", response);
         }
@@ -1035,29 +1036,29 @@ pub mod tests {
     }
 
     fn get_service_connect(network_msg_bytes: Vec<u8>) -> ServiceConnectRequest {
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&network_msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&network_msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let request: ServiceConnectRequest =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
         request
     }
 
     fn get_circuit_direct_msg(network_msg_bytes: Vec<u8>) -> CircuitDirectMessage {
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&network_msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&network_msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: CircuitDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
         direct_message
     }
 
     fn get_admin_direct_msg(network_msg_bytes: Vec<u8>) -> AdminDirectMessage {
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&network_msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&network_msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: AdminDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
         direct_message
     }
 }

--- a/libsplinter/src/service/registry.rs
+++ b/libsplinter/src/service/registry.rs
@@ -175,11 +175,11 @@ pub mod tests {
             .name("test_admin_connect".to_string())
             .spawn(move || {
                 let msg_bytes = outgoing_receiver.recv().unwrap();
-                let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+                let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
                 let circuit_msg: CircuitMessage =
-                    protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(network_msg.get_payload()).unwrap();
                 let mut connect_request: ServiceConnectRequest =
-                    protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
                 assert_eq!(connect_request.get_service_id(), "service_a");
                 assert_eq!(connect_request.get_circuit(), ADMIN_CIRCUIT_NAME);
@@ -223,11 +223,11 @@ pub mod tests {
             .name("test_standard_connect".to_string())
             .spawn(move || {
                 let msg_bytes = outgoing_receiver.recv().unwrap();
-                let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+                let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
                 let circuit_msg: CircuitMessage =
-                    protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(network_msg.get_payload()).unwrap();
                 let mut connect_request: ServiceConnectRequest =
-                    protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
                 assert_eq!(connect_request.get_service_id(), "service_a");
                 assert_eq!(connect_request.get_circuit(), "test");
@@ -271,11 +271,11 @@ pub mod tests {
             .name("test_disconnect".to_string())
             .spawn(move || {
                 let msg_bytes = outgoing_receiver.recv().unwrap();
-                let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+                let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
                 let circuit_msg: CircuitMessage =
-                    protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(network_msg.get_payload()).unwrap();
                 let mut disconnect_request: ServiceDisconnectRequest =
-                    protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+                    Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
                 assert_eq!(disconnect_request.get_service_id(), "service_a");
                 assert_eq!(disconnect_request.get_circuit(), "test");

--- a/libsplinter/src/service/sender.rs
+++ b/libsplinter/src/service/sender.rs
@@ -312,11 +312,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: CircuitDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_b");
         assert_eq!(direct_message.get_sender(), "service_a");
@@ -357,11 +357,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let mut direct_message: CircuitDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_b");
         assert_eq!(direct_message.get_sender(), "service_a");
@@ -424,11 +424,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: CircuitDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_b");
         assert_eq!(direct_message.get_sender(), "service_a");
@@ -462,11 +462,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: AdminDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_a");
         assert_eq!(direct_message.get_sender(), "service_b");
@@ -506,11 +506,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let mut direct_message: AdminDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_a");
         assert_eq!(direct_message.get_sender(), "service_b");
@@ -572,11 +572,11 @@ pub mod tests {
             Err(err) => panic!("Received error: {}", err),
         };
 
-        let network_msg: NetworkMessage = protobuf::parse_from_bytes(&msg_bytes).unwrap();
+        let network_msg: NetworkMessage = Message::parse_from_bytes(&msg_bytes).unwrap();
         let circuit_msg: CircuitMessage =
-            protobuf::parse_from_bytes(network_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(network_msg.get_payload()).unwrap();
         let direct_message: AdminDirectMessage =
-            protobuf::parse_from_bytes(circuit_msg.get_payload()).unwrap();
+            Message::parse_from_bytes(circuit_msg.get_payload()).unwrap();
 
         assert_eq!(direct_message.get_recipient(), "service_b");
         assert_eq!(direct_message.get_sender(), "service_a");

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -29,7 +29,7 @@ actix-web = { version = "1.0", optional = true, default-features = false, featur
 futures = { version = "0.1", optional = true }
 log = "0.3.0"
 openssl = "0.10"
-protobuf = "~2.18"
+protobuf = "2.19"
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 sawtooth = { version = "0.3", default-features = false, features = ["lmdb-store", "receipt-store"] }
 sawtooth-sabre = "0.5"

--- a/services/scabbard/libscabbard/src/protos/mod.rs
+++ b/services/scabbard/libscabbard/src/protos/mod.rs
@@ -59,7 +59,7 @@ where
     N: FromProto<P>,
 {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        let p: P = protobuf::parse_from_bytes(bytes)
+        let p: P = protobuf::Message::parse_from_bytes(bytes)
             .map_err(|err| ProtoConversionError::DeserializationError(err.to_string()))?;
         N::from_proto(p)
     }

--- a/services/scabbard/libscabbard/src/service/consensus.rs
+++ b/services/scabbard/libscabbard/src/service/consensus.rs
@@ -417,7 +417,7 @@ mod tests {
         assert_eq!(recipient, "1".to_string());
 
         let scabbard_message: ScabbardMessage =
-            protobuf::parse_from_bytes(&message).expect("failed to parse 1st scabbard message");
+            Message::parse_from_bytes(&message).expect("failed to parse 1st scabbard message");
         assert_eq!(
             scabbard_message.get_message_type(),
             ScabbardMessage_Type::CONSENSUS_MESSAGE
@@ -443,7 +443,7 @@ mod tests {
         assert!(peer_services.remove(&recipient));
 
         let scabbard_message: ScabbardMessage =
-            protobuf::parse_from_bytes(&message).expect("failed to parse 2nd scabbard message");
+            Message::parse_from_bytes(&message).expect("failed to parse 2nd scabbard message");
         assert_eq!(
             scabbard_message.get_message_type(),
             ScabbardMessage_Type::CONSENSUS_MESSAGE
@@ -466,7 +466,7 @@ mod tests {
         assert!(peer_services.remove(&recipient));
 
         let scabbard_message: ScabbardMessage =
-            protobuf::parse_from_bytes(&message).expect("failed to parse 3rd scabbard message");
+            Message::parse_from_bytes(&message).expect("failed to parse 3rd scabbard message");
         assert_eq!(
             scabbard_message.get_message_type(),
             ScabbardMessage_Type::CONSENSUS_MESSAGE

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use openssl::hash::{hash, MessageDigest};
+use protobuf::Message;
 use splinter::{
     consensus::{Proposal, ProposalUpdate},
     service::{
@@ -315,7 +316,7 @@ impl Service for Scabbard {
         message_bytes: &[u8],
         _message_context: &ServiceMessageContext,
     ) -> Result<(), ServiceError> {
-        let message: ScabbardMessage = protobuf::parse_from_bytes(message_bytes)?;
+        let message: ScabbardMessage = Message::parse_from_bytes(message_bytes)?;
 
         match message.get_message_type() {
             ScabbardMessage_Type::CONSENSUS_MESSAGE => self

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -37,7 +37,7 @@ flexi_logger = "0.14"
 health = { path = "../services/health", optional = true }
 log = "0.4"
 openssl = { version = "0.10", optional = true }
-protobuf = "~2.18"
+protobuf = "2.19"
 rand = "0.7"
 serde = "1.0.80"
 serde_derive = "1.0.80"


### PR DESCRIPTION
protobuf::parse_from_bytes is deprecated.
Also update version of protobuf used to 2.19.

The version was previously enforced to stay 2.18, however
components that wish to use splinter would need to also
stay at 2.18. This changes updates the protobuf version for
compatibility with them.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>