### PR TITLE
REST API cleanup

### DIFF
--- a/cli/src/action/circuit/mod.rs
+++ b/cli/src/action/circuit/mod.rs
@@ -26,8 +26,10 @@ use std::fs::File;
 use clap::ArgMatches;
 use cylinder::Signer;
 use serde::Deserialize;
-use splinter::admin::messages::{CircuitStatus, CreateCircuit, SplinterNode, SplinterService};
-use splinter::protocol::CIRCUIT_PROTOCOL_VERSION;
+use splinter::admin::{
+    messages::{CircuitStatus, CreateCircuit, SplinterNode, SplinterService},
+    CIRCUIT_PROTOCOL_VERSION,
+};
 
 use crate::circuit::builder::parse_hex;
 use crate::error::CliError;

--- a/examples/gameroom/daemon/src/rest_api/routes/authenticate.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/authenticate.rs
@@ -14,11 +14,12 @@
 
 use actix_web::{client::Client, http::StatusCode, web, Error, HttpResponse};
 use serde::{Deserialize, Serialize};
-use splinter::protocol;
 
 use crate::rest_api::GameroomdData;
 
 use super::{ErrorResponse, SuccessResponse};
+
+const BIOME_PROTOCOL_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -86,7 +87,7 @@ pub async fn login(
         .post(format!("{}/biome/login", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
-            protocol::BIOME_PROTOCOL_VERSION.to_string(),
+            BIOME_PROTOCOL_VERSION.to_string(),
         )
         .send_json(&UsernamePassword::from(auth_data.into_inner()))
         .await?;
@@ -126,7 +127,7 @@ pub async fn login(
         .get(format!("{}/biome/keys", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
-            protocol::BIOME_PROTOCOL_VERSION.to_string(),
+            BIOME_PROTOCOL_VERSION.to_string(),
         )
         .header("Authorization", authorization)
         .send()
@@ -196,7 +197,7 @@ pub async fn register(
         .post(format!("{}/biome/register", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
-            protocol::BIOME_PROTOCOL_VERSION.to_string(),
+            BIOME_PROTOCOL_VERSION.to_string(),
         )
         .send_json(&username_password)
         .await?;
@@ -225,7 +226,7 @@ pub async fn register(
         .post(format!("{}/biome/login", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
-            protocol::BIOME_PROTOCOL_VERSION.to_string(),
+            BIOME_PROTOCOL_VERSION.to_string(),
         )
         .send_json(&username_password)
         .await?;
@@ -256,7 +257,7 @@ pub async fn register(
         .post(format!("{}/biome/keys", &gameroomd_data.splinterd_url))
         .header(
             "SplinterProtocolVersion",
-            protocol::BIOME_PROTOCOL_VERSION.to_string(),
+            BIOME_PROTOCOL_VERSION.to_string(),
         )
         .header("Authorization", authorization)
         .send_json(&NewKey {

--- a/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/gameroom.rs
@@ -25,7 +25,6 @@ use splinter::admin::messages::{
     AuthorizationType, CreateCircuit, CreateCircuitBuilder, SplinterNode,
 };
 use splinter::circuit::template::CircuitTemplateManager;
-use splinter::protocol;
 use splinter::protos::admin::{
     CircuitManagementPayload, CircuitManagementPayload_Action as Action,
     CircuitManagementPayload_Header as Header,
@@ -38,6 +37,8 @@ use super::{
     get_response_paging_info, validate_limit, ErrorResponse, SuccessResponse, DEFAULT_LIMIT,
     DEFAULT_OFFSET,
 };
+
+const REGISTRY_PROTOCOL_VERSION: u32 = 1;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateGameroomForm {
@@ -229,7 +230,7 @@ async fn fetch_node_information(
         .header("Authorization", authorization)
         .header(
             "SplinterProtocolVersion",
-            protocol::REGISTRY_PROTOCOL_VERSION.to_string(),
+            REGISTRY_PROTOCOL_VERSION.to_string(),
         )
         .send()
         .await

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -14,12 +14,13 @@
 
 use actix_web::{client::Client, http::StatusCode, web, Error, HttpResponse};
 use percent_encoding::utf8_percent_encode;
-use splinter::protocol;
 use std::collections::HashMap;
 
 use crate::rest_api::GameroomdData;
 
 use super::{ErrorResponse, SuccessResponse, DEFAULT_LIMIT, DEFAULT_OFFSET, QUERY_ENCODE_SET};
+
+const REGISTRY_PROTOCOL_VERSION: u32 = 1;
 
 pub async fn fetch_node(
     identity: web::Path<String>,
@@ -34,7 +35,7 @@ pub async fn fetch_node(
         .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
-            protocol::REGISTRY_PROTOCOL_VERSION.to_string(),
+            REGISTRY_PROTOCOL_VERSION.to_string(),
         )
         .send()
         .await?;
@@ -93,7 +94,7 @@ pub async fn list_nodes(
         .header("Authorization", gameroomd_data.authorization.as_str())
         .header(
             "SplinterProtocolVersion",
-            protocol::REGISTRY_PROTOCOL_VERSION.to_string(),
+            REGISTRY_PROTOCOL_VERSION.to_string(),
         )
         .send()
         .await?;

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -103,7 +103,7 @@ stable = [
     "registry",
     "registry-remote",
     "rest-api",
-    "rest-api-actix",
+    "rest-api-actix-web-1",
     "rest-api-cors",
     "sqlite",
     "store",
@@ -178,7 +178,7 @@ rest-api = [
     "jsonwebtoken",
     "percent-encoding",
 ]
-rest-api-actix = ["actix", "actix-http", "actix-web", "actix-web-actors"]
+rest-api-actix-web-1 = ["actix", "actix-http", "actix-web", "actix-web-actors", "rest-api"]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
 service-network = []

--- a/libsplinter/src/admin/client/event/ws/actix_web_client.rs
+++ b/libsplinter/src/admin/client/event/ws/actix_web_client.rs
@@ -29,6 +29,7 @@ use crate::events::{
     Igniter, ParseBytes, ParseError, Reactor, WebSocketClient, WebSocketError, WsResponse,
 };
 use crate::hex;
+use crate::rest_api::ADMIN_PROTOCOL_VERSION;
 use crate::threading::lifecycle::ShutdownHandle;
 
 enum WsRuntime {
@@ -187,7 +188,7 @@ impl RunnableAwcAdminServiceEventClient {
 
         ws_client.header(
             "SplinterProtocolVersion",
-            crate::protocol::ADMIN_SERVICE_PROTOCOL_VERSION.to_string(),
+            ADMIN_PROTOCOL_VERSION.to_string(),
         );
 
         ws_client.set_reconnect(true);

--- a/libsplinter/src/admin/client/reqwest.rs
+++ b/libsplinter/src/admin/client/reqwest.rs
@@ -17,7 +17,7 @@
 use reqwest::{blocking::Client, header, StatusCode};
 
 use crate::error::InternalError;
-use crate::protocol::ADMIN_PROTOCOL_VERSION;
+use crate::rest_api::ADMIN_PROTOCOL_VERSION;
 
 use super::{AdminServiceClient, CircuitListSlice, CircuitSlice, ProposalListSlice, ProposalSlice};
 

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -21,3 +21,5 @@ pub mod rest_api;
 pub mod service;
 pub mod store;
 mod token;
+
+pub const CIRCUIT_PROTOCOL_VERSION: i32 = 2;

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -22,22 +22,21 @@ use std::collections::HashMap;
 #[cfg(feature = "authorization")]
 use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::store::{AdminServiceStore, CircuitPredicate, CircuitStatus};
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    ErrorResponse,
+    ErrorResponse, ADMIN_PROTOCOL_VERSION,
 };
 
 use super::super::error::CircuitListError;
 use super::super::resources;
 
+const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
+
 pub fn make_list_circuits_resource(store: Box<dyn AdminServiceStore>) -> Resource {
-    let resource =
-        Resource::build("/admin/circuits").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_LIST_CIRCUITS_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/admin/circuits").add_request_guard(
+        ProtocolVersionRangeGuard::new(ADMIN_LIST_CIRCUITS_MIN, ADMIN_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(Method::Get, CIRCUIT_READ_PERMISSION, move |r, _| {
@@ -135,7 +134,7 @@ fn list_circuits(
                 )
             }
         },
-        None => format!("{}", protocol::ADMIN_PROTOCOL_VERSION),
+        None => format!("{}", ADMIN_PROTOCOL_VERSION),
     };
 
     Box::new(query_list_circuits(
@@ -270,7 +269,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -359,7 +358,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -406,7 +405,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -454,7 +453,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -503,7 +502,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -544,7 +543,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -588,7 +587,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -21,21 +21,19 @@ use futures::Future;
 #[cfg(feature = "authorization")]
 use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::store::AdminServiceStore;
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, ADMIN_PROTOCOL_VERSION,
 };
 
 use super::super::error::CircuitFetchError;
 use super::super::resources;
 
+const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
+
 pub fn make_fetch_circuit_resource(store: Box<dyn AdminServiceStore>) -> Resource {
     let resource = Resource::build("/admin/circuits/{circuit_id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_FETCH_CIRCUIT_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
-        ),
+        ProtocolVersionRangeGuard::new(ADMIN_FETCH_CIRCUIT_MIN, ADMIN_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -68,7 +66,7 @@ fn fetch_circuit(
                 "Unable to get SplinterProtocolVersion".to_string(),
             )),
         },
-        None => Ok(format!("{}", protocol::ADMIN_PROTOCOL_VERSION)),
+        None => Ok(format!("{}", ADMIN_PROTOCOL_VERSION)),
     };
 
     Box::new(
@@ -155,7 +153,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -224,7 +222,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -23,22 +23,21 @@ use futures::{future::IntoFuture, Future};
 use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::service::proposal_store::ProposalStore;
 use crate::admin::store::CircuitPredicate;
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    ErrorResponse,
+    ErrorResponse, ADMIN_PROTOCOL_VERSION,
 };
 
 use super::super::error::ProposalListError;
 use super::super::resources;
 
+const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
+
 pub fn make_list_proposals_resource<PS: ProposalStore + 'static>(proposal_store: PS) -> Resource {
-    let resource =
-        Resource::build("admin/proposals").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_LIST_PROPOSALS_PROTOCOL_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("admin/proposals").add_request_guard(
+        ProtocolVersionRangeGuard::new(ADMIN_LIST_PROPOSALS_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
+    );
 
     #[cfg(feature = "authorization")]
     {
@@ -131,7 +130,7 @@ fn list_proposals<PS: ProposalStore + 'static>(
                 )
             }
         },
-        None => format!("{}", protocol::ADMIN_PROTOCOL_VERSION),
+        None => format!("{}", ADMIN_PROTOCOL_VERSION),
     };
 
     Box::new(query_list_proposals(
@@ -264,7 +263,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -380,7 +379,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -431,7 +430,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -484,7 +483,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -531,7 +530,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -578,7 +577,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -24,20 +24,18 @@ use crate::admin::rest_api::error::ProposalFetchError;
 #[cfg(feature = "authorization")]
 use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::service::proposal_store::ProposalStore;
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, ADMIN_PROTOCOL_VERSION,
 };
 
 use super::super::resources;
 
+const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
+
 pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store: PS) -> Resource {
     let resource = Resource::build("admin/proposals/{circuit_id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
-        ),
+        ProtocolVersionRangeGuard::new(ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
     );
 
     #[cfg(feature = "authorization")]
@@ -71,7 +69,7 @@ fn fetch_proposal<PS: ProposalStore + 'static>(
                 "Unable to get SplinterProtocolVersion".to_string(),
             )),
         },
-        None => Ok(format!("{}", protocol::ADMIN_PROTOCOL_VERSION)),
+        None => Ok(format!("{}", ADMIN_PROTOCOL_VERSION)),
     };
 
     Box::new(
@@ -163,7 +161,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -233,7 +231,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/libsplinter/src/admin/rest_api/actix/submit.rs
+++ b/libsplinter/src/admin/rest_api/actix/submit.rs
@@ -18,17 +18,19 @@ use futures::{Future, IntoFuture};
 #[cfg(feature = "authorization")]
 use crate::admin::rest_api::CIRCUIT_WRITE_PERMISSION;
 use crate::admin::service::{AdminCommands, AdminServiceError};
-use crate::protocol;
 use crate::protos::admin::CircuitManagementPayload;
-use crate::rest_api::actix_web_1::{into_protobuf, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{
+    actix_web_1::{into_protobuf, Method, ProtocolVersionRangeGuard, Resource},
+    ADMIN_PROTOCOL_VERSION,
+};
 use crate::service::ServiceError;
 
+const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
+
 pub fn make_submit_route<A: AdminCommands + Clone + 'static>(admin_commands: A) -> Resource {
-    let resource =
-        Resource::build("/admin/submit").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_SUBMIT_PROTOCOL_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/admin/submit").add_request_guard(
+        ProtocolVersionRangeGuard::new(ADMIN_SUBMIT_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
+    );
 
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
+++ b/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
@@ -29,22 +29,23 @@ use crate::admin::service::{
 };
 use crate::admin::store;
 use crate::error::InvalidStateError;
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{
         new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Request,
         Resource,
     },
-    ErrorResponse,
+    ErrorResponse, ADMIN_PROTOCOL_VERSION,
 };
+
+const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 'static>(
     admin_commands: A,
 ) -> Resource {
     let resource = Resource::build("/ws/admin/register/{type}").add_request_guard(
         ProtocolVersionRangeGuard::new(
-            protocol::ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN,
-            protocol::ADMIN_PROTOCOL_VERSION,
+            ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN,
+            ADMIN_PROTOCOL_VERSION,
         ),
     );
 
@@ -94,7 +95,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                             )
                         }
                     },
-                    None => protocol::ADMIN_PROTOCOL_VERSION,
+                    None => ADMIN_PROTOCOL_VERSION,
                 };
 
                 debug!(
@@ -225,7 +226,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                         )
                     }
                 },
-                None => protocol::ADMIN_PROTOCOL_VERSION,
+                None => ADMIN_PROTOCOL_VERSION,
             };
 
             debug!(

--- a/libsplinter/src/admin/rest_api/mod.rs
+++ b/libsplinter/src/admin/rest_api/mod.rs
@@ -14,27 +14,27 @@
 
 //! This module defines the REST API endpoints for interacting with the Splinter admin service.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
 #[cfg(feature = "rest-api-actix-web-3")]
 pub mod actix_web_3;
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod error;
 mod resources;
 
 use crate::admin::service::AdminService;
 use crate::admin::store::AdminServiceStore;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const CIRCUIT_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "circuit.read",
     permission_display_name: "Circuit read",
     permission_description: "Allows the client to read circuit state",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const CIRCUIT_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "circuit.write",
     permission_display_name: "Circuit write",
@@ -52,15 +52,15 @@ const CIRCUIT_WRITE_PERMISSION: Permission = Permission::Check {
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
-/// * `rest-api-actix`
+/// * `rest-api-actix-web-1`
 impl RestResourceProvider for AdminService {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
+        // Allowing unused_mut because resources must be mutable if feature rest-api-actix-web-1 is
         // enabled
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.append(&mut vec![
                 actix::ws_register_type::make_application_handler_registration_route(
@@ -87,7 +87,7 @@ impl RestResourceProvider for AdminService {
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
-/// * `rest-api-actix`
+/// * `rest-api-actix-web-1`
 #[derive(Clone)]
 pub struct CircuitResourceProvider {
     store: Box<dyn AdminServiceStore>,
@@ -107,15 +107,15 @@ impl CircuitResourceProvider {
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
-/// * `rest-api-actix`
+/// * `rest-api-actix-web-1`
 impl RestResourceProvider for CircuitResourceProvider {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
+        // Allowing unused_mut because resources must be mutable if feature rest-api-actix-web-1 is
         // enabled
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.append(&mut vec![
                 actix::circuits_circuit_id::make_fetch_circuit_resource(self.store.clone()),

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -38,7 +38,6 @@ use crate::hex::to_hex;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::{ServiceDefinition, ServiceOrchestrator};
 use crate::peer::{PeerManagerConnector, PeerManagerNotification, PeerTokenPair};
-use crate::protocol::{ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION};
 use crate::protos::admin::{
     AdminMessage, AdminMessage_Type, CircuitManagementPayload, ServiceProtocolVersionResponse,
 };
@@ -61,6 +60,9 @@ pub use self::error::AdminServiceError;
 pub use self::error::AdminSubscriberError;
 pub use self::shared::AdminServiceStatus;
 pub use self::subscriber::AdminServiceEventSubscriber;
+
+const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
+pub(crate) const ADMIN_SERVICE_PROTOCOL_VERSION: u32 = 2;
 
 pub trait AdminCommands: Send + Sync {
     fn submit_circuit_change(

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -28,6 +28,7 @@ use crate::admin::store::{
     ProposalType, ProposedCircuit, Service as StoreService, Vote, VoteRecordBuilder,
 };
 use crate::admin::token::{PeerAuthorizationTokenReader, PeerNode};
+use crate::admin::CIRCUIT_PROTOCOL_VERSION;
 use crate::circuit::routing::{self, RoutingTableWriter};
 use crate::consensus::{Proposal, ProposalId, ProposalUpdate};
 use crate::error::InternalError;
@@ -36,9 +37,6 @@ use crate::hex::to_hex;
 use crate::keys::KeyPermissionManager;
 use crate::orchestrator::{ServiceDefinition, ServiceOrchestrator};
 use crate::peer::{PeerAuthorizationToken, PeerManagerConnector, PeerRef, PeerTokenPair};
-use crate::protocol::{
-    ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION, CIRCUIT_PROTOCOL_VERSION,
-};
 use crate::protos::admin::{
     AbandonedCircuit, AdminMessage, AdminMessage_Type, Circuit, CircuitManagementPayload,
     CircuitManagementPayload_Action, CircuitManagementPayload_Header, CircuitProposal,
@@ -57,6 +55,7 @@ use super::error::{AdminSharedError, MarshallingError};
 use super::messages;
 use super::subscriber::SubscriberMap;
 use super::{admin_service_id, sha256, AdminKeyVerifier, AdminServiceEventSubscriber, Events};
+use super::{ADMIN_SERVICE_PROTOCOL_MIN, ADMIN_SERVICE_PROTOCOL_VERSION};
 
 static VOTER_ROLE: &str = "voter";
 static PROPOSER_ROLE: &str = "proposer";

--- a/libsplinter/src/biome/client/reqwest.rs
+++ b/libsplinter/src/biome/client/reqwest.rs
@@ -19,7 +19,7 @@ use std::convert::From;
 use reqwest::{blocking::Client, StatusCode};
 
 use crate::error::InternalError;
-use crate::protocol::BIOME_PROTOCOL_VERSION;
+use crate::rest_api::BIOME_PROTOCOL_VERSION;
 
 use super::{Authorization, BiomeClient, Credentials, Key, NewKey, Profile, UpdateUser};
 

--- a/libsplinter/src/biome/credentials/mod.rs
+++ b/libsplinter/src/biome/credentials/mod.rs
@@ -15,6 +15,6 @@
 //! Defines a basic API to register and authenticate a User using a username and a password.
 //! Not recommended for use in production.
 
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod rest_api;
 pub mod store;

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/login.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/login.rs
@@ -17,18 +17,19 @@ use std::sync::Arc;
 use crate::actix_web::HttpResponse;
 use crate::biome::refresh_tokens::store::RefreshTokenStore;
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
 
 use crate::biome::credentials::rest_api::actix_web_1::BiomeCredentialsRestConfig;
 use crate::biome::credentials::rest_api::resources::credentials::UsernamePassword;
 use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use crate::rest_api::sessions::{AccessTokenIssuer, ClaimsBuilder, TokenIssuer};
+
+const BIOME_LOGIN_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint for login
 ///
@@ -43,11 +44,9 @@ pub fn make_login_route(
     rest_config: Arc<BiomeCredentialsRestConfig>,
     token_issuer: Arc<AccessTokenIssuer>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/login").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_LOGIN_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/login").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_LOGIN_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/logout.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/logout.rs
@@ -21,15 +21,16 @@ use crate::biome::credentials::rest_api::{
 };
 use crate::biome::refresh_tokens::store::{RefreshTokenError, RefreshTokenStore};
 use crate::futures::IntoFuture;
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     secrets::SecretManager,
     sessions::default_validation,
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
+
+const BIOME_LOGOUT_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint to remove any refresh tokens belonging to the user.
 ///
@@ -38,11 +39,9 @@ pub fn make_logout_route(
     secret_manager: Arc<dyn SecretManager>,
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/logout").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_LOGIN_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/logout").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_LOGOUT_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/register.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/register.rs
@@ -22,12 +22,11 @@ use crate::biome::credentials::store::{
     CredentialsBuilder, CredentialsStore, CredentialsStoreError,
 };
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
 
 /// This is the UUID namespace for Biome user IDs generated for users that register with Biome
@@ -35,6 +34,8 @@ use crate::rest_api::{
 /// with OAuth. The `u128` was calculated by creating a v5 UUID with the nil namespace and the name
 /// `b"biome credentials"`.
 const UUID_NAMESPACE: Uuid = Uuid::from_u128(140899893353887994607859851180695869034);
+
+const BIOME_REGISTER_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint to add a user and credentials to the database
 ///
@@ -47,11 +48,9 @@ pub fn make_register_route(
     credentials_store: Arc<dyn CredentialsStore>,
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/register").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_REGISTER_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/register").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_REGISTER_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/token.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/token.rs
@@ -26,7 +26,6 @@ use crate::biome::{
     refresh_tokens::store::{RefreshTokenError, RefreshTokenStore},
 };
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::secrets::SecretManager;
@@ -35,8 +34,10 @@ use crate::rest_api::{
     sessions::{
         default_validation, ignore_exp_validation, AccessTokenIssuer, ClaimsBuilder, TokenIssuer,
     },
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
+
+const BIOME_TOKEN_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint for requesting a new authorization token
 ///
@@ -56,11 +57,9 @@ pub fn make_token_route(
     token_issuer: Arc<AccessTokenIssuer>,
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/token").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_LOGIN_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/token").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_TOKEN_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/user.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/user.rs
@@ -18,10 +18,9 @@ use crate::actix_web::HttpResponse;
 use crate::biome::credentials::rest_api::actix_web_1::config::BiomeCredentialsRestConfig;
 use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{into_bytes, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
 
 #[cfg(feature = "biome-key-management")]
@@ -39,13 +38,14 @@ use crate::biome::credentials::rest_api::{
     BIOME_USER_READ_PERMISSION, BIOME_USER_WRITE_PERMISSION,
 };
 
+const BIOME_LIST_USERS_PROTOCOL_MIN: u32 = 1;
+const BIOME_USER_PROTOCOL_MIN: u32 = 1;
+
 /// Defines a REST endpoint to list users from the db
 pub fn make_list_route(credentials_store: Arc<dyn CredentialsStore>) -> Resource {
-    let resource =
-        Resource::build("/biome/users").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_LIST_USERS_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/users").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_LIST_USERS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(Method::Get, BIOME_USER_READ_PERMISSION, move |_, _| {
@@ -85,11 +85,9 @@ pub fn make_user_routes(
     credentials_store: Arc<dyn CredentialsStore>,
     key_store: Arc<dyn KeyStore>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/users/{id}").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_USER_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/users/{id}").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_USER_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/verify.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/verify.rs
@@ -16,14 +16,13 @@ use std::sync::Arc;
 
 use crate::actix_web::HttpResponse;
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
     secrets::SecretManager,
     sessions::default_validation,
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
 
 use crate::biome::credentials::rest_api::actix_web_1::config::BiomeCredentialsRestConfig;
@@ -32,6 +31,8 @@ use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use super::super::resources::authorize::AuthorizationResult;
 use super::super::resources::credentials::UsernamePassword;
 use super::authorize::authorize_user;
+
+const BIOME_VERIFY_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint to verify a user's password
 ///
@@ -45,11 +46,9 @@ pub fn make_verify_route(
     rest_config: Arc<BiomeCredentialsRestConfig>,
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
-    let resource =
-        Resource::build("/biome/verify").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_VERIFY_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/verify").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_VERIFY_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/credentials/rest_api/mod.rs
+++ b/libsplinter/src/biome/credentials/rest_api/mod.rs
@@ -12,26 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 mod resources;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::{
     BiomeCredentialsRestConfig, BiomeCredentialsRestConfigBuilder,
     BiomeCredentialsRestResourceProvider, BiomeCredentialsRestResourceProviderBuilder,
 };
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 const BIOME_USER_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.user.read",
     permission_display_name: "Biome user read",
     permission_description: "Allows the client to view all Biome users",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 const BIOME_USER_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.user.write",
     permission_display_name: "Biome user write",

--- a/libsplinter/src/biome/credentials/rest_api/mod.rs
+++ b/libsplinter/src/biome/credentials/rest_api/mod.rs
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 mod resources;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::{
     BiomeCredentialsRestConfig, BiomeCredentialsRestConfigBuilder,
     BiomeCredentialsRestResourceProvider, BiomeCredentialsRestResourceProviderBuilder,
 };
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const BIOME_USER_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.user.read",
     permission_display_name: "Biome user read",
     permission_description: "Allows the client to view all Biome users",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const BIOME_USER_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.user.write",
     permission_display_name: "Biome user write",

--- a/libsplinter/src/biome/key_management/mod.rs
+++ b/libsplinter/src/biome/key_management/mod.rs
@@ -14,7 +14,7 @@
 
 //! Provides an API for storing key pairs and associating them with users.
 
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod rest_api;
 pub mod store;
 

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
@@ -21,22 +21,22 @@ use crate::biome::key_management::{
     Key,
 };
 use crate::futures::{Future, IntoFuture};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     auth::identity::Identity,
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
+
+const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;
+const BIOME_REPLACE_KEYS_PROTOCOL_MIN: u32 = 2;
 
 /// Defines a REST endpoint for managing keys including inserting, listing and updating keys
 pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
-    let resource =
-        Resource::build("/biome/keys").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_KEYS_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/keys").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource
@@ -47,8 +47,8 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
             )
             .add_request_guard(
                 ProtocolVersionRangeGuard::new(
-                    protocol::BIOME_REPLACE_KEYS_PROTOCOL_MIN,
-                    protocol::BIOME_PROTOCOL_VERSION,
+                    BIOME_REPLACE_KEYS_PROTOCOL_MIN,
+                    BIOME_PROTOCOL_VERSION,
                 )
                 .with_method(Method::Put),
             )
@@ -74,8 +74,8 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
             .add_method(Method::Put, handle_put(key_store.clone()))
             .add_request_guard(
                 ProtocolVersionRangeGuard::new(
-                    protocol::BIOME_REPLACE_KEYS_PROTOCOL_MIN,
-                    protocol::BIOME_PROTOCOL_VERSION,
+                    BIOME_REPLACE_KEYS_PROTOCOL_MIN,
+                    BIOME_PROTOCOL_VERSION,
                 )
                 .with_method(Method::Put),
             )
@@ -305,10 +305,7 @@ fn handle_patch(key_store: Arc<dyn KeyStore>) -> HandlerFunction {
 /// Defines a REST endpoint for managing keys including fetching and deleting a user's key
 pub fn make_key_management_route_with_public_key(key_store: Arc<dyn KeyStore>) -> Resource {
     let resource = Resource::build("/biome/keys/{public_key}").add_request_guard(
-        ProtocolVersionRangeGuard::new(
-            protocol::BIOME_KEYS_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ),
+        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/key_management/rest_api/mod.rs
+++ b/libsplinter/src/biome/key_management/rest_api/mod.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 mod resources;
 
-#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::BiomeKeyManagementRestResourceProvider;

--- a/libsplinter/src/biome/key_management/rest_api/mod.rs
+++ b/libsplinter/src/biome/key_management/rest_api/mod.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 mod resources;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::BiomeKeyManagementRestResourceProvider;

--- a/libsplinter/src/biome/profile/mod.rs
+++ b/libsplinter/src/biome/profile/mod.rs
@@ -14,6 +14,6 @@
 
 //! Biome functionality to support user profiles.
 
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod rest_api;
 pub mod store;

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profile.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profile.rs
@@ -17,21 +17,20 @@ use std::sync::Arc;
 use crate::actix_web::HttpResponse;
 use crate::biome::profile::store::UserProfileStore;
 use crate::futures::IntoFuture;
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     auth::identity::Identity,
-    ErrorResponse,
+    ErrorResponse, BIOME_PROTOCOL_VERSION,
 };
 
+const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;
+
 pub fn make_profile_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
-    let resource =
-        Resource::build("/biome/profile").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_FETCH_PROFILE_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/profile").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_FETCH_PROFILE_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles.rs
@@ -19,16 +19,17 @@ use crate::actix_web::HttpResponse;
 use crate::biome::profile::rest_api::BIOME_PROFILE_READ_PERMISSION;
 use crate::biome::profile::store::UserProfileStore;
 use crate::futures::IntoFuture;
-use crate::protocol;
-use crate::rest_api::{ErrorResponse, Method, ProtocolVersionRangeGuard, Resource};
+use crate::rest_api::{
+    ErrorResponse, Method, ProtocolVersionRangeGuard, Resource, BIOME_PROTOCOL_VERSION,
+};
+
+const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
 
 /// Defines a REST endpoint to list profiles from the database
 pub fn make_profiles_list_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
-    let resource =
-        Resource::build("/biome/profiles").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_LIST_PROFILES_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/profiles").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_LIST_PROFILES_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(Method::Get, BIOME_PROFILE_READ_PERMISSION, move |_, _| {

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles_identity.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles_identity.rs
@@ -19,17 +19,17 @@ use crate::actix_web::HttpResponse;
 use crate::biome::profile::rest_api::BIOME_PROFILE_READ_PERMISSION;
 use crate::biome::profile::store::{UserProfileStore, UserProfileStoreError};
 use crate::futures::IntoFuture;
-use crate::protocol;
 use crate::rest_api::{
     ErrorResponse, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource,
+    BIOME_PROTOCOL_VERSION,
 };
 
+const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
+
 pub fn make_profiles_routes(profile_store: Arc<dyn UserProfileStore>) -> Resource {
-    let resource =
-        Resource::build("/biome/profiles/{id}").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::BIOME_FETCH_PROFILES_PROTOCOL_MIN,
-            protocol::BIOME_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/biome/profiles/{id}").add_request_guard(
+        ProtocolVersionRangeGuard::new(BIOME_FETCH_PROFILES_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/biome/profile/rest_api/mod.rs
+++ b/libsplinter/src/biome/profile/rest_api/mod.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::BiomeProfileRestResourceProvider;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 const BIOME_PROFILE_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.profile.read",
     permission_display_name: "Biome profile read",

--- a/libsplinter/src/biome/profile/rest_api/mod.rs
+++ b/libsplinter/src/biome/profile/rest_api/mod.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::BiomeProfileRestResourceProvider;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const BIOME_PROFILE_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "biome.profile.read",
     permission_display_name: "Biome profile read",

--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -17,7 +17,7 @@
 mod builder;
 mod error;
 mod profile;
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub(crate) mod rest_api;
 pub mod store;
 mod subject;

--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -34,24 +34,23 @@ use crate::oauth::{
     rest_api::resources::callback::{generate_redirect_query, CallbackQuery},
     OAuthClient,
 };
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, OAUTH_PROTOCOL_VERSION,
 };
+
+const OAUTH_CALLBACK_MIN: u32 = 1;
 
 pub fn make_callback_route(
     client: OAuthClient,
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
     #[cfg(feature = "biome-profile")] user_profile_store: Box<dyn UserProfileStore>,
 ) -> Resource {
-    let resource =
-        Resource::build("/oauth/callback").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::OAUTH_CALLBACK_MIN,
-            protocol::OAUTH_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/oauth/callback").add_request_guard(
+        ProtocolVersionRangeGuard::new(OAUTH_CALLBACK_MIN, OAUTH_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(
@@ -437,7 +436,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -541,7 +540,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -621,7 +620,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -703,7 +702,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/list_users.rs
+++ b/libsplinter/src/oauth/rest_api/actix/list_users.rs
@@ -18,22 +18,21 @@ use crate::oauth::rest_api::{
     resources::list_users::{ListOAuthUserResponse, OAuthUserResponse, PagingQuery},
     OAUTH_USER_READ_PERMISSION,
 };
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::get_response_paging_info,
-    ErrorResponse,
+    ErrorResponse, OAUTH_PROTOCOL_VERSION,
 };
 use futures::future::IntoFuture;
+
+const OAUTH_USER_READ_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_oauth_list_users_resource(
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
 ) -> Resource {
-    let resource =
-        Resource::build("/oauth/users").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::OAUTH_USER_READ_PROTOCOL_MIN,
-            protocol::OAUTH_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/oauth/users").add_request_guard(
+        ProtocolVersionRangeGuard::new(OAUTH_USER_READ_PROTOCOL_MIN, OAUTH_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(Method::Get, OAUTH_USER_READ_PERMISSION, move |req, _| {
@@ -191,10 +190,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -256,10 +252,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -283,10 +276,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/login.rs
+++ b/libsplinter/src/oauth/rest_api/actix/login.rs
@@ -19,17 +19,18 @@ use futures::future::IntoFuture;
 use std::collections::HashMap;
 
 use crate::oauth::OAuthClient;
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, OAUTH_PROTOCOL_VERSION,
 };
+
+const OAUTH_LOGIN_MIN: u32 = 1;
 
 pub fn make_login_route(client: OAuthClient) -> Resource {
     let resource = Resource::build("/oauth/login").add_request_guard(
-        ProtocolVersionRangeGuard::new(protocol::OAUTH_LOGIN_MIN, protocol::OAUTH_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(OAUTH_LOGIN_MIN, OAUTH_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -212,7 +213,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -273,7 +274,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .header("Referer", CLIENT_REDIRECT_URL)
             .send()
             .expect("Failed to perform request");
@@ -331,7 +332,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/logout.rs
+++ b/libsplinter/src/oauth/rest_api/actix/logout.rs
@@ -18,21 +18,20 @@ use actix_web::{HttpRequest, HttpResponse};
 use futures::{future::IntoFuture, Future};
 
 use crate::biome::oauth::store::{OAuthUserSessionStore, OAuthUserSessionStoreError};
-use crate::protocol;
 #[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::{AuthorizationHeader, BearerToken},
-    ErrorResponse,
+    ErrorResponse, OAUTH_PROTOCOL_VERSION,
 };
 
+const OAUTH_LOGOUT_MIN: u32 = 1;
+
 pub fn make_logout_route(oauth_user_session_store: Box<dyn OAuthUserSessionStore>) -> Resource {
-    let resource =
-        Resource::build("/oauth/logout").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::OAUTH_LOGOUT_MIN,
-            protocol::OAUTH_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/oauth/logout").add_request_guard(
+        ProtocolVersionRangeGuard::new(OAUTH_LOGOUT_MIN, OAUTH_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource.add_method(
@@ -176,7 +175,7 @@ mod tests {
             Url::parse(&format!("http://{}/oauth/logout", bind_url)).expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .header(
                 "Authorization",
                 format!("Bearer OAuth2:{}", SPLINTER_ACCESS_TOKEN),
@@ -217,7 +216,7 @@ mod tests {
             Url::parse(&format!("http://{}/oauth/logout", bind_url)).expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", protocol::OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
             .header(
                 "Authorization",
                 format!("Bearer OAuth2:{}", SPLINTER_ACCESS_TOKEN),

--- a/libsplinter/src/oauth/rest_api/mod.rs
+++ b/libsplinter/src/oauth/rest_api/mod.rs
@@ -14,13 +14,12 @@
 
 //! OAuth REST API endpoints
 
-#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
 mod resources;
 
 use crate::biome::OAuthUserSessionStore;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1",))]
+#[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 
 #[cfg(feature = "biome-profile")]
@@ -28,7 +27,7 @@ use crate::biome::UserProfileStore;
 
 use super::OAuthClient;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1",))]
+#[cfg(feature = "authorization")]
 const OAUTH_USER_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "oauth.users.read",
     permission_display_name: "OAuth Users read",
@@ -41,10 +40,6 @@ const OAUTH_USER_READ_PERMISSION: Permission = Permission::Check {
 /// * `GET /oauth/login` - Get the URL for requesting authorization from the provider
 /// * `GET /oauth/callback` - Receive the authorization code from the provider
 /// * `GET /oauth/logout` - Remove the user's access and refresh tokens
-///
-/// These endpoints are only available if the following REST API backend feature is enabled:
-///
-/// * `rest-api-actix-web-1`
 #[derive(Clone)]
 pub struct OAuthResourceProvider {
     client: OAuthClient,
@@ -75,36 +70,20 @@ impl OAuthResourceProvider {
 /// * `GET /oauth/callback` - Receive the authorization code from the provider
 /// * `GET /oauth/logout` - Remove the user's access and refresh tokens
 /// * `GET` /oauth/users` - Get a list of the OAuth users
-///
-/// These endpoints are only available if the following REST API backend feature is enabled:
-///
-/// * `rest-api-actix-web-1`
 impl RestResourceProvider for OAuthResourceProvider {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature `rest-api-actix-web-1` is
-        // enabled
-        #[allow(unused_mut)]
-        let mut resources = Vec::new();
-
-        #[cfg(feature = "rest-api-actix-web-1")]
-        {
-            resources.append(&mut vec![
-                actix::login::make_login_route(self.client.clone()),
-                actix::callback::make_callback_route(
-                    self.client.clone(),
-                    self.oauth_user_session_store.clone(),
-                    #[cfg(feature = "biome-profile")]
-                    self.user_profile_store.clone(),
-                ),
-                actix::logout::make_logout_route(self.oauth_user_session_store.clone()),
-            ]);
-            resources.append(&mut vec![
-                actix::list_users::make_oauth_list_users_resource(
-                    self.oauth_user_session_store.clone(),
-                ),
-            ]);
-        }
-
-        resources
+        vec![
+            actix::login::make_login_route(self.client.clone()),
+            actix::callback::make_callback_route(
+                self.client.clone(),
+                self.oauth_user_session_store.clone(),
+                #[cfg(feature = "biome-profile")]
+                self.user_profile_store.clone(),
+            ),
+            actix::logout::make_logout_route(self.oauth_user_session_store.clone()),
+            actix::list_users::make_oauth_list_users_resource(
+                self.oauth_user_session_store.clone(),
+            ),
+        ]
     }
 }

--- a/libsplinter/src/oauth/rest_api/mod.rs
+++ b/libsplinter/src/oauth/rest_api/mod.rs
@@ -14,13 +14,13 @@
 
 //! OAuth REST API endpoints
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
 mod resources;
 
 use crate::biome::OAuthUserSessionStore;
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(feature = "authorization", feature = "rest-api-actix",))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1",))]
 use crate::rest_api::auth::authorization::Permission;
 
 #[cfg(feature = "biome-profile")]
@@ -28,7 +28,7 @@ use crate::biome::UserProfileStore;
 
 use super::OAuthClient;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix",))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1",))]
 const OAUTH_USER_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "oauth.users.read",
     permission_display_name: "OAuth Users read",
@@ -44,7 +44,7 @@ const OAUTH_USER_READ_PERMISSION: Permission = Permission::Check {
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
-/// * `rest-api-actix`
+/// * `rest-api-actix-web-1`
 #[derive(Clone)]
 pub struct OAuthResourceProvider {
     client: OAuthClient,
@@ -78,15 +78,15 @@ impl OAuthResourceProvider {
 ///
 /// These endpoints are only available if the following REST API backend feature is enabled:
 ///
-/// * `rest-api-actix`
+/// * `rest-api-actix-web-1`
 impl RestResourceProvider for OAuthResourceProvider {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature `rest-api-actix` is
+        // Allowing unused_mut because resources must be mutable if feature `rest-api-actix-web-1` is
         // enabled
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.append(&mut vec![
                 actix::login::make_login_route(self.client.clone()),

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -12,118 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Protocol versions for various endpoints provided by splinter.
+//! Protocol structs for working with protocol-level data in Rust.
 
 pub mod authorization;
 pub mod component;
 pub mod network;
 pub mod service;
-
-// Admin REST API protocol versions
-pub const ADMIN_PROTOCOL_VERSION: u32 = 2;
-
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
-
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
-
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
-pub(crate) const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
-
-// Admin Service protocol versions
-pub const ADMIN_SERVICE_PROTOCOL_VERSION: u32 = 2;
-
-#[cfg(feature = "admin-service")]
-pub(crate) const ADMIN_SERVICE_PROTOCOL_MIN: u32 = 1;
-
-// The currently supported circuit version
-pub const CIRCUIT_PROTOCOL_VERSION: i32 = 2;
-
-#[cfg(feature = "authorization")]
-pub const AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
-
-#[cfg(all(
-    feature = "authorization-handler-maintenance",
-    feature = "rest-api-actix-web-1"
-))]
-pub(crate) const AUTHORIZATION_MAINTENANCE_MIN: u32 = 1;
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
-pub(crate) const AUTHORIZATION_PERMISSIONS_MIN: u32 = 1;
-
-// Authorization (namely RBAC management)  protocol versions
-#[cfg(all(
-    feature = "authorization-handler-rbac",
-    feature = "rest-api-actix-web-1"
-))]
-pub(crate) const AUTHORIZATION_RBAC_ROLES_MIN: u32 = 1;
-#[cfg(all(
-    feature = "authorization-handler-rbac",
-    feature = "rest-api-actix-web-1"
-))]
-pub(crate) const AUTHORIZATION_RBAC_ROLE_MIN: u32 = 1;
-#[cfg(all(
-    feature = "authorization-handler-rbac",
-    feature = "rest-api-actix-web-1"
-))]
-pub(crate) const AUTHORIZATION_RBAC_ASSIGNMENTS_MIN: u32 = 1;
-
-#[cfg(feature = "oauth")]
-pub const OAUTH_PROTOCOL_VERSION: u32 = 1;
-
-#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
-pub(crate) const OAUTH_CALLBACK_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
-pub(crate) const OAUTH_LOGIN_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
-pub(crate) const OAUTH_LOGOUT_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
-pub(crate) const OAUTH_USER_READ_PROTOCOL_MIN: u32 = 1;
-
-#[cfg(feature = "registry")]
-pub const REGISTRY_PROTOCOL_VERSION: u32 = 1;
-
-#[cfg(all(feature = "registry", feature = "rest-api-actix-web-1"))]
-pub(crate) const REGISTRY_LIST_NODES_MIN: u32 = 1;
-#[cfg(all(feature = "registry", feature = "rest-api-actix-web-1"))]
-pub(crate) const REGISTRY_FETCH_NODE_MIN: u32 = 1;
-
-#[cfg(any(
-    feature = "biome-credentials",
-    feature = "biome-key-management",
-    feature = "biome-notifications",
-    feature = "oauth"
-))]
-pub const BIOME_PROTOCOL_VERSION: u32 = 2;
-
-#[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
-pub(crate) const BIOME_REGISTER_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
-pub(crate) const BIOME_LOGIN_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
-pub(crate) const BIOME_USER_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-credentials", feature = "rest-api",))]
-pub(crate) const BIOME_LIST_USERS_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-credentials", feature = "rest-api"))]
-pub(crate) const BIOME_VERIFY_PROTOCOL_MIN: u32 = 1;
-
-#[cfg(all(feature = "biome-key-management", feature = "rest-api",))]
-pub(crate) const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-key-management", feature = "rest-api",))]
-pub(crate) const BIOME_REPLACE_KEYS_PROTOCOL_MIN: u32 = 2;
-
-#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
-pub(crate) const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
-pub(crate) const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "biome-profile", feature = "rest-api",))]
-pub(crate) const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
 
 // Peer authorization protocol versions
 #[cfg(any(feature = "trust-authorization", feature = "challenge-authorization"))]

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -58,11 +58,20 @@ pub(crate) const AUTHORIZATION_MAINTENANCE_MIN: u32 = 1;
 pub(crate) const AUTHORIZATION_PERMISSIONS_MIN: u32 = 1;
 
 // Authorization (namely RBAC management)  protocol versions
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
+#[cfg(all(
+    feature = "authorization-handler-rbac",
+    feature = "rest-api-actix-web-1"
+))]
 pub(crate) const AUTHORIZATION_RBAC_ROLES_MIN: u32 = 1;
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
+#[cfg(all(
+    feature = "authorization-handler-rbac",
+    feature = "rest-api-actix-web-1"
+))]
 pub(crate) const AUTHORIZATION_RBAC_ROLE_MIN: u32 = 1;
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
+#[cfg(all(
+    feature = "authorization-handler-rbac",
+    feature = "rest-api-actix-web-1"
+))]
 pub(crate) const AUTHORIZATION_RBAC_ASSIGNMENTS_MIN: u32 = 1;
 
 #[cfg(feature = "oauth")]

--- a/libsplinter/src/protocol/mod.rs
+++ b/libsplinter/src/protocol/mod.rs
@@ -22,19 +22,19 @@ pub mod service;
 // Admin REST API protocol versions
 pub const ADMIN_PROTOCOL_VERSION: u32 = 2;
 
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
 
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api-actix", feature = "admin-service"))]
+#[cfg(all(feature = "rest-api-actix-web-1", feature = "admin-service"))]
 pub(crate) const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
 
 // Admin Service protocol versions
@@ -51,38 +51,38 @@ pub const AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
 
 #[cfg(all(
     feature = "authorization-handler-maintenance",
-    feature = "rest-api-actix"
+    feature = "rest-api-actix-web-1"
 ))]
 pub(crate) const AUTHORIZATION_MAINTENANCE_MIN: u32 = 1;
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 pub(crate) const AUTHORIZATION_PERMISSIONS_MIN: u32 = 1;
 
 // Authorization (namely RBAC management)  protocol versions
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
 pub(crate) const AUTHORIZATION_RBAC_ROLES_MIN: u32 = 1;
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
 pub(crate) const AUTHORIZATION_RBAC_ROLE_MIN: u32 = 1;
-#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization-handler-rbac", feature = "rest-api-actix-web-1"))]
 pub(crate) const AUTHORIZATION_RBAC_ASSIGNMENTS_MIN: u32 = 1;
 
 #[cfg(feature = "oauth")]
 pub const OAUTH_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
 pub(crate) const OAUTH_CALLBACK_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
 pub(crate) const OAUTH_LOGIN_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
 pub(crate) const OAUTH_LOGOUT_MIN: u32 = 1;
-#[cfg(all(feature = "oauth", feature = "rest-api-actix"))]
+#[cfg(all(feature = "oauth", feature = "rest-api-actix-web-1"))]
 pub(crate) const OAUTH_USER_READ_PROTOCOL_MIN: u32 = 1;
 
 #[cfg(feature = "registry")]
 pub const REGISTRY_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(all(feature = "registry", feature = "rest-api-actix"))]
+#[cfg(all(feature = "registry", feature = "rest-api-actix-web-1"))]
 pub(crate) const REGISTRY_LIST_NODES_MIN: u32 = 1;
-#[cfg(all(feature = "registry", feature = "rest-api-actix"))]
+#[cfg(all(feature = "registry", feature = "rest-api-actix-web-1"))]
 pub(crate) const REGISTRY_FETCH_NODE_MIN: u32 = 1;
 
 #[cfg(any(

--- a/libsplinter/src/registry/client/reqwest.rs
+++ b/libsplinter/src/registry/client/reqwest.rs
@@ -17,7 +17,7 @@
 use reqwest::{blocking::Client, StatusCode};
 
 use crate::error::InternalError;
-use crate::protocol::REGISTRY_PROTOCOL_VERSION;
+use crate::rest_api::REGISTRY_PROTOCOL_VERSION;
 
 use super::{RegistryClient, RegistryNode, RegistryNodeListSlice};
 

--- a/libsplinter/src/registry/mod.rs
+++ b/libsplinter/src/registry/mod.rs
@@ -29,7 +29,7 @@ pub mod client;
 #[cfg(feature = "diesel")]
 mod diesel;
 mod error;
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod rest_api;
 mod unified;
 mod yaml;

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -23,7 +23,6 @@ use std::convert::TryFrom;
 use crate::actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
 use crate::error::InvalidStateError;
 use crate::futures::{future::IntoFuture, stream::Stream, Future};
-use crate::protocol;
 use crate::registry::rest_api::error::RegistryRestApiError;
 #[cfg(feature = "authorization")]
 use crate::registry::rest_api::{REGISTRY_READ_PERMISSION, REGISTRY_WRITE_PERMISSION};
@@ -34,18 +33,18 @@ use crate::registry::{
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    percent_encode_filter_query, ErrorResponse,
+    percent_encode_filter_query, ErrorResponse, REGISTRY_PROTOCOL_VERSION,
 };
+
+const REGISTRY_LIST_NODES_MIN: u32 = 1;
 
 type Filter = HashMap<String, (String, String)>;
 
 pub fn make_nodes_resource(registry: Box<dyn RwRegistry>) -> Resource {
     let registry1 = registry.clone();
-    let resource =
-        Resource::build("/registry/nodes").add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::REGISTRY_LIST_NODES_MIN,
-            protocol::REGISTRY_PROTOCOL_VERSION,
-        ));
+    let resource = Resource::build("/registry/nodes").add_request_guard(
+        ProtocolVersionRangeGuard::new(REGISTRY_LIST_NODES_MIN, REGISTRY_PROTOCOL_VERSION),
+    );
     #[cfg(feature = "authorization")]
     {
         resource
@@ -301,10 +300,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -362,10 +358,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -412,10 +405,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -438,10 +428,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .post(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -452,10 +439,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .post(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .json(&get_new_node_1())
             .send()
             .expect("Failed to perform request");

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -23,7 +23,6 @@ use std::convert::TryFrom;
 use crate::actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
 use crate::error::InvalidStateError;
 use crate::futures::{future::IntoFuture, stream::Stream, Future};
-use crate::protocol;
 use crate::registry::rest_api::error::RegistryRestApiError;
 #[cfg(feature = "authorization")]
 use crate::registry::rest_api::{REGISTRY_READ_PERMISSION, REGISTRY_WRITE_PERMISSION};
@@ -33,17 +32,16 @@ use crate::registry::{
 };
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse,
+    ErrorResponse, REGISTRY_PROTOCOL_VERSION,
 };
+
+const REGISTRY_FETCH_NODE_MIN: u32 = 1;
 
 pub fn make_nodes_identity_resource(registry: Box<dyn RwRegistry>) -> Resource {
     let registry1 = registry.clone();
     let registry2 = registry.clone();
     let resource = Resource::build("/registry/nodes/{identity}").add_request_guard(
-        ProtocolVersionRangeGuard::new(
-            protocol::REGISTRY_FETCH_NODE_MIN,
-            protocol::REGISTRY_PROTOCOL_VERSION,
-        ),
+        ProtocolVersionRangeGuard::new(REGISTRY_FETCH_NODE_MIN, REGISTRY_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -234,10 +232,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -270,10 +265,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -302,10 +294,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -325,10 +314,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .json(&node)
             .send()
             .expect("Failed to perform request");
@@ -337,10 +323,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -359,10 +342,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .json(&node)
             .send()
             .expect("Failed to perform request");
@@ -392,10 +372,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .delete(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -404,10 +381,7 @@ mod tests {
         // Verify that a non-existent node gets a NOT_FOUND response
         let resp = Client::new()
             .delete(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::REGISTRY_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/registry/rest_api/mod.rs
+++ b/libsplinter/src/registry/rest_api/mod.rs
@@ -14,24 +14,24 @@
 
 //! This module defines the REST API endpoints for interacting with registries.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
 mod error;
 mod resources;
 
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 use crate::rest_api::auth::authorization::Permission;
 
 use super::RwRegistry;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const REGISTRY_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "registry.read",
     permission_display_name: "Registry read",
     permission_description: "Allows the client to read the registry",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const REGISTRY_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "registry.write",
     permission_display_name: "Registry write",
@@ -56,7 +56,7 @@ impl RestResourceProvider for dyn RwRegistry {
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.append(&mut vec![
                 actix::nodes_identity::make_nodes_identity_resource(self.clone_box()),

--- a/libsplinter/src/registry/rest_api/mod.rs
+++ b/libsplinter/src/registry/rest_api/mod.rs
@@ -14,24 +14,23 @@
 
 //! This module defines the REST API endpoints for interacting with registries.
 
-#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
 mod error;
 mod resources;
 
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 use crate::rest_api::auth::authorization::Permission;
 
 use super::RwRegistry;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 const REGISTRY_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "registry.read",
     permission_display_name: "Registry read",
     permission_description: "Allows the client to read the registry",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
+#[cfg(feature = "authorization")]
 const REGISTRY_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "registry.write",
     permission_display_name: "Registry write",
@@ -45,25 +44,11 @@ const REGISTRY_WRITE_PERMISSION: Permission = Permission::Check {
 /// * `GET /registry/nodes/{identity}` - Fetch a specific node in the registry
 /// * `PUT /registry/nodes/{identity}` - Replace a node in the registry
 /// * `DELETE /registry/nodes/{identity}` - Delete a node from the registry
-///
-/// These endpoints are only available if the following REST API backend feature is enabled:
-///
-/// * `rest-api-actix`
 impl RestResourceProvider for dyn RwRegistry {
     fn resources(&self) -> Vec<Resource> {
-        // Allowing unused_mut because resources must be mutable if feature rest-api-actix is
-        // enabled
-        #[allow(unused_mut)]
-        let mut resources = Vec::new();
-
-        #[cfg(feature = "rest-api-actix-web-1")]
-        {
-            resources.append(&mut vec![
-                actix::nodes_identity::make_nodes_identity_resource(self.clone_box()),
-                actix::nodes::make_nodes_resource(self.clone_box()),
-            ]);
-        }
-
-        resources
+        vec![
+            actix::nodes_identity::make_nodes_identity_resource(self.clone_box()),
+            actix::nodes::make_nodes_resource(self.clone_box()),
+        ]
     }
 }

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -429,7 +429,7 @@ impl ShutdownHandle for RemoteYamlShutdownHandle {
     }
 }
 
-#[cfg(all(test, feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(test, feature = "rest-api-actix-web-1"))]
 mod tests {
     use super::*;
 

--- a/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
@@ -20,11 +20,10 @@
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use futures::{future::IntoFuture, Future};
 
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::authorization::maintenance::MaintenanceModeAuthorizationHandler,
-    ErrorResponse,
+    ErrorResponse, AUTHORIZATION_PROTOCOL_VERSION,
 };
 
 use super::{
@@ -32,12 +31,14 @@ use super::{
     AUTHORIZATION_MAINTENANCE_WRITE_PERMISSION,
 };
 
+const AUTHORIZATION_MAINTENANCE_MIN: u32 = 1;
+
 pub fn make_maintenance_resource(auth_handler: MaintenanceModeAuthorizationHandler) -> Resource {
     let auth_handler1 = auth_handler.clone();
     Resource::build("/authorization/maintenance")
         .add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::AUTHORIZATION_MAINTENANCE_MIN,
-            protocol::AUTHORIZATION_PROTOCOL_VERSION,
+            AUTHORIZATION_MAINTENANCE_MIN,
+            AUTHORIZATION_PROTOCOL_VERSION,
         ))
         .add_method(
             Method::Get,
@@ -108,10 +109,7 @@ mod tests {
         // Check disabled
         let resp = Client::new()
             .get(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -121,10 +119,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -132,10 +127,7 @@ mod tests {
         // Check enabled
         let resp = Client::new()
             .get(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -145,10 +137,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "false")])
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -156,10 +145,7 @@ mod tests {
         // Check disabled
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -196,10 +182,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "false")])
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -209,10 +192,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -222,10 +202,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/rest_api/auth/authorization/maintenance/routes/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/maintenance/routes/mod.rs
@@ -14,24 +14,24 @@
 
 //! REST API endpoints for the maintenance mode authorization handler
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod resources;
 
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 use crate::rest_api::auth::authorization::Permission;
 
 use super::MaintenanceModeAuthorizationHandler;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 const AUTHORIZATION_MAINTENANCE_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "authorization.maintenance.read",
     permission_display_name: "Maintenance mode read",
     permission_description: "Allows the client to check maintenance mode status",
 };
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 const AUTHORIZATION_MAINTENANCE_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "authorization.maintenance.write",
     permission_display_name: "Maintenance mode write",
@@ -54,7 +54,7 @@ impl RestResourceProvider for MaintenanceModeAuthorizationHandler {
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.push(actix::make_maintenance_resource(self.clone()));
         }

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
@@ -17,7 +17,6 @@ use std::convert::TryInto;
 use crate::actix_web::{error::BlockingError, web, Error, HttpRequest, HttpResponse};
 use crate::error::InvalidStateError;
 use crate::futures::{Future, IntoFuture, Stream};
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::authorization::rbac::{
@@ -34,10 +33,12 @@ use crate::rest_api::{
         store::{Assignment, Identity, RoleBasedAuthorizationStore},
     },
     paging::get_response_paging_info,
-    ErrorResponse,
+    ErrorResponse, AUTHORIZATION_PROTOCOL_VERSION,
 };
 
 use super::error::SendableRoleBasedAuthorizationStoreError;
+
+const AUTHORIZATION_RBAC_ASSIGNMENTS_MIN: u32 = 1;
 
 pub fn make_assignments_resource(
     role_based_auth_store: Box<dyn RoleBasedAuthorizationStore>,
@@ -46,8 +47,8 @@ pub fn make_assignments_resource(
     let add_store = role_based_auth_store;
     Resource::build("/authorization/assignments")
         .add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
-            protocol::AUTHORIZATION_PROTOCOL_VERSION,
+            AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
+            AUTHORIZATION_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             list_assignments(r, web::Data::new(list_store.clone()))
@@ -65,8 +66,8 @@ pub fn make_assignment_resource(
     let delete_store = role_based_auth_store;
     Resource::build("/authorization/assignments/{identity_type}/{identity}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
-            protocol::AUTHORIZATION_PROTOCOL_VERSION,
+            AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
+            AUTHORIZATION_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             get_assignment(r, web::Data::new(get_store.clone()))
@@ -456,10 +457,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -565,10 +563,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -614,10 +609,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -687,10 +679,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -702,10 +691,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -781,10 +767,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -803,10 +786,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -890,10 +870,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -919,10 +896,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -967,10 +941,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1003,10 +974,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1086,10 +1054,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .json(&json!({
                 "roles": ["role-1"]
             }))
@@ -1100,10 +1065,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1129,10 +1091,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .json(&json!({
                 "roles": ["role-2"]
             }))
@@ -1143,10 +1102,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1239,10 +1195,7 @@ mod tests {
 
         let resp = Client::new()
             .delete(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1250,10 +1203,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -1266,10 +1216,7 @@ mod tests {
 
         let resp = Client::new()
             .delete(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1277,10 +1224,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url.clone())
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1289,10 +1233,7 @@ mod tests {
         // show delete is idempotent
         let resp = Client::new()
             .delete(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/mod.rs
@@ -14,23 +14,23 @@
 
 //! Role-based Authorization REST API resources.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix_web_1;
 mod resources;
 
 use crate::rest_api::auth::Permission;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::RoleBasedAuthorizationResourceProvider;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 const RBAC_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "authorization.rbac.read",
     permission_display_name: "RBAC read",
     permission_description: "Allows the client to read roles, identities, and role assignments",
 };
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 const RBAC_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "authorization.rbac.write",
     permission_display_name: "RBAC write",

--- a/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
@@ -19,13 +19,15 @@
 use actix_web::HttpResponse;
 use futures::future::IntoFuture;
 
-use crate::protocol;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::authorization::Permission,
+    AUTHORIZATION_PROTOCOL_VERSION,
 };
 
 use super::{resources::PermissionResponse, AUTHORIZATION_PERMISSIONS_READ_PERMISSION};
+
+const AUTHORIZATION_PERMISSIONS_MIN: u32 = 1;
 
 pub fn make_permissions_resource(permissions: Vec<Permission>) -> Resource {
     let permissions = permissions
@@ -57,8 +59,8 @@ pub fn make_permissions_resource(permissions: Vec<Permission>) -> Resource {
 
     Resource::build("/authorization/permissions")
         .add_request_guard(ProtocolVersionRangeGuard::new(
-            protocol::AUTHORIZATION_PERMISSIONS_MIN,
-            protocol::AUTHORIZATION_PROTOCOL_VERSION,
+            AUTHORIZATION_PERMISSIONS_MIN,
+            AUTHORIZATION_PROTOCOL_VERSION,
         ))
         .add_method(
             Method::Get,
@@ -117,10 +119,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header(
-                "SplinterProtocolVersion",
-                protocol::AUTHORIZATION_PROTOCOL_VERSION,
-            )
+            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/rest_api/auth/authorization/routes/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/mod.rs
@@ -14,16 +14,16 @@
 
 //! REST API endpoints for authorization tools
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod actix;
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod resources;
 
 use crate::rest_api::actix_web_1::{Resource, RestResourceProvider};
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 use crate::rest_api::auth::authorization::Permission;
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 const AUTHORIZATION_PERMISSIONS_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "authorization.permissions.read",
     permission_display_name: "Permissions read",
@@ -39,15 +39,15 @@ const AUTHORIZATION_PERMISSIONS_READ_PERMISSION: Permission = Permission::Check 
 ///
 /// * `rest-api-actix`
 pub struct AuthorizationResourceProvider {
-    #[cfg(feature = "rest-api-actix")]
+    #[cfg(feature = "rest-api-actix-web-1")]
     permissions: Vec<Permission>,
 }
 
 impl AuthorizationResourceProvider {
     /// Creates a new `AuthorizationResourceProvider`
-    pub fn new(#[cfg(feature = "rest-api-actix")] permissions: Vec<Permission>) -> Self {
+    pub fn new(#[cfg(feature = "rest-api-actix-web-1")] permissions: Vec<Permission>) -> Self {
         Self {
-            #[cfg(feature = "rest-api-actix")]
+            #[cfg(feature = "rest-api-actix-web-1")]
             permissions,
         }
     }
@@ -67,7 +67,7 @@ impl RestResourceProvider for AuthorizationResourceProvider {
         #[allow(unused_mut)]
         let mut resources = Vec::new();
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             resources.push(actix::make_permissions_resource(self.permissions.clone()));
         }

--- a/libsplinter/src/rest_api/auth/mod.rs
+++ b/libsplinter/src/rest_api/auth/mod.rs
@@ -14,7 +14,7 @@
 
 //! Authentication and authorization for Splinter
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub(crate) mod actix;
 #[cfg(feature = "authorization")]
 pub mod authorization;

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -98,6 +98,21 @@ pub use actix_web_1::{
     RestApiShutdownHandle, RestResourceProvider,
 };
 
+#[cfg(feature = "admin-service")]
+pub(crate) const ADMIN_PROTOCOL_VERSION: u32 = 2;
+#[cfg(feature = "authorization")]
+pub(crate) const AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
+#[cfg(feature = "oauth")]
+pub(crate) const OAUTH_PROTOCOL_VERSION: u32 = 1;
+#[cfg(feature = "registry")]
+pub(crate) const REGISTRY_PROTOCOL_VERSION: u32 = 1;
+#[cfg(any(
+    feature = "biome-credentials",
+    feature = "biome-key-management",
+    feature = "biome-notifications",
+))]
+pub(crate) const BIOME_PROTOCOL_VERSION: u32 = 2;
+
 const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b' ')
     .add(b'"')

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -68,7 +68,7 @@ stable = [
   "metrics",
   "postgres",
   "rest-api",
-  "rest-api-actix",
+  "rest-api-actix-web-1",
   "sqlite",
 ]
 
@@ -87,6 +87,6 @@ https = []
 lmdb = []
 postgres = ["diesel/postgres", "diesel_migrations", "log", "sawtooth/postgres", "transact/postgres"]
 rest-api = ["futures", "splinter/rest-api"]
-rest-api-actix = ["actix-web", "splinter/rest-api-actix"]
+rest-api-actix-web-1 = ["actix-web", "rest-api", "splinter/rest-api-actix-web-1"]
 splinter-service = ["log", "sawtooth"]
 sqlite = ["diesel/sqlite", "diesel_migrations", "log", "sawtooth/sqlite", "transact/sqlite"]

--- a/services/scabbard/libscabbard/src/client/reqwest/mod.rs
+++ b/services/scabbard/libscabbard/src/client/reqwest/mod.rs
@@ -431,7 +431,7 @@ impl std::fmt::Display for ErrorResponse {
     }
 }
 
-#[cfg(all(test, feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(test, feature = "rest-api-actix-web-1"))]
 mod tests {
     use super::*;
 

--- a/services/scabbard/libscabbard/src/protocol.rs
+++ b/services/scabbard/libscabbard/src/protocol.rs
@@ -14,15 +14,15 @@
 
 pub const SCABBARD_PROTOCOL_VERSION: u32 = 1;
 
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_SUBSCRIBE_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_ADD_BATCHES_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_BATCH_STATUSES_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_GET_STATE_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_LIST_STATE_PROTOCOL_MIN: u32 = 1;
-#[cfg(all(feature = "rest-api", feature = "rest-api-actix"))]
+#[cfg(all(feature = "rest-api", feature = "rest-api-actix-web-1"))]
 pub(crate) const SCABBARD_STATE_ROOT_PROTOCOL_MIN: u32 = 1;

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -44,7 +44,7 @@ use transact::database::Database;
 use transact::state::merkle::sql;
 
 use crate::hex::parse_hex;
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 use crate::service::rest_api::actix;
 #[cfg(all(feature = "lmdb", any(feature = "postgres", feature = "sqlite")))]
 use crate::service::ScabbardStatePurgeHandler;
@@ -566,7 +566,7 @@ impl ServiceFactory for ScabbardFactory {
         #[allow(unused_mut)]
         let mut endpoints = vec![];
 
-        #[cfg(feature = "rest-api-actix")]
+        #[cfg(feature = "rest-api-actix-web-1")]
         {
             endpoints.append(&mut vec![
                 actix::batches::make_add_batches_to_queue_endpoint(),

--- a/services/scabbard/libscabbard/src/service/rest_api/mod.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/mod.rs
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "rest-api-actix")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod actix;
 pub mod resources;
 
-#[cfg(feature = "authorization")]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 use splinter::rest_api::auth::authorization::Permission;
 
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const SCABBARD_READ_PERMISSION: Permission = Permission::Check {
     permission_id: "scabbard.read",
     permission_display_name: "Scabbard read",
     permission_description: "Allows the client to read scabbard services' state and batch statuses",
 };
-#[cfg(all(feature = "authorization", feature = "rest-api-actix"))]
+#[cfg(all(feature = "authorization", feature = "rest-api-actix-web-1"))]
 const SCABBARD_WRITE_PERMISSION: Permission = Permission::Check {
     permission_id: "scabbard.write",
     permission_display_name: "Scabbard write",

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -60,8 +60,7 @@ transact = "0.4"
 path = "../services/scabbard/libscabbard"
 features = [
   "lmdb",
-  "rest-api",
-  "rest-api-actix",
+  "rest-api-actix-web-1",
   "splinter-service",
 ]
 
@@ -74,8 +73,7 @@ features = [
   "memory",
   "registry",
   "registry-remote",
-  "rest-api",
-  "rest-api-actix",
+  "rest-api-actix-web-1",
   "store-factory",
   "node-id-store",
 ]


### PR DESCRIPTION
This PR cleans up some aspects of the REST API organization. In particular, it starts some feature rework and distributes consts found in crate::protocol.

Subsequent PR(s) will make the "rest-api" feature only turn on crate::rest_api specifically.