### PR TITLE
Backport 0-6: Add sqlite migration for renamed role tables

### DIFF
--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2022-01-06-160426_update_rbac_roles_permission_foreign_key/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2022-01-06-160426_update_rbac_roles_permission_foreign_key/down.sql
@@ -1,0 +1,31 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys = off;
+
+CREATE TABLE temp (
+    role_id      TEXT    NOT NULL,
+    permission   TEXT    NOT NULL,
+    PRIMARY KEY(role_id, permission),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+);
+
+INSERT INTO temp SELECT role_id,permission FROM rbac_role_permissions;
+
+DROP TABLE rbac_role_permissions;
+
+ALTER TABLE temp RENAME TO rbac_role_permissions;
+
+PRAGMA foreign_keys = on;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2022-01-06-160426_update_rbac_roles_permission_foreign_key/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2022-01-06-160426_update_rbac_roles_permission_foreign_key/up.sql
@@ -1,0 +1,31 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys = off;
+
+CREATE TABLE temp (
+    role_id      TEXT    NOT NULL,
+    permission   TEXT    NOT NULL,
+    PRIMARY KEY(role_id, permission),
+    FOREIGN KEY (role_id) REFERENCES rbac_roles(id) ON DELETE CASCADE
+);
+
+INSERT INTO temp SELECT role_id,permission FROM rbac_role_permissions;
+
+DROP TABLE rbac_role_permissions;
+
+ALTER TABLE temp RENAME TO rbac_role_permissions;
+
+PRAGMA foreign_keys = on;


### PR DESCRIPTION
sqlite does not always update the parent table references on table
renames. When the `roles` table was updated to be named `rbac_roles` the
foreign key constraint on the `role_permission' table was not updated
making it impossible to insert any new role:permission relations because
the foreign key constraint would fail.

This commit adds a database migration to update the foreign key
constraint on the `rbac_role_permissions` table to reference the
`rbac_roles` table instead of the `roles` table.

It also adds an undo sql migration that breaks it again.

Signed-off-by: Caleb Hill <hill@bitwise.io>