### PR TITLE
Change function signature of InvalidArgumentError::new()

### DIFF
--- a/libsplinter/src/biome/oauth/store/diesel/operations/update_session.rs
+++ b/libsplinter/src/biome/oauth/store/diesel/operations/update_session.rs
@@ -51,9 +51,8 @@ where
                     if session.subject() != existing_session.subject {
                         Err(OAuthUserSessionStoreError::InvalidArgument(
                             InvalidArgumentError::new(
-                                "session".to_string(),
-                                "Cannot update the 'subject' field for an OAuth user session"
-                                    .into(),
+                                "session",
+                                "Cannot update the 'subject' field for an OAuth user session",
                             ),
                         ))
                     } else {

--- a/libsplinter/src/biome/oauth/store/memory.rs
+++ b/libsplinter/src/biome/oauth/store/memory.rs
@@ -90,8 +90,8 @@ impl OAuthUserSessionStore for MemoryOAuthUserSessionStore {
                 if session.subject() != existing_session.subject {
                     Err(OAuthUserSessionStoreError::InvalidArgument(
                         InvalidArgumentError::new(
-                            "session".to_string(),
-                            "Cannot update the 'subject' field for an OAuth user session".into(),
+                            "session",
+                            "Cannot update the 'subject' field for an OAuth user session",
                         ),
                     ))
                 } else {

--- a/libsplinter/src/error/invalid_argument.rs
+++ b/libsplinter/src/error/invalid_argument.rs
@@ -42,11 +42,14 @@ impl InvalidArgumentError {
     /// ```
     /// use splinter::error::InvalidArgumentError;
     ///
-    /// let invalid_arg_error = InvalidArgumentError::new("arg1".to_string(), "argument too long".to_string());
+    /// let invalid_arg_error = InvalidArgumentError::new("arg1", "argument too long");
     /// assert_eq!(format!("{}", invalid_arg_error), "argument too long (arg1)");
     /// ```
-    pub fn new(argument: String, message: String) -> Self {
-        Self { argument, message }
+    pub fn new<T1: Into<String>, T2: Into<String>>(argument: T1, message: T2) -> Self {
+        Self {
+            argument: argument.into(),
+            message: message.into(),
+        }
     }
 
     /// Returns the name of the invalid argument.

--- a/libsplinter/src/oauth/mod.rs
+++ b/libsplinter/src/oauth/mod.rs
@@ -224,15 +224,15 @@ fn new_basic_client(
         ClientId::new(client_id),
         Some(ClientSecret::new(client_secret)),
         AuthUrl::new(auth_url)
-            .map_err(|err| InvalidArgumentError::new("auth_url".into(), err.to_string()))?,
+            .map_err(|err| InvalidArgumentError::new("auth_url", err.to_string()))?,
         Some(
             TokenUrl::new(token_url)
-                .map_err(|err| InvalidArgumentError::new("token_url".into(), err.to_string()))?,
+                .map_err(|err| InvalidArgumentError::new("token_url", err.to_string()))?,
         ),
     )
     .set_redirect_uri(
         RedirectUrl::new(redirect_url)
-            .map_err(|err| InvalidArgumentError::new("redirect_url".into(), err.to_string()))?,
+            .map_err(|err| InvalidArgumentError::new("redirect_url", err.to_string()))?,
     ))
 }
 

--- a/libsplinter/src/service/validation.rs
+++ b/libsplinter/src/service/validation.rs
@@ -48,10 +48,7 @@ mod test {
     impl ServiceArgValidator for ContainsFoo {
         fn validate(&self, args: &Args) -> ValidationResult {
             if !args.contains_key("foo") {
-                return Err(InvalidArgumentError::new(
-                    "foo".into(),
-                    r#""foo" is missing"#.into(),
-                ));
+                return Err(InvalidArgumentError::new("foo", r#""foo" is missing"#));
             }
 
             Ok(())
@@ -64,8 +61,8 @@ mod test {
         fn validate(&self, args: &Args) -> ValidationResult {
             if args.get("bar").map(|v| v.is_empty()).unwrap_or(true) {
                 return Err(InvalidArgumentError::new(
-                    "bar".into(),
-                    r#""bar" is missing or empty"#.into(),
+                    "bar",
+                    r#""bar" is missing or empty"#,
                 ));
             }
 
@@ -98,9 +95,8 @@ mod test {
         let mut args: Args = HashMap::new();
         args.insert("bar".into(), "yes".into());
 
-        let _expected_result: Option<Result<(), InvalidArgumentError>> = Some(Err(
-            InvalidArgumentError::new("foo".into(), "argument is missing".into()),
-        ));
+        let _expected_result: Option<Result<(), InvalidArgumentError>> =
+            Some(Err(InvalidArgumentError::new("foo", "argument is missing")));
 
         assert!(matches!(
             validators
@@ -121,9 +117,8 @@ mod test {
         args.insert("foo".into(), "one".into());
         args.insert("bar".into(), "".into());
 
-        let _expected_result: Option<Result<(), InvalidArgumentError>> = Some(Err(
-            InvalidArgumentError::new("bar".into(), "missing or empty".into()),
-        ));
+        let _expected_result: Option<Result<(), InvalidArgumentError>> =
+            Some(Err(InvalidArgumentError::new("bar", "missing or empty")));
 
         assert!(matches!(
             validators

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -486,55 +486,49 @@ pub struct ScabbardArgValidator;
 
 impl ServiceArgValidator for ScabbardArgValidator {
     fn validate(&self, args: &HashMap<String, String>) -> Result<(), InvalidArgumentError> {
-        let peer_services_str = args.get("peer_services").ok_or_else(|| {
-            InvalidArgumentError::new("peer_services".into(), "argument not provided".into())
-        })?;
+        let peer_services_str = args
+            .get("peer_services")
+            .ok_or_else(|| InvalidArgumentError::new("peer_services", "argument not provided"))?;
 
         let peer_services = parse_list(peer_services_str).map_err(|err| {
-            InvalidArgumentError::new(
-                "peer_services".into(),
-                format!("failed to parse list: {}", err,),
-            )
+            InvalidArgumentError::new("peer_services", format!("failed to parse list: {}", err,))
         })?;
 
         for service in peer_services {
             if service.is_empty() {
                 return Err(InvalidArgumentError::new(
-                    "peer_services".into(),
-                    "must provide at least one service ID".into(),
+                    "peer_services",
+                    "must provide at least one service ID",
                 ));
             }
         }
 
-        let admin_keys_str = args.get("admin_keys").ok_or_else(|| {
-            InvalidArgumentError::new("admin_keys".into(), "argument not provided".into())
-        })?;
+        let admin_keys_str = args
+            .get("admin_keys")
+            .ok_or_else(|| InvalidArgumentError::new("admin_keys", "argument not provided"))?;
 
         let admin_keys = parse_list(admin_keys_str).map_err(|err| {
-            InvalidArgumentError::new(
-                "admin_keys".into(),
-                format!("failed to parse list: {}", err,),
-            )
+            InvalidArgumentError::new("admin_keys", format!("failed to parse list: {}", err,))
         })?;
 
         for key in admin_keys {
             if key.is_empty() {
                 return Err(InvalidArgumentError::new(
-                    "admin_keys".into(),
-                    "must provide at least one admin key".into(),
+                    "admin_keys",
+                    "must provide at least one admin key",
                 ));
             }
 
             let key_bytes = parse_hex(&key).map_err(|_| {
                 InvalidArgumentError::new(
-                    "admin_keys".into(),
+                    "admin_keys",
                     format!("{:?} is not a valid hex-formatted public key", key,),
                 )
             })?;
 
             if key_bytes.len() != 33 {
                 return Err(InvalidArgumentError::new(
-                    "admin_keys".into(),
+                    "admin_keys",
                     format!("{} is not a valid public key: invalid length", key),
                 ));
             }

--- a/services/scabbard/libscabbard/src/store/transact/mod.rs
+++ b/services/scabbard/libscabbard/src/store/transact/mod.rs
@@ -73,7 +73,7 @@ impl<D: Database + Clone> CommitHashStore for TransactCommitHashStore<D> {
     fn set_current_commit_hash(&self, commit_hash: &str) -> Result<(), CommitHashStoreError> {
         let current_root_bytes = hex::parse_hex(commit_hash).map_err(|e| {
             InvalidArgumentError::new(
-                "commit_hash".into(),
+                "commit_hash",
                 format!("The commit hash provided is invalid: {}", e),
             )
         })?;


### PR DESCRIPTION
This changes InvalidArgumentError::new() to take generic Into<String>
arguments instead of String directly. This prevents the caller from
needing to call to_string() or into() explicitly in several cases.

While this is mostly compatible with existing code, it is not compatible
when the calling code was using into() because the compiler can not
determine the intermediate type in that case.