### PR TITLE
Add support for Arc-RwLock-wrapped SQLite pool

### DIFF
--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -82,6 +82,14 @@ pub fn create_sqlite_connection_pool(
     Ok(pool)
 }
 
+pub fn create_sqlite_connection_pool_with_write_exclusivity(
+    conn_str: &str,
+) -> Result<Arc<RwLock<Pool<ConnectionManager<SqliteConnection>>>>, InternalError> {
+    Ok(Arc::new(RwLock::new(create_sqlite_connection_pool(
+        conn_str,
+    )?)))
+}
+
 /// A `StoreFactory` backed by a SQLite database.
 pub struct SqliteStoreFactory {
     pool: Arc<RwLock<Pool<ConnectionManager<SqliteConnection>>>>,
@@ -93,6 +101,13 @@ impl SqliteStoreFactory {
         Self {
             pool: Arc::new(RwLock::new(pool)),
         }
+    }
+
+    /// Create a new `SqliteStoreFactory` with shared write-exclusivity.
+    pub fn new_with_write_exclusivity(
+        pool: Arc<RwLock<Pool<ConnectionManager<SqliteConnection>>>>,
+    ) -> Self {
+        Self { pool }
     }
 }
 

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -39,10 +39,10 @@ sawtooth-sabre = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.4", features = ["sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.4.2", features = ["sawtooth-compat", "state-merkle-sql"] }
 
 [dependencies.sawtooth]
-version = "0.7.1"
+version = "0.7.2"
 optional = true
 default-features = false
 features = ["lmdb", "transaction-receipt-store"]


### PR DESCRIPTION
This change adds support for an Arc-RwLock-wrapped SQLite pool in scabbard as a configuration option. 
It adds the ability to create a `SqliteStoreFactory` from an existing arc-rwlock-pool. It configures splinterd to use this type of wrapper for SQLite.