### PR TITLE
Run all scabbard migrations during check

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/mod.rs
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/mod.rs
@@ -57,7 +57,7 @@ pub fn any_pending_migrations(conn: &PgConnection) -> Result<bool, InternalError
     // to run the migrations, so we'll do that in a test transaction.
     let latest_version =
         conn.test_transaction::<Result<Option<String>, InternalError>, (), _>(|| {
-            Ok(match embedded_migrations::run(conn) {
+            Ok(match run_migrations(conn) {
                 Ok(_) => conn
                     .latest_run_migration_version()
                     .map_err(|err| InternalError::from_source(Box::new(err))),

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/mod.rs
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/mod.rs
@@ -57,7 +57,7 @@ pub fn any_pending_migrations(conn: &SqliteConnection) -> Result<bool, InternalE
     // to run the migrations, so we'll do that in a test transaction.
     let latest_version =
         conn.test_transaction::<Result<Option<String>, InternalError>, (), _>(|| {
-            Ok(match embedded_migrations::run(conn) {
+            Ok(match run_migrations(conn) {
                 Ok(_) => conn
                     .latest_run_migration_version()
                     .map_err(|err| InternalError::from_source(Box::new(err))),


### PR DESCRIPTION
This change updates `any_pending_migrations` for both SQLite and Postgres to include both the transact and sawtooth migrations.

Previously, it only checked the scabbard embedded migrations, but included the others in during the run_migrations phase. This would mean that `any_pending_migrations` would return false, even if there were required migrations from transact or sawtooth.
