### PR TITLE
Backport 0-6: Make RoutingTableReaderError publicly available

### DIFF
--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -39,7 +39,7 @@ pub mod memory;
 use std::cmp::Ordering;
 use std::fmt;
 
-use self::error::RoutingTableReaderError;
+pub use self::error::RoutingTableReaderError;
 
 use crate::error::InternalError;
 use crate::error::InvalidStateError;


### PR DESCRIPTION
Backport of #1839 