### PR TITLE
0-6: Add GHA for publishing artifacts when a tag is pushed

### DIFF
--- a/.github/workflows/0-6-publish-release.yaml
+++ b/.github/workflows/0-6-publish-release.yaml
@@ -1,0 +1,92 @@
+name: 0-6 Publish Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  slack-channel: 'alerts'
+
+jobs:
+
+  unit_test_splinter:
+    if: >-
+      github.repository_owner == 'Cargill'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Display envvars
+        run: env
+
+      - name: Install Just
+        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+
+      - name: Run tests
+        run: just ci-test
+
+  publish_docker:
+    needs: unit_test_splinter
+    if: >-
+      github.repository_owner == 'Cargill'
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Display envvars
+        run: env
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Publish release to dockerhub
+        run: |
+          git fetch --tags --force
+          ./ci/publish-docker
+        env:
+          NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
+          VERSION: AUTO_STRICT
+          CARGO_TERM_COLOR: always
+
+      - name: Notify Slack of Failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  publish_to_crates:
+    needs: unit_test_splinter
+    if: >-
+      github.repository_owner == 'Cargill'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Display envvars
+        run: env
+
+      - name: Publish release to crates
+        run: |
+          git fetch --tags --force
+          CARGO_TOKEN=${{ secrets.CARGO_TOKEN }} ./ci/publish-crates
+      - name: Notify Slack of Failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This workflow was copied from main with branch specific changes.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>