### PR TITLE
Only label PRs when they're opened

### DIFF
--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -1,6 +1,7 @@
 name: "Label PRs"
 on:
-- pull_request_target
+  pull_request_target:
+    types: [ opened ]
 
 jobs:
   label_pr:

--- a/.github/workflows/label-prs.yaml
+++ b/.github/workflows/label-prs.yaml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/labeler@v3
       with:
-        repo-token: "${{ secrets.GH_TOKEN }}"
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
When new commits are pushed to a pull request, the synchronize action
is triggered which re-runs all GHA workflows. By limiting the activity
type to "opened", this action will not re-apply labels to PRs if
they're updated.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>