### PR TITLE
Correct rustdoc code links

### DIFF
--- a/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/mod.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides [OAuthUserSessionStore] operations implemented for a diesel backend
+//! Provides [`OAuthUserSessionStore`](crate::biome::oauth::store::OAuthUserSessionStore)
+//! operations implemented for a diesel backend
 
 pub(super) mod add_session;
 pub(super) mod get_session;

--- a/libsplinter/src/biome/oauth/store/error.rs
+++ b/libsplinter/src/biome/oauth/store/error.rs
@@ -23,7 +23,7 @@ use crate::error::{
     ConstraintViolationError, InternalError, InvalidArgumentError, InvalidStateError,
 };
 
-/// Errors that may occur during [OAuthUserSessionStore] operations.
+/// Errors that may occur during [`OAuthUserSessionStore`](super::OAuthUserSessionStore) operations.
 #[derive(Debug)]
 pub enum OAuthUserSessionStoreError {
     ConstraintViolation(ConstraintViolationError),

--- a/libsplinter/src/biome/profile/store/diesel/operations/mod.rs
+++ b/libsplinter/src/biome/profile/store/diesel/operations/mod.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides [UserProfileStore] operations implemented for a diesel backend
+//! Provides [`UserProfileStore`](crate::biome::profile::store::UserProfileStore) operations
+//! implemented for a diesel backend
 
 pub(super) mod add_profile;
 pub(super) mod get_profile;

--- a/libsplinter/src/biome/profile/store/error.rs
+++ b/libsplinter/src/biome/profile/store/error.rs
@@ -21,7 +21,7 @@ use crate::error::{
     ConstraintViolationError, InternalError, InvalidArgumentError, InvalidStateError,
 };
 
-/// Errors that may occur during [UserProfileStore] operations.
+/// Errors that may occur during [`UserProfileStore`](super::UserProfileStore) operations.
 #[derive(Debug)]
 pub enum UserProfileStoreError {
     ConstraintViolation(ConstraintViolationError),


### PR DESCRIPTION
This change corrects several rustdoc code links from one struct to another in different modules, where the linked-struct is not explicitly in a use statement.
