### PR TITLE
Remove all actix 1 related compression deps

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -29,12 +29,12 @@ repository = "https://github.com/cargill/splinter"
 [dependencies]
 actix = { version = "0.8", optional = true, default-features = false }
 actix-0-10 = { package = "actix", version = "0.10", optional = true, default-features = false }
-actix-http = { version = "0.2", optional = true, features = ["flate2-zlib"] }
+actix-http = { version = "0.2", optional = true, default-features = false }
 actix-service-1-0 = { package = "actix-service", version = "1.0", optional = true }
-actix-web = { version = "1.0", optional = true, default-features = false, features = ["flate2-zlib"] }
+actix-web = { version = "1.0", optional = true, default-features = false }
 actix-web-actors = { version = "1.0", optional = true }
 actix-web-3 = { package = "actix-web", version = "3", optional = true, features = ["openssl"] }
-awc = { version = "0.2", optional = true }
+awc = { version = "0.2", optional = true, default-features = false }
 base64 = { version = "0.13", optional = true }
 bcrypt = {version = "0.10", optional = true}
 byteorder = "1"

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -25,7 +25,7 @@ description = """\
 """
 
 [dependencies]
-actix-web = { version = "1.0", optional = true, default-features = false, features = ["flate2-zlib"] }
+actix-web = { version = "1.0", optional = true, default-features = false }
 cylinder = "0.2"
 diesel = { version = "1.0", features = ["r2d2", "serde_json"], optional = true }
 diesel_migrations = { version = "1.4", optional = true }


### PR DESCRIPTION
This change removes all transient dependencies of actix-web, actix-http and awc (actix web client) for compression libraries. It both ensures that the transient dependency of brotli and the flate2 dependencies are removed.

These older libraries' dependencies may cause conflicts with library consumers that are using newer versions of the actix libraries.

As none of the current splinter clients use compressed responses, this is safe to remove.  It may be provided in the future as the rest-api is broken up into additional crates.
