### PR TITLE
Add description for error_data field

### DIFF
--- a/splinterd/api/static/openapi.yaml
+++ b/splinterd/api/static/openapi.yaml
@@ -2590,6 +2590,7 @@ components:
                       type: array
                       items:
                         type: integer
+                        description: Byte array for arbitrary error data. Each byte is represented as an unsigned integer ranging from 0-255.
 
     Circuit:
       type: object


### PR DESCRIPTION
The error_data field in the openapi spec currently defines error_data as
an array of integers, which while technically accurate is misleading.
This change clarifies that the error_data field is actually an arbitrary
array of bytes, and specifically calls out the allowed ranges for these
values.

Signed-off-by: Lee Bradley <bradley@bitwise.io>