### PR TITLE
Archive .debs during PR builds

### DIFF
--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -26,3 +26,14 @@ jobs:
 
       - name: Test Docker Build
         run: just docker-build
+
+      - name: Copy Artifacts
+        run: docker-compose -f docker/compose/copy-debs.yaml up
+
+      - name: Archive Artifacts
+        run: zip -r splinter-pr${{ github.event.number }}.zip build/*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: splinter-pr${{ github.event.number }}
+          path: splinter-pr*.zip


### PR DESCRIPTION
Archiving .deb artifacts from PR builds will allow for faster turnaround on
PR reviews and LR testing.

The `github.event.number` variable contains the pull request number.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>