### PR TITLE
Fix admin service protocol response sender for challenge auth

### DIFF
--- a/libsplinter/src/admin/service/shared.rs
+++ b/libsplinter/src/admin/service/shared.rs
@@ -3634,7 +3634,7 @@ impl AdminServiceShared {
 }
 
 // This should never return an error since we recieved a message from this service id
-fn get_peer_token_from_service_id(
+pub fn get_peer_token_from_service_id(
     service_id: &str,
     local_node_id: &str,
 ) -> Result<PeerTokenPair, InternalError> {


### PR DESCRIPTION
The incorrect peer token was being added to the protocol agreement
map, a trust id instead of challenge. Everything would continue to
act normally until a new proposals was added that used Trust. The
AdminService would think it was already connected to the node
via trust and sending the proposal would fail because the
connection does not exist.

This PR switches the sender of the protocol response to be the
correct format, admin::public_key::PUBLIC_KEY::public_key::PUBLIC_KEY,
when using challenge authorization which fixes this issue.

To test set up to splinter nodes and create a circuit proposal using challenge. You should see the
proposal be accepted. Then submit another proposal that uses trust and verify it was accepted.

 Before this change the follow error would be seen and the proposal would not be successful

```
[2022-02-08 12:38:59.138] T[PeerInterconnect Sender] ERROR [splinter::peer::interconnect] Unable to send message to Peer: Trust ( peer_id: node2 ), Local: Trust ( peer_id: node1 ): Unable to send message to connection: requested connection cannot be found
```