### PR TITLE
Fix error with missing root logger level from toml

### DIFF
--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -191,8 +191,11 @@ impl TryFrom<TomlUnnamedLoggerConfig> for RootConfig {
                 appenders,
                 level: level.into(),
             }),
+            (Some(appenders), None) => {
+                let level = Level::Warn;
+                Ok(Self { appenders, level })
+            }
             (None, _) => Err(ConfigError::MissingValue("root.appenders".to_string())),
-            (_, None) => Err(ConfigError::MissingValue("root.level".to_string())),
         }
     }
 }


### PR DESCRIPTION
This adds a default level to the root logger so you don't have to write it out in the config file. This new default level matches what it would be if it came from the default partial config.

Signed-off-by: Caleb Hill <hill@bitwise.io>