### PR TITLE
Fix comma separated list in splinterd

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -229,6 +229,7 @@ fn main() {
                 .long_help("Publicly-visible network endpoints")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("advertised-endpoint"),
         )
         .arg(
@@ -254,6 +255,7 @@ fn main() {
                 .long_help("Endpoints to connect to the network, protocol-prefix://ip:port")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("network-endpoint"),
         )
         .arg(
@@ -279,6 +281,7 @@ fn main() {
                 )
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("peer"),
         )
         .arg(
@@ -293,6 +296,7 @@ fn main() {
                 .help("Read-only Splinter registries")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("registry"),
         )
         .arg(
@@ -387,6 +391,7 @@ fn main() {
             .multiple(true)
             .required(false)
             .takes_value(true)
+            .use_delimiter(true)
             .help("Whitelisted domains"),
     );
 


### PR DESCRIPTION
Several options say that they take comma separated lists
but provding them did not properly split them up. Adding
`.use_delimiter(true)` fixes this issue.

For example in documentation we say this can be used for registry:

```
agunde$ splinterd --scabbard-state lmdb \
    --tls-insecure --registries file:////Users/agunde/cargill/splinter/home/registry.yaml,https://www.example.com/remote_registry.yaml -vv
```

But it results in the following error:
```
[2021-12-20 11:26:09.485] T[main] ERROR [splinterd::daemon] Failed to add read-only LocalYamlRegistry '//Users/agunde/cargill/splinter/home/registry.yaml,https://www.example.com/remote_registry.yaml': Failed to open YAML registry file '//Users/agunde/cargill/splinter/home/registry.yaml,https://www.example.com/remote_registry.yaml'
```

After adding `.use_delimiter(true)` both csv and multiple `--registries` work as expected.  