### PR TITLE
Replace tempdir library with tempfile

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -63,7 +63,7 @@ optional = true
 [dev-dependencies]
 gag = "1"
 serial_test = "0.5"
-tempdir = "0.3"
+tempfile = "3"
 
 [features]
 default = [

--- a/cli/src/action/database/upgrade/node_id.rs
+++ b/cli/src/action/database/upgrade/node_id.rs
@@ -96,7 +96,7 @@ mod tests {
 
     use splinter::error::InternalError;
     use splinter::node_id::store::{error::NodeIdStoreError, NodeIdStore};
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
 
@@ -201,7 +201,10 @@ mod tests {
     #[test]
     // Test reading from the node_id file works as intended.
     fn test_migrate_to_db_with_file() {
-        let directory = TempDir::new("test").expect("could not create temp directory");
+        let directory = Builder::new()
+            .prefix("test")
+            .tempdir()
+            .expect("could not create temp directory");
         let path = directory.path();
         let mut file = File::create(path.join("node_id")).expect("could not open node_id file");
         write!(file, "{}", NODE_ID).expect("could not write to node_id file");
@@ -220,7 +223,10 @@ mod tests {
     #[test]
     // Test reading from an empty node_id file fails how we expect it to.
     fn test_migrate_from_empty_file() {
-        let directory = TempDir::new("test").expect("could not create temp directory");
+        let directory = Builder::new()
+            .prefix("test")
+            .tempdir()
+            .expect("could not create temp directory");
         let path = directory.path();
         File::create(path.join("node_id")).expect("could not open node_id file");
         let empty_store = MockNodeIdStore::new(None);
@@ -238,7 +244,10 @@ mod tests {
     // Test migrating to a store with values doesn't overwrite its contained value or move the
     // node_id file.
     fn test_migrate_to_store_with_value() {
-        let directory = TempDir::new("test").expect("could not create temp directory");
+        let directory = Builder::new()
+            .prefix("test")
+            .tempdir()
+            .expect("could not create temp directory");
         let path = directory.path();
         let mut file = File::create(path.join("node_id")).expect("could not open node_id file");
         write!(file, "{}", NODE_ID).expect("could not write to node_id file");

--- a/cli/src/action/database/upgrade/yaml.rs
+++ b/cli/src/action/database/upgrade/yaml.rs
@@ -192,7 +192,7 @@ mod action_tests {
     use std::io::Write;
     use std::path::Path;
 
-    use tempdir::TempDir;
+    use tempfile::{Builder, TempDir};
 
     use diesel::r2d2::{ConnectionManager, Pool};
     use diesel::sqlite::SqliteConnection;
@@ -330,7 +330,10 @@ proposals:
     #[test]
     fn test_import_command_files_do_not_exist_aborts() {
         // Create only the temporary directory, but no state files
-        let temp_dir = TempDir::new("test_no_files").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_no_files")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let pool = create_connection_pool_and_migrate();
         let db_store = DieselAdminServiceStore::new(pool);
@@ -358,7 +361,10 @@ proposals:
     }
 
     fn create_temp_files_from_data(circuits: &[u8], proposals: &[u8]) -> TempData {
-        let temp_dir = TempDir::new("test_read_existing_files").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_existing_files")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuits_path = temp_dir
             .path()
             .join(CIRCUITS_FILE)

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -71,7 +71,7 @@ uuid = { version = "0.8", features = ["v4", "v5"] }
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-tempdir = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/libsplinter/src/admin/store/yaml/mod.rs
+++ b/libsplinter/src/admin/store/yaml/mod.rs
@@ -1853,7 +1853,7 @@ impl From<YamlCircuitStatus> for CircuitStatus {
 mod tests {
     use std::io::Read;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use super::*;
 
@@ -1954,7 +1954,10 @@ proposals:
     // 3. Validate that the circuit and proposals YAMLfiles were created in the temp dir.
     #[test]
     fn test_write_new_files() {
-        let temp_dir = TempDir::new("test_write_new_files").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_write_new_files")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -1991,7 +1994,10 @@ proposals:
     #[test]
     fn test_read_existing_files() {
         // create temp dir
-        let temp_dir = TempDir::new("test_read_existing_files").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_existing_files")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -2039,7 +2045,10 @@ proposals:
     #[test]
     fn test_proposals() {
         // create temp dir
-        let temp_dir = TempDir::new("test_proposals").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_proposals")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -2155,7 +2164,10 @@ proposals:
     #[test]
     fn test_circuit() {
         // create temp dir
-        let temp_dir = TempDir::new("test_circuit").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_circuit")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -2321,7 +2333,10 @@ proposals:
     #[test]
     fn test_node() {
         // create temp dir
-        let temp_dir = TempDir::new("test_node").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_node")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -2383,7 +2398,10 @@ proposals:
     #[test]
     fn test_service() {
         // create temp dir
-        let temp_dir = TempDir::new("test_service").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_service")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")
@@ -2474,8 +2492,10 @@ proposals:
     #[test]
     fn test_upgrading_proposals_to_circuit() {
         // create temp dir
-        let temp_dir =
-            TempDir::new("est_upgrading_proposals_to_circuit").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("est_upgrading_proposals_to_circuit")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let circuit_path = temp_dir
             .path()
             .join("circuits.yaml")

--- a/libsplinter/src/circuit/template/mod.rs
+++ b/libsplinter/src/circuit/template/mod.rs
@@ -352,7 +352,7 @@ mod test {
     use std::io::Write;
     use std::path::PathBuf;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     use crate::admin::messages::SplinterService;
 
@@ -402,7 +402,10 @@ rules:
     /// applied successfully to the `arguments`.
     #[test]
     fn test_builds_template_v1() {
-        let temp_dir = TempDir::new("test_builds_template_v1").unwrap();
+        let temp_dir = Builder::new()
+            .prefix("test_builds_template_v1")
+            .tempdir()
+            .unwrap();
         let temp_dir = temp_dir.path().to_path_buf();
         let file_path = get_file_path(temp_dir);
 
@@ -498,9 +501,9 @@ rules:
     /// find the correct template file.
     #[test]
     fn test_multiple_template_paths() {
-        let temp_dir1 = TempDir::new("test1").unwrap();
+        let temp_dir1 = Builder::new().prefix("test1").tempdir().unwrap();
         let temp_dir1 = temp_dir1.path().to_path_buf();
-        let temp_dir2 = TempDir::new("test2").unwrap();
+        let temp_dir2 = Builder::new().prefix("test2").tempdir().unwrap();
         let temp_dir2 = temp_dir2.path().to_path_buf();
 
         let manager = CircuitTemplateManager::new(&[
@@ -547,9 +550,9 @@ rules:
     /// the `CircuitTemplateManager` is able to locate multiple template files.
     #[test]
     fn test_list_available_templates() {
-        let temp_dir1 = TempDir::new("test1").unwrap();
+        let temp_dir1 = Builder::new().prefix("test1").tempdir().unwrap();
         let temp_dir1 = temp_dir1.path().to_path_buf();
-        let temp_dir2 = TempDir::new("test2").unwrap();
+        let temp_dir2 = Builder::new().prefix("test2").tempdir().unwrap();
         let temp_dir2 = temp_dir2.path().to_path_buf();
 
         // Create the manager with the multiple temporary directories.
@@ -615,7 +618,7 @@ rules:
     /// the `CircuitTemplateManager` is able to load the raw YAML from a template file.
     #[test]
     fn test_raw_yaml_string() {
-        let temp_dir1 = TempDir::new("test1").unwrap();
+        let temp_dir1 = Builder::new().prefix("test1").tempdir().unwrap();
         let temp_dir1 = temp_dir1.path().to_path_buf();
 
         // Create the manager with the temporary directory.

--- a/libsplinter/src/circuit/template/yaml_parser/mod.rs
+++ b/libsplinter/src/circuit/template/yaml_parser/mod.rs
@@ -93,7 +93,7 @@ mod test {
     use std::io::Write;
     use std::path::PathBuf;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     /// Example circuit template YAML file.
     const EXAMPLE_TEMPLATE_YAML: &[u8] = br##"version: v1
@@ -134,7 +134,10 @@ rules:
     /// expected values and that all are correctly constructed.
     #[test]
     fn test_parse_template_v1() {
-        let temp_dir = TempDir::new("test_parse_template_v1").unwrap();
+        let temp_dir = Builder::new()
+            .prefix("test_parse_template_v1")
+            .tempdir()
+            .unwrap();
         let temp_dir = temp_dir.path().to_path_buf();
         let file_path = get_file_path(temp_dir);
 

--- a/libsplinter/src/registry/yaml/local.rs
+++ b/libsplinter/src/registry/yaml/local.rs
@@ -349,13 +349,15 @@ mod test {
 
     use std::fs::{remove_file, File};
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     ///
     /// Verifies that reading from an empty YAML file still successfully returns an empty result
     #[test]
     fn test_read_empty_yaml_file() -> Result<(), Box<dyn std::error::Error>> {
-        let temp_dir = TempDir::new("test_read_yaml_duplicate_identity_error")?;
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_duplicate_identity_error")
+            .tempdir()?;
 
         let path = temp_dir
             .path()
@@ -378,7 +380,9 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_duplicate_identity_error() {
-        let temp_dir = TempDir::new("test_read_yaml_duplicate_identity_error")
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_duplicate_identity_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -410,7 +414,9 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_duplicate_endpoint_error() {
-        let temp_dir = TempDir::new("test_read_yaml_duplicate_endpoint_error")
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_duplicate_endpoint_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -442,8 +448,10 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_empty_identity_error() {
-        let temp_dir =
-            TempDir::new("test_read_yaml_empty_identity_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_empty_identity_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -473,8 +481,10 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_empty_endpoint_error() {
-        let temp_dir =
-            TempDir::new("test_read_yaml_empty_endpoint_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_empty_endpoint_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -504,7 +514,9 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_empty_display_name_error() {
-        let temp_dir = TempDir::new("test_read_yaml_empty_display_name_error")
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_empty_display_name_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -535,8 +547,10 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_empty_key_error() {
-        let temp_dir =
-            TempDir::new("test_read_yaml_empty_key_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_empty_key_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -566,7 +580,9 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_missing_endpoints_error() {
-        let temp_dir = TempDir::new("test_read_yaml_missing_endpoints_error")
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_missing_endpoints_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -597,8 +613,10 @@ mod test {
     ///
     #[test]
     fn test_read_yaml_missing_keys_error() {
-        let temp_dir =
-            TempDir::new("test_read_yaml_missing_keys_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_read_yaml_missing_keys_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -627,7 +645,10 @@ mod test {
     ///
     #[test]
     fn test_get_node_ok() {
-        let temp_dir = TempDir::new("test_get_node_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_get_node_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -651,7 +672,10 @@ mod test {
     ///
     #[test]
     fn test_get_node_not_found() {
-        let temp_dir = TempDir::new("test_get_node_not_found").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_get_node_not_found")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -675,7 +699,10 @@ mod test {
     ///
     #[test]
     fn test_has_node() {
-        let temp_dir = TempDir::new("test_has_node").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_has_node")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -700,7 +727,10 @@ mod test {
     ///
     #[test]
     fn test_list_nodes_ok() {
-        let temp_dir = TempDir::new("test_list_nodes_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_list_nodes_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -727,7 +757,10 @@ mod test {
     ///
     #[test]
     fn test_list_nodes_empty_ok() {
-        let temp_dir = TempDir::new("test_list_nodes_empty_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_list_nodes_empty_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -751,8 +784,10 @@ mod test {
     ///
     #[test]
     fn test_list_nodes_filter_metadata_ok() {
-        let temp_dir =
-            TempDir::new("test_list_nodes_filter_metadata_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_list_nodes_filter_metadata_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -783,8 +818,10 @@ mod test {
     ///
     #[test]
     fn test_list_nodes_filter_multiple_ok() {
-        let temp_dir =
-            TempDir::new("test_list_nodes_filter_multiple_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_list_nodes_filter_multiple_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -821,8 +858,10 @@ mod test {
     ///
     #[test]
     fn test_list_nodes_filter_empty_ok() {
-        let temp_dir =
-            TempDir::new("test_list_nodes_filter_empty_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_list_nodes_filter_empty_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -853,7 +892,9 @@ mod test {
     ///
     #[test]
     fn test_add_node_duplicate_endpoint_error() {
-        let temp_dir = TempDir::new("test_xv_node_duplicate_endpoint_error")
+        let temp_dir = Builder::new()
+            .prefix("test_xv_node_duplicate_endpoint_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -888,8 +929,10 @@ mod test {
     ///
     #[test]
     fn test_add_node_empty_identity_error() {
-        let temp_dir =
-            TempDir::new("test_add_node_empty_identity_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_empty_identity_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -921,8 +964,10 @@ mod test {
     ///
     #[test]
     fn test_add_node_empty_endpoint_error() {
-        let temp_dir =
-            TempDir::new("test_add_node_empty_endpoint_error").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_empty_endpoint_error")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -954,7 +999,9 @@ mod test {
     ///
     #[test]
     fn test_add_node_empty_display_name_error() {
-        let temp_dir = TempDir::new("test_add_node_missing_endpoints_error")
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_missing_endpoints_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -987,7 +1034,9 @@ mod test {
     ///
     #[test]
     fn test_add_node_empty_key_error() {
-        let temp_dir = TempDir::new("test_add_node_missing_endpoints_error")
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_missing_endpoints_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -1020,7 +1069,9 @@ mod test {
     ///
     #[test]
     fn test_add_node_missing_endpoints_error() {
-        let temp_dir = TempDir::new("test_add_node_missing_endpoints_error")
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_missing_endpoints_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -1053,7 +1104,9 @@ mod test {
     ///
     #[test]
     fn test_add_node_missing_keys_error() {
-        let temp_dir = TempDir::new("test_add_node_missing_endpoints_error")
+        let temp_dir = Builder::new()
+            .prefix("test_add_node_missing_endpoints_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -1085,7 +1138,10 @@ mod test {
     ///
     #[test]
     fn test_update_node_ok() {
-        let temp_dir = TempDir::new("test_update_node_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_update_node_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -1120,7 +1176,9 @@ mod test {
     ///
     #[test]
     fn test_update_node_duplicate_endpoint_error() {
-        let temp_dir = TempDir::new("test_xv_node_duplicate_endpoint_error")
+        let temp_dir = Builder::new()
+            .prefix("test_xv_node_duplicate_endpoint_error")
+            .tempdir()
             .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
@@ -1155,7 +1213,10 @@ mod test {
     ///
     #[test]
     fn test_delete_node_ok() {
-        let temp_dir = TempDir::new("test_delete_node_ok").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_delete_node_ok")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -1188,8 +1249,10 @@ mod test {
     ///
     #[test]
     fn test_delete_node_not_found() {
-        let temp_dir =
-            TempDir::new("test_delete_node_not_found").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_delete_node_not_found")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -1214,7 +1277,10 @@ mod test {
     ///
     #[test]
     fn test_create_file() {
-        let temp_dir = TempDir::new("test_create_file").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_create_file")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -1242,8 +1308,10 @@ mod test {
     ///
     #[test]
     fn test_reload_modified_file() {
-        let temp_dir =
-            TempDir::new("test_reload_modified_file").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_reload_modified_file")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")
@@ -1278,7 +1346,10 @@ mod test {
     ///
     #[test]
     fn test_file_removed() {
-        let temp_dir = TempDir::new("test_file_removed").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_file_removed")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("registry.yaml")

--- a/libsplinter/src/registry/yaml/remote.rs
+++ b/libsplinter/src/registry/yaml/remote.rs
@@ -437,7 +437,7 @@ mod tests {
 
     use actix_web::HttpResponse;
     use futures::future::IntoFuture;
-    use tempdir::TempDir;
+    use tempfile::{Builder, TempDir};
 
     use crate::rest_api::actix_web_1::{Method, Resource, RestApiBuilder, RestApiShutdownHandle};
     #[cfg(feature = "authorization")]
@@ -1220,7 +1220,10 @@ mod tests {
         /// `registry` to populate the remote file (if `Some`, otherwise the remote file won't be
         /// available).
         fn setup(test_name: &str, registry: Option<Vec<Node>>) -> Self {
-            let temp_dir = TempDir::new(test_name).expect("Failed to create temp dir");
+            let temp_dir = Builder::new()
+                .prefix(test_name)
+                .tempdir()
+                .expect("Failed to create temp dir");
             let temp_dir_path = temp_dir
                 .path()
                 .to_str()

--- a/libsplinter/src/rest_api/auth/authorization/allow_keys.rs
+++ b/libsplinter/src/rest_api/auth/authorization/allow_keys.rs
@@ -188,7 +188,7 @@ mod tests {
     use std::thread::sleep;
     use std::time::Duration;
 
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     const KEY1: &str = "012345";
     const KEY2: &str = "abcdef";
@@ -202,8 +202,10 @@ mod tests {
     ///    returned
     #[test]
     fn auth_handler_unexpected_identity() {
-        let temp_dir =
-            TempDir::new("auth_handler_unexpected_identity").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("auth_handler_unexpected_identity")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")
@@ -234,7 +236,10 @@ mod tests {
     ///    returned
     #[test]
     fn auth_handler_unknown_key() {
-        let temp_dir = TempDir::new("auth_handler_unknown_key").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("auth_handler_unknown_key")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")
@@ -260,7 +265,10 @@ mod tests {
     ///    returned
     #[test]
     fn auth_handler_allow() {
-        let temp_dir = TempDir::new("auth_handler_allow").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("auth_handler_allow")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")
@@ -294,7 +302,10 @@ mod tests {
     ///    returned
     #[test]
     fn reload_modified_file() {
-        let temp_dir = TempDir::new("reload_modified_file").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("reload_modified_file")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")
@@ -342,7 +353,10 @@ mod tests {
     ///    returned
     #[test]
     fn file_removed() {
-        let temp_dir = TempDir::new("file_removed").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("file_removed")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")
@@ -380,7 +394,10 @@ mod tests {
     /// 4. Call `has_permission` with the key in the file and verify that `Allow` is returned
     #[test]
     fn load_after_file_created() {
-        let temp_dir = TempDir::new("load_after_file_created").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("load_after_file_created")
+            .tempdir()
+            .expect("Failed to create temp dir");
         let path = temp_dir
             .path()
             .join("allow_keys")

--- a/libsplinter/src/transport/socket/tls.rs
+++ b/libsplinter/src/transport/socket/tls.rs
@@ -352,7 +352,7 @@ pub(crate) mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     fn write_file(mut temp_dir: PathBuf, file_name: &str, bytes: &[u8]) -> String {
         temp_dir.push(file_name);
@@ -368,7 +368,10 @@ pub(crate) mod tests {
         let (ca_key, ca_cert) = make_ca_cert();
 
         // create temp directory to store ca.cert
-        let temp_dir = TempDir::new("tls-transport-test").unwrap();
+        let temp_dir = Builder::new()
+            .prefix("tls-transport-test")
+            .tempdir()
+            .unwrap();
         let temp_dir_path = temp_dir.path();
         let ca_path_file = {
             if insecure {

--- a/libsplinter/src/transport/ws/mod.rs
+++ b/libsplinter/src/transport/ws/mod.rs
@@ -35,7 +35,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
-    use tempdir::TempDir;
+    use tempfile::{Builder, TempDir};
 
     fn write_file(mut temp_dir: PathBuf, file_name: &str, bytes: &[u8]) -> String {
         temp_dir.push(file_name);
@@ -132,7 +132,10 @@ mod tests {
 
     #[test]
     fn test_wss_transport() {
-        let temp_dir = TempDir::new("test-wss-transport").unwrap();
+        let temp_dir = Builder::new()
+            .prefix("test-wss-transport")
+            .tempdir()
+            .unwrap();
         let config = create_test_tls_config(&temp_dir, true);
         let transport = WsTransport::new(Some(&config)).unwrap();
         tests::test_transport(transport, "wss://127.0.0.1:18082");
@@ -140,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_wss_poll() {
-        let temp_dir = TempDir::new("test-wss-poll").unwrap();
+        let temp_dir = Builder::new().prefix("test-wss-poll").tempdir().unwrap();
         let config = create_test_tls_config(&temp_dir, false);
         let transport = WsTransport::new(Some(&config)).unwrap();
         tests::test_poll(transport, "wss://127.0.0.1:18083");

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -47,7 +47,6 @@ default-features = false
 features = ["lmdb", "transaction-receipt-store"]
 
 [dev-dependencies]
-tempdir = "0.3"
 transact = { version = "0.5", features = ["family-command", "family-command-transaction-builder", "state-merkle-sql"] }
 
 [build-dependencies]

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -47,13 +47,13 @@ rand = "0.8"
 sawtooth = { version = "0.7", default-features = false, optional = true }
 serde = "1.0.80"
 serde_derive = "1.0.80"
-tempdir = "0.3"
 toml = "0.5"
 
 [dev-dependencies]
 openssl = { version = "0.10" }
 reqwest = { version = "0.11", features = ["blocking"] }
 sabre-sdk = "0.9"
+tempfile = "3"
 transact = "0.5"
 
 [dependencies.scabbard]

--- a/splinterd/tests/framework/network.rs
+++ b/splinterd/tests/framework/network.rs
@@ -24,7 +24,7 @@ use splinter::threading::lifecycle::ShutdownHandle;
 use splinterd::node::{
     Node, NodeBuilder, PermissionConfig, RestApiVariant, RunnableNode, ScabbardConfigBuilder,
 };
-use tempdir::TempDir;
+use tempfile::{Builder, TempDir};
 
 use super::circuit_builder::CircuitBuilder;
 
@@ -81,7 +81,9 @@ impl Network {
             let public_key = admin_signer
                 .public_key()
                 .map_err(|e| InternalError::from_source(Box::new(e)))?;
-            let temp_dir = TempDir::new("scabbard_data")
+            let temp_dir = Builder::new()
+                .prefix("scabbard_data")
+                .tempdir()
                 .map_err(|e| InternalError::from_source(Box::new(e)))?;
             let temp_db_path = temp_dir.path().join("sqlite_receipt_store.db");
 


### PR DESCRIPTION
Replace tempdir library with tempfile:3.3 because tempdir is no longer
maintained. See advisory: https://rustsec.org/advisories/RUSTSEC-2018-0017

Remove tempdir from libscabbard, as it is unused.

Move the library to dev-dependencies in splinterd, as it is only ever used
for testing purposes.

Signed-off-by: Lee Bradley <bradley@bitwise.io>