### PR TITLE
Remove sawtooth-compat from Transact dependency

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 splinter = { path = "../../../libsplinter" }
-transact = { version = "0.5", features = ["sawtooth-compat", "state-merkle-sql", "family-sabre"] }
+transact = { version = "0.5", features = ["state-merkle-sql", "family-sabre"] }
 
 [dependencies.sawtooth]
 version = "0.8"
@@ -48,7 +48,7 @@ features = ["lmdb", "transaction-receipt-store"]
 
 [dev-dependencies]
 tempdir = "0.3"
-transact = { version = "0.5", features = ["family-command", "family-command-transaction-builder", "sawtooth-compat", "state-merkle-sql"] }
+transact = { version = "0.5", features = ["family-command", "family-command-transaction-builder", "state-merkle-sql"] }
 
 [build-dependencies]
 protoc-rust = "2.14"


### PR DESCRIPTION
This was required when the Sabre handler was a
Sawtooth handler so it could work with transact.

However, now that Sabre is a transact handler it is
not required. Removing this features removes pulling
in the sawtooth-sdk.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>