### PR TITLE
Add GHA to label pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+backport-triage:
+- '**'
+
+main:
+- '**'

--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -1,0 +1,11 @@
+name: "Label PRs"
+on:
+- pull_request_target
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
Adding the backport-triage label to new pull requests will help ensure
that changes are backported when appropriate.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>