### PR TITLE
Remove `include_str` that causes `cargo publish` to fail

### DIFF
--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![cfg_attr(feature = "benchmark", feature(test))]
-#![doc = include_str!("../../README.md")]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
When this line is preset, `cargo publish` fails with the error
error: couldn't read src/../../README.md:
No such file or directory (os error 2)

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>