### PR TITLE
Remove atomicwrites dependency

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -34,7 +34,6 @@ actix-service-1-0 = { package = "actix-service", version = "1.0", optional = tru
 actix-web = { version = "1.0", optional = true, default-features = false, features = ["flate2-zlib"] }
 actix-web-actors = { version = "1.0", optional = true }
 actix-web-3 = { package = "actix-web", version = "3", optional = true, features = ["openssl"] }
-atomicwrites = "0.2"
 awc = { version = "0.2", optional = true }
 base64 = { version = "0.12", optional = true }
 bcrypt = {version = "0.10", optional = true}


### PR DESCRIPTION
This dependency is no longer used as the code which used it was removed
in a historical commit.
