### PR TITLE
Only label PRs when they're opened

### DIFF
--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -1,6 +1,7 @@
 name: "Label PRs"
 on:
-- pull_request_target
+  pull_request_target:
+    types: [ opened, ready_for_review ]
 
 jobs:
   label_pr:


### PR DESCRIPTION
When new commits are pushed to a pull request, the synchronize action
is triggered which re-runs all GHA workflows. By limiting the activity
type to "opened" and "ready_for_review", this action will not re-apply
labels to PRs if they're updated.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>