### PR TITLE
Update oauth2 dependency

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -54,7 +54,7 @@ log = "0.4"
 metrics = {version = "0.17", features = ["std"], optional = true}
 mio = { version = "0.6", default-features = false }
 mio-extras = "2"
-oauth2 = { version = "3.0", optional = true }
+oauth2 = { version = "4", optional = true }
 openssl = "0.10"
 percent-encoding = { version = "2.0", optional = true }
 protobuf = "2.23"

--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -230,7 +230,7 @@ fn new_basic_client(
                 .map_err(|err| InvalidArgumentError::new("token_url".into(), err.to_string()))?,
         ),
     )
-    .set_redirect_url(
+    .set_redirect_uri(
         RedirectUrl::new(redirect_url)
             .map_err(|err| InvalidArgumentError::new("redirect_url".into(), err.to_string()))?,
     ))


### PR DESCRIPTION
Update the oauth2 dependency to 4 from 3. Update
`set_redirect_url` to `set_redirect_uri` based on changes in oauth2.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>