### PR TITLE
Update (or remove) serial_test dependency

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,7 +62,7 @@ optional = true
 
 [dev-dependencies]
 gag = "1"
-serial_test = "0.3"
+serial_test = "0.5"
 tempdir = "0.3"
 
 [features]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -71,7 +71,6 @@ uuid = { version = "0.8", features = ["v4", "v5"] }
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-serial_test = "0.3"
 tempdir = "0.3"
 
 [build-dependencies]

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -38,10 +38,6 @@ sabre-sdk = "0.8"
 transact = { version = "0.4", features = ["contract-archive"] }
 scabbard = { path = "../libscabbard", features = ["client-reqwest"], default-features=false }
 
-[dev-dependencies]
-serial_test = "0.3"
-tempfile = "3.1"
-
 [features]
 default = []
 


### PR DESCRIPTION
This PR removes the `serial_test` from crates where it is not used and updates in the CLI crate