### PR TITLE
Make RoutingTableReaderError publicly available

### DIFF
--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -39,7 +39,7 @@ pub mod memory;
 use std::cmp::Ordering;
 use std::fmt;
 
-use self::error::RoutingTableReaderError;
+pub use self::error::RoutingTableReaderError;
 
 use crate::error::InternalError;
 use crate::error::InvalidStateError;


### PR DESCRIPTION
This change makes the RoutingTableReaderError publicly available as it is part of the reader trait, but does not share the same visibility.
