### PR TITLE
Update transact dependency to 0.4.3

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -39,7 +39,7 @@ sawtooth-sabre = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.4.2", features = ["sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.4.3", features = ["sawtooth-compat", "state-merkle-sql"] }
 
 [dependencies.sawtooth]
 version = "0.7.2"
@@ -49,7 +49,7 @@ features = ["lmdb", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
-transact = { version = "0.4", features = ["family-command", "family-command-workload", "sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.4", features = ["family-command", "family-command-transaction-builder", "sawtooth-compat", "state-merkle-sql"] }
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -113,7 +113,7 @@ mod tests {
         state::merkle::INDEXES,
     };
     use transact::{
-        families::command::workload::CommandTransactionBuilder,
+        families::command::CommandTransactionBuilder,
         protocol::command::{BytesEntry, Command, SetState},
     };
 

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -91,7 +91,7 @@ mod tests {
         state::merkle::INDEXES,
     };
     use transact::{
-        families::command::workload::CommandTransactionBuilder,
+        families::command::CommandTransactionBuilder,
         protocol::command::{BytesEntry, Command, SetState},
     };
 

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -83,7 +83,7 @@ mod tests {
         state::merkle::INDEXES,
     };
     use transact::{
-        families::command::workload::CommandTransactionBuilder,
+        families::command::CommandTransactionBuilder,
         protocol::command::{BytesEntry, Command, SetState},
     };
 

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -848,7 +848,7 @@ mod tests {
     use sawtooth::receipt::store::diesel::DieselReceiptStore;
     use transact::{
         database::{btree::BTreeDatabase, Database},
-        families::command::workload::CommandTransactionBuilder,
+        families::command::CommandTransactionBuilder,
         protocol::command::{BytesEntry, Command, SetState},
         state::merkle::INDEXES,
     };


### PR DESCRIPTION
This update requires changing the dev-dependency features for transact as the `CommandTransactionBuilder` has its own feature, and the previous location has been deprecated.
