### PR TITLE
Add quotations around user input in error

### DIFF
--- a/libsplinter/src/circuit/template/rules/create_services.rs
+++ b/libsplinter/src/circuit/template/rules/create_services.rs
@@ -44,7 +44,7 @@ impl CreateServices {
 
         if !is_valid_service_id(&self.first_service) {
             return Err(CircuitTemplateError::new(&format!(
-                "Field first_service is invalid ({}): must be a 4 character base62 string",
+                "Field first_service is invalid (\"{}\"): must be a 4 character base62 string",
                 self.first_service,
             )));
         }


### PR DESCRIPTION
The `first_service` field needs to be a 4 char base 62 string. If it
isn't an error is returned that says:

"Field first_service is invalid (abcde)"

This commit adds "" marks around the user sourced `first_service`
string to better show what constitutes the wrong string.

Like so:

"Field first_service is invalid ("abcde")"

Signed-off-by: Caleb Hill <hill@bitwise.io>