### PR TITLE
BACKPORT 0-6: Fix error with missing root logger level from toml

### DIFF
--- a/splinterd/src/config/logging.rs
+++ b/splinterd/src/config/logging.rs
@@ -187,8 +187,11 @@ impl TryFrom<TomlUnnamedLoggerConfig> for RootConfig {
                 appenders,
                 level: level.into(),
             }),
+            (Some(appenders), None) => {
+                let level = Level::Warn;
+                Ok(Self { appenders, level })
+            }
             (None, _) => Err(ConfigError::MissingValue("root.appenders".to_string())),
-            (_, None) => Err(ConfigError::MissingValue("root.level".to_string())),
         }
     }
 }


### PR DESCRIPTION
The root logger should have a default level to be consistent with the
other loggers in the config file. So that you can ommit it in the config
file.

This commit adds a default level of `Warn` if the root logger
doesn't have a specified level. This matches the default config.

Backport of https://github.com/Cargill/splinter/pull/1805

Signed-off-by: Caleb Hill <hill@bitwise.io>