### PR TITLE
Update `splinter circuit show` CLI command

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -275,6 +275,12 @@ impl fmt::Display for CircuitSlice {
             if let Some(public_key) = &member.public_key {
                 display_string += &format!("        Public Key: {}\n", public_key);
             }
+
+            display_string += &"        Endpoints:\n".to_string();
+            for endpoint in member.endpoints.iter() {
+                display_string += &format!("            {}\n", endpoint);
+            }
+
             for service in self.roster.iter() {
                 if member.node_id == service.node_id {
                     display_string += &format!(


### PR DESCRIPTION
Update the splinter circuit show command to include the endpoints in the information displayed.

Below is example output of `splinter circuit show` after this change

```
Circuit: vheXq-oqMNF
    Display Name: -
    Circuit Status: Active
    Schema Version: 2
    Management Type: example2

    node1
        Public Key: <public-key>
        Endpoints:
            tcp://127.0.0.1:18044
            tcps://127.0.0.1:18045
        Service (scabbard): gsXX
          admin_keys:
              <admin-key>
          peer_services:
              gsQQ
          version:
              2

    node2
        Public Key: <public-key>
        Endpoints:
            tcps://127.0.0.1:28045
        Service (scabbard): gsQQ
          admin_keys:
              <admin-key>
          peer_services:
              gsXX
          version:
              2
```