### PR TITLE
Make crate::channel pub(crate)

### DIFF
--- a/libsplinter/src/channel/mock.rs
+++ b/libsplinter/src/channel/mock.rs
@@ -33,26 +33,6 @@ impl<T: Clone> Default for MockSender<T> {
     }
 }
 
-impl<T: Clone> MockSender<T> {
-    pub fn new(sent: Arc<Mutex<Vec<T>>>) -> Self {
-        MockSender { sent }
-    }
-
-    pub fn sent(&self) -> Vec<T> {
-        self.sent.lock().unwrap().clone()
-    }
-
-    /// Clear the Sent list, and return the previous items
-    pub fn clear(&self) -> Vec<T> {
-        let mut sent = self.sent.lock().unwrap();
-        let mut current = Vec::new();
-
-        std::mem::swap(&mut *sent, &mut current);
-
-        current
-    }
-}
-
 impl<T: Any + Clone + Send> Sender<T> for MockSender<T> {
     fn send(&self, message: T) -> Result<(), SendError> {
         self.sent.lock().unwrap().push(message);

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -71,7 +71,7 @@ pub mod admin;
 mod base62;
 #[cfg(feature = "biome")]
 pub mod biome;
-pub mod channel;
+pub(crate) mod channel;
 pub mod circuit;
 mod collections;
 pub mod consensus;


### PR DESCRIPTION
This crate does not need to be part of the public API.

This commit also removes portions of MockSender which were not used,
which turned into compiler warnings after crate::channel was no longer
pub.
