### PR TITLE
Remove PRAGMA settings

### DIFF
--- a/libsplinter/src/store/sqlite.rs
+++ b/libsplinter/src/store/sqlite.rs
@@ -201,9 +201,6 @@ impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for ConnectionCu
         conn.batch_execute(
             r#"
             PRAGMA busy_timeout = 2000;
-            PRAGMA journal_mode = WAL;
-            PRAGMA wal_checkpoint(truncate);
-            PRAGMA synchronous = FULL;
             PRAGMA foreign_keys = ON;
             "#,
         )


### PR DESCRIPTION
This change removes the PRAGMA settings and reverts things such that those values will be the equivalent of the SQLite defaults.

Only the foreign_keys PRAGMA remains.