### PR TITLE
Use a single SplinterProtocolVersion value across libsplinter

### DIFF
--- a/libsplinter/src/admin/client/event/ws/actix_web_client.rs
+++ b/libsplinter/src/admin/client/event/ws/actix_web_client.rs
@@ -29,7 +29,7 @@ use crate::events::{
     Igniter, ParseBytes, ParseError, Reactor, WebSocketClient, WebSocketError, WsResponse,
 };
 use crate::hex;
-use crate::rest_api::ADMIN_PROTOCOL_VERSION;
+use crate::rest_api::SPLINTER_PROTOCOL_VERSION;
 use crate::threading::lifecycle::ShutdownHandle;
 
 enum WsRuntime {
@@ -188,7 +188,7 @@ impl RunnableAwcAdminServiceEventClient {
 
         ws_client.header(
             "SplinterProtocolVersion",
-            ADMIN_PROTOCOL_VERSION.to_string(),
+            SPLINTER_PROTOCOL_VERSION.to_string(),
         );
 
         ws_client.set_reconnect(true);

--- a/libsplinter/src/admin/client/reqwest.rs
+++ b/libsplinter/src/admin/client/reqwest.rs
@@ -17,7 +17,7 @@
 use reqwest::{blocking::Client, header, StatusCode};
 
 use crate::error::InternalError;
-use crate::rest_api::ADMIN_PROTOCOL_VERSION;
+use crate::rest_api::SPLINTER_PROTOCOL_VERSION;
 
 use super::{AdminServiceClient, CircuitListSlice, CircuitSlice, ProposalListSlice, ProposalSlice};
 
@@ -45,7 +45,7 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
         let request = Client::new()
             .post(&format!("{}/admin/submit", self.url))
             .header(header::CONTENT_TYPE, "octet-stream")
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .body(payload)
             .header("Authorization", &self.auth);
 
@@ -93,7 +93,7 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
 
         let request = Client::new()
             .get(&url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         let response = request.send();
@@ -139,7 +139,7 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
     fn fetch_circuit(&self, circuit_id: &str) -> Result<Option<CircuitSlice>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/admin/circuits/{}", self.url, circuit_id))
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request
@@ -200,7 +200,7 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
 
         let request = Client::new()
             .get(&url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request
@@ -242,7 +242,7 @@ impl AdminServiceClient for ReqwestAdminServiceClient {
     fn fetch_proposal(&self, circuit_id: &str) -> Result<Option<ProposalSlice>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/admin/proposals/{}", self.url, circuit_id))
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request

--- a/libsplinter/src/admin/rest_api/actix/circuits.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits.rs
@@ -25,7 +25,7 @@ use crate::admin::store::{AdminServiceStore, CircuitPredicate, CircuitStatus};
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    ErrorResponse, ADMIN_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::super::error::CircuitListError;
@@ -35,7 +35,7 @@ const ADMIN_LIST_CIRCUITS_MIN: u32 = 1;
 
 pub fn make_list_circuits_resource(store: Box<dyn AdminServiceStore>) -> Resource {
     let resource = Resource::build("/admin/circuits").add_request_guard(
-        ProtocolVersionRangeGuard::new(ADMIN_LIST_CIRCUITS_MIN, ADMIN_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(ADMIN_LIST_CIRCUITS_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -134,7 +134,7 @@ fn list_circuits(
                 )
             }
         },
-        None => format!("{}", ADMIN_PROTOCOL_VERSION),
+        None => format!("{}", SPLINTER_PROTOCOL_VERSION),
     };
 
     Box::new(query_list_circuits(
@@ -269,7 +269,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -358,7 +358,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -405,7 +405,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -453,7 +453,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -502,7 +502,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -543,7 +543,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -587,7 +587,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/circuits_circuit_id.rs
@@ -23,7 +23,7 @@ use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::store::AdminServiceStore;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, ADMIN_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::super::error::CircuitFetchError;
@@ -33,7 +33,7 @@ const ADMIN_FETCH_CIRCUIT_MIN: u32 = 1;
 
 pub fn make_fetch_circuit_resource(store: Box<dyn AdminServiceStore>) -> Resource {
     let resource = Resource::build("/admin/circuits/{circuit_id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(ADMIN_FETCH_CIRCUIT_MIN, ADMIN_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(ADMIN_FETCH_CIRCUIT_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -66,7 +66,7 @@ fn fetch_circuit(
                 "Unable to get SplinterProtocolVersion".to_string(),
             )),
         },
-        None => Ok(format!("{}", ADMIN_PROTOCOL_VERSION)),
+        None => Ok(format!("{}", SPLINTER_PROTOCOL_VERSION)),
     };
 
     Box::new(
@@ -153,7 +153,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -222,7 +222,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/libsplinter/src/admin/rest_api/actix/proposals.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals.rs
@@ -26,7 +26,7 @@ use crate::admin::store::CircuitPredicate;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    ErrorResponse, ADMIN_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::super::error::ProposalListError;
@@ -35,9 +35,11 @@ use super::super::resources;
 const ADMIN_LIST_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_list_proposals_resource<PS: ProposalStore + 'static>(proposal_store: PS) -> Resource {
-    let resource = Resource::build("admin/proposals").add_request_guard(
-        ProtocolVersionRangeGuard::new(ADMIN_LIST_PROPOSALS_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
-    );
+    let resource =
+        Resource::build("admin/proposals").add_request_guard(ProtocolVersionRangeGuard::new(
+            ADMIN_LIST_PROPOSALS_PROTOCOL_MIN,
+            SPLINTER_PROTOCOL_VERSION,
+        ));
 
     #[cfg(feature = "authorization")]
     {
@@ -130,7 +132,7 @@ fn list_proposals<PS: ProposalStore + 'static>(
                 )
             }
         },
-        None => format!("{}", ADMIN_PROTOCOL_VERSION),
+        None => format!("{}", SPLINTER_PROTOCOL_VERSION),
     };
 
     Box::new(query_list_proposals(
@@ -263,7 +265,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -379,7 +381,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -430,7 +432,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -483,7 +485,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -530,7 +532,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -577,7 +579,7 @@ mod tests {
             .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
+++ b/libsplinter/src/admin/rest_api/actix/proposals_circuit_id.rs
@@ -26,7 +26,7 @@ use crate::admin::rest_api::CIRCUIT_READ_PERMISSION;
 use crate::admin::service::proposal_store::ProposalStore;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, ADMIN_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::super::resources;
@@ -35,7 +35,10 @@ const ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_fetch_proposal_resource<PS: ProposalStore + 'static>(proposal_store: PS) -> Resource {
     let resource = Resource::build("admin/proposals/{circuit_id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(
+            ADMIN_FETCH_PROPOSALS_PROTOCOL_MIN,
+            SPLINTER_PROTOCOL_VERSION,
+        ),
     );
 
     #[cfg(feature = "authorization")]
@@ -69,7 +72,7 @@ fn fetch_proposal<PS: ProposalStore + 'static>(
                 "Unable to get SplinterProtocolVersion".to_string(),
             )),
         },
-        None => Ok(format!("{}", ADMIN_PROTOCOL_VERSION)),
+        None => Ok(format!("{}", SPLINTER_PROTOCOL_VERSION)),
     };
 
     Box::new(
@@ -161,7 +164,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -231,7 +234,7 @@ mod tests {
         .expect("Failed to parse URL");
         let req = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", ADMIN_PROTOCOL_VERSION);
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION);
         let resp = req.send().expect("Failed to perform request");
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/libsplinter/src/admin/rest_api/actix/submit.rs
+++ b/libsplinter/src/admin/rest_api/actix/submit.rs
@@ -21,7 +21,7 @@ use crate::admin::service::{AdminCommands, AdminServiceError};
 use crate::protos::admin::CircuitManagementPayload;
 use crate::rest_api::{
     actix_web_1::{into_protobuf, Method, ProtocolVersionRangeGuard, Resource},
-    ADMIN_PROTOCOL_VERSION,
+    SPLINTER_PROTOCOL_VERSION,
 };
 use crate::service::ServiceError;
 
@@ -29,7 +29,7 @@ const ADMIN_SUBMIT_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_submit_route<A: AdminCommands + Clone + 'static>(admin_commands: A) -> Resource {
     let resource = Resource::build("/admin/submit").add_request_guard(
-        ProtocolVersionRangeGuard::new(ADMIN_SUBMIT_PROTOCOL_MIN, ADMIN_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(ADMIN_SUBMIT_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
 
     #[cfg(feature = "authorization")]

--- a/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
+++ b/libsplinter/src/admin/rest_api/actix/ws_register_type.rs
@@ -34,7 +34,7 @@ use crate::rest_api::{
         new_websocket_event_sender, EventSender, Method, ProtocolVersionRangeGuard, Request,
         Resource,
     },
-    ErrorResponse, ADMIN_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN: u32 = 1;
@@ -45,7 +45,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
     let resource = Resource::build("/ws/admin/register/{type}").add_request_guard(
         ProtocolVersionRangeGuard::new(
             ADMIN_APPLICATION_REGISTRATION_PROTOCOL_MIN,
-            ADMIN_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ),
     );
 
@@ -95,7 +95,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                             )
                         }
                     },
-                    None => ADMIN_PROTOCOL_VERSION,
+                    None => SPLINTER_PROTOCOL_VERSION,
                 };
 
                 debug!(
@@ -226,7 +226,7 @@ pub fn make_application_handler_registration_route<A: AdminCommands + Clone + 's
                         )
                     }
                 },
-                None => ADMIN_PROTOCOL_VERSION,
+                None => SPLINTER_PROTOCOL_VERSION,
             };
 
             debug!(

--- a/libsplinter/src/biome/client/reqwest.rs
+++ b/libsplinter/src/biome/client/reqwest.rs
@@ -19,7 +19,7 @@ use std::convert::From;
 use reqwest::{blocking::Client, StatusCode};
 
 use crate::error::InternalError;
-use crate::rest_api::BIOME_PROTOCOL_VERSION;
+use crate::rest_api::SPLINTER_PROTOCOL_VERSION;
 
 use super::{Authorization, BiomeClient, Credentials, Key, NewKey, Profile, UpdateUser};
 
@@ -59,7 +59,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn register(&self, username: &str, password: &str) -> Result<Credentials, InternalError> {
         let request = Client::new()
             .post(&format!("{}/biome/register", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "username": username,
                 "hashed_password": password,
@@ -112,7 +112,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn login(&self, username: &str, password: &str) -> Result<Authorization, InternalError> {
         let request = Client::new()
             .post(&format!("{}/biome/login", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "username": username,
                 "hashed_password": password,
@@ -164,7 +164,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn logout(&self) -> Result<(), InternalError> {
         let request = Client::new()
             .patch(&format!("{}/biome/logout", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -207,7 +207,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn get_new_access_token(&self, refresh_token: &str) -> Result<String, InternalError> {
         let request = Client::new()
             .post(&format!("{}/biome/token", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&json!({ "token": refresh_token }));
 
@@ -258,7 +258,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn verify(&self, username: &str, password: &str) -> Result<(), InternalError> {
         let request = Client::new()
             .post(&format!("{}/biome/verify", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&json!({"username": username, "hashed_password": password}));
 
@@ -302,7 +302,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn list_users(&self) -> Result<Box<dyn Iterator<Item = Credentials>>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/biome/users?limit={}", self.url, PAGING_LIMIT))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -363,7 +363,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn get_user(&self, user_id: &str) -> Result<Option<Credentials>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/biome/users/{}", self.url, user_id))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -419,7 +419,7 @@ impl BiomeClient for ReqwestBiomeClient {
     ) -> Result<Box<dyn Iterator<Item = Key>>, InternalError> {
         let request = Client::new()
             .put(&format!("{}/biome/users/{}", self.url, user_id))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&ClientUpdateUser::from(updated_user));
 
@@ -474,7 +474,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn delete_user(&self, user_id: &str) -> Result<(), InternalError> {
         let request = Client::new()
             .delete(&format!("{}/biome/users/{}", self.url, user_id))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -520,7 +520,7 @@ impl BiomeClient for ReqwestBiomeClient {
                 "{}/biome/profiles?limit={}",
                 self.url, PAGING_LIMIT
             ))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -581,7 +581,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn get_profile(&self, user_id: &str) -> Result<Option<Profile>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/biome/profiles/{}", self.url, user_id))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -630,7 +630,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn list_user_keys(&self) -> Result<Box<dyn Iterator<Item = Key>>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/biome/keys?limit={}", self.url, PAGING_LIMIT))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -684,7 +684,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn update_key(&self, public_key: &str, new_display_name: &str) -> Result<(), InternalError> {
         let request = Client::new()
             .patch(&format!("{}/biome/keys", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&json!({
                 "public_key": public_key,
@@ -731,7 +731,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn add_key(&self, user_id: &str, new_key: NewKey) -> Result<(), InternalError> {
         let request = Client::new()
             .post(&format!("{}/biome/keys", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&ClientKey::from((user_id.to_string(), new_key)));
 
@@ -776,7 +776,7 @@ impl BiomeClient for ReqwestBiomeClient {
         let keys: Vec<ClientNewKey> = keys.into_iter().map(ClientNewKey::from).collect();
         let request = Client::new()
             .put(&format!("{}/biome/keys", self.url))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?)
             .json(&keys);
 
@@ -820,7 +820,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn get_key(&self, public_key: &str) -> Result<Option<Key>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/biome/keys/{}", self.url, public_key))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();
@@ -873,7 +873,7 @@ impl BiomeClient for ReqwestBiomeClient {
     fn delete_key(&self, public_key: &str) -> Result<Option<Key>, InternalError> {
         let request = Client::new()
             .delete(&format!("{}/biome/keys/{}", self.url, public_key))
-            .header("SplinterProtocolVersion", BIOME_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth()?);
 
         let response = request.send();

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/login.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/login.rs
@@ -21,7 +21,7 @@ use crate::futures::{Future, IntoFuture};
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use crate::biome::credentials::rest_api::actix_web_1::BiomeCredentialsRestConfig;
@@ -45,7 +45,7 @@ pub fn make_login_route(
     token_issuer: Arc<AccessTokenIssuer>,
 ) -> Resource {
     let resource = Resource::build("/biome/login").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_LOGIN_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_LOGIN_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/logout.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/logout.rs
@@ -27,7 +27,7 @@ use crate::rest_api::{
     actix_web_1::{HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     secrets::SecretManager,
     sessions::default_validation,
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_LOGOUT_PROTOCOL_MIN: u32 = 1;
@@ -40,7 +40,7 @@ pub fn make_logout_route(
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
     let resource = Resource::build("/biome/logout").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_LOGOUT_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_LOGOUT_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/register.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/register.rs
@@ -26,7 +26,7 @@ use crate::futures::{Future, IntoFuture};
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 /// This is the UUID namespace for Biome user IDs generated for users that register with Biome
@@ -49,7 +49,7 @@ pub fn make_register_route(
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
     let resource = Resource::build("/biome/register").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_REGISTER_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_REGISTER_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/token.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/token.rs
@@ -34,7 +34,7 @@ use crate::rest_api::{
     sessions::{
         default_validation, ignore_exp_validation, AccessTokenIssuer, ClaimsBuilder, TokenIssuer,
     },
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_TOKEN_PROTOCOL_MIN: u32 = 1;
@@ -58,7 +58,7 @@ pub fn make_token_route(
     rest_config: Arc<BiomeCredentialsRestConfig>,
 ) -> Resource {
     let resource = Resource::build("/biome/token").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_TOKEN_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_TOKEN_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/user.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/user.rs
@@ -20,7 +20,7 @@ use crate::biome::credentials::store::{CredentialsStore, CredentialsStoreError};
 use crate::futures::{Future, IntoFuture};
 use crate::rest_api::{
     actix_web_1::{into_bytes, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 #[cfg(feature = "biome-key-management")]
@@ -44,7 +44,7 @@ const BIOME_USER_PROTOCOL_MIN: u32 = 1;
 /// Defines a REST endpoint to list users from the db
 pub fn make_list_route(credentials_store: Arc<dyn CredentialsStore>) -> Resource {
     let resource = Resource::build("/biome/users").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_LIST_USERS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_LIST_USERS_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -86,7 +86,7 @@ pub fn make_user_routes(
     key_store: Arc<dyn KeyStore>,
 ) -> Resource {
     let resource = Resource::build("/biome/users/{id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_USER_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_USER_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/credentials/rest_api/actix_web_1/verify.rs
+++ b/libsplinter/src/biome/credentials/rest_api/actix_web_1/verify.rs
@@ -22,7 +22,7 @@ use crate::rest_api::{
     actix_web_1::{into_bytes, Method, ProtocolVersionRangeGuard, Resource},
     secrets::SecretManager,
     sessions::default_validation,
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use crate::biome::credentials::rest_api::actix_web_1::config::BiomeCredentialsRestConfig;
@@ -47,7 +47,7 @@ pub fn make_verify_route(
     secret_manager: Arc<dyn SecretManager>,
 ) -> Resource {
     let resource = Resource::build("/biome/verify").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_VERIFY_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_VERIFY_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
+++ b/libsplinter/src/biome/key_management/rest_api/actix_web_1/key_management.rs
@@ -26,7 +26,7 @@ use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{into_bytes, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     auth::identity::Identity,
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_KEYS_PROTOCOL_MIN: u32 = 1;
@@ -35,7 +35,7 @@ const BIOME_REPLACE_KEYS_PROTOCOL_MIN: u32 = 2;
 /// Defines a REST endpoint for managing keys including inserting, listing and updating keys
 pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
     let resource = Resource::build("/biome/keys").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -48,7 +48,7 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
             .add_request_guard(
                 ProtocolVersionRangeGuard::new(
                     BIOME_REPLACE_KEYS_PROTOCOL_MIN,
-                    BIOME_PROTOCOL_VERSION,
+                    SPLINTER_PROTOCOL_VERSION,
                 )
                 .with_method(Method::Put),
             )
@@ -75,7 +75,7 @@ pub fn make_key_management_route(key_store: Arc<dyn KeyStore>) -> Resource {
             .add_request_guard(
                 ProtocolVersionRangeGuard::new(
                     BIOME_REPLACE_KEYS_PROTOCOL_MIN,
-                    BIOME_PROTOCOL_VERSION,
+                    SPLINTER_PROTOCOL_VERSION,
                 )
                 .with_method(Method::Put),
             )
@@ -305,7 +305,7 @@ fn handle_patch(key_store: Arc<dyn KeyStore>) -> HandlerFunction {
 /// Defines a REST endpoint for managing keys including fetching and deleting a user's key
 pub fn make_key_management_route_with_public_key(key_store: Arc<dyn KeyStore>) -> Resource {
     let resource = Resource::build("/biome/keys/{public_key}").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_KEYS_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profile.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profile.rs
@@ -22,14 +22,14 @@ use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{HandlerFunction, Method, ProtocolVersionRangeGuard, Resource},
     auth::identity::Identity,
-    ErrorResponse, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_FETCH_PROFILE_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_profile_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
     let resource = Resource::build("/biome/profile").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_FETCH_PROFILE_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_FETCH_PROFILE_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles.rs
@@ -20,7 +20,7 @@ use crate::biome::profile::rest_api::BIOME_PROFILE_READ_PERMISSION;
 use crate::biome::profile::store::UserProfileStore;
 use crate::futures::IntoFuture;
 use crate::rest_api::{
-    ErrorResponse, Method, ProtocolVersionRangeGuard, Resource, BIOME_PROTOCOL_VERSION,
+    ErrorResponse, Method, ProtocolVersionRangeGuard, Resource, SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
@@ -28,7 +28,7 @@ const BIOME_LIST_PROFILES_PROTOCOL_MIN: u32 = 1;
 /// Defines a REST endpoint to list profiles from the database
 pub fn make_profiles_list_route(profile_store: Arc<dyn UserProfileStore>) -> Resource {
     let resource = Resource::build("/biome/profiles").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_LIST_PROFILES_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(BIOME_LIST_PROFILES_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {

--- a/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles_identity.rs
+++ b/libsplinter/src/biome/profile/rest_api/actix_web_1/profiles_identity.rs
@@ -21,15 +21,17 @@ use crate::biome::profile::store::{UserProfileStore, UserProfileStoreError};
 use crate::futures::IntoFuture;
 use crate::rest_api::{
     ErrorResponse, HandlerFunction, Method, ProtocolVersionRangeGuard, Resource,
-    BIOME_PROTOCOL_VERSION,
+    SPLINTER_PROTOCOL_VERSION,
 };
 
 const BIOME_FETCH_PROFILES_PROTOCOL_MIN: u32 = 1;
 
 pub fn make_profiles_routes(profile_store: Arc<dyn UserProfileStore>) -> Resource {
-    let resource = Resource::build("/biome/profiles/{id}").add_request_guard(
-        ProtocolVersionRangeGuard::new(BIOME_FETCH_PROFILES_PROTOCOL_MIN, BIOME_PROTOCOL_VERSION),
-    );
+    let resource =
+        Resource::build("/biome/profiles/{id}").add_request_guard(ProtocolVersionRangeGuard::new(
+            BIOME_FETCH_PROFILES_PROTOCOL_MIN,
+            SPLINTER_PROTOCOL_VERSION,
+        ));
     #[cfg(feature = "authorization")]
     {
         resource.add_method(

--- a/libsplinter/src/oauth/rest_api/actix/callback.rs
+++ b/libsplinter/src/oauth/rest_api/actix/callback.rs
@@ -38,7 +38,7 @@ use crate::oauth::{
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, OAUTH_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const OAUTH_CALLBACK_MIN: u32 = 1;
@@ -49,7 +49,7 @@ pub fn make_callback_route(
     #[cfg(feature = "biome-profile")] user_profile_store: Box<dyn UserProfileStore>,
 ) -> Resource {
     let resource = Resource::build("/oauth/callback").add_request_guard(
-        ProtocolVersionRangeGuard::new(OAUTH_CALLBACK_MIN, OAUTH_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(OAUTH_CALLBACK_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -436,7 +436,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -540,7 +540,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -620,7 +620,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -702,7 +702,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/list_users.rs
+++ b/libsplinter/src/oauth/rest_api/actix/list_users.rs
@@ -21,7 +21,7 @@ use crate::oauth::rest_api::{
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::get_response_paging_info,
-    ErrorResponse, OAUTH_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 use futures::future::IntoFuture;
 
@@ -31,7 +31,7 @@ pub fn make_oauth_list_users_resource(
     oauth_user_session_store: Box<dyn OAuthUserSessionStore>,
 ) -> Resource {
     let resource = Resource::build("/oauth/users").add_request_guard(
-        ProtocolVersionRangeGuard::new(OAUTH_USER_READ_PROTOCOL_MIN, OAUTH_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(OAUTH_USER_READ_PROTOCOL_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -190,7 +190,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -252,7 +252,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -276,7 +276,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/login.rs
+++ b/libsplinter/src/oauth/rest_api/actix/login.rs
@@ -23,14 +23,14 @@ use crate::oauth::OAuthClient;
 use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, OAUTH_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const OAUTH_LOGIN_MIN: u32 = 1;
 
 pub fn make_login_route(client: OAuthClient) -> Resource {
     let resource = Resource::build("/oauth/login").add_request_guard(
-        ProtocolVersionRangeGuard::new(OAUTH_LOGIN_MIN, OAUTH_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(OAUTH_LOGIN_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -213,7 +213,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -274,7 +274,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Referer", CLIENT_REDIRECT_URL)
             .send()
             .expect("Failed to perform request");
@@ -332,7 +332,7 @@ mod tests {
             .build()
             .expect("Failed to build client")
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/oauth/rest_api/actix/logout.rs
+++ b/libsplinter/src/oauth/rest_api/actix/logout.rs
@@ -23,14 +23,14 @@ use crate::rest_api::auth::authorization::Permission;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::{AuthorizationHeader, BearerToken},
-    ErrorResponse, OAUTH_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const OAUTH_LOGOUT_MIN: u32 = 1;
 
 pub fn make_logout_route(oauth_user_session_store: Box<dyn OAuthUserSessionStore>) -> Resource {
     let resource = Resource::build("/oauth/logout").add_request_guard(
-        ProtocolVersionRangeGuard::new(OAUTH_LOGOUT_MIN, OAUTH_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(OAUTH_LOGOUT_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -175,7 +175,7 @@ mod tests {
             Url::parse(&format!("http://{}/oauth/logout", bind_url)).expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header(
                 "Authorization",
                 format!("Bearer OAuth2:{}", SPLINTER_ACCESS_TOKEN),
@@ -216,7 +216,7 @@ mod tests {
             Url::parse(&format!("http://{}/oauth/logout", bind_url)).expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", OAUTH_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header(
                 "Authorization",
                 format!("Bearer OAuth2:{}", SPLINTER_ACCESS_TOKEN),

--- a/libsplinter/src/registry/client/reqwest.rs
+++ b/libsplinter/src/registry/client/reqwest.rs
@@ -17,7 +17,7 @@
 use reqwest::{blocking::Client, StatusCode};
 
 use crate::error::InternalError;
-use crate::rest_api::REGISTRY_PROTOCOL_VERSION;
+use crate::rest_api::SPLINTER_PROTOCOL_VERSION;
 
 use super::{RegistryClient, RegistryNode, RegistryNodeListSlice};
 
@@ -45,7 +45,7 @@ impl RegistryClient for ReqwestRegistryClient {
         let request = Client::new()
             .post(&format!("{}/registry/nodes", self.url))
             .json(&node)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request
@@ -82,7 +82,7 @@ impl RegistryClient for ReqwestRegistryClient {
     fn get_node(&self, identity: &str) -> Result<Option<RegistryNode>, InternalError> {
         let request = Client::new()
             .get(&format!("{}/registry/nodes/{}", self.url, &identity))
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request
@@ -132,7 +132,7 @@ impl RegistryClient for ReqwestRegistryClient {
 
         let request = Client::new()
             .get(&url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request.send()
@@ -179,7 +179,7 @@ impl RegistryClient for ReqwestRegistryClient {
         let request = Client::new()
             .put(&format!("{}/registry/nodes/{}", self.url, node.identity))
             .json(&node)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request
@@ -216,7 +216,7 @@ impl RegistryClient for ReqwestRegistryClient {
     fn delete_node(&self, identity: &str) -> Result<(), InternalError> {
         let request = Client::new()
             .delete(&format!("{}/registry/nodes/{}", self.url, identity))
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .header("Authorization", &self.auth);
 
         request

--- a/libsplinter/src/registry/rest_api/actix/nodes.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes.rs
@@ -33,7 +33,7 @@ use crate::registry::{
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     paging::{get_response_paging_info, DEFAULT_LIMIT, DEFAULT_OFFSET},
-    percent_encode_filter_query, ErrorResponse, REGISTRY_PROTOCOL_VERSION,
+    percent_encode_filter_query, ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const REGISTRY_LIST_NODES_MIN: u32 = 1;
@@ -43,7 +43,7 @@ type Filter = HashMap<String, (String, String)>;
 pub fn make_nodes_resource(registry: Box<dyn RwRegistry>) -> Resource {
     let registry1 = registry.clone();
     let resource = Resource::build("/registry/nodes").add_request_guard(
-        ProtocolVersionRangeGuard::new(REGISTRY_LIST_NODES_MIN, REGISTRY_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(REGISTRY_LIST_NODES_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -300,7 +300,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -358,7 +358,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -405,7 +405,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -428,7 +428,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .post(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -439,7 +439,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .post(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&get_new_node_1())
             .send()
             .expect("Failed to perform request");

--- a/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
+++ b/libsplinter/src/registry/rest_api/actix/nodes_identity.rs
@@ -32,7 +32,7 @@ use crate::registry::{
 };
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    ErrorResponse, REGISTRY_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 const REGISTRY_FETCH_NODE_MIN: u32 = 1;
@@ -41,7 +41,7 @@ pub fn make_nodes_identity_resource(registry: Box<dyn RwRegistry>) -> Resource {
     let registry1 = registry.clone();
     let registry2 = registry.clone();
     let resource = Resource::build("/registry/nodes/{identity}").add_request_guard(
-        ProtocolVersionRangeGuard::new(REGISTRY_FETCH_NODE_MIN, REGISTRY_PROTOCOL_VERSION),
+        ProtocolVersionRangeGuard::new(REGISTRY_FETCH_NODE_MIN, SPLINTER_PROTOCOL_VERSION),
     );
     #[cfg(feature = "authorization")]
     {
@@ -232,7 +232,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -265,7 +265,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -294,7 +294,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -314,7 +314,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url.clone())
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&node)
             .send()
             .expect("Failed to perform request");
@@ -323,7 +323,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -342,7 +342,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .put(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&node)
             .send()
             .expect("Failed to perform request");
@@ -372,7 +372,7 @@ mod tests {
         .expect("Failed to parse URL");
         let resp = Client::new()
             .delete(url.clone())
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -381,7 +381,7 @@ mod tests {
         // Verify that a non-existent node gets a NOT_FOUND response
         let resp = Client::new()
             .delete(url)
-            .header("SplinterProtocolVersion", REGISTRY_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/maintenance/routes/actix.rs
@@ -23,7 +23,7 @@ use futures::{future::IntoFuture, Future};
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::authorization::maintenance::MaintenanceModeAuthorizationHandler,
-    ErrorResponse, AUTHORIZATION_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::{
@@ -38,7 +38,7 @@ pub fn make_maintenance_resource(auth_handler: MaintenanceModeAuthorizationHandl
     Resource::build("/authorization/maintenance")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_MAINTENANCE_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(
             Method::Get,
@@ -109,7 +109,7 @@ mod tests {
         // Check disabled
         let resp = Client::new()
             .get(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -119,7 +119,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -127,7 +127,7 @@ mod tests {
         // Check enabled
         let resp = Client::new()
             .get(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -137,7 +137,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "false")])
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -145,7 +145,7 @@ mod tests {
         // Check disabled
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -182,7 +182,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "false")])
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -192,7 +192,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -202,7 +202,7 @@ mod tests {
         let resp = Client::new()
             .post(url.clone())
             .query(&[("enabled", "true")])
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
@@ -33,7 +33,7 @@ use crate::rest_api::{
         store::{Assignment, Identity, RoleBasedAuthorizationStore},
     },
     paging::get_response_paging_info,
-    ErrorResponse, AUTHORIZATION_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::error::SendableRoleBasedAuthorizationStoreError;
@@ -48,7 +48,7 @@ pub fn make_assignments_resource(
     Resource::build("/authorization/assignments")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             list_assignments(r, web::Data::new(list_store.clone()))
@@ -67,7 +67,7 @@ pub fn make_assignment_resource(
     Resource::build("/authorization/assignments/{identity_type}/{identity}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_RBAC_ASSIGNMENTS_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             get_assignment(r, web::Data::new(get_store.clone()))
@@ -457,7 +457,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -563,7 +563,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -609,7 +609,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -679,7 +679,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -691,7 +691,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -767,7 +767,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -786,7 +786,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "identity": "Bob",
                 "identity_type": "user",
@@ -870,7 +870,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -896,7 +896,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -941,7 +941,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -974,7 +974,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1054,7 +1054,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "roles": ["role-1"]
             }))
@@ -1065,7 +1065,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1091,7 +1091,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "roles": ["role-2"]
             }))
@@ -1102,7 +1102,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1195,7 +1195,7 @@ mod tests {
 
         let resp = Client::new()
             .delete(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1203,7 +1203,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -1216,7 +1216,7 @@ mod tests {
 
         let resp = Client::new()
             .delete(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1224,7 +1224,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -1233,7 +1233,7 @@ mod tests {
         // show delete is idempotent
         let resp = Client::new()
             .delete(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
@@ -34,7 +34,7 @@ use crate::rest_api::{
         store::{Role, RoleBasedAuthorizationStore},
     },
     paging::get_response_paging_info,
-    ErrorResponse, AUTHORIZATION_PROTOCOL_VERSION,
+    ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::error::SendableRoleBasedAuthorizationStoreError;
@@ -50,7 +50,7 @@ pub fn make_roles_resource(
     Resource::build("/authorization/roles")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_RBAC_ROLES_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             list_roles(r, web::Data::new(list_store.clone()))
@@ -69,7 +69,7 @@ pub fn make_role_resource(
     Resource::build("/authorization/roles/{role_id}")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_RBAC_ROLE_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(Method::Get, RBAC_READ_PERMISSION, move |r, _| {
             get_role(r, web::Data::new(get_store.clone()))
@@ -409,7 +409,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -488,7 +488,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -534,7 +534,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -578,7 +578,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "role_id": "new_test_role",
                 "display_name": "New Test Display Name",
@@ -592,7 +592,7 @@ mod tests {
         // verify the role is in the list
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
 
@@ -648,7 +648,7 @@ mod tests {
 
         let resp = Client::new()
             .post(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "role_id": "test-role-1",
                 "display_name": "Doesn't matter",
@@ -704,7 +704,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -767,7 +767,7 @@ mod tests {
 
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -820,7 +820,7 @@ mod tests {
         // update the display name
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "display_name": "New Test Display Name",
             }))
@@ -831,7 +831,7 @@ mod tests {
         // verify the change
         let resp = Client::new()
             .get(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -851,7 +851,7 @@ mod tests {
         // update the permissions
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "permissions": ["new-perm-1", "new-perm-2"],
             }))
@@ -862,7 +862,7 @@ mod tests {
         // verify the change
         let resp = Client::new()
             .get(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -882,7 +882,7 @@ mod tests {
         // update both display name and permissions
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "display_name": "Better Display Name",
                 "permissions": ["updated-perm-1", "updated-perm-2"],
@@ -894,7 +894,7 @@ mod tests {
         // verify the change
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -932,7 +932,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "display_name": "New Test Display Name",
             }))
@@ -973,7 +973,7 @@ mod tests {
 
         let resp = Client::new()
             .patch(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .json(&json!({
                 "permissions": [],
             }))
@@ -1014,7 +1014,7 @@ mod tests {
 
         let resp = Client::new()
             .delete(url.clone())
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1027,7 +1027,7 @@ mod tests {
         // verify that it is idempotent
         let resp = Client::new()
             .delete(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
+++ b/libsplinter/src/rest_api/auth/authorization/routes/actix.rs
@@ -22,7 +22,7 @@ use futures::future::IntoFuture;
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
     auth::authorization::Permission,
-    AUTHORIZATION_PROTOCOL_VERSION,
+    SPLINTER_PROTOCOL_VERSION,
 };
 
 use super::{resources::PermissionResponse, AUTHORIZATION_PERMISSIONS_READ_PERMISSION};
@@ -60,7 +60,7 @@ pub fn make_permissions_resource(permissions: Vec<Permission>) -> Resource {
     Resource::build("/authorization/permissions")
         .add_request_guard(ProtocolVersionRangeGuard::new(
             AUTHORIZATION_PERMISSIONS_MIN,
-            AUTHORIZATION_PROTOCOL_VERSION,
+            SPLINTER_PROTOCOL_VERSION,
         ))
         .add_method(
             Method::Get,
@@ -119,7 +119,7 @@ mod tests {
             .expect("Failed to parse URL");
         let resp = Client::new()
             .get(url)
-            .header("SplinterProtocolVersion", AUTHORIZATION_PROTOCOL_VERSION)
+            .header("SplinterProtocolVersion", SPLINTER_PROTOCOL_VERSION)
             .send()
             .expect("Failed to perform request");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/libsplinter/src/rest_api/mod.rs
+++ b/libsplinter/src/rest_api/mod.rs
@@ -98,20 +98,16 @@ pub use actix_web_1::{
     RestApiShutdownHandle, RestResourceProvider,
 };
 
-#[cfg(feature = "admin-service")]
-pub(crate) const ADMIN_PROTOCOL_VERSION: u32 = 2;
-#[cfg(feature = "authorization")]
-pub(crate) const AUTHORIZATION_PROTOCOL_VERSION: u32 = 1;
-#[cfg(feature = "oauth")]
-pub(crate) const OAUTH_PROTOCOL_VERSION: u32 = 1;
-#[cfg(feature = "registry")]
-pub(crate) const REGISTRY_PROTOCOL_VERSION: u32 = 1;
 #[cfg(any(
+    feature = "admin-service",
+    feature = "authorization",
     feature = "biome-credentials",
     feature = "biome-key-management",
     feature = "biome-notifications",
+    feature = "oauth",
+    feature = "registry",
 ))]
-pub(crate) const BIOME_PROTOCOL_VERSION: u32 = 2;
+pub(crate) const SPLINTER_PROTOCOL_VERSION: u32 = 2;
 
 const QUERY_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b' ')


### PR DESCRIPTION
This replaces crate::rest_api::*_PROTOCOL_VERSION with a single
SPLINTER_PROTOCOL_VERSION. This is consistent with the original
intended design and the future direction of the entire Splinter REST API
being versioned as a whole (as opposed to versioned per-component).