### PR TITLE
Add `StoreCommand` and `StoreCommandExecutor` traits

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -127,6 +127,7 @@ experimental = [
     "registry-client-reqwest",
     "rest-api-actix-web-3",
     "service-network",
+    "store-command",
     "ws-transport",
 ]
 
@@ -179,6 +180,7 @@ rest-api-cors = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations", "store"]
 store = []
+store-command = ["store"]
 store-factory = ["store"]
 tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-1"]
 trust-authorization = []

--- a/libsplinter/src/store/command/executor/diesel/error.rs
+++ b/libsplinter/src/store/command/executor/diesel/error.rs
@@ -12,21 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-mod diesel;
-
 use crate::error::InternalError;
-use crate::store::command::StoreCommand;
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-pub use self::diesel::DieselStoreCommandExecutor;
-
-/// Provides an API for executing `StoreCommand`s
-pub trait StoreCommandExecutor {
-    type Context;
-
-    fn execute<C: StoreCommand<Context = Self::Context>>(
-        &self,
-        store_commands: Vec<C>,
-    ) -> Result<(), InternalError>;
+impl From<diesel::result::Error> for InternalError {
+    fn from(err: diesel::result::Error) -> Self {
+        InternalError::from_source(Box::new(err))
+    }
 }

--- a/libsplinter/src/store/command/executor/diesel/mod.rs
+++ b/libsplinter/src/store/command/executor/diesel/mod.rs
@@ -12,21 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-mod diesel;
+mod error;
+#[cfg(feature = "postgres")]
+mod postgres;
+#[cfg(feature = "sqlite")]
+mod sqlite;
 
-use crate::error::InternalError;
-use crate::store::command::StoreCommand;
+use ::diesel::r2d2::{ConnectionManager, Pool};
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-pub use self::diesel::DieselStoreCommandExecutor;
+pub struct DieselStoreCommandExecutor<C: diesel::Connection + 'static> {
+    conn: Pool<ConnectionManager<C>>,
+}
 
-/// Provides an API for executing `StoreCommand`s
-pub trait StoreCommandExecutor {
-    type Context;
-
-    fn execute<C: StoreCommand<Context = Self::Context>>(
-        &self,
-        store_commands: Vec<C>,
-    ) -> Result<(), InternalError>;
+impl<C: diesel::Connection> DieselStoreCommandExecutor<C> {
+    pub fn new(conn: Pool<ConnectionManager<C>>) -> Self {
+        DieselStoreCommandExecutor { conn }
+    }
 }

--- a/libsplinter/src/store/command/executor/diesel/postgres.rs
+++ b/libsplinter/src/store/command/executor/diesel/postgres.rs
@@ -12,21 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-mod diesel;
+use diesel::{pg::PgConnection, Connection};
 
 use crate::error::InternalError;
-use crate::store::command::StoreCommand;
+use crate::store::command::{DieselStoreCommandExecutor, StoreCommand, StoreCommandExecutor};
 
-#[cfg(any(feature = "postgres", feature = "sqlite"))]
-pub use self::diesel::DieselStoreCommandExecutor;
-
-/// Provides an API for executing `StoreCommand`s
-pub trait StoreCommandExecutor {
-    type Context;
+impl StoreCommandExecutor for DieselStoreCommandExecutor<PgConnection> {
+    type Context = PgConnection;
 
     fn execute<C: StoreCommand<Context = Self::Context>>(
         &self,
         store_commands: Vec<C>,
-    ) -> Result<(), InternalError>;
+    ) -> Result<(), InternalError> {
+        let conn = &*self
+            .conn
+            .get()
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        conn.transaction::<(), InternalError, _>(|| {
+            for cmd in store_commands {
+                cmd.execute(conn)?;
+            }
+            Ok(())
+        })
+    }
 }

--- a/libsplinter/src/store/command/executor/mod.rs
+++ b/libsplinter/src/store/command/executor/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Cargill Incorporated
+// Copyright 2018-2022 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! StoreCommand trait
-mod executor;
-
-pub use executor::StoreCommandExecutor;
-
 use crate::error::InternalError;
+use crate::store::command::StoreCommand;
 
-/// Trait for defining a command
-///
-/// A command will contain information that is to be applied to a database
-pub trait StoreCommand {
+/// Provides an API for executing `StoreCommand`s
+pub trait StoreCommandExecutor {
     type Context;
 
-    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError>;
+    fn execute<C: StoreCommand<Context = Self::Context>>(
+        &self,
+        store_commands: Vec<C>,
+    ) -> Result<(), InternalError>;
 }

--- a/libsplinter/src/store/command/mod.rs
+++ b/libsplinter/src/store/command/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! StoreCommand trait
+
+use crate::error::InternalError;
+
+/// Trait for defining a command
+///
+/// A command will contain information that is to be applied to a database
+pub trait StoreCommand {
+    type Context;
+
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError>;
+}

--- a/libsplinter/src/store/command/mod.rs
+++ b/libsplinter/src/store/command/mod.rs
@@ -15,6 +15,8 @@
 //! StoreCommand trait
 mod executor;
 
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub use executor::DieselStoreCommandExecutor;
 pub use executor::StoreCommandExecutor;
 
 use crate::error::InternalError;

--- a/libsplinter/src/store/mod.rs
+++ b/libsplinter/src/store/mod.rs
@@ -14,6 +14,8 @@
 
 //! Contains a `StoreFactory` trait, which is an abstract factory for building stores
 //! backed by a single storage mechanism (e.g. database)
+#[cfg(feature = "store-command")]
+pub mod command;
 #[cfg(all(feature = "store-factory", feature = "memory"))]
 pub mod memory;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]


### PR DESCRIPTION
- Add a `command` sub-module to the libsplinter `store` module. This module contains the `StoreCommand` trait.
- Add a `StoreCommandExecutor` trait to the `store::command::executor` module in libsplinter. Add a `DieselStoreCommandExecutor` that implement the `StoreCommandExecutor` trait for postgres and sqlite.