### PR TITLE
Backport 0-6: Fix `biome/profiles` endpoint permissions in `openapi.yaml`

### DIFF
--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -1780,7 +1780,7 @@ paths:
       description: |
         List all user profiles
 
-        This endpoint requires the permission "biome.user.read".
+        This endpoint requires the permission "biome.profile.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1809,7 +1809,7 @@ paths:
       description: |
         Fetch a profile by ID
 
-        This endpoint requires the permission "biome.user.read".
+        This endpoint requires the permission "biome.profile.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"


### PR DESCRIPTION
Backport of #1772