### PR TITLE
"store-command" stabilization updates

### DIFF
--- a/libsplinter/src/store/command/executor/mod.rs
+++ b/libsplinter/src/store/command/executor/mod.rs
@@ -25,6 +25,12 @@ pub use self::diesel::DieselStoreCommandExecutor;
 pub trait StoreCommandExecutor {
     type Context;
 
+    /// Execute each [`StoreCommand`] in `store_commands`
+    ///
+    /// # Arguments
+    ///
+    /// * `store_commands` - A list of items that implement the [`StoreCommand`]
+    ///   trait
     fn execute<C: StoreCommand<Context = Self::Context>>(
         &self,
         store_commands: Vec<C>,

--- a/libsplinter/src/store/command/mod.rs
+++ b/libsplinter/src/store/command/mod.rs
@@ -27,5 +27,10 @@ use crate::error::InternalError;
 pub trait StoreCommand {
     type Context;
 
+    /// Update the database using the provided connection
+    ///
+    /// # Arguments
+    ///
+    /// * `conn` - Connection to the database being updated
     fn execute(&self, conn: &Self::Context) -> Result<(), InternalError>;
 }


### PR DESCRIPTION
stabilization updates for the store-command feature
- Add rust docs for the execute function in both `StoreCommand` and `StoreCommandExecutor`.