### PR TITLE
Shutdown scabbard executor on service stop

### DIFF
--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -334,6 +334,12 @@ impl ServiceInstance for Scabbard {
             .map_err(|_| ServiceStartError::PoisonedLock("shared lock poisoned".into()))?
             .set_network_sender(service_registry.connect(self.service_id())?);
 
+        self.state
+            .lock()
+            .map_err(|_| ServiceStartError::PoisonedLock("shared lock poisoned".into()))?
+            .start_executor()
+            .map_err(|err| ServiceStartError::Internal(err.to_string()))?;
+
         // Setup consensus
         consensus.replace(
             ScabbardConsensusManager::new(
@@ -372,10 +378,14 @@ impl ServiceInstance for Scabbard {
             .take_network_sender()
             .ok_or_else(|| ServiceStopError::Internal(Box::new(ScabbardError::NotConnected)))?;
 
-        self.state
+        let mut state = self
+            .state
             .lock()
-            .map_err(|_| ServiceStopError::PoisonedLock("state lock poisoned".into()))?
-            .clear_subscribers();
+            .map_err(|_| ServiceStopError::PoisonedLock("state lock poisoned".into()))?;
+
+        state.clear_subscribers();
+
+        state.stop_executor();
 
         service_registry.disconnect(self.service_id())?;
 

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -189,6 +189,8 @@ mod tests {
             )
             .expect("Failed to initialize state");
 
+            state.start_executor().expect("Failed to start executor");
+
             let signing_context = Secp256k1Context::new();
             let signer = signing_context.new_signer(signing_context.new_random_private_key());
             let batch = CommandTransactionBuilder::new()
@@ -207,6 +209,8 @@ mod tests {
                 .prepare_change(batch)
                 .expect("Failed to prepare change");
             state.commit().expect("Failed to commit change");
+
+            state.stop_executor();
         }
 
         // Initialize scabbard

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -158,6 +158,8 @@ mod tests {
             )
             .expect("Failed to initialize state");
 
+            state.start_executor().expect("Failed to start executor");
+
             let signing_context = Secp256k1Context::new();
             let signer = signing_context.new_signer(signing_context.new_random_private_key());
             let batch = CommandTransactionBuilder::new()
@@ -174,6 +176,8 @@ mod tests {
                 .prepare_change(batch)
                 .expect("Failed to prepare change");
             state.commit().expect("Failed to commit change");
+
+            state.stop_executor();
         }
 
         // Initialize scabbard

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -148,6 +148,8 @@ mod tests {
             )
             .expect("Failed to initialize state");
 
+            state.start_executor().expect("Failed to start executor");
+
             let signing_context = Secp256k1Context::new();
             let signer = signing_context.new_signer(signing_context.new_random_private_key());
             let batch = CommandTransactionBuilder::new()
@@ -165,6 +167,9 @@ mod tests {
                 .prepare_change(batch)
                 .expect("Failed to prepare change");
             state.commit().expect("Failed to commit change");
+
+            state.stop_executor();
+
             state.current_state_root().to_string()
         };
 

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -1057,6 +1057,8 @@ mod tests {
         )
         .expect("Failed to initialize state");
 
+        state.start_executor().expect("Failed to start executor");
+
         // Set a value in state
         let address = "abcdef".to_string();
         let value = b"value".to_vec();
@@ -1093,6 +1095,8 @@ mod tests {
                 .expect("Failed to get state for unset address"),
             None,
         );
+
+        state.stop_executor();
     }
 
     /// Verify that the `ScabbardState::get_state_with_prefix` method works properly.
@@ -1129,6 +1133,8 @@ mod tests {
             vec![],
         )
         .expect("Failed to initialize state");
+
+        state.start_executor().expect("Failed to start executor");
 
         // Set some values in state
         let prefix = "abcdef".to_string();
@@ -1187,6 +1193,8 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .expect("Failed to collect entries under unset prefix");
         assert!(no_entries.is_empty());
+
+        state.stop_executor();
     }
 
     fn mock_transaction_receipt(id: &str) -> TransactionReceipt {

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -64,7 +64,7 @@ pub struct ScabbardState {
     merkle_state: merkle_state::MerkleState,
     commit_hash_store: Box<dyn CommitHashStore>,
     context_manager: ContextManager,
-    executor: Executor,
+    executor: Option<Executor>,
     current_state_root: String,
     receipt_store: Arc<dyn ReceiptStore>,
     pending_changes: Option<(String, Vec<TransactionReceipt>)>,
@@ -144,7 +144,7 @@ impl ScabbardState {
             merkle_state,
             commit_hash_store,
             context_manager,
-            executor,
+            executor: Some(executor),
             current_state_root,
             receipt_store,
             pending_changes: None,
@@ -200,6 +200,9 @@ impl ScabbardState {
     }
 
     pub fn prepare_change(&mut self, batch: BatchPair) -> Result<String, ScabbardStateError> {
+        let executor = self.executor.as_ref().ok_or_else(|| {
+            ScabbardStateError("attempting to prepare a change on a stopped service".into())
+        })?;
         // Setup the transact scheduler
         let (result_tx, result_rx) = std::sync::mpsc::channel();
         let mut scheduler = SerialScheduler::new(
@@ -215,8 +218,7 @@ impl ScabbardState {
         // Add the batch to, finalize, and execute the scheduler
         scheduler.add_batch(batch.clone())?;
         scheduler.finalize()?;
-        self.executor
-            .execute(scheduler.take_task_iterator()?, scheduler.new_notifier()?)?;
+        executor.execute(scheduler.take_task_iterator()?, scheduler.new_notifier()?)?;
 
         let mut recv_result: Option<BatchExecutionResult> = None;
 

--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -120,20 +120,6 @@ impl ScabbardState {
 
         // Initialize transact
         let context_manager = ContextManager::new(Box::new(merkle_state.clone()));
-        let mut executor = Executor::new(vec![Box::new(StaticExecutionAdapter::new_adapter(
-            vec![
-                Box::new(SabreTransactionHandler::new(Box::new(
-                    SettingsAdminPermission,
-                ))),
-                #[cfg(test)]
-                Box::new(CommandTransactionHandler::new()),
-            ],
-            context_manager.clone(),
-        )?)]);
-        executor
-            .start()
-            .map_err(|err| ScabbardStateError(format!("failed to start executor: {}", err)))?;
-
         // initialize committed_batches metric
         counter!("splinter.scabbard.committed_batches", 0,
             "circuit" => circuit_id.clone(),
@@ -144,7 +130,7 @@ impl ScabbardState {
             merkle_state,
             commit_hash_store,
             context_manager,
-            executor: Some(executor),
+            executor: None,
             current_state_root,
             receipt_store,
             pending_changes: None,


### PR DESCRIPTION
This PR updates the scabbard service to start and stop the transact executor instance with the start and stop of the service.