### PR TITLE
Add retry to sending messages in PeerInterconnect

### DIFF
--- a/libsplinter/src/peer/error.rs
+++ b/libsplinter/src/peer/error.rs
@@ -185,25 +185,6 @@ impl fmt::Display for PeerUpdateError {
     }
 }
 
-/// Errors that could be raised by `PeerInterconnect`
-#[derive(Debug, PartialEq)]
-pub enum PeerInterconnectError {
-    /// `PeerInterconnect` start up failed
-    StartUpError(String),
-}
-
-impl error::Error for PeerInterconnectError {}
-
-impl fmt::Display for PeerInterconnectError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            PeerInterconnectError::StartUpError(msg) => {
-                write!(f, "Unable to start peer interconnect: {}", msg)
-            }
-        }
-    }
-}
-
 /// Errors that could be raised when looking up a peer
 #[derive(Debug)]
 pub struct PeerLookupError(pub String);

--- a/libsplinter/src/peer/interconnect/error.rs
+++ b/libsplinter/src/peer/interconnect/error.rs
@@ -1,0 +1,34 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error, fmt};
+
+/// Errors that could be raised by `PeerInterconnect`
+#[derive(Debug, PartialEq)]
+pub enum PeerInterconnectError {
+    /// `PeerInterconnect` start up failed
+    StartUpError(String),
+}
+
+impl error::Error for PeerInterconnectError {}
+
+impl fmt::Display for PeerInterconnectError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PeerInterconnectError::StartUpError(msg) => {
+                write!(f, "Unable to start peer interconnect: {}", msg)
+            }
+        }
+    }
+}

--- a/libsplinter/src/peer/interconnect/mod.rs
+++ b/libsplinter/src/peer/interconnect/mod.rs
@@ -21,6 +21,7 @@
 //! [`PeerInterconnect`]: struct.PeerInterconnect.html
 //! [`PeerInterconnectBuilder`]: struct.PeerInterconnectBuilder.html
 //! [`ShutdownSignaler`]: struct.ShutdownSignaler.html
+mod error;
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -40,7 +41,7 @@ use crate::transport::matrix::{
 };
 
 use super::connector::{PeerLookup, PeerLookupProvider};
-use super::error::PeerInterconnectError;
+use self::error::PeerInterconnectError;
 use super::PeerTokenPair;
 
 const DEFAULT_PENDING_QUEUE_SIZE: usize = 100;

--- a/libsplinter/src/peer/interconnect/mod.rs
+++ b/libsplinter/src/peer/interconnect/mod.rs
@@ -22,8 +22,9 @@
 //! [`PeerInterconnectBuilder`]: struct.PeerInterconnectBuilder.html
 //! [`ShutdownSignaler`]: struct.ShutdownSignaler.html
 mod error;
+mod pending;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use std::time::Instant;
@@ -36,16 +37,18 @@ use crate::protos::network::{NetworkMessage, NetworkMessageType};
 use crate::threading::lifecycle::ShutdownHandle;
 use crate::threading::pacemaker;
 use crate::transport::matrix::{
-    ConnectionMatrixEnvelope, ConnectionMatrixReceiver, ConnectionMatrixRecvError,
-    ConnectionMatrixSender,
+    ConnectionMatrixReceiver, ConnectionMatrixRecvError, ConnectionMatrixSender,
 };
 
 use super::connector::{PeerLookup, PeerLookupProvider};
-use self::error::PeerInterconnectError;
 use super::PeerTokenPair;
 
-const DEFAULT_PENDING_QUEUE_SIZE: usize = 100;
-const DEFAULT_TIME_BETWEEN_ATTEMPTS: u64 = 10; // 10 seconds
+use self::error::PeerInterconnectError;
+use self::pending::{
+    run_pending_loop, PendingIncomingMsg, PendingOutgoingMsg, RetryMessage,
+    DEFAULT_TIME_BETWEEN_ATTEMPTS,
+};
+
 const DEFAULT_INITIAL_ATTEMPTS: usize = 3; // 3 attempts
 
 /// Message to send to the network message sender with the recipient and payload
@@ -109,7 +112,7 @@ pub struct PeerInterconnect {
     recv_join_handle: thread::JoinHandle<()>,
     send_join_handle: thread::JoinHandle<()>,
     recv_pending_join_handle: thread::JoinHandle<()>,
-    pending_shutdown_sender: Sender<RetryIncoming>,
+    pending_shutdown_sender: Sender<RetryMessage>,
     pacemaker_shutdown_signaler: pacemaker::ShutdownSignaler,
 }
 
@@ -130,7 +133,7 @@ impl ShutdownHandle for PeerInterconnect {
 
         if self
             .pending_shutdown_sender
-            .send(RetryIncoming::Shutdown)
+            .send(RetryMessage::Shutdown)
             .is_err()
         {
             warn!(
@@ -282,6 +285,7 @@ where
         let recv_peer_lookup = peer_lookup_provider.peer_lookup();
         let pending_network_dispatcher_sender = network_dispatcher_sender.clone();
         let pacemaker_pending_incoming_sender = pending_incoming_sender.clone();
+        let pending_outgoing_sender = pending_incoming_sender.clone();
         let pending_shutdown_sender = pending_incoming_sender.clone();
         debug!("Starting peer interconnect receiver");
         let recv_join_handle = thread::Builder::new()
@@ -303,14 +307,22 @@ where
                 ))
             })?;
 
+        let message_sender = self
+            .message_sender
+            .take()
+            .ok_or_else(|| PeerInterconnectError::StartUpError("Already started".to_string()))?;
+
+        let pending_message_sender = message_sender.clone();
+
         let pending_recv_peer_lookup = peer_lookup_provider.peer_lookup();
         let recv_pending_join_handle = thread::Builder::new()
-            .name("PeerInterconnect Pending Recv".into())
+            .name("PeerInterconnect Pending".into())
             .spawn(move || {
-                if let Err(err) = run_pending_recv_loop(
+                if let Err(err) = run_pending_loop(
                     &*pending_recv_peer_lookup,
                     pending_incoming_receiver,
                     pending_network_dispatcher_sender,
+                    pending_message_sender,
                 ) {
                     error!("Shutting down peer interconnect pending receiver: {}", err);
                 }
@@ -323,17 +335,17 @@ where
             })?;
 
         let send_peer_lookup = peer_lookup_provider.peer_lookup();
-        let message_sender = self
-            .message_sender
-            .take()
-            .ok_or_else(|| PeerInterconnectError::StartUpError("Already started".to_string()))?;
+
         debug!("Starting peer interconnect sender");
         let send_join_handle = thread::Builder::new()
             .name("PeerInterconnect Sender".into())
             .spawn(move || {
-                if let Err(err) =
-                    run_send_loop(&*send_peer_lookup, dispatched_receiver, message_sender)
-                {
+                if let Err(err) = run_send_loop(
+                    &*send_peer_lookup,
+                    dispatched_receiver,
+                    message_sender,
+                    pending_outgoing_sender,
+                ) {
                     error!("Shutting down peer interconnect sender: {}", err);
                 }
             })
@@ -348,7 +360,7 @@ where
         let pacemaker = pacemaker::Pacemaker::builder()
             .with_interval(DEFAULT_TIME_BETWEEN_ATTEMPTS)
             .with_sender(pacemaker_pending_incoming_sender)
-            .with_message_factory(|| RetryIncoming::Retry)
+            .with_message_factory(|| RetryMessage::Retry)
             .start()
             .map_err(|err| PeerInterconnectError::StartUpError(err.to_string()))?;
 
@@ -369,7 +381,7 @@ fn run_recv_loop<R>(
     peer_connector: &dyn PeerLookup,
     message_receiver: R,
     dispatch_msg_sender: DispatchMessageSender<NetworkMessageType>,
-    pending_sender: Sender<RetryIncoming>,
+    pending_sender: Sender<RetryMessage>,
 ) -> Result<(), String>
 where
     R: ConnectionMatrixReceiver + 'static,
@@ -432,7 +444,7 @@ where
                 }
             }
         } else {
-            match pending_sender.send(RetryIncoming::Pending(PendingIncomingMsg {
+            match pending_sender.send(RetryMessage::PendingIncoming(PendingIncomingMsg {
                 envelope,
                 last_attempt: Instant::now(),
                 remaining_attempts: DEFAULT_INITIAL_ATTEMPTS,
@@ -454,6 +466,7 @@ fn run_send_loop<S>(
     peer_connector: &dyn PeerLookup,
     receiver: Receiver<SendRequest>,
     message_sender: S,
+    pending_sender: Sender<RetryMessage>,
 ) -> Result<(), String>
 where
     S: ConnectionMatrixSender + 'static,
@@ -484,11 +497,15 @@ where
             None
         };
 
+        let mut pending = None;
         // if peer exists, send message over the network
         if let Some(connection_id) = connection_id {
             // If connection is missing, check with peer manager to see if connection id has
             // changed and try to resend message. Otherwise remove cached connection_id.
-            if let Err(err) = message_sender.send(connection_id.to_string(), payload.to_vec()) {
+            if message_sender
+                .send(connection_id.to_string(), payload.to_vec())
+                .is_err()
+            {
                 if let Some(new_connection_id) =
                     peer_connector.connection_id(&recipient).map_err(|err| {
                         format!("Unable to get connection ID for {}: {}", recipient, err)
@@ -498,140 +515,44 @@ where
                     if new_connection_id != connection_id {
                         peer_id_to_connection_id
                             .insert(recipient.clone(), new_connection_id.clone());
-                        if let Err(err) = message_sender.send(new_connection_id, payload) {
-                            error!("Unable to send message to {}: {}", recipient, err);
+                        if message_sender
+                            .send(new_connection_id, payload.to_vec())
+                            .is_err()
+                        {
+                            pending = Some((recipient, payload));
                         }
                     } else {
-                        error!("Unable to send message to {}: {}", recipient, err);
                         // remove cached connection id, peer has gone away
                         peer_id_to_connection_id.remove(&recipient);
+                        pending = Some((recipient, payload));
                     }
                 } else {
-                    error!("Unable to send message to {}: {}", recipient, err);
                     // remove cached connection id, peer has gone away
                     peer_id_to_connection_id.remove(&recipient);
+                    pending = Some((recipient, payload));
                 }
             }
         } else {
-            error!("Cannot send message, unknown peer: {}", recipient);
-        }
-    }
-}
-
-/// Internal struct for keeping track of an pending message whose peer was not known at time of
-/// receipt.
-struct PendingIncomingMsg {
-    envelope: ConnectionMatrixEnvelope,
-    last_attempt: Instant,
-    remaining_attempts: usize,
-}
-
-/// Message for telling the pending_recv_loop, to check if messages should be retried, a new
-/// message was received whose peer is currently missing, or to shutdown.
-enum RetryIncoming {
-    Retry,
-    Pending(PendingIncomingMsg),
-    Shutdown,
-}
-
-/// This thread is in charge of retrying messages that were received but interconnect did not yet
-/// have a matching peer ID for the connection ID. It is possible this peer did not exist yet due
-/// to timing so it should be retried in the future. The message will be rechecked serveral
-/// times, but if the peer is not added after a configured number of attempts the message will
-/// be dropped. The number of pending queue messages is limited to a set size.
-fn run_pending_recv_loop(
-    peer_connector: &dyn PeerLookup,
-    receiver: Receiver<RetryIncoming>,
-    dispatch_msg_sender: DispatchMessageSender<NetworkMessageType>,
-) -> Result<(), String> {
-    let mut connection_id_to_peer_id: HashMap<String, PeerTokenPair> = HashMap::new();
-    let mut pending_queue = VecDeque::new();
-    loop {
-        match receiver.recv() {
-            Ok(RetryIncoming::Pending(pending)) => {
-                if pending_queue.len() > DEFAULT_PENDING_QUEUE_SIZE {
-                    warn!(
-                        "PeerInterconnect pending recv queue is to large, dropping oldest message"
-                    );
-                    pending_queue.pop_front();
-                }
-                pending_queue.push_back(pending);
-                continue;
-            }
-            Ok(RetryIncoming::Retry) => (),
-            Ok(RetryIncoming::Shutdown) => {
-                info!("Received Shutdown");
-                break Ok(());
-            }
-            Err(_) => break Err("Pending retry receiver dropped".to_string()),
-        };
-
-        let mut still_need_retry = VecDeque::new();
-        for mut pending in pending_queue.into_iter() {
-            if pending.last_attempt.elapsed().as_secs() < DEFAULT_TIME_BETWEEN_ATTEMPTS {
-                still_need_retry.push_back(pending);
-                continue;
-            }
-
-            let connection_id = pending.envelope.id().to_string();
-            let peer_id = if let Some(peer_id) = connection_id_to_peer_id.get(&connection_id) {
-                Some(peer_id.to_owned())
-            } else if let Some(peer_id) = peer_connector
-                .peer_id(&connection_id)
-                .map_err(|err| format!("Unable to get peer ID for {}: {}", connection_id, err))?
-            {
-                connection_id_to_peer_id.insert(connection_id.to_string(), peer_id.clone());
-                Some(peer_id)
-            } else {
-                None
-            };
-
-            // If we have the peer, pass message to dispatcher, otherwise check if we should drop
-            // the message
-            if let Some(peer_id) = peer_id {
-                let mut network_msg: NetworkMessage =
-                    match Message::parse_from_bytes(pending.envelope.payload()) {
-                        Ok(msg) => msg,
-                        Err(err) => {
-                            error!("Unable to dispatch message: {}", err);
-                            continue;
-                        }
-                    };
-
-                trace!(
-                    "Received message from {}({}): {:?}",
-                    peer_id,
-                    connection_id,
-                    network_msg.get_message_type()
-                );
-                match dispatch_msg_sender.send(
-                    network_msg.get_message_type(),
-                    network_msg.take_payload(),
-                    peer_id.into(),
-                ) {
-                    Ok(()) => (),
-                    Err((message_type, _, _)) => {
-                        error!("Unable to dispatch message of type {:?}", message_type)
-                    }
-                }
-            } else if pending.remaining_attempts > 0 {
-                pending.remaining_attempts -= 1;
-                debug!(
-                    "Received message from removed or unknown peer with connection_id {},\
-                         attempts left {}",
-                    connection_id, pending.remaining_attempts
-                );
-                still_need_retry.push_back(pending);
-            } else {
-                error!(
-                    "Received message from removed or unknown peer with connection_id {},\
-                    dropping",
-                    connection_id
-                );
-            }
+            pending = Some((recipient, payload));
         }
 
-        pending_queue = still_need_retry;
+        if let Some((recipient, payload)) = pending {
+            match pending_sender.send(RetryMessage::PendingOutgoing(PendingOutgoingMsg {
+                recipient: recipient.clone(),
+                payload,
+                last_attempt: Instant::now(),
+                remaining_attempts: DEFAULT_INITIAL_ATTEMPTS,
+            })) {
+                Ok(()) => debug!(
+                    "Trying to send message to removed or unknown connection with peer_id {},\
+                             adding to pending, attempts left {}",
+                    recipient, DEFAULT_INITIAL_ATTEMPTS
+                ),
+                Err(_) => {
+                    error!("Unable to send message to pending message thread");
+                }
+            }
+        }
     }
 }
 

--- a/libsplinter/src/peer/interconnect/pending.rs
+++ b/libsplinter/src/peer/interconnect/pending.rs
@@ -1,0 +1,255 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::mpsc::Receiver;
+use std::time::Instant;
+
+use protobuf::Message;
+
+use crate::network::dispatch::DispatchMessageSender;
+use crate::peer::connector::PeerLookup;
+use crate::protos::network::{NetworkMessage, NetworkMessageType};
+use crate::transport::matrix::{ConnectionMatrixEnvelope, ConnectionMatrixSender};
+
+use super::PeerTokenPair;
+
+const DEFAULT_PENDING_QUEUE_SIZE: usize = 100;
+pub const DEFAULT_TIME_BETWEEN_ATTEMPTS: u64 = 10; // 10 seconds
+
+/// Internal struct for keeping track of an pending message whose peer was not known at time of
+/// receipt.
+pub struct PendingIncomingMsg {
+    pub envelope: ConnectionMatrixEnvelope,
+    pub last_attempt: Instant,
+    pub remaining_attempts: usize,
+}
+
+/// Internal struct for keeping track of an pending outgoing message whose peer connection was not
+/// known at time of receipt.
+pub struct PendingOutgoingMsg {
+    pub recipient: PeerTokenPair,
+    pub payload: Vec<u8>,
+    pub last_attempt: Instant,
+    pub remaining_attempts: usize,
+}
+
+/// Message for telling the pending_loop, to check if messages should be retried, a new
+/// message was received whose peer is currently missing, or to shutdown.
+pub enum RetryMessage {
+    Retry,
+    PendingIncoming(PendingIncomingMsg),
+    PendingOutgoing(PendingOutgoingMsg),
+    Shutdown,
+}
+
+/// This thread is in charge of retrying messages that were received but interconnect did not yet
+/// have a matching peer ID for the connection ID. It is possible this peer did not exist yet due
+/// to timing so it should be retried in the future. The message will be rechecked serveral
+/// times, but if the peer is not added after a configured number of attempts the message will
+/// be dropped. The number of pending queue messages is limited to a set size.
+pub fn run_pending_loop<S>(
+    peer_connector: &dyn PeerLookup,
+    receiver: Receiver<RetryMessage>,
+    dispatch_msg_sender: DispatchMessageSender<NetworkMessageType>,
+
+    message_sender: S,
+) -> Result<(), String>
+where
+    S: ConnectionMatrixSender + 'static,
+{
+    let mut connection_id_to_peer_id: HashMap<String, PeerTokenPair> = HashMap::new();
+    let mut peer_id_to_connection_id: HashMap<PeerTokenPair, String> = HashMap::new();
+    let mut pending_queue_incoming = VecDeque::new();
+    let mut pending_queue_outgoing = VecDeque::new();
+    loop {
+        match receiver.recv() {
+            Ok(RetryMessage::PendingIncoming(pending)) => {
+                if pending_queue_incoming.len() > DEFAULT_PENDING_QUEUE_SIZE {
+                    warn!(
+                        "PeerInterconnect pending recv queue is to large, dropping oldest message"
+                    );
+                    pending_queue_incoming.pop_front();
+                }
+                pending_queue_incoming.push_back(pending);
+                continue;
+            }
+            Ok(RetryMessage::PendingOutgoing(pending)) => {
+                if pending_queue_outgoing.len() > DEFAULT_PENDING_QUEUE_SIZE {
+                    warn!(
+                        "PeerInterconnect pending send queue is to large, dropping oldest message"
+                    );
+                    pending_queue_outgoing.pop_front();
+                }
+                pending_queue_outgoing.push_back(pending);
+                continue;
+            }
+            Ok(RetryMessage::Retry) => (),
+            Ok(RetryMessage::Shutdown) => {
+                info!("Received Shutdown");
+                break Ok(());
+            }
+            Err(_) => break Err("Pending retry receiver dropped".to_string()),
+        };
+
+        let mut still_need_retry_incoming = VecDeque::new();
+        for mut pending in pending_queue_incoming.into_iter() {
+            if pending.last_attempt.elapsed().as_secs() < DEFAULT_TIME_BETWEEN_ATTEMPTS {
+                still_need_retry_incoming.push_back(pending);
+                continue;
+            }
+
+            let connection_id = pending.envelope.id().to_string();
+            let peer_id = if let Some(peer_id) = connection_id_to_peer_id.get(&connection_id) {
+                Some(peer_id.to_owned())
+            } else if let Some(peer_id) = peer_connector
+                .peer_id(&connection_id)
+                .map_err(|err| format!("Unable to get peer ID for {}: {}", connection_id, err))?
+            {
+                connection_id_to_peer_id.insert(connection_id.to_string(), peer_id.clone());
+                Some(peer_id)
+            } else {
+                None
+            };
+
+            // If we have the peer, pass message to dispatcher, otherwise check if we should drop
+            // the message
+            if let Some(peer_id) = peer_id {
+                let mut network_msg: NetworkMessage =
+                    match Message::parse_from_bytes(pending.envelope.payload()) {
+                        Ok(msg) => msg,
+                        Err(err) => {
+                            error!("Unable to dispatch message: {}", err);
+                            continue;
+                        }
+                    };
+
+                trace!(
+                    "Received message from {}({}): {:?}",
+                    peer_id,
+                    connection_id,
+                    network_msg.get_message_type()
+                );
+                match dispatch_msg_sender.send(
+                    network_msg.get_message_type(),
+                    network_msg.take_payload(),
+                    peer_id.into(),
+                ) {
+                    Ok(()) => (),
+                    Err((message_type, _, _)) => {
+                        error!("Unable to dispatch message of type {:?}", message_type)
+                    }
+                }
+            } else if pending.remaining_attempts > 0 {
+                pending.remaining_attempts -= 1;
+                debug!(
+                    "Received message from removed or unknown peer with connection_id {},\
+                         attempts left {}",
+                    connection_id, pending.remaining_attempts
+                );
+                still_need_retry_incoming.push_back(pending);
+            } else {
+                error!(
+                    "Received message from removed or unknown peer with connection_id {},\
+                    dropping",
+                    connection_id
+                );
+            }
+        }
+
+        pending_queue_incoming = still_need_retry_incoming;
+
+        let mut still_need_retry_outgoing = VecDeque::new();
+        for mut pending in pending_queue_outgoing.into_iter() {
+            if pending.last_attempt.elapsed().as_secs() < DEFAULT_TIME_BETWEEN_ATTEMPTS {
+                still_need_retry_outgoing.push_back(pending);
+                continue;
+            }
+
+            // convert recipient (peer_id) to connection_id
+            let connection_id = if let Some(connection_id) =
+                peer_id_to_connection_id.get(&pending.recipient)
+            {
+                Some(connection_id.to_owned())
+            } else if let Some(connection_id) = peer_connector
+                .connection_id(&pending.recipient)
+                .map_err(|err| {
+                    format!(
+                        "Unable to get connection ID for {}: {}",
+                        pending.recipient, err
+                    )
+                })?
+            {
+                peer_id_to_connection_id.insert(pending.recipient.clone(), connection_id.clone());
+                Some(connection_id)
+            } else {
+                None
+            };
+
+            // if peer exists, send message over the network
+            if let Some(connection_id) = connection_id {
+                // If connection is missing, check with peer manager to see if connection id has
+                // changed and try to resend message. Otherwise remove cached connection_id.
+                if message_sender
+                    .send(connection_id.to_string(), pending.payload.to_vec())
+                    .is_err()
+                {
+                    if let Some(new_connection_id) = peer_connector
+                        .connection_id(&pending.recipient)
+                        .map_err(|err| {
+                            format!(
+                                "Unable to get connection ID for {}: {}",
+                                &pending.recipient, err
+                            )
+                        })?
+                    {
+                        // if connection_id has changed replace it and try to send again
+                        if new_connection_id != connection_id {
+                            peer_id_to_connection_id
+                                .insert(pending.recipient.clone(), new_connection_id.clone());
+                            if message_sender
+                                .send(new_connection_id, pending.payload.to_vec())
+                                .is_ok()
+                            {
+                                // if send was sucessfully move on to next pending message
+                                continue;
+                            }
+                        }
+                    }
+                } else {
+                    // if send was sucessfully move on to next pending message
+                    continue;
+                }
+            }
+
+            // Send was not sucessful, check to see if the pending message still has retry attempts
+            // remaining
+            if pending.remaining_attempts > 0 {
+                pending.remaining_attempts -= 1;
+                debug!(
+                    "Tried to send message to removed or unknown peer with \
+                    peer_id {}, attempts left {}",
+                    pending.recipient, pending.remaining_attempts
+                );
+                still_need_retry_outgoing.push_back(pending);
+            } else {
+                error!(
+                    "Cannot send message, unknown peer: {}, dropping",
+                    pending.recipient
+                );
+            }
+        }
+        pending_queue_outgoing = still_need_retry_outgoing;
+    }
+}


### PR DESCRIPTION
This commit adds retry to sending messages to a connection by
updating the pending incoming messages loop to handle booth
incoming and outgoing messages.

Now if the PeerInterconnect receives a message that should be
sent to a Peer, but the message fails to send because the
connection has disconnected, the message will be sent to the
pending thread, where it will be retried up to 3 times, with
10 seconds in between each try.

The connection could go away because of race condition where,
duplicate connections are rectified but one side removes
the old connection before the other finishes authorization.
This change would allow for the message to be sent over the
new connection successfully.

Also fixes periodic test failures in integration test
test_2_party_circuit_duplicate_connection

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>