### PR TITLE
Add Timer for new service API 

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -138,6 +138,7 @@ experimental = [
     "service-message-sender-factory",
     "service-network",
     "service-routable",
+    "service-timer",
     "service-timer-filter",
     "service-timer-handler",
     "service-timer-handler-factory",
@@ -204,6 +205,14 @@ service-message-sender = ["service-id", "service-message-converter"]
 service-message-sender-factory = ["service-message-sender"]
 service-network = []
 service-routable = ["service-type"]
+service-timer =[
+  "service-id",
+  "service-message-sender-factory",
+  "service-routable",
+  "service-timer-filter",
+  "service-timer-handler",
+  "service-timer-handler-factory"
+]
 service-timer-filter = ["service-id"]
 service-timer-handler = ["service-id", "service-message-converter", "service-message-sender"]
 service-timer-handler-factory = ["service-timer-handler"]

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -15,6 +15,8 @@
 pub mod instance;
 #[cfg(feature = "service-lifecycle-executor")]
 mod lifecycle_executor;
+#[cfg(feature = "service-timer")]
+mod timer;
 
 #[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
 pub use lifecycle_executor::DieselLifecycleStore;
@@ -28,3 +30,5 @@ pub use lifecycle_executor::{
     LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
     LifecycleStoreError, LifecycleStoreFactory,
 };
+#[cfg(feature = "service-timer")]
+pub use timer::{Timer, TimerAlarm};

--- a/libsplinter/src/runtime/service/timer/alarm/channel.rs
+++ b/libsplinter/src/runtime/service/timer/alarm/channel.rs
@@ -1,0 +1,67 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An alarm can be used to prematurely wake all or specific message handlers
+
+use std::sync::mpsc::Sender;
+
+use crate::error::InternalError;
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+use super::{TimerAlarm, TimerMessage};
+
+pub struct ChannelTimerAlarm {
+    sender: Sender<TimerMessage>,
+}
+
+impl ChannelTimerAlarm {
+    pub fn new(sender: Sender<TimerMessage>) -> Self {
+        ChannelTimerAlarm { sender }
+    }
+}
+
+impl TimerAlarm for ChannelTimerAlarm {
+    /// Notify the `Timer` to check all `TimerFilters` for pending work
+    fn wake_up_all(&self) -> Result<(), InternalError> {
+        self.sender
+            .send(TimerMessage::WakeUpAll)
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+
+    /// Notify the `Timer` to check a specific `TimerFilter` for pending work
+    ///
+    /// # Arguments
+    ///
+    /// * `service_type` - The service type of the the filter that will be checked
+    /// * `service_id` - An optional service ID
+    ///
+    /// If a service ID is provided, only the `TimerHandler` for that ID will be run. The serivce
+    /// ID must be returned from the `TimerFilter` to show there is pending work. If ther service
+    /// ID is not returned, no handlers will be run.
+    ///
+    /// If the service ID is not provided, the handlers for all service IDs returned from the
+    /// `TimerFilter` will be run.
+    fn wake_up(
+        &self,
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    ) -> Result<(), InternalError> {
+        self.sender
+            .send(TimerMessage::WakeUp {
+                service_type,
+                service_id,
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}

--- a/libsplinter/src/runtime/service/timer/alarm/mod.rs
+++ b/libsplinter/src/runtime/service/timer/alarm/mod.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An alarm can be used to prematurely wake all or specific message handlers
+mod channel;
+
+use crate::error::InternalError;
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+use super::message::TimerMessage;
+
+pub use channel::ChannelTimerAlarm;
+
+pub trait TimerAlarm {
+    /// Notify the `Timer` to check all `TimerFilters` for pending work
+    fn wake_up_all(&self) -> Result<(), InternalError>;
+
+    /// Notify the `Timer` to check a specific `TimerFilter` for pending work
+    ///
+    /// # Arguments
+    ///
+    /// * `service_type` - The service type of the the filter that will be checked
+    /// * `service_id` - An optional service ID
+    ///
+    /// If a service ID is provided, only the `TimerHandler` for that ID will be run. The serivce
+    /// ID must be returned from the `TimerFilter` to show there is pending work. If ther service
+    /// ID is not returned, no handlers will be run.
+    ///
+    /// If the service ID is not provided, the handlers for all service IDs returned from the
+    /// `TimerFilter` will be run.
+    fn wake_up(
+        &self,
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    ) -> Result<(), InternalError>;
+}

--- a/libsplinter/src/runtime/service/timer/message.rs
+++ b/libsplinter/src/runtime/service/timer/message.rs
@@ -1,0 +1,27 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The message used by the Timer to know when to execute service handler
+
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+#[derive(Clone, Debug)]
+pub enum TimerMessage {
+    WakeUpAll,
+    WakeUp {
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    },
+    Shutdown,
+}

--- a/libsplinter/src/runtime/service/timer/mod.rs
+++ b/libsplinter/src/runtime/service/timer/mod.rs
@@ -1,0 +1,384 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains a Timer and its component for waking up service handlers that have
+//! pending messages
+
+mod alarm;
+mod message;
+mod thread;
+
+use std::sync::mpsc::{channel, Sender};
+use std::time::Duration;
+
+use crate::error::InternalError;
+use crate::service::{MessageSenderFactory, TimerFilter, TimerHandlerFactory};
+use crate::threading::{lifecycle::ShutdownHandle, pacemaker::Pacemaker};
+
+use self::alarm::ChannelTimerAlarm;
+use self::message::TimerMessage;
+use self::thread::TimerThread;
+
+pub use self::alarm::TimerAlarm;
+
+pub struct Timer {
+    pacemaker: Pacemaker,
+    sender: Sender<TimerMessage>,
+    timer_thread: TimerThread,
+}
+
+type FilterCollection = Vec<(
+    Box<dyn TimerFilter + Send>,
+    Box<dyn TimerHandlerFactory<Message = Vec<u8>>>,
+)>;
+
+/// Create a `Timer`
+///
+/// # Arguments
+///
+/// * `filters` - The collection of `TimerFilter`s and their associated `TimerHandlerFactory`
+/// * `wake_up_interval` - How often the `TimerFilter`s will be checked for pending work
+/// * `service_sender` - The `Sender` that will be used to create the `MessageSender` that will be
+///    passed to the `TimerHandlers` to send messages
+impl Timer {
+    pub fn new(
+        filters: FilterCollection,
+        wake_up_interval: Duration,
+        message_sender_factory: Box<dyn MessageSenderFactory<Vec<u8>>>,
+    ) -> Result<Timer, InternalError> {
+        let (sender, recv) = channel();
+        let pacemaker = Pacemaker::builder()
+            .with_interval(wake_up_interval.as_secs())
+            .with_sender(sender.clone())
+            .with_message_factory(|| TimerMessage::WakeUpAll)
+            .start()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let timer_thread =
+            TimerThread::start(filters, recv, message_sender_factory, sender.clone())?;
+
+        Ok(Timer {
+            pacemaker,
+            sender,
+            timer_thread,
+        })
+    }
+
+    /// Get a `TimerAlarm` that can be use to prematurely wake up the `Timer`
+    pub fn alarm(&self) -> Box<dyn TimerAlarm> {
+        Box::new(ChannelTimerAlarm::new(self.sender.clone()))
+    }
+}
+
+impl ShutdownHandle for Timer {
+    fn signal_shutdown(&mut self) {
+        self.pacemaker.shutdown_signaler().shutdown();
+        self.timer_thread.signal_shutdown();
+    }
+
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        debug!("Shutting down timer...");
+        self.pacemaker.await_shutdown();
+        self.timer_thread.wait_for_shutdown()?;
+        debug!("Shutting down timer(complete)");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::service::{
+        FullyQualifiedServiceId, MessageSender, Routable, ServiceId, ServiceType, TimerHandler,
+    };
+
+    struct TestTimerFilter {}
+
+    impl TimerFilter for TestTimerFilter {
+        fn filter(&self) -> Result<Vec<FullyQualifiedServiceId>, InternalError> {
+            Ok(vec![FullyQualifiedServiceId::new_from_string(
+                "abcde-12345::a000",
+            )
+            .unwrap()])
+        }
+    }
+
+    const TEST_TYPES: &'static [ServiceType] = &[ServiceType::new_static("test")];
+
+    impl Routable for TestTimerFilter {
+        fn service_types(&self) -> &[ServiceType] {
+            TEST_TYPES
+        }
+    }
+
+    struct TestTimerHandler {}
+
+    impl TimerHandler for TestTimerHandler {
+        type Message = Vec<u8>;
+
+        fn handle_timer(
+            &mut self,
+            sender: &dyn MessageSender<Self::Message>,
+            _service: FullyQualifiedServiceId,
+        ) -> Result<(), InternalError> {
+            sender
+                .send(&ServiceId::new("a000").unwrap(), b"woke-up".to_vec())
+                .unwrap();
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestTimerHandlerFactory {}
+
+    impl TimerHandlerFactory for TestTimerHandlerFactory {
+        type Message = Vec<u8>;
+
+        fn new_handler(
+            &self,
+        ) -> Result<Box<dyn TimerHandler<Message = Self::Message>>, InternalError> {
+            Ok(Box::new(TestTimerHandler {}))
+        }
+
+        fn clone_box(&self) -> Box<dyn TimerHandlerFactory<Message = Self::Message>> {
+            Box::new(self.clone())
+        }
+    }
+
+    struct TestMessageSender {
+        scope: FullyQualifiedServiceId,
+        tx: Sender<(FullyQualifiedServiceId, ServiceId, Vec<u8>)>,
+    }
+
+    impl MessageSender<Vec<u8>> for TestMessageSender {
+        fn send(&self, to_service: &ServiceId, message: Vec<u8>) -> Result<(), InternalError> {
+            self.tx
+                .send((self.scope.clone(), to_service.clone(), message))
+                .map_err(|_| InternalError::with_message("Receiver dropped".into()))
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestMessageSenderFactory {
+        tx: Sender<(FullyQualifiedServiceId, ServiceId, Vec<u8>)>,
+    }
+
+    impl MessageSenderFactory<Vec<u8>> for TestMessageSenderFactory {
+        fn new_message_sender(
+            &self,
+            from_service: &FullyQualifiedServiceId,
+        ) -> Result<Box<dyn MessageSender<Vec<u8>>>, InternalError> {
+            Ok(Box::new(TestMessageSender {
+                scope: from_service.clone(),
+                tx: self.tx.clone(),
+            }))
+        }
+
+        fn clone_boxed(&self) -> Box<dyn MessageSenderFactory<Vec<u8>>> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// Test that a Timer set to 1 second interval will send multiple messages by waking up the
+    /// timer handler.
+    /// 1. Create Timer with 1 second wake up interval
+    /// 2. Wait for two messages to be received
+    /// 3. Shutdown timer
+    #[test]
+    fn test_timer_wake_up_all() {
+        let wake_up_interval = Duration::from_secs(1);
+
+        let (service_sender, service_recv) = channel();
+        let message_sender_factory = Box::new(TestMessageSenderFactory { tx: service_sender });
+        let filters: FilterCollection = vec![(
+            Box::new(TestTimerFilter {}),
+            Box::new(TestTimerHandlerFactory {}),
+        )];
+
+        let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
+
+        if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
+        {
+            assert_eq!(msg_bytes, b"woke-up".to_vec())
+        } else {
+            panic!("Test timed out, timer handler did not wake up the first time")
+        }
+
+        if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
+        {
+            assert_eq!(msg_bytes, b"woke-up".to_vec())
+        } else {
+            panic!("Test timed out, timer handle did not wake up the second time")
+        }
+
+        timer.signal_shutdown();
+        timer.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that an Alarm can be used to wake up the handlers
+    /// 1. Create a Timer with a wake up interval of 1000, this will make sure the Timer does not
+    ///    trigger during this test.
+    /// 2. Get an alarm from the Timer
+    /// 3. Use the alarm to wake up all timers
+    /// 4. Wait for one message to be received
+    /// 5. Shutdown the timer
+    #[test]
+    fn test_timer_wake_up() {
+        // set to large interval so it wont trigger
+        let wake_up_interval = Duration::from_secs(1000);
+
+        let (service_sender, service_recv) = channel();
+        let message_sender_factory = Box::new(TestMessageSenderFactory { tx: service_sender });
+        let filters: FilterCollection = vec![(
+            Box::new(TestTimerFilter {}),
+            Box::new(TestTimerHandlerFactory {}),
+        )];
+
+        let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
+
+        let alarm = timer.alarm();
+
+        alarm.wake_up_all().unwrap();
+
+        if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
+        {
+            assert_eq!(msg_bytes, b"woke-up".to_vec())
+        } else {
+            panic!("Test timed out, timer handler did not wake up the first time")
+        }
+
+        timer.signal_shutdown();
+        timer.wait_for_shutdown().unwrap();
+    }
+
+    // Test that an Alarm can be used to wake up the specific service type handlers
+    /// 1. Create a Timer with a wake up interval of 1000, this will make sure the Timer does not
+    ///    trigger during this test.
+    /// 2. Get an alarm from the Timer
+    /// 3. Use the alarm to wake up handlers with service type "test"
+    /// 4. Wait for one message to be received
+    /// 5. Shutdown the timer
+    #[test]
+    fn test_timer_wake_up_service_type() {
+        // set to large interval so it won't trigger
+        let wake_up_interval = Duration::from_secs(1000);
+
+        let (service_sender, service_recv) = channel();
+        let message_sender_factory = Box::new(TestMessageSenderFactory { tx: service_sender });
+        let filters: FilterCollection = vec![(
+            Box::new(TestTimerFilter {}),
+            Box::new(TestTimerHandlerFactory {}),
+        )];
+
+        let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
+
+        let alarm = timer.alarm();
+
+        alarm
+            .wake_up(ServiceType::new("test").unwrap(), None)
+            .unwrap();
+
+        if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
+        {
+            assert_eq!(msg_bytes, b"woke-up".to_vec())
+        } else {
+            panic!("Test timed out, timer handler did not wake up the first time")
+        }
+
+        timer.signal_shutdown();
+        timer.wait_for_shutdown().unwrap();
+    }
+
+    // Test that an Alarm can be used to wake up the specific service type handler for a specific
+    // id
+    /// 1. Create a Timer with a wake up interval of 1000, this will make sure the Timer does not
+    ///    trigger during this test.
+    /// 2. Get an alarm from the Timer
+    /// 3. Use the alarm to wake up handlers with service type "test" for a specific service id
+    /// 4. Wait for one message to be received
+    /// 5. Shutdown the timer
+    #[test]
+    fn test_timer_wake_up_service_id() {
+        // set to large interval so it won't trigger
+        let wake_up_interval = Duration::from_secs(1000);
+
+        let (service_sender, service_recv) = channel();
+        let message_sender_factory = Box::new(TestMessageSenderFactory { tx: service_sender });
+        let filters: FilterCollection = vec![(
+            Box::new(TestTimerFilter {}),
+            Box::new(TestTimerHandlerFactory {}),
+        )];
+
+        let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
+
+        let alarm = timer.alarm();
+
+        alarm
+            .wake_up(
+                ServiceType::new("test").unwrap(),
+                Some(FullyQualifiedServiceId::new_from_string("abcde-12345::a000").unwrap()),
+            )
+            .unwrap();
+
+        if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
+        {
+            assert_eq!(msg_bytes, b"woke-up".to_vec())
+        } else {
+            panic!("Test timed out, timer handler did not wake up the first time")
+        }
+
+        timer.signal_shutdown();
+        timer.wait_for_shutdown().unwrap();
+    }
+
+    // Test that an Alarm used to wake up the specific service type handler for a specific
+    // id that is not returned by the filter will not trigger
+    /// 1. Create a Timer with a wake up interval of 1000, this will make sure the Timer does not
+    ///    trigger during this test.
+    /// 2. Get an alarm from the Timer
+    /// 3. Use the alarm to wake up handlers with service type "test" for a bad service id
+    /// 4. Wait for two seconds to make sure no message is returned
+    /// 5. Shutdown the timer
+    #[test]
+    fn test_timer_wake_up_bad_service_id() {
+        // set to large interval so it won't trigger
+        let wake_up_interval = Duration::from_secs(1000);
+
+        let (service_sender, service_recv) = channel();
+        let message_sender_factory = Box::new(TestMessageSenderFactory { tx: service_sender });
+        let filters: FilterCollection = vec![(
+            Box::new(TestTimerFilter {}),
+            Box::new(TestTimerHandlerFactory {}),
+        )];
+
+        let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
+
+        let alarm = timer.alarm();
+
+        alarm
+            .wake_up(
+                ServiceType::new("test").unwrap(),
+                Some(FullyQualifiedServiceId::new_from_string("abcde-12bad::a000").unwrap()),
+            )
+            .unwrap();
+
+        if let Ok(_) = service_recv.recv_timeout(std::time::Duration::from_secs(2)) {
+            panic!("Should not have received a message")
+        }
+
+        timer.signal_shutdown();
+        timer.wait_for_shutdown().unwrap();
+    }
+}

--- a/libsplinter/src/runtime/service/timer/thread.rs
+++ b/libsplinter/src/runtime/service/timer/thread.rs
@@ -1,0 +1,261 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you mcay not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The internal thread used by the Timer
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+
+use crate::error::InternalError;
+use crate::service::{FullyQualifiedServiceId, MessageSenderFactory, ServiceType};
+use crate::threading::{
+    lifecycle::ShutdownHandle,
+    pool::{JobExecutor, ThreadPool, ThreadPoolBuilder},
+};
+
+use super::message::TimerMessage;
+use super::FilterCollection;
+
+const DEFAULT_POOL_SIZE: usize = 8;
+
+pub struct TimerThread {
+    join_handle: thread::JoinHandle<()>,
+    thread_pool: ThreadPool,
+    shutdown_sender: Sender<TimerMessage>,
+}
+
+impl TimerThread {
+    pub fn start(
+        filters: FilterCollection,
+        recv: Receiver<TimerMessage>,
+        message_sender_factory: Box<dyn MessageSenderFactory<Vec<u8>>>,
+        sender: Sender<TimerMessage>,
+    ) -> Result<TimerThread, InternalError> {
+        let thread_pool = ThreadPoolBuilder::new()
+            .with_size(DEFAULT_POOL_SIZE)
+            .with_prefix("TimerThread-".into())
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let executor = thread_pool.executor();
+
+        let join_handle = thread::Builder::new()
+            .name("TimerMainThread".to_string())
+            .spawn(move || loop {
+                match recv.recv() {
+                    Ok(TimerMessage::WakeUpAll) => {
+                        wake_up_all(&filters, &executor, &*message_sender_factory)
+                    }
+                    Ok(TimerMessage::WakeUp {
+                        service_type,
+                        service_id,
+                    }) => wake_up(
+                        &filters,
+                        &executor,
+                        &*message_sender_factory,
+                        service_type,
+                        service_id,
+                    ),
+                    Ok(TimerMessage::Shutdown) => {
+                        debug!("Service timer received shutdown");
+                        break;
+                    }
+                    Err(_) => {
+                        error!("Service timer channel dropped");
+                        break;
+                    }
+                }
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(TimerThread {
+            join_handle,
+            thread_pool,
+            shutdown_sender: sender,
+        })
+    }
+}
+
+impl ShutdownHandle for TimerThread {
+    fn signal_shutdown(&mut self) {
+        if self.shutdown_sender.send(TimerMessage::Shutdown).is_err() {
+            warn!("Timer is no longer running");
+        }
+        self.thread_pool.shutdown_signaler().shutdown();
+    }
+
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        debug!("Shutting down timer thread...");
+        self.join_handle.join().map_err(|err| {
+            InternalError::with_message(format!(
+                "Timer thread did not shutdown correctly: {:?}",
+                err
+            ))
+        })?;
+
+        self.thread_pool.join_all();
+        debug!("Shutting down timer thread (complete)");
+        Ok(())
+    }
+}
+
+/// Check all filters for pending work
+fn wake_up_all(
+    filters: &FilterCollection,
+    executor: &JobExecutor,
+    message_sender_factory: &(dyn MessageSenderFactory<Vec<u8>> + 'static),
+) {
+    for (filter, handler_factory) in filters {
+        let service_ids = match filter.filter() {
+            Ok(service_ids) => service_ids,
+            Err(err) => {
+                warn!("Unable to get service IDs from timer filter: {}", err);
+                continue;
+            }
+        };
+
+        for service_id in service_ids.into_iter() {
+            let new_handle_factory = handler_factory.clone_box();
+            let msg_sender_factory = message_sender_factory.clone_boxed();
+            executor.execute(move || {
+                let timer_sender = match msg_sender_factory.new_message_sender(&service_id) {
+                    Ok(timer_sender) => timer_sender,
+                    Err(err) => {
+                        error!("Unable to get message sender: {}", err);
+                        return;
+                    }
+                };
+
+                let mut handler = {
+                    match new_handle_factory.new_handler() {
+                        Ok(handler) => handler,
+                        Err(err) => {
+                            error!(
+                                "Unable to get timer handler for service \
+                                {}: {}",
+                                service_id, err
+                            );
+                            return;
+                        }
+                    }
+                };
+
+                if let Err(err) = handler.handle_timer(&*timer_sender, service_id) {
+                    error!("{}", err);
+                }
+            })
+        }
+    }
+}
+
+/// Check the filter for the provided service type for pending work. If a service id is provided
+/// verify it is returned by the filter and only run that handler.
+fn wake_up(
+    filters: &FilterCollection,
+    executor: &JobExecutor,
+    message_sender_factory: &(dyn MessageSenderFactory<Vec<u8>> + 'static),
+    service_type: ServiceType<'static>,
+    service_id: Option<FullyQualifiedServiceId>,
+) {
+    let (filter, handler_factory) = match filters
+        .iter()
+        .find(|(filter, _)| filter.service_types().contains(&service_type))
+    {
+        Some((filter, handler_factory)) => (filter, handler_factory),
+        None => {
+            error!("No filter for serivce type {}", service_type);
+            return;
+        }
+    };
+
+    let service_ids = match filter.filter() {
+        Ok(service_ids) => service_ids,
+        Err(err) => {
+            warn!("Unable to get service IDs from timer filter: {}", err);
+            return;
+        }
+    };
+
+    if let Some(id) = service_id {
+        if service_ids.contains(&id) {
+            let new_handle_factory = handler_factory.clone_box();
+            let msg_sender_factory = message_sender_factory.clone_boxed();
+            executor.execute(move || {
+                let timer_sender = match msg_sender_factory.new_message_sender(&id) {
+                    Ok(timer_sender) => timer_sender,
+                    Err(err) => {
+                        error!("Unable to get message sender: {}", err);
+                        return;
+                    }
+                };
+
+                let mut handler = {
+                    match new_handle_factory.new_handler() {
+                        Ok(handler) => handler,
+                        Err(err) => {
+                            error!(
+                                "Unable to get timer handler for \
+                                    service {}: {}",
+                                id, err
+                            );
+                            return;
+                        }
+                    }
+                };
+
+                if let Err(err) = handler.handle_timer(&*timer_sender, id) {
+                    error!("{}", err);
+                }
+            })
+        } else {
+            warn!(
+                "Received a wake up for service id that doesn't have \
+                pending work: {}",
+                id
+            )
+        }
+    } else {
+        for service_id in service_ids.into_iter() {
+            let new_handle_factory = handler_factory.clone_box();
+            let msg_sender_factory = message_sender_factory.clone_boxed();
+            executor.execute(move || {
+                let timer_sender = match msg_sender_factory.new_message_sender(&service_id) {
+                    Ok(timer_sender) => timer_sender,
+                    Err(err) => {
+                        error!("Unable to get message sender: {}", err);
+                        return;
+                    }
+                };
+
+                let mut handler = {
+                    match new_handle_factory.new_handler() {
+                        Ok(handler) => handler,
+                        Err(err) => {
+                            error!(
+                                "Unable to get timer handler for \
+                                        service {}: {}",
+                                service_id, err
+                            );
+                            return;
+                        }
+                    }
+                };
+
+                if let Err(err) = handler.handle_timer(&*timer_sender, service_id) {
+                    error!("{}", err);
+                }
+            })
+        }
+    }
+}

--- a/libsplinter/src/service/timer_filter.rs
+++ b/libsplinter/src/service/timer_filter.rs
@@ -17,7 +17,5 @@ use crate::error::InternalError;
 use super::{FullyQualifiedServiceId, Routable};
 
 pub trait TimerFilter: Routable {
-    type Message;
-
     fn filter(&self) -> Result<Vec<FullyQualifiedServiceId>, InternalError>;
 }

--- a/libsplinter/src/service/timer_filter.rs
+++ b/libsplinter/src/service/timer_filter.rs
@@ -14,9 +14,9 @@
 
 use crate::error::InternalError;
 
-use super::FullyQualifiedServiceId;
+use super::{FullyQualifiedServiceId, Routable};
 
-pub trait TimerFilter {
+pub trait TimerFilter: Routable {
     type Message;
 
     fn filter(&self) -> Result<Vec<FullyQualifiedServiceId>, InternalError>;


### PR DESCRIPTION
The Timer is in charge of checking the configured
`TimerFilters` for pending work.

On start up the Timer takes a list of `TimerFilters`
and their associated `TimerHandlerFactory`. The factories
must return a handler that can handle messages of type `Vec<u8>`.

On wake up, the Timer will check each `TimerFilter` for pending work.
For each `FullyQualifiedServiceId` returned from the filter,
the associated `TimerHandlerFactory` will be used to get a
new `TimerHandler` that will run in a threadpool.