### PR TITLE
Pull in SabreTransactionHandler from Transact in Scabbard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,8 @@ members = [
     "services/scabbard/cli",
     "services/scabbard/libscabbard",
 ]
+
+[patch.crates-io]
+transact = { git = "https://github.com/hyperledger/transact" }
+sabre-sdk = { git = "https://github.com/hyperledger/sawtooth-sabre" }
+sawtooth = { git = "https://github.com/hyperledger/sawtooth-lib" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,10 +44,10 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 whoami = "0.7.0"
 users = "0.11"
-transact = { version = "0.4", features = ["state-merkle-sql"] }
+transact = { version = "0.5", features = ["state-merkle-sql"] }
 
 [dependencies.sawtooth]
-version = "0.7"
+version = "0.8"
 default-features = false
 features = ["lmdb", "transaction-receipt-store"]
 

--- a/examples/gameroom/daemon/Cargo.toml
+++ b/examples/gameroom/daemon/Cargo.toml
@@ -48,14 +48,14 @@ log = "0.4"
 openssl = "0.10"
 percent-encoding = "2.0"
 protobuf = "2.23"
-sabre-sdk = "0.8"
+sabre-sdk = "0.9"
 scabbard = { path = "../../../services/scabbard/libscabbard", features = ["events"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["blocking"] }
 tokio = "0.1"
-transact = "0.4"
+transact = "0.5"
 
 [dependencies.splinter]
 path = "../../../libsplinter"

--- a/services/scabbard/cli/Cargo.toml
+++ b/services/scabbard/cli/Cargo.toml
@@ -34,8 +34,8 @@ cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 dirs = "4"
 flexi_logger = { version = "0.21", features = ["use_chrono_for_offset"] }
 log = "0.4"
-sabre-sdk = "0.8"
-transact = { version = "0.4", features = ["contract-archive"] }
+sabre-sdk = "0.9"
+transact = { version = "0.5", features = ["contract-archive"] }
 scabbard = { path = "../libscabbard", features = ["client-reqwest"], default-features=false }
 
 [features]

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -39,17 +39,17 @@ sawtooth-sabre = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.4.3", features = ["sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.5", features = ["sawtooth-compat", "state-merkle-sql", "family-sabre"] }
 
 [dependencies.sawtooth]
-version = "0.7.3"
+version = "0.8"
 optional = true
 default-features = false
 features = ["lmdb", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
-transact = { version = "0.4", features = ["family-command", "family-command-transaction-builder", "sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.5", features = ["family-command", "family-command-transaction-builder", "sawtooth-compat", "state-merkle-sql"] }
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -35,7 +35,6 @@ metrics = { version = "0.17", optional = true}
 openssl = "0.10"
 protobuf = "2.23"
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
-sawtooth-sabre = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -756,6 +756,7 @@ pub mod tests {
         }
     }
 
+    #[derive(Clone)]
     struct MockReceiptStore;
 
     impl ReceiptStore for MockReceiptStore {
@@ -803,6 +804,10 @@ pub mod tests {
             _id: Option<String>,
         ) -> Result<ReceiptIter, ReceiptStoreError> {
             unimplemented!()
+        }
+
+        fn clone_box(&self) -> Box<(dyn sawtooth::receipt::store::ReceiptStore + 'static)> {
+            Box::new(self.clone())
         }
     }
 

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -25,10 +25,6 @@ use std::time::{Duration, Instant, SystemTime};
 
 use protobuf::Message;
 use sawtooth::receipt::store::ReceiptStore;
-use sawtooth_sabre::{
-    admin::SettingsAdminPermission, handler::SabreTransactionHandler,
-    ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY,
-};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "events")]
 use splinter::events::{ParseBytes, ParseError};
@@ -37,11 +33,14 @@ use transact::families::command::CommandTransactionHandler;
 use transact::{
     context::manager::sync::ContextManager,
     execution::{adapter::static_adapter::StaticExecutionAdapter, executor::Executor},
+    families::sabre::{
+        admin::SettingsAdminPermission, handler::SabreTransactionHandler,
+        ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY,
+    },
     protocol::{
         batch::BatchPair,
         receipt::{TransactionReceipt, TransactionResult},
     },
-    sawtooth::SawtoothToTransactHandlerAdapter,
     scheduler::{serial::SerialScheduler, BatchExecutionResult, Scheduler},
     state::{
         merkle::{MerkleRadixLeafReadError, MerkleRadixLeafReader},
@@ -123,9 +122,9 @@ impl ScabbardState {
         let context_manager = ContextManager::new(Box::new(merkle_state.clone()));
         let mut executor = Executor::new(vec![Box::new(StaticExecutionAdapter::new_adapter(
             vec![
-                Box::new(SawtoothToTransactHandlerAdapter::new(
-                    SabreTransactionHandler::new(Box::new(SettingsAdminPermission)),
-                )),
+                Box::new(SabreTransactionHandler::new(Box::new(
+                    SettingsAdminPermission,
+                ))),
                 #[cfg(test)]
                 Box::new(CommandTransactionHandler::new()),
             ],

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -53,8 +53,8 @@ toml = "0.5"
 [dev-dependencies]
 openssl = { version = "0.10" }
 reqwest = { version = "0.11", features = ["blocking"] }
-sabre-sdk = "0.8"
-transact = "0.4"
+sabre-sdk = "0.9"
+transact = "0.5"
 
 [dependencies.scabbard]
 path = "../services/scabbard/libscabbard"


### PR DESCRIPTION
This PR updates the version of sawtooth, sabre-sdk, and transact
to the versions that will be included in the 0.7 release of Splinter:

transact 0.5
sawtooth 0.8
sabre-sdk 0.9

These versions are not yet released, so they are patched in the
workspace Cargo.toml to point to their main git branch.

Also pulls in SabreTransactionHandler from Transact.