### PR TITLE
Add service and circuit id structs

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -126,6 +126,7 @@ experimental = [
     "registry-client",
     "registry-client-reqwest",
     "rest-api-actix-web-3",
+    "service-id",
     "service-network",
     "ws-transport",
 ]
@@ -176,6 +177,7 @@ rest-api-actix-web-1 = [
 ]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
+service-id = []
 service-network = []
 sqlite = ["diesel/sqlite", "diesel_migrations", "store"]
 store = []

--- a/libsplinter/src/service/id/circuit.rs
+++ b/libsplinter/src/service/id/circuit.rs
@@ -1,0 +1,340 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of circuit identifier, CircuitId.
+
+use std::convert::TryFrom;
+use std::fmt;
+
+use rand::{distributions::Alphanumeric, Rng};
+
+use crate::error::InvalidArgumentError;
+
+// Circuit id strings are always 11 characters in length.
+const CIRCUIT_ID_STR_LEN: usize = 11;
+
+/// A circuit identifier.
+///
+/// A valid circuit identifier is a string of length 11 with the following structure:
+///
+/// - characters 0-4 are alphanumeric
+/// - character 5 is a `-`
+/// - characters 6-10 are alphanumeric
+///
+/// The circuit identifier `00000-00000` is reserved for use as the management (admin) circuit.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct CircuitId {
+    inner: Box<str>,
+}
+
+impl CircuitId {
+    /// Create a `CircuitId` from a string.
+    ///
+    /// # Arguments
+    ///
+    /// * `circuit_id` - A string representation of a circuit identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`InvalidArgumentError`] can occur when the string length is incorrect (a length of 11 is
+    /// expected) or the string contains invalid characters.
+    pub fn new<T: Into<String>>(circuit_id: T) -> Result<Self, InvalidArgumentError> {
+        CircuitId::new_box_str(circuit_id.into().into_boxed_str())
+    }
+
+    /// Creates a new `CircuitId` with a random value.
+    pub fn new_random() -> Self {
+        let mut rng = rand::thread_rng();
+
+        let mut circuit_id_str: String = std::iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(CIRCUIT_ID_STR_LEN - 1)
+            .collect();
+
+        circuit_id_str.insert(5, '-');
+
+        CircuitId {
+            inner: circuit_id_str.into(),
+        }
+    }
+
+    // Private as external API for this is to use try_from.
+    fn new_box_str(circuit_id: Box<str>) -> Result<Self, InvalidArgumentError> {
+        if circuit_id.len() != CIRCUIT_ID_STR_LEN {
+            return Err(InvalidArgumentError::new(
+                "circuit_id".to_string(),
+                format!(
+                    "incorrect length of {}, expected {}",
+                    circuit_id.len(),
+                    CIRCUIT_ID_STR_LEN
+                ),
+            ));
+        }
+
+        if !circuit_id.char_indices().all(|(i, c)| match i {
+            5 => c == '-',
+            _ => c.is_ascii_alphanumeric(),
+        }) {
+            return Err(InvalidArgumentError::new(
+                "circuit_id".to_string(),
+                "invalid characters, expected ASCII alphanumeric characters separated with a dash ('-')".to_string(),
+            ));
+        }
+
+        Ok(CircuitId { inner: circuit_id })
+    }
+
+    /// Returns a `&str` representing the value of CircuitId.
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Returns a `Box<str>`, consuming the CircuitId.
+    pub fn deconstruct(self) -> Box<str> {
+        self.inner
+    }
+}
+
+impl TryFrom<String> for CircuitId {
+    type Error = InvalidArgumentError;
+
+    fn try_from(circuit_id: String) -> Result<Self, Self::Error> {
+        CircuitId::new(circuit_id)
+    }
+}
+
+impl TryFrom<Box<str>> for CircuitId {
+    type Error = InvalidArgumentError;
+
+    fn try_from(circuit_id: Box<str>) -> Result<Self, Self::Error> {
+        CircuitId::new_box_str(circuit_id)
+    }
+}
+
+impl fmt::Display for CircuitId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::convert::{TryFrom, TryInto};
+
+    use crate::error::InvalidArgumentError;
+
+    use super::CircuitId;
+
+    /// Tests successfully creating a CircuitId from a well-formed `&str` using CircuitId::new().
+    #[test]
+    fn test_circuit_id_well_formed_new_str() {
+        let circuit_id =
+            CircuitId::new("abcde-abcde").expect("creating CircuitId from \"abcde-abcde\"");
+        assert_eq!(circuit_id.as_str(), "abcde-abcde")
+    }
+
+    /// Tests successfully creating a CircuitId from a well-formed `Box<str>` using CircuitId::new().
+    #[test]
+    fn test_circuit_id_well_formed_new_box_str() {
+        let s: Box<str> = "abcde-fghij".into();
+        let circuit_id = CircuitId::new(s).expect("creating CircuitId from \"abcde-fghij\"");
+        assert_eq!(circuit_id.as_str(), "abcde-fghij");
+    }
+
+    /// Tests successfully creating a CircuitId from a well-formed `String` using CircuitId::new().
+    #[test]
+    fn test_circuit_id_well_formed_new_string() {
+        let circuit_id = CircuitId::new(String::from("abcde-00000"))
+            .expect("creating CircuitId from \"abcde-00000\"");
+        assert_eq!(circuit_id.as_str(), "abcde-00000")
+    }
+
+    /// Tests successfully creating a CircuitId from a well-formed `String` using CircuitId::try_from().
+    #[test]
+    fn test_circuit_id_well_formed_try_from_string() {
+        let circuit_id = CircuitId::try_from(String::from("11111-abcde"))
+            .expect("creating CircuitId from \"11111-abcde\"");
+        assert_eq!(circuit_id.as_str(), "11111-abcde")
+    }
+
+    /// Tests successfully creating a CircuitId from a well-formed `String` using String::try_into().
+    #[test]
+    fn test_circuit_id_well_formed_try_into_string() {
+        let circuit_id: CircuitId = String::from("abcde-1abcd")
+            .try_into()
+            .expect("creating CircuitId from \"abcde-1abcd\"");
+        assert_eq!(circuit_id.as_str(), "abcde-1abcd")
+    }
+
+    /// Tests successfully creating a CircuitId from a well-fromed `Box<str>` using Box<str>::try_into().
+    #[test]
+    fn test_circuit_id_well_formed_from_box_str() {
+        let s: Box<str> = "abcd4-ABCDE".into();
+        let circuit_id: CircuitId = s
+            .try_into()
+            .expect("creating CircuitId from \"abcd4-ABCDE\"");
+        assert_eq!(circuit_id.as_str(), "abcd4-ABCDE")
+    }
+
+    /// Tests successfully creating a CircuitId, deconstructing, and turning it back into
+    /// a CircuitId while avoiding the need to allocate a String.
+    #[test]
+    fn test_circuit_id_round_trip_without_string() {
+        let circuit_id: CircuitId = CircuitId::new("abcde-abcde")
+            .expect("creating CircuitId from \"abcde-abcde\"")
+            .deconstruct()
+            .try_into()
+            .expect("creating CircuitId from \"abcde-abcde\"");
+        assert_eq!(circuit_id.as_str(), "abcde-abcde");
+    }
+
+    /// Tests for error creating a CircuitId with two few characters using CircuitId::new().
+    #[test]
+    fn test_circuit_id_too_short_new() {
+        assert_eq!(
+            &CircuitId::new("abcd").unwrap_err().to_string(),
+            "incorrect length of 4, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with two few characters using String::try_into().
+    #[test]
+    fn test_circuit_id_too_short_from_string() {
+        let result: Result<CircuitId, InvalidArgumentError> = String::from("abcd").try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "incorrect length of 4, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with two few characters using Box<str>::try_into().
+    #[test]
+    fn test_circuit_id_too_short_from_box_str() {
+        let s: Box<str> = "abcd".into();
+        let result: Result<CircuitId, InvalidArgumentError> = s.try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "incorrect length of 4, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with two many characters using CircuitId::new().
+    #[test]
+    fn test_circuit_id_too_long_new() {
+        assert_eq!(
+            &CircuitId::new("abcde-123456").unwrap_err().to_string(),
+            "incorrect length of 12, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with two many characters using String::try_into().
+    #[test]
+    fn test_circuit_id_too_long_from_string() {
+        let result: Result<CircuitId, InvalidArgumentError> =
+            String::from("abcdef-12345").try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "incorrect length of 12, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with two many characters using Box<str>::try_into().
+    #[test]
+    fn test_circuit_id_too_long_from_box_str() {
+        let s: Box<str> = "abcdef-abcde".into();
+        let result: Result<CircuitId, InvalidArgumentError> = s.try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "incorrect length of 12, expected 11 (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with invalid characters using CircuitId::new().
+    #[test]
+    fn test_circuit_id_invalid_characters_new() {
+        assert_eq!(
+            &CircuitId::new("abcd!-12345").unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric characters separated with a dash ('-') (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId without dash using CircuitId::new().
+    #[test]
+    fn test_circuit_id_invalid_no_dash_new() {
+        assert_eq!(
+            &CircuitId::new("abcdef12345").unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric characters separated with a dash ('-') (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with invalid characters using String::try_into().
+    #[test]
+    fn test_circuit_id_invalid_characters_from_string() {
+        let result: Result<CircuitId, InvalidArgumentError> =
+            String::from("abcd--abcde").try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric characters separated with a dash ('-') (circuit_id)",
+        );
+    }
+
+    /// Tests for error creating a CircuitId with invalid characters using Box<str>::try_into().
+    #[test]
+    fn test_circuit_id_invalid_characters_from_box_str() {
+        let s: Box<str> = "ab(de-00000".into();
+        let result: Result<CircuitId, InvalidArgumentError> = s.try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric characters separated with a dash ('-') (circuit_id)",
+        );
+    }
+
+    /// Test successfully creation CircuitIds with CircuitId::new_random().
+    ///
+    /// Calls new_random() many times and verifies that the results are reasonably random (that,
+    /// for example, we aren't getting the same CircuitId every time).
+    #[test]
+    fn test_circuit_id_new_random() {
+        const ITERATIONS: usize = 100_000;
+
+        let mut set = HashSet::new();
+
+        for _ in 0..ITERATIONS {
+            let circuit_id = CircuitId::new_random();
+            assert_eq!(circuit_id.as_str().len(), 11);
+            assert!(circuit_id.as_str().char_indices().all(|(i, c)| match i {
+                5 => c == '-',
+                _ => c.is_ascii_alphanumeric(),
+            }));
+
+            set.insert(circuit_id);
+        }
+
+        // Check that the set is of a reasonable size. Because there may be overlap due to the
+        // random nature of new_random(), we check the length of the set is greater than 90% of the
+        // number of iterations.
+        assert!(set.len() > (ITERATIONS as f32 * 0.9) as usize);
+    }
+
+    /// Test that CircuitId is displayed as its alphanumberic string of characters.
+    #[test]
+    fn test_circuit_id_display_value() {
+        let circuit_id: CircuitId = String::from("abcde-01234")
+            .try_into()
+            .expect("creating a CircuitId from \"abcde-01234\"");
+        assert_eq!(&format!("{}", circuit_id), "abcde-01234");
+    }
+}

--- a/libsplinter/src/service/id/mod.rs
+++ b/libsplinter/src/service/id/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Definitions of structs which represent circuit and service identifiers.
+
+mod circuit;
+mod qualified;
+mod service;
+
+pub use circuit::CircuitId;
+pub use qualified::FullyQualifiedServiceId;
+pub use service::ServiceId;

--- a/libsplinter/src/service/id/qualified.rs
+++ b/libsplinter/src/service/id/qualified.rs
@@ -1,0 +1,212 @@
+// Copyright 2018-2022 Cargill Incorporated
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of fully qualified service id, FullyQualifiedServiceId.
+
+use std::fmt;
+
+use crate::error::InvalidArgumentError;
+
+use super::{CircuitId, ServiceId};
+
+const CIRCUIT_ID_LEN: usize = 11;
+
+const FQSI_SEPARATOR_LEN: usize = 2;
+
+const FQSI_MINIMUM_LEN: usize = CIRCUIT_ID_LEN + FQSI_SEPARATOR_LEN + 1;
+
+/// A fully-qualified service identifier.
+///
+/// A `FullyQualifiedServiceId` consists of a [`CircuitId`] and [`ServiceId`]. The combination is
+/// considered to be fully-qualified because it contains enough context to identify a service.
+///
+/// The string representation of a fully-qualified service identifier consists of a circuit id
+/// followed by a double-colon separator "::" followed by a service id.  For example, the string
+/// "fuKi4-fhek3::93kd" is a valid fully-qualified service identifier.
+///
+/// The acronym FQSI may be used to refer to a fully-qualified service identifier.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FullyQualifiedServiceId {
+    circuit_id: CircuitId,
+    service_id: ServiceId,
+}
+
+impl FullyQualifiedServiceId {
+    /// Create a `FullyQualifiedServiceId` from a [`CircuitId`] and [`ServiceId`].
+    pub fn new(circuit_id: CircuitId, service_id: ServiceId) -> Self {
+        FullyQualifiedServiceId {
+            circuit_id,
+            service_id,
+        }
+    }
+
+    /// Create a `FullyQualifiedServiceId` by parsing a string.
+    ///
+    /// The string must be a valid circuit id followed by a "::" separator followed by a service
+    /// id.
+    pub fn new_from_string<T: AsRef<str>>(
+        fully_qualified_service_id: T,
+    ) -> Result<Self, InvalidArgumentError> {
+        let fqsi_str = fully_qualified_service_id.as_ref();
+
+        // Make sure the string is the minimum length.
+        if fqsi_str.len() < FQSI_MINIMUM_LEN {
+            return Err(InvalidArgumentError::new(
+                "fully_qualified_service_id".to_string(),
+                format!(
+                    "incorrect length of {}, expected at least {}",
+                    fqsi_str.len(),
+                    FQSI_MINIMUM_LEN,
+                ),
+            ));
+        }
+
+        // Make sure separator "::" immediately follows the circuit id.
+        if !(fqsi_str.chars().nth(CIRCUIT_ID_LEN) == Some(':')
+            && fqsi_str.chars().nth(CIRCUIT_ID_LEN + 1) == Some(':'))
+        {
+            return Err(InvalidArgumentError::new(
+                "fully_qualified_service_id".to_string(),
+                format!(
+                    "separator '::' not found at position {} of string",
+                    CIRCUIT_ID_LEN
+                ),
+            ));
+        }
+
+        // Extract the CircuitId part, or return error if it's invalid
+        let circuit_id = CircuitId::new(&fqsi_str[..CIRCUIT_ID_LEN]).map_err(|e| {
+            InvalidArgumentError::new(
+                "fully_qualified_service_id".to_string(),
+                format!("invalid circuit id part: {}", e.message()),
+            )
+        })?;
+
+        // Extract the ServiceId part, or return error if it's invalid
+        let service_id =
+            ServiceId::new(&fqsi_str[CIRCUIT_ID_LEN + FQSI_SEPARATOR_LEN..]).map_err(|e| {
+                InvalidArgumentError::new(
+                    "fully_qualified_service_id".to_string(),
+                    format!("invalid service id part: {}", e.message()),
+                )
+            })?;
+
+        Ok(FullyQualifiedServiceId {
+            circuit_id,
+            service_id,
+        })
+    }
+
+    /// Creates a new randomly generated `FullyQualifiedServiceId`.
+    pub fn new_random() -> Self {
+        FullyQualifiedServiceId {
+            circuit_id: CircuitId::new_random(),
+            service_id: ServiceId::new_random(),
+        }
+    }
+
+    /// Returns a reference to the [`CircuitId`].
+    pub fn circuit_id(&self) -> &CircuitId {
+        &self.circuit_id
+    }
+
+    /// Returns a reference to the [`ServiceId`].
+    pub fn service_id(&self) -> &ServiceId {
+        &self.service_id
+    }
+
+    /// Returns a tuple of (CircuitId, ServiceId) and consumes this struct.
+    pub fn deconstruct(self) -> (CircuitId, ServiceId) {
+        (self.circuit_id, self.service_id)
+    }
+}
+
+impl fmt::Display for FullyQualifiedServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}::{}", self.circuit_id, self.service_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CircuitId, FullyQualifiedServiceId, ServiceId};
+
+    /// Test creating a FullyQualifiedServiceId with new().
+    #[test]
+    fn test_fqsi_new() {
+        let circuit_id =
+            CircuitId::new("abcde-abcde").expect("creating CircuitId from \"abcde-abcde\"");
+        let service_id = ServiceId::new("fghi").expect("creating CircuitId from \"fghi\"");
+
+        let fqsi = FullyQualifiedServiceId::new(circuit_id.clone(), service_id.clone());
+        assert_eq!(*fqsi.circuit_id(), circuit_id);
+        assert_eq!(*fqsi.service_id(), service_id);
+    }
+
+    /// Tests parsing a string with new_from_string() works for well-formed strings.
+    #[test]
+    fn test_fqsi_new_from_string_well_formed() {
+        let fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::0011")
+            .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::0011'");
+        assert_eq!(fqsi.circuit_id().as_str(), "abcde-fghij");
+        assert_eq!(fqsi.service_id().as_str(), "0011");
+    }
+
+    /// Tests that parsing a string which is too short gives an error.
+    #[test]
+    fn test_fqsi_new_from_string_too_short() {
+        let result = FullyQualifiedServiceId::new_from_string("abcde-fghi::a");
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "incorrect length of 13, expected at least 14 (fully_qualified_service_id)"
+        );
+    }
+
+    /// Tests that parsing a string which lackes a "::" separator gives an error.
+    #[test]
+    fn test_fqsi_new_from_string_no_separator() {
+        let result = FullyQualifiedServiceId::new_from_string("abcde-fghij--0011");
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "separator '::' not found at position 11 of string (fully_qualified_service_id)"
+        );
+    }
+
+    /// Tests that parsing a string containing an invalid circuit id gives an error.
+    #[test]
+    fn test_fqsi_new_from_string_invalid_circuit_id() {
+        let result = FullyQualifiedServiceId::new_from_string("abc?e-fghij::0011");
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid circuit id part: invalid characters, expected ASCII alphanumeric characters separated with a dash ('-') (fully_qualified_service_id)"
+        );
+    }
+
+    /// Tests that parsing a string containing an invalid service id gives an error.
+    #[test]
+    fn test_fqsi_new_from_string_invalid_service_id() {
+        let result = FullyQualifiedServiceId::new_from_string("abcde-fghij::00?0");
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid service id part: invalid characters, expected ASCII alphanumeric (fully_qualified_service_id)"
+        );
+    }
+
+    /// Tests that Display is implemented to give the expected string.
+    #[test]
+    fn test_fqsi_new_from_string_display() {
+        let fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::0012")
+            .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::0012'");
+        assert_eq!(&format!("{}", fqsi), "abcde-fghij::0012");
+    }
+}

--- a/libsplinter/src/service/id/service.rs
+++ b/libsplinter/src/service/id/service.rs
@@ -1,0 +1,253 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of service identifier, ServiceId.
+
+use std::convert::TryFrom;
+use std::fmt;
+
+use rand::{distributions::Alphanumeric, Rng};
+
+use crate::error::InvalidArgumentError;
+
+/// A service identifier.
+///
+/// A service id consists of a string, with one of the following formats:
+///
+/// - 4 character alphanumeric string (non-management circuits)
+/// - a public key hex string (management circuit only)
+/// - a node identifier (management circuit only)
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ServiceId {
+    inner: Box<str>,
+}
+
+impl ServiceId {
+    /// Create a `ServiceId` from a string.
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - A alphanumeric string of representing a service identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`InvalidArgumentError`] can occur when the string contains invalid characters (only
+    /// alphanumeric characters are allowed).
+    pub fn new<T: Into<String>>(service_id: T) -> Result<Self, InvalidArgumentError> {
+        ServiceId::new_box_str(service_id.into().into_boxed_str())
+    }
+
+    /// Creates a new `ServiceId` with a random value.
+    pub fn new_random() -> Self {
+        let mut rng = rand::thread_rng();
+
+        let service_id_str: String = std::iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(4)
+            .collect();
+
+        ServiceId {
+            inner: service_id_str.into(),
+        }
+    }
+
+    // Private as external API for this is to use try_from.
+    fn new_box_str(service_id: Box<str>) -> Result<Self, InvalidArgumentError> {
+        if !service_id.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(InvalidArgumentError::new(
+                "service_id".to_string(),
+                "invalid characters, expected ASCII alphanumeric".to_string(),
+            ));
+        }
+
+        Ok(ServiceId { inner: service_id })
+    }
+
+    /// Returns a `&str` representing the value of ServiceId.
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Returns a `Box<str>`, consuming the ServiceId.
+    pub fn deconstruct(self) -> Box<str> {
+        self.inner
+    }
+}
+
+impl TryFrom<String> for ServiceId {
+    type Error = InvalidArgumentError;
+
+    fn try_from(service_id: String) -> Result<Self, Self::Error> {
+        ServiceId::new(service_id)
+    }
+}
+
+impl TryFrom<Box<str>> for ServiceId {
+    type Error = InvalidArgumentError;
+
+    fn try_from(service_id: Box<str>) -> Result<Self, Self::Error> {
+        ServiceId::new_box_str(service_id)
+    }
+}
+
+impl TryFrom<&str> for ServiceId {
+    type Error = InvalidArgumentError;
+
+    fn try_from(service_id: &str) -> Result<Self, Self::Error> {
+        ServiceId::new(service_id)
+    }
+}
+
+impl fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::convert::{TryFrom, TryInto};
+
+    use crate::error::InvalidArgumentError;
+
+    use super::ServiceId;
+
+    /// Tests successfully creating a ServiceId from a well-formed `&str` using ServiceId::new().
+    #[test]
+    fn test_service_id_well_formed_new_str() {
+        let service_id = ServiceId::new("abcd").expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd")
+    }
+
+    /// Tests successfully creating a ServiceId from a well-formed `Box<str>` using ServiceId::new().
+    #[test]
+    fn test_service_id_well_formed_new_box_str() {
+        let s: Box<str> = "abc0".into();
+        let service_id = ServiceId::new(s).expect("creating ServiceId from \"abc0\"");
+        assert_eq!(service_id.as_str(), "abc0");
+    }
+
+    /// Tests successfully creating a ServiceId from a well-formed `String` using ServiceId::new().
+    #[test]
+    fn test_service_id_well_formed_new_string() {
+        let service_id =
+            ServiceId::new(String::from("abcd")).expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd")
+    }
+
+    /// Tests successfully creating a ServiceId from a well-formed `String` using ServiceId::try_from().
+    #[test]
+    fn test_service_id_well_formed_try_from_string() {
+        let service_id =
+            ServiceId::try_from(String::from("abcd")).expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd")
+    }
+
+    /// Tests successfully creating a ServiceId from a well-formed `String` using String::try_into().
+    #[test]
+    fn test_service_id_well_formed_try_into_string() {
+        let service_id: ServiceId = String::from("abcd")
+            .try_into()
+            .expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd")
+    }
+
+    /// Tests successfully creating a ServiceId from a well-fromed `Box<str>` using Box<str>::try_into().
+    #[test]
+    fn test_service_id_well_formed_from_box_str() {
+        let s: Box<str> = "abcd".into();
+        let service_id: ServiceId = s.try_into().expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd")
+    }
+
+    /// Tests successfully creating a ServiceId, deconstructing, and turning it back into
+    /// a ServiceId while avoiding the need to allocate a String.
+    #[test]
+    fn test_service_id_round_trip_without_string() {
+        let service_id: ServiceId = ServiceId::new("abcd")
+            .expect("creating ServiceId from \"abcd\"")
+            .deconstruct()
+            .try_into()
+            .expect("creating ServiceId from \"abcd\"");
+        assert_eq!(service_id.as_str(), "abcd");
+    }
+
+    /// Tests for error creating a ServiceId with invalid characters using ServiceId::new().
+    #[test]
+    fn test_service_id_invalid_characters_new() {
+        assert_eq!(
+            &ServiceId::new("abcd!").unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric (service_id)",
+        );
+    }
+
+    /// Tests for error creating a ServiceId with invalid characters using String::try_into().
+    #[test]
+    fn test_service_id_invalid_characters_from_string() {
+        let result: Result<ServiceId, InvalidArgumentError> = String::from("a-cde").try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric (service_id)",
+        );
+    }
+
+    /// Tests for error creating a ServiceId with invalid characters using Box<str>::try_into().
+    #[test]
+    fn test_service_id_invalid_characters_from_box_str() {
+        let s: Box<str> = "ab(de".into();
+        let result: Result<ServiceId, InvalidArgumentError> = s.try_into();
+        assert_eq!(
+            &result.unwrap_err().to_string(),
+            "invalid characters, expected ASCII alphanumeric (service_id)",
+        );
+    }
+
+    /// Test successfully creation ServiceIds with ServiceId::new_random().
+    ///
+    /// Calls new_random() many times and verifies that the results are reasonably random (that,
+    /// for example, we aren't getting the same ServiceId every time).
+    #[test]
+    fn test_service_id_new_random() {
+        const ITERATIONS: usize = 100_000;
+
+        let mut set = HashSet::new();
+
+        for _ in 0..ITERATIONS {
+            let service_id = ServiceId::new_random();
+            assert_eq!(service_id.as_str().len(), 4);
+            assert!(service_id
+                .as_str()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric()));
+
+            set.insert(service_id);
+        }
+
+        // Check that the set is of a reasonable size. Because there may be overlap due to the
+        // random nature of new_random(), we check the length of the set is greater than 90% of the
+        // number of iterations.
+        assert!(set.len() > (ITERATIONS as f32 * 0.9) as usize);
+    }
+
+    /// Test that ServiceId is displayed as its alphanumberic string of characters.
+    #[test]
+    fn test_service_id_display_value() {
+        let service_id: ServiceId = String::from("abcde")
+            .try_into()
+            .expect("creating a ServiceId from \"abcde\"");
+        assert_eq!(&format!("{}", service_id), "abcde");
+    }
+}

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -37,6 +37,8 @@
 
 pub mod error;
 mod factory;
+#[cfg(feature = "service-id")]
+mod id;
 #[cfg(feature = "service-network")]
 pub mod network;
 mod processor;
@@ -49,6 +51,8 @@ use std::any::Any;
 use crate::error::InternalError;
 
 pub use factory::ServiceFactory;
+#[cfg(feature = "service-id")]
+pub use id::{CircuitId, FullyQualifiedServiceId, ServiceId};
 pub use processor::registry::StandardServiceNetworkRegistry;
 pub use processor::JoinHandles;
 pub use processor::ServiceProcessor;


### PR DESCRIPTION
Contains the following structs:

  CircuitId - represents a circuit identfiier
  ServiceId - represents a service identifier
  FullyQualifiedServiceId - contains both CircuitId and ServiceId

These structs will be used in place of strings in order to create better
APIs between components.
