### PR TITLE
Simplify rest-api feature guard

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -145,7 +145,7 @@ admin-service-event-client-actix-web-client = [
 admin-service-event-subscriber-glob = ["admin-service"]
 authorization-handler-allow-keys = ["authorization"]
 authorization-handler-maintenance = ["authorization"]
-authorization = ["rest-api"]
+authorization = ["rest-api-actix-web-1"]
 authorization-handler-rbac = ["authorization"]
 biome = []
 biome-client = ["biome"]
@@ -168,16 +168,15 @@ registry = []
 registry-client = ["registry"]
 registry-client-reqwest = ["registry-client", "reqwest"]
 registry-remote = ["reqwest", "registry"]
-rest-api = [
+rest-api = ["jsonwebtoken", "percent-encoding"]
+rest-api-actix-web-1 = [
     "actix",
     "actix-http",
     "actix-web",
     "actix-web-actors",
     "futures",
-    "jsonwebtoken",
-    "percent-encoding",
+    "rest-api",
 ]
-rest-api-actix-web-1 = ["actix", "actix-http", "actix-web", "actix-web-actors", "rest-api"]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
 service-network = []

--- a/libsplinter/src/admin/mod.rs
+++ b/libsplinter/src/admin/mod.rs
@@ -16,7 +16,7 @@
 pub mod client;
 pub mod error;
 pub mod messages;
-#[cfg(feature = "rest-api")]
+#[cfg(any(feature = "rest-api-actix-web-1", feature = "rest-api-actix-web-3"))]
 pub mod rest_api;
 pub mod service;
 pub mod store;

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -20,7 +20,7 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 extern crate serde_json;
 #[macro_use]
 #[cfg(feature = "diesel")]
@@ -103,7 +103,7 @@ pub mod store;
 pub mod threading;
 pub mod transport;
 
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web;
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use futures;

--- a/libsplinter/src/orchestrator/mod.rs
+++ b/libsplinter/src/orchestrator/mod.rs
@@ -14,7 +14,7 @@
 
 mod builder;
 mod error;
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 mod rest_api;
 mod runnable;
 

--- a/libsplinter/src/rest_api/auth/mod.rs
+++ b/libsplinter/src/rest_api/auth/mod.rs
@@ -29,9 +29,11 @@ use super::Method;
 
 #[cfg(feature = "authorization")]
 use authorization::{AuthorizationHandler, AuthorizationHandlerResult, Permission, PermissionMap};
+#[cfg(feature = "rest-api-actix-web-1")]
 use identity::{Identity, IdentityProvider};
 
 /// The possible outcomes of attempting to authorize a client
+#[cfg(feature = "rest-api-actix-web-1")]
 enum AuthorizationResult {
     /// The client was authorized to the given identity based on the authorization header
     Authorized(Identity),
@@ -60,6 +62,7 @@ enum AuthorizationResult {
 /// * `identity_providers` - The identity providers that will be used to check the client's identity
 /// * `authorization_handlers` - The authorization handlers that will be used to check the client's
 ///   permissions
+#[cfg(feature = "rest-api-actix-web-1")]
 fn authorize(
     #[cfg(feature = "authorization")] method: &Method,
     #[cfg(any(
@@ -145,6 +148,7 @@ fn authorize(
     }
 }
 
+#[cfg(feature = "rest-api-actix-web-1")]
 fn get_identity(
     auth_header: Option<&str>,
     identity_providers: &[Box<dyn IdentityProvider>],

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -67,6 +67,7 @@
 //!     .run();
 //! ```
 
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod actix_web_1;
 #[cfg(feature = "rest-api-actix-web-3")]
 pub mod actix_web_3;
@@ -91,6 +92,7 @@ pub use errors::{RequestError, RestApiServerError};
 
 pub use response_models::ErrorResponse;
 
+#[cfg(feature = "rest-api-actix-web-1")]
 pub use actix_web_1::{
     get_authorization_token, into_bytes, into_protobuf, new_websocket_event_sender, require_header,
     AuthConfig, Continuation, EventSender, HandlerFunction, Method, ProtocolVersionRangeGuard,

--- a/libsplinter/src/service/factory.rs
+++ b/libsplinter/src/service/factory.rs
@@ -31,7 +31,7 @@ pub trait ServiceFactory: Send {
         args: HashMap<String, String>,
     ) -> Result<Box<dyn Service>, FactoryCreateError>;
 
-    #[cfg(feature = "rest-api")]
+    #[cfg(feature = "rest-api-actix-web-1")]
     /// Get the [`ServiceEndpoint`] definitions that represent the REST API resources provided by
     /// the services that this factory can create.
     ///

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -40,7 +40,7 @@ mod factory;
 #[cfg(feature = "service-network")]
 pub mod network;
 mod processor;
-#[cfg(feature = "rest-api")]
+#[cfg(feature = "rest-api-actix-web-1")]
 pub mod rest_api;
 pub mod validation;
 


### PR DESCRIPTION
Changes feature guards which actually guard code using Actix Web 1 with
rest-api-actix-web-1. The remainder is code in crate::rest_api. Removes
the actix dependencies from the rest-api feature.

This makes explicit what requires Actix Web 1 and now rest-api feature
can be used for non-framework-specific REST API code.
