### PR TITLE
Updates to `StoreCommand` and `StoreCommandExecutor`

### DIFF
--- a/libsplinter/src/store/command/executor/diesel/mod.rs
+++ b/libsplinter/src/store/command/executor/diesel/mod.rs
@@ -24,15 +24,29 @@ use ::diesel::r2d2::{ConnectionManager, Pool};
 
 use crate::store::pool::ConnectionPool;
 
+/// A `StoreCommandExecutor`, powered by [`Diesel`](https://crates.io/crates/diesel).
 pub struct DieselStoreCommandExecutor<C: diesel::Connection + 'static> {
     conn: ConnectionPool<C>,
 }
 
 impl<C: diesel::Connection> DieselStoreCommandExecutor<C> {
+    /// Creates a new `DieselStoreCommandExecutor`.
+    ///
+    /// # Arguments
+    ///
+    ///  * `conn`: connection pool for the database
     pub fn new(conn: Pool<ConnectionManager<C>>) -> Self {
         DieselStoreCommandExecutor { conn: conn.into() }
     }
 
+    /// Create a new `DieselStoreCommandExecutor` with write exclusivity enabled.
+    ///
+    /// Write exclusivity is enforced by providing a connection pool that is wrapped in a
+    /// [`RwLock`]. This ensures that there may be only one writer, but many readers.
+    ///
+    /// # Arguments
+    ///
+    ///  * `conn`: read-write lock-guarded connection pool for the database
     pub fn new_with_write_exclusivity(conn: Arc<RwLock<Pool<ConnectionManager<C>>>>) -> Self {
         Self { conn: conn.into() }
     }

--- a/libsplinter/src/store/command/executor/diesel/mod.rs
+++ b/libsplinter/src/store/command/executor/diesel/mod.rs
@@ -18,14 +18,22 @@ mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 
+use std::sync::{Arc, RwLock};
+
 use ::diesel::r2d2::{ConnectionManager, Pool};
 
+use crate::store::pool::ConnectionPool;
+
 pub struct DieselStoreCommandExecutor<C: diesel::Connection + 'static> {
-    conn: Pool<ConnectionManager<C>>,
+    conn: ConnectionPool<C>,
 }
 
 impl<C: diesel::Connection> DieselStoreCommandExecutor<C> {
     pub fn new(conn: Pool<ConnectionManager<C>>) -> Self {
-        DieselStoreCommandExecutor { conn }
+        DieselStoreCommandExecutor { conn: conn.into() }
+    }
+
+    pub fn new_with_write_exclusivity(conn: Arc<RwLock<Pool<ConnectionManager<C>>>>) -> Self {
+        Self { conn: conn.into() }
     }
 }

--- a/libsplinter/src/store/command/executor/diesel/postgres.rs
+++ b/libsplinter/src/store/command/executor/diesel/postgres.rs
@@ -24,16 +24,13 @@ impl StoreCommandExecutor for DieselStoreCommandExecutor<PgConnection> {
         &self,
         store_commands: Vec<C>,
     ) -> Result<(), InternalError> {
-        let conn = &*self
-            .conn
-            .get()
-            .map_err(|e| InternalError::from_source(Box::new(e)))?;
-
-        conn.transaction::<(), InternalError, _>(|| {
-            for cmd in store_commands {
-                cmd.execute(conn)?;
-            }
-            Ok(())
+        self.conn.execute_write(|conn| {
+            conn.transaction::<(), InternalError, _>(|| {
+                for cmd in store_commands {
+                    cmd.execute(conn)?;
+                }
+                Ok(())
+            })
         })
     }
 }

--- a/libsplinter/src/store/command/executor/diesel/sqlite.rs
+++ b/libsplinter/src/store/command/executor/diesel/sqlite.rs
@@ -24,16 +24,13 @@ impl StoreCommandExecutor for DieselStoreCommandExecutor<SqliteConnection> {
         &self,
         store_commands: Vec<C>,
     ) -> Result<(), InternalError> {
-        let conn = &*self
-            .conn
-            .get()
-            .map_err(|e| InternalError::from_source(Box::new(e)))?;
-
-        conn.transaction::<(), InternalError, _>(|| {
-            for cmd in store_commands {
-                cmd.execute(conn)?;
-            }
-            Ok(())
+        self.conn.execute_write(|conn| {
+            conn.transaction::<(), InternalError, _>(|| {
+                for cmd in store_commands {
+                    cmd.execute(conn)?;
+                }
+                Ok(())
+            })
         })
     }
 }

--- a/libsplinter/src/store/command/executor/mod.rs
+++ b/libsplinter/src/store/command/executor/mod.rs
@@ -30,3 +30,11 @@ pub trait StoreCommandExecutor {
         store_commands: Vec<C>,
     ) -> Result<(), InternalError>;
 }
+
+impl<C> StoreCommand for Box<dyn StoreCommand<Context = C>> {
+    type Context = C;
+
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        (&**self).execute(conn)
+    }
+}


### PR DESCRIPTION
- Add a `new_with_write_exclusivity` method to `DieselStoreCommandExecutor` which creates a new diesel backed store
command executor with write exclusivity enabled.
- Implement the `StoreCommand` trait for `Box<dyn StoreCommand<Context = C>>`