### PR TITLE
Fix to_string_in_format_args lint

### DIFF
--- a/cli/src/action/database/upgrade/yaml.rs
+++ b/cli/src/action/database/upgrade/yaml.rs
@@ -122,7 +122,7 @@ pub fn import_yaml_state_to_database(
     info!("Processing import data... ");
     let result = import_store(db_store, &yaml_admin_service_store).map_err(|e| {
         CliError::ActionError(match e.source() {
-            Some(source) => format!("{}: {}", e.to_string(), source),
+            Some(source) => format!("{}: {}", e, source),
             None => e.to_string(),
         })
     })?;

--- a/examples/gameroom/daemon/src/rest_api/routes/node.rs
+++ b/examples/gameroom/daemon/src/rest_api/routes/node.rs
@@ -85,7 +85,7 @@ pub async fn list_nodes(
         request_url = format!(
             "{}&filter={}",
             request_url,
-            utf8_percent_encode(filter, QUERY_ENCODE_SET).to_string()
+            utf8_percent_encode(filter, QUERY_ENCODE_SET)
         );
     }
 

--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -373,7 +373,7 @@ impl AdminServiceShared {
                                     .map_err(|err| {
                                         AdminSharedError::SplinterStateError(format!(
                                             "Unable to convert proto Circuit to store Circuit: {}",
-                                            err.to_string()
+                                            err
                                         ))
                                     })?;
 

--- a/splinterd/src/node/builder/mod.rs
+++ b/splinterd/src/node/builder/mod.rs
@@ -251,7 +251,7 @@ impl NodeBuilder {
         let node_id = self
             .node_id
             .take()
-            .unwrap_or_else(|| format!("n{}", thread_rng().gen::<u16>().to_string()));
+            .unwrap_or_else(|| format!("n{}", thread_rng().gen::<u16>()));
 
         let context = Secp256k1Context::new();
 

--- a/splinterd/src/node_id.rs
+++ b/splinterd/src/node_id.rs
@@ -26,7 +26,7 @@ pub fn get_node_id(
 }
 
 fn get_random_node_id() -> String {
-    format!("n{}", rand::thread_rng().gen::<u16>().to_string())
+    format!("n{}", rand::thread_rng().gen::<u16>())
 }
 
 fn get_from_store(


### PR DESCRIPTION
This change fixes a lint introduced with the Rust 1.58.0 release. The lint warns of using the `to_string` function on items that implement `Display`.  This is considered redundant.

See https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args for more details.
