### PR TITLE
Update flexi_logger dependency to v0.21

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ clap = "2"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0", features = ["postgres"], optional = true }
 dirs = "4"
-flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
+flexi_logger = { version = "0.21", features = ["use_chrono_for_offset"] }
 libc = "0.2"
 log = "0.4"
 openssl = "0.10"

--- a/examples/gameroom/cli/Cargo.toml
+++ b/examples/gameroom/cli/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/main.rs"
 clap = "2"
 diesel = { version = "1.0", features = ["postgres"] }
 diesel_migrations = "1.4"
-flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
+flexi_logger = { version = "0.21", features = ["use_chrono_for_offset"] }
 log = "0.4"
 
 [features]

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -40,7 +40,7 @@ ctrlc = "3.0"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 diesel = { version = "1.0.0", features = ["serde_json"] }
 flate2 = "1.0.10"
-flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
+flexi_logger = { version = "0.21", features = ["use_chrono_for_offset"] }
 futures = "0.1"
 gameroom-database = { path = "../database" }
 hyper = "0.12"

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 clap = "2"
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 dirs = "4"
-flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
+flexi_logger = { version = "0.21", features = ["use_chrono_for_offset"] }
 log = "0.4"
 sabre-sdk = "0.8"
 transact = { version = "0.4", features = ["contract-archive"] }


### PR DESCRIPTION
This is a non-functional change to track the latest version of the
dependency.
