### PR TITLE
Backport 0.4: Fix comma separated list in splinterd

### DIFF
--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -192,6 +192,7 @@ fn main() {
                 .long_help("Publicly-visible network endpoints")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("advertised-endpoint"),
         )
         .arg(
@@ -217,6 +218,7 @@ fn main() {
                 .long_help("Endpoints to connect to the network, protocol-prefix://ip:port")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("network-endpoint"),
         )
         .arg(
@@ -239,6 +241,7 @@ fn main() {
                 .help("Endpoint that service will connect to, protocol-prefix://ip:port")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("peer"),
         )
         .arg(
@@ -247,6 +250,7 @@ fn main() {
                 .help("Read-only Splinter registries")
                 .takes_value(true)
                 .multiple(true)
+                .use_delimiter(true)
                 .alias("registry"),
         )
         .arg(
@@ -326,6 +330,7 @@ fn main() {
             .multiple(true)
             .required(false)
             .takes_value(true)
+            .use_delimiter(true)
             .help("Whitelisted domains"),
     );
 


### PR DESCRIPTION
Several options say that they take comma separated lists
but provding them did not properly split them up. Adding
`.use_delimiter(true)` fixes this issue.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>

backport of #1742