### PR TITLE
Update sawtooth-lib dependency to 0.7.3

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -42,7 +42,7 @@ splinter = { path = "../../../libsplinter" }
 transact = { version = "0.4.3", features = ["sawtooth-compat", "state-merkle-sql"] }
 
 [dependencies.sawtooth]
-version = "0.7.2"
+version = "0.7.3"
 optional = true
 default-features = false
 features = ["lmdb", "transaction-receipt-store"]


### PR DESCRIPTION
This change updates the sawtooth-lib dependency for scabbard to 0.7.3. It includes a new migration to add an index for the transaction_release table, which mitigates a slow-down of processing after a large number of transactions.
