### PR TITLE
BACKPORT 0-6: Add sabre to default loggers

### DIFF
--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -138,7 +138,21 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 },
             ),
             (
+                "sabre_sdk".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
+            (
                 "sawtooth".to_string(),
+                UnnamedLoggerConfig {
+                    appenders: None,
+                    level: Some(log::Level::Trace),
+                },
+            ),
+            (
+                "sawtooth_sabre".to_string(),
                 UnnamedLoggerConfig {
                     appenders: None,
                     level: Some(log::Level::Trace),


### PR DESCRIPTION
Backport to 0-6 of #1795