### PR TITLE
Update base64 and glob dependency versions

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -35,7 +35,7 @@ actix-web = { version = "1.0", optional = true, default-features = false, featur
 actix-web-actors = { version = "1.0", optional = true }
 actix-web-3 = { package = "actix-web", version = "3", optional = true, features = ["openssl"] }
 awc = { version = "0.2", optional = true }
-base64 = { version = "0.12", optional = true }
+base64 = { version = "0.13", optional = true }
 bcrypt = {version = "0.10", optional = true}
 byteorder = "1"
 chrono = {version = "0.4", optional = true}

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -75,7 +75,7 @@ tempdir = "0.3"
 
 [build-dependencies]
 protoc-rust = "2.14"
-glob = "0.2"
+glob = "0.3"
 
 [features]
 default = []

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -53,7 +53,7 @@ transact = { version = "0.4", features = ["family-command", "family-command-work
 
 [build-dependencies]
 protoc-rust = "2.14"
-glob = "0.2"
+glob = "0.3"
 
 [features]
 default = ["splinter-service"]


### PR DESCRIPTION
- Update the base64 dependency version used in libsplinter to 0.13
- Update the glob build-dependency version in libscabbard and libsplinter to 0.3.