### PR TITLE
Implement LifecycleExecutor

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -130,6 +130,7 @@ experimental = [
     "service-id",
     "service-lifecycle",
     "service-lifecycle-executor",
+    "service-lifecycle-store",
     "service-message-converter",
     "service-message-handler",
     "service-message-handler-factory",
@@ -194,7 +195,8 @@ rest-api-cors = []
 service-arguments-converter = []
 service-id = []
 service-lifecycle = ["service-arguments-converter", "service-id", "store-command"]
-service-lifecycle-executor = ["service-lifecycle"]
+service-lifecycle-executor = ["service-lifecycle", "service-lifecycle-store"]
+service-lifecycle-store = ["service-lifecycle"]
 service-message-converter = []
 service-message-handler = ["service-id", "service-message-converter", "service-message-sender"]
 service-message-handler-factory = ["service-message-handler"]

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -129,6 +129,7 @@ experimental = [
     "service-arguments-converter",
     "service-id",
     "service-lifecycle",
+    "service-lifecycle-executor",
     "service-message-converter",
     "service-message-handler",
     "service-message-handler-factory",
@@ -193,6 +194,7 @@ rest-api-cors = []
 service-arguments-converter = []
 service-id = []
 service-lifecycle = ["service-arguments-converter", "service-id", "store-command"]
+service-lifecycle-executor = ["service-lifecycle"]
 service-message-converter = []
 service-message-handler = ["service-id", "service-message-converter", "service-message-sender"]
 service-message-handler-factory = ["service-message-handler"]

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2022-02-17-183942_service_lifecycle/down.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2022-02-17-183942_service_lifecycle/down.sql
@@ -1,0 +1,17 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE service_lifecycle_status;
+DROP TABLE service_lifecycle_argument;

--- a/libsplinter/src/migrations/diesel/postgres/migrations/2022-02-17-183942_service_lifecycle/up.sql
+++ b/libsplinter/src/migrations/diesel/postgres/migrations/2022-02-17-183942_service_lifecycle/up.sql
@@ -1,0 +1,35 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE command_type AS ENUM ('PREPARE', 'FINALIZE', 'RETIRE', 'PURGE');
+CREATE TYPE status_type AS ENUM ('NEW', 'COMPLETE');
+
+CREATE TABLE IF NOT EXISTS service_lifecycle_status (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    status                    status_type NOT NULL,
+    command                   command_type NOT NULL,
+    PRIMARY KEY (circuit_id, service_id)
+);
+
+CREATE TABLE IF NOT EXISTS service_lifecycle_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    position                  INTEGER NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key)
+);

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2022-02-17-183942_service_lifecycle/down.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2022-02-17-183942_service_lifecycle/down.sql
@@ -1,0 +1,17 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE service_lifecycle_status;
+DROP TABLE service_lifecycle_argument;

--- a/libsplinter/src/migrations/diesel/sqlite/migrations/2022-02-17-183942_service_lifecycle/up.sql
+++ b/libsplinter/src/migrations/diesel/sqlite/migrations/2022-02-17-183942_service_lifecycle/up.sql
@@ -1,0 +1,34 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS service_lifecycle_status (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    service_type              TEXT NOT NULL,
+    status                    TEXT NOT NULL
+    CHECK ( status IN ('NEW', 'COMPLETE' ) ),
+    command                   TEXT NOT NULL
+    CHECK ( command IN ('PREPARE', 'FINALIZE', 'RETIRE', 'PURGE') ),
+    PRIMARY KEY (circuit_id, service_id)
+);
+
+CREATE TABLE IF NOT EXISTS service_lifecycle_argument (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    key                       TEXT NOT NULL,
+    value                     TEXT NOT NULL,
+    position                  INTEGER NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, key)
+);

--- a/libsplinter/src/runtime/service/lifecycle_executor/commands/generator.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/commands/generator.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::sync::Arc;
+
+use crate::error::InternalError;
+use crate::runtime::service::{
+    LifecycleCommand, LifecycleService, LifecycleStatus, LifecycleStoreFactory,
+};
+use crate::store::command::StoreCommand;
+
+use super::{LifecycleCompleteCommand, LifecycleRemoveCommand};
+
+pub struct LifecycleCommandGenerator<C: 'static> {
+    store_factory: Arc<dyn LifecycleStoreFactory<C>>,
+}
+
+impl<C: 'static> LifecycleCommandGenerator<C> {
+    pub fn new(store_factory: Arc<dyn LifecycleStoreFactory<C>>) -> Self {
+        LifecycleCommandGenerator { store_factory }
+    }
+
+    pub fn complete_service(
+        &self,
+        service: LifecycleService,
+    ) -> Result<Box<dyn StoreCommand<Context = C>>, InternalError> {
+        match service.command() {
+            LifecycleCommand::Purge => Ok(Box::new(LifecycleRemoveCommand {
+                service,
+                store_factory: self.store_factory.clone(),
+            })),
+            _ => {
+                let service = service
+                    .into_builder()
+                    .with_status(&LifecycleStatus::Complete)
+                    .build()
+                    .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+                Ok(Box::new(LifecycleCompleteCommand {
+                    service,
+                    store_factory: self.store_factory.clone(),
+                }))
+            }
+        }
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/commands/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/commands/mod.rs
@@ -1,0 +1,56 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Commands for updating the lifecycle status of a service
+mod generator;
+
+use std::sync::Arc;
+
+use crate::error::InternalError;
+use crate::runtime::service::{LifecycleService, LifecycleStoreFactory};
+use crate::store::command::StoreCommand;
+
+pub use self::generator::LifecycleCommandGenerator;
+
+pub struct LifecycleCompleteCommand<C> {
+    service: LifecycleService,
+    store_factory: Arc<dyn LifecycleStoreFactory<C>>,
+}
+
+impl<C> StoreCommand for LifecycleCompleteCommand<C> {
+    type Context = C;
+
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        self.store_factory
+            .new_store(&*conn)
+            .update_service(self.service.clone())
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+pub struct LifecycleRemoveCommand<C> {
+    service: LifecycleService,
+    store_factory: Arc<dyn LifecycleStoreFactory<C>>,
+}
+
+impl<C> StoreCommand for LifecycleRemoveCommand<C> {
+    type Context = C;
+
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        self.store_factory
+            .new_store(&*conn)
+            .remove_service(self.service.service_id())
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/executor/alarm/channel.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/executor/alarm/channel.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An alarm can be used to prematurely wake all or specific message handlers
+
+use std::sync::mpsc::Sender;
+
+use crate::error::InternalError;
+use crate::runtime::service::lifecycle_executor::executor::message::ExecutorMessage;
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+use super::ExecutorAlarm;
+
+pub struct ChannelExecutorAlarm {
+    sender: Sender<ExecutorMessage>,
+}
+
+impl ChannelExecutorAlarm {
+    pub fn new(sender: Sender<ExecutorMessage>) -> Self {
+        ChannelExecutorAlarm { sender }
+    }
+}
+
+impl ExecutorAlarm for ChannelExecutorAlarm {
+    fn wake_up_all(&self) -> Result<(), InternalError> {
+        self.sender
+            .send(ExecutorMessage::WakeUpAll)
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+
+    fn wake_up(
+        &self,
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    ) -> Result<(), InternalError> {
+        self.sender
+            .send(ExecutorMessage::WakeUp {
+                service_type,
+                service_id,
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/executor/alarm/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/executor/alarm/mod.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An alarm can be used to prematurely wake all or specific message handlers
+mod channel;
+
+use crate::error::InternalError;
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+pub use self::channel::ChannelExecutorAlarm;
+
+pub trait ExecutorAlarm: Send {
+    fn wake_up_all(&self) -> Result<(), InternalError>;
+
+    fn wake_up(
+        &self,
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    ) -> Result<(), InternalError>;
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/executor/message.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/executor/message.rs
@@ -1,0 +1,27 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The message used by the LifecycleExecutor to know when to execute service handler
+
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+#[derive(Clone, Debug)]
+pub enum ExecutorMessage {
+    WakeUpAll,
+    WakeUp {
+        service_type: ServiceType<'static>,
+        service_id: Option<FullyQualifiedServiceId>,
+    },
+    Shutdown,
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/executor/mod.rs
@@ -1,0 +1,645 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains an Executor for running lifecycles
+
+mod alarm;
+mod message;
+mod thread;
+
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::mpsc::{channel, Sender};
+use std::time::Duration;
+
+use crate::error::InternalError;
+use crate::runtime::service::{LifecycleCommandGenerator, LifecycleStore};
+use crate::service::{Lifecycle, ServiceType};
+use crate::store::command::StoreCommandExecutor;
+use crate::threading::{lifecycle::ShutdownHandle, pacemaker::Pacemaker};
+
+use self::message::ExecutorMessage;
+use self::thread::ExecutorThread;
+
+pub use self::alarm::{ChannelExecutorAlarm, ExecutorAlarm};
+
+pub struct LifecycleExecutor<E: 'static>
+where
+    E: StoreCommandExecutor + Send,
+{
+    pacemaker: Pacemaker,
+    sender: Sender<ExecutorMessage>,
+    executor_thread: ExecutorThread<E>,
+    _executor: PhantomData<E>,
+}
+
+type LifecycleMap<E> =
+    HashMap<ServiceType<'static>, Box<dyn Lifecycle<E, Arguments = Vec<(String, String)>> + Send>>;
+
+impl<E: 'static> LifecycleExecutor<E>
+where
+    E: StoreCommandExecutor + Send,
+{
+    pub fn new(
+        wake_up_interval: Duration,
+        lifecycles: LifecycleMap<E::Context>,
+        store: Box<dyn LifecycleStore + Send>,
+        command_generator: LifecycleCommandGenerator<E::Context>,
+        command_executor: E,
+    ) -> Result<LifecycleExecutor<E>, InternalError> {
+        let (sender, recv) = channel();
+        let pacemaker = Pacemaker::builder()
+            .with_interval(wake_up_interval.as_secs())
+            .with_sender(sender.clone())
+            .with_message_factory(|| ExecutorMessage::WakeUpAll)
+            .start()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let executor_thread =
+            ExecutorThread::start(recv, lifecycles, store, command_generator, command_executor)?;
+
+        Ok(LifecycleExecutor {
+            pacemaker,
+            sender,
+            executor_thread,
+            _executor: PhantomData,
+        })
+    }
+
+    /// Get a `ExecutorAlarm` that can be use to prematurely wake up the `LifecycleExecutor`
+    pub fn alarm(&self) -> Box<dyn ExecutorAlarm> {
+        Box::new(ChannelExecutorAlarm::new(self.sender.clone()))
+    }
+}
+
+impl<E> ShutdownHandle for LifecycleExecutor<E>
+where
+    E: StoreCommandExecutor + Send,
+{
+    fn signal_shutdown(&mut self) {
+        self.pacemaker.shutdown_signaler().shutdown();
+        if self.sender.send(ExecutorMessage::Shutdown).is_err() {
+            warn!("Timer is no longer running");
+        }
+    }
+
+    fn wait_for_shutdown(self) -> Result<(), InternalError> {
+        debug!("Shutting down lifecycle executor...");
+        self.executor_thread.join()?;
+        debug!("Shutting down lifecycle executor(complete)");
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use super::*;
+
+    use std::sync::{mpsc::Receiver, Arc};
+
+    use diesel::r2d2::{ConnectionManager, Pool};
+
+    use crate::migrations::run_sqlite_migrations;
+    use crate::runtime::service::lifecycle_executor::store::diesel::factory::SqliteLifecycleStoreFactory;
+    use crate::runtime::service::{
+        DieselLifecycleStore, LifecycleCommand, LifecycleService, LifecycleServiceBuilder,
+        LifecycleStatus, LifecycleStore, LifecycleStoreFactory,
+    };
+    use crate::service::FullyQualifiedServiceId;
+    use crate::store::command::{DieselStoreCommandExecutor, StoreCommand};
+
+    // Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection ensures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate(
+    ) -> Pool<ConnectionManager<diesel::sqlite::SqliteConnection>> {
+        let connection_manager =
+            ConnectionManager::<diesel::sqlite::SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    fn create_service() -> LifecycleService {
+        let service_id = FullyQualifiedServiceId::new_random();
+        LifecycleServiceBuilder::new()
+            .with_service_id(&service_id)
+            .with_service_type(&ServiceType::new("test").unwrap())
+            .with_arguments(&[("arg1".into(), "1".into()), ("arg2".into(), "2".into())])
+            .with_command(&LifecycleCommand::Prepare)
+            .with_status(&LifecycleStatus::New)
+            .build()
+            .unwrap()
+    }
+
+    struct TestCommand<C> {
+        message: String,
+        sender: Sender<String>,
+        _context: PhantomData<C>,
+    }
+
+    impl<C> StoreCommand for TestCommand<C> {
+        type Context = C;
+
+        fn execute(&self, _conn: &Self::Context) -> Result<(), InternalError> {
+            self.sender
+                .send(self.message.clone())
+                .map_err(|err| InternalError::from_source(Box::new(err)))
+        }
+    }
+
+    struct TestLifecycle<K: 'static> {
+        sender: Sender<String>,
+        _context: PhantomData<K>,
+    }
+
+    impl<K: 'static> TestLifecycle<K> {
+        fn new(sender: Sender<String>) -> Self {
+            TestLifecycle {
+                sender,
+                _context: PhantomData,
+            }
+        }
+    }
+
+    impl<K> Lifecycle<K> for TestLifecycle<K> {
+        type Arguments = Vec<(String, String)>;
+
+        fn command_to_prepare(
+            &self,
+            _service: FullyQualifiedServiceId,
+            _arguments: Self::Arguments,
+        ) -> Result<Box<dyn StoreCommand<Context = K>>, InternalError> {
+            Ok(Box::new(TestCommand {
+                message: "Prepare".to_string(),
+                sender: self.sender.clone(),
+                _context: PhantomData,
+            }))
+        }
+
+        fn command_to_finalize(
+            &self,
+            _service: FullyQualifiedServiceId,
+        ) -> Result<Box<dyn StoreCommand<Context = K>>, InternalError> {
+            Ok(Box::new(TestCommand {
+                message: "Finalize".to_string(),
+                sender: self.sender.clone(),
+                _context: PhantomData,
+            }))
+        }
+
+        fn command_to_retire(
+            &self,
+            _service: FullyQualifiedServiceId,
+        ) -> Result<Box<dyn StoreCommand<Context = K>>, InternalError> {
+            Ok(Box::new(TestCommand {
+                message: "Retire".to_string(),
+                sender: self.sender.clone(),
+                _context: PhantomData,
+            }))
+        }
+
+        fn command_to_purge(
+            &self,
+            _service: FullyQualifiedServiceId,
+        ) -> Result<Box<dyn StoreCommand<Context = K>>, InternalError> {
+            Ok(Box::new(TestCommand {
+                message: "Purge".to_string(),
+                sender: self.sender.clone(),
+                _context: PhantomData,
+            }))
+        }
+    }
+
+    fn create_executor(
+        wake_up_interval: Duration,
+    ) -> (
+        LifecycleExecutor<DieselStoreCommandExecutor<diesel::sqlite::SqliteConnection>>,
+        Box<dyn LifecycleStore>,
+        Receiver<String>,
+    ) {
+        let pool = create_connection_pool_and_migrate();
+
+        let mut lifecycles: HashMap<
+            ServiceType<'static>,
+            Box<
+                dyn Lifecycle<diesel::sqlite::SqliteConnection, Arguments = Vec<(String, String)>>
+                    + Send,
+            >,
+        > = HashMap::new();
+
+        let (sender, recv) = channel();
+
+        let test_lifecycle = TestLifecycle::new(sender);
+
+        lifecycles.insert(ServiceType::new("test").unwrap(), Box::new(test_lifecycle));
+
+        let store = Box::new(DieselLifecycleStore::new(pool.clone()));
+        let store_factory: Arc<(dyn LifecycleStoreFactory<diesel::sqlite::SqliteConnection>)> =
+            Arc::new(SqliteLifecycleStoreFactory);
+
+        let command_generator = LifecycleCommandGenerator::new(store_factory);
+        let command_executor = DieselStoreCommandExecutor::new(pool.clone());
+
+        let executor = LifecycleExecutor::new(
+            wake_up_interval,
+            lifecycles,
+            store.clone(),
+            command_generator,
+            command_executor,
+        )
+        .unwrap();
+
+        (executor, store, recv)
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be prepared.
+    ///
+    /// 1. Start the executor
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Wait for the pacemaker to wake the lifecycle executor
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_all_prepare() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(1));
+        let service = create_service();
+
+        store.add_service(service.clone()).unwrap();
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Prepare".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be finalized.
+    ///
+    /// 1. Start the executor
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Wait for the pacemaker to wake the lifecycle executor
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_all_finalized() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(1));
+        let service = create_service();
+
+        let service = service
+            .into_builder()
+            .with_command(&LifecycleCommand::Finalize)
+            .build()
+            .unwrap();
+
+        store.add_service(service.clone()).unwrap();
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Finalize".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be retired.
+    ///
+    /// 1. Start the executor
+    /// 2. Add Service with status New and command Retire
+    /// 3. Wait for the pacemaker to wake the lifecycle executor
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_all_retire() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(1));
+        let service = create_service();
+
+        let service = service
+            .into_builder()
+            .with_command(&LifecycleCommand::Retire)
+            .build()
+            .unwrap();
+
+        store.add_service(service.clone()).unwrap();
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Retire".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be purged.
+    ///
+    /// 1. Start the executor
+    /// 2. Add Service with status New and command Purged
+    /// 3. Wait for the pacemaker to wake the lifecycle executor
+    /// 4. Verify that the Service has been removed
+    #[test]
+    fn test_executor_wake_up_all_purge() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(1));
+        let service = create_service();
+
+        let service = service
+            .into_builder()
+            .with_command(&LifecycleCommand::Purge)
+            .build()
+            .unwrap();
+
+        store.add_service(service.clone()).unwrap();
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Purge".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.is_none() {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+        }
+
+        assert!(fetched_service.is_none());
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be prepared by an alarm.
+    ///
+    /// 1. Start the executor with a large wake up interval so it will not trigger
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Use the alarm to wake up all
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_all_alarm_prepare() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(500));
+        let alarm = executor.alarm();
+
+        let service = create_service();
+        store.add_service(service.clone()).unwrap();
+
+        alarm.wake_up_all().unwrap();
+
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Prepare".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be prepared by an alarm.
+    ///
+    /// 1. Start the executor with a large wake up interval so it will not trigger
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Use the alarm to wake up "test" service type with no service id
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_service_type_prepare() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(500));
+        let alarm = executor.alarm();
+
+        let service = create_service();
+        store.add_service(service.clone()).unwrap();
+
+        alarm
+            .wake_up(ServiceType::new("test").unwrap(), None)
+            .unwrap();
+
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Prepare".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be prepared by an alarm.
+    ///
+    /// 1. Start the executor with a large wake up interval so it will not trigger
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Use the alarm to wake up "test" service with specific service id
+    /// 4. Verify that the Service has been updated
+    #[test]
+    fn test_executor_wake_up_service_id_prepare() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(500));
+        let alarm = executor.alarm();
+
+        let service = create_service();
+        store.add_service(service.clone()).unwrap();
+
+        alarm
+            .wake_up(
+                ServiceType::new("test").unwrap(),
+                Some(service.service_id().clone()),
+            )
+            .unwrap();
+
+        if let Ok(msg) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            assert_eq!(msg, "Prepare".to_string())
+        } else {
+            panic!("Test timed out, lifecycle did not wake up to handle pending service")
+        }
+
+        let mut fetched_service = store
+            .get_service(service.service_id())
+            .expect("unable to get service")
+            .expect("service was none");
+
+        // there is a chance the message will be sent before the store is finished updating,
+        // this is not an issue when only writing to the database
+        for _ in 1..5 {
+            if fetched_service.status() == &LifecycleStatus::Complete {
+                break;
+            }
+
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            fetched_service = store
+                .get_service(service.service_id())
+                .expect("unable to get service")
+                .expect("service was none");
+        }
+
+        assert_eq!(fetched_service.status(), &LifecycleStatus::Complete);
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+
+    /// Test that the lifecycle executor will properly wake up and handle a service that needs to
+    /// be prepared by an alarm.
+    ///
+    /// 1. Start the executor with a large wake up interval so it will not trigger
+    /// 2. Add Service with status New and command Prepare
+    /// 3. Use the alarm to wake up "test" services with a bad service id
+    /// 4. Verify that the executor does not run the test lifecycle
+    #[test]
+    fn test_executor_wake_up_bad_service_id_prepare() {
+        let (mut executor, store, recv) = create_executor(Duration::from_secs(500));
+        let alarm = executor.alarm();
+
+        let service = create_service();
+        store.add_service(service.clone()).unwrap();
+
+        alarm
+            .wake_up(
+                ServiceType::new("test").unwrap(),
+                Some(FullyQualifiedServiceId::new_random()),
+            )
+            .unwrap();
+
+        if let Ok(_) = recv.recv_timeout(std::time::Duration::from_secs(5)) {
+            panic!("Should not have recieved a message")
+        }
+
+        executor.signal_shutdown();
+        executor.wait_for_shutdown().unwrap();
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/executor/thread.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/executor/thread.rs
@@ -1,0 +1,234 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you mcay not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The internal thread used by the LifecycleExecutor
+
+use std::marker::PhantomData;
+use std::sync::mpsc::Receiver;
+use std::thread;
+
+use crate::error::InternalError;
+use crate::runtime::service::{
+    LifecycleCommand, LifecycleCommandGenerator, LifecycleService, LifecycleStatus, LifecycleStore,
+};
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+use crate::store::command::StoreCommandExecutor;
+
+use super::{message::ExecutorMessage, LifecycleMap};
+
+pub struct ExecutorThread<E: 'static>
+where
+    E: StoreCommandExecutor + Send,
+{
+    join_handle: thread::JoinHandle<()>,
+    _executor: PhantomData<E>,
+}
+
+impl<E> ExecutorThread<E>
+where
+    E: StoreCommandExecutor + Send,
+{
+    pub fn start(
+        recv: Receiver<ExecutorMessage>,
+        lifecycles: LifecycleMap<E::Context>,
+        store: Box<dyn LifecycleStore + Send>,
+        command_generator: LifecycleCommandGenerator<E::Context>,
+        command_executor: E,
+    ) -> Result<ExecutorThread<E>, InternalError> {
+        let join_handle = thread::Builder::new()
+            .name("LifecycleExecutorMainThread".to_string())
+            .spawn(move || loop {
+                match recv.recv() {
+                    Ok(ExecutorMessage::WakeUpAll) => {
+                        wake_up_all(&lifecycles, &*store, &command_generator, &command_executor)
+                    }
+                    Ok(ExecutorMessage::WakeUp {
+                        service_type,
+                        service_id,
+                    }) => wake_up(
+                        &lifecycles,
+                        &*store,
+                        &command_generator,
+                        &command_executor,
+                        service_type,
+                        service_id,
+                    ),
+                    Ok(ExecutorMessage::Shutdown) => {
+                        debug!("LifecycleExecutor received shutdown");
+                        break;
+                    }
+                    Err(_) => {
+                        error!("LifecycleExecutor timer channel dropped");
+                        break;
+                    }
+                }
+            })
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(ExecutorThread {
+            join_handle,
+            _executor: PhantomData,
+        })
+    }
+
+    pub fn join(self) -> Result<(), InternalError> {
+        self.join_handle.join().map_err(|err| {
+            InternalError::with_message(format!(
+                "LifecycleExecutor thread did not shutdown correctly: {:?}",
+                err
+            ))
+        })
+    }
+}
+
+fn wake_up_all<E>(
+    lifecycles: &LifecycleMap<E::Context>,
+    store: &dyn LifecycleStore,
+    command_generator: &LifecycleCommandGenerator<E::Context>,
+    command_executor: &E,
+) where
+    E: StoreCommandExecutor + Send,
+{
+    let services = match store.list_services(&LifecycleStatus::New) {
+        Ok(services) => services,
+        Err(err) => {
+            error!("Unable able to check for pending services: {}", err);
+            return;
+        }
+    };
+
+    handle_command(lifecycles, services, command_generator, command_executor);
+}
+
+fn wake_up<E>(
+    lifecycles: &LifecycleMap<E::Context>,
+    store: &dyn LifecycleStore,
+    command_generator: &LifecycleCommandGenerator<E::Context>,
+    command_executor: &E,
+    service_type: ServiceType<'static>,
+    service_id: Option<FullyQualifiedServiceId>,
+) where
+    E: StoreCommandExecutor + Send,
+{
+    let services = match store.list_services(&LifecycleStatus::New) {
+        Ok(services) => {
+            let mut services: Vec<LifecycleService> = services
+                .into_iter()
+                .filter(|service| service.service_type() == &service_type)
+                .collect();
+
+            if let Some(service_id) = &service_id {
+                services = match services
+                    .into_iter()
+                    .find(|service| service.service_id() == service_id)
+                {
+                    Some(service) => vec![service],
+                    None => {
+                        error!(
+                            "No pending work found for service {} (service type: {})",
+                            service_type, service_id,
+                        );
+                        return;
+                    }
+                }
+            };
+
+            services
+        }
+        Err(err) => {
+            error!("Unable able to check for pending services: {}", err);
+            return;
+        }
+    };
+
+    handle_command(lifecycles, services, command_generator, command_executor);
+}
+
+fn handle_command<E>(
+    lifecycles: &LifecycleMap<E::Context>,
+    services: Vec<LifecycleService>,
+    command_generator: &LifecycleCommandGenerator<E::Context>,
+    command_executor: &E,
+) where
+    E: StoreCommandExecutor + Send,
+{
+    for service in services {
+        debug!(
+            "Handling service {} (service type: {}) with command {}",
+            service.service_id(),
+            service.service_type(),
+            service.command(),
+        );
+        let lifecycle = match lifecycles.get(service.service_type()) {
+            Some(lifecycle) => lifecycle,
+            None => {
+                error!(
+                    "No lifecycle found for service {} (service type: {})",
+                    service.service_id(),
+                    service.service_type()
+                );
+                continue;
+            }
+        };
+        let mut service_commands = {
+            let command_result = match service.command() {
+                LifecycleCommand::Prepare => lifecycle
+                    .command_to_prepare(service.service_id().clone(), service.arguments().to_vec()),
+                LifecycleCommand::Finalize => {
+                    lifecycle.command_to_finalize(service.service_id().clone())
+                }
+                LifecycleCommand::Retire => {
+                    lifecycle.command_to_retire(service.service_id().clone())
+                }
+                LifecycleCommand::Purge => lifecycle.command_to_purge(service.service_id().clone()),
+            };
+
+            match command_result {
+                Ok(commands) => vec![commands],
+                Err(err) => {
+                    error!(
+                        "Unable to get lifecycle commands for service {} (service type: {}): {}",
+                        service.service_id(),
+                        service.service_type(),
+                        err
+                    );
+                    continue;
+                }
+            }
+        };
+
+        match command_generator.complete_service(service.clone()) {
+            Ok(new_command) => service_commands.push(new_command),
+            Err(err) => {
+                error!(
+                    "Unable to get lifecycle commands for service {} (service type: {}): {}",
+                    service.service_id(),
+                    service.service_type(),
+                    err
+                );
+                continue;
+            }
+        }
+
+        if let Err(err) = command_executor.execute(service_commands) {
+            error!(
+                "Unable to execute lifecycle commands for service {} (service type: {}): {}",
+                service.service_id(),
+                service.service_type(),
+                err
+            );
+            continue;
+        }
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -23,3 +23,6 @@ pub use store::{
     service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus},
     LifecycleStore,
 };
+
+#[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
+pub use store::diesel::DieselLifecycleStore;

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -18,6 +18,8 @@
 mod store;
 
 mod commands;
+mod executor;
+
 #[cfg(all(feature = "service-lifecycle-store", feature = "postgres"))]
 pub use store::diesel::factory::PostgresLifecycleStoreFactory;
 #[cfg(all(feature = "service-lifecycle-store", feature = "sqlite"))]
@@ -32,3 +34,4 @@ pub use store::{
 };
 
 pub use commands::LifecycleCommandGenerator;
+pub use executor::{ExecutorAlarm, LifecycleExecutor};

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod instance;
-#[cfg(feature = "service-lifecycle-executor")]
-mod lifecycle_executor;
+//! This module contains an Executor for running lifecycles
+
+#[cfg(feature = "service-lifecycle-store")]
+mod store;
+
+#[cfg(feature = "service-lifecycle-store")]
+pub use store::{
+    service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus},
+};

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -19,5 +19,7 @@ mod store;
 
 #[cfg(feature = "service-lifecycle-store")]
 pub use store::{
+    error::LifecycleStoreError,
     service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus},
+    LifecycleStore,
 };

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -17,6 +17,7 @@
 #[cfg(feature = "service-lifecycle-store")]
 mod store;
 
+mod commands;
 #[cfg(all(feature = "service-lifecycle-store", feature = "postgres"))]
 pub use store::diesel::factory::PostgresLifecycleStoreFactory;
 #[cfg(all(feature = "service-lifecycle-store", feature = "sqlite"))]
@@ -29,3 +30,5 @@ pub use store::{
     service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus},
     LifecycleStore, LifecycleStoreFactory,
 };
+
+pub use commands::LifecycleCommandGenerator;

--- a/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/mod.rs
@@ -17,12 +17,15 @@
 #[cfg(feature = "service-lifecycle-store")]
 mod store;
 
+#[cfg(all(feature = "service-lifecycle-store", feature = "postgres"))]
+pub use store::diesel::factory::PostgresLifecycleStoreFactory;
+#[cfg(all(feature = "service-lifecycle-store", feature = "sqlite"))]
+pub use store::diesel::factory::SqliteLifecycleStoreFactory;
+#[cfg(all(feature = "service-lifecycle-store", feature = "diesel"))]
+pub use store::diesel::DieselLifecycleStore;
 #[cfg(feature = "service-lifecycle-store")]
 pub use store::{
     error::LifecycleStoreError,
     service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus},
-    LifecycleStore,
+    LifecycleStore, LifecycleStoreFactory,
 };
-
-#[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
-pub use store::diesel::DieselLifecycleStore;

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/factory.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/factory.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{DieselConnectionLifecycleStore, LifecycleStore, LifecycleStoreFactory};
+
+#[cfg(feature = "sqlite")]
+pub struct SqliteLifecycleStoreFactory;
+
+#[cfg(feature = "sqlite")]
+impl LifecycleStoreFactory<diesel::sqlite::SqliteConnection> for SqliteLifecycleStoreFactory {
+    fn new_store<'a>(
+        &'a self,
+        conn: &'a diesel::sqlite::SqliteConnection,
+    ) -> Box<dyn LifecycleStore + 'a> {
+        Box::new(DieselConnectionLifecycleStore::new(conn))
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub struct PostgresLifecycleStoreFactory;
+
+#[cfg(feature = "postgres")]
+impl LifecycleStoreFactory<diesel::pg::PgConnection> for PostgresLifecycleStoreFactory {
+    fn new_store<'a>(&'a self, conn: &'a diesel::pg::PgConnection) -> Box<dyn LifecycleStore + 'a> {
+        Box::new(DieselConnectionLifecycleStore::new(conn))
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod factory;
 mod models;
 mod operations;
 mod schema;
@@ -24,7 +25,7 @@ use diesel::{
 };
 
 use crate::runtime::service::{
-    LifecycleService, LifecycleStatus, LifecycleStore, LifecycleStoreError,
+    LifecycleService, LifecycleStatus, LifecycleStore, LifecycleStoreError, LifecycleStoreFactory,
 };
 use crate::service::FullyQualifiedServiceId;
 use crate::store::pool::ConnectionPool;

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/mod.rs
@@ -1,0 +1,384 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod models;
+mod operations;
+mod schema;
+
+use std::sync::{Arc, RwLock};
+
+use diesel::r2d2::{ConnectionManager, Pool};
+
+use crate::runtime::service::{
+    LifecycleService, LifecycleStatus, LifecycleStore, LifecycleStoreError,
+};
+use crate::service::FullyQualifiedServiceId;
+use crate::store::pool::ConnectionPool;
+
+use operations::add_service::LifecycleStoreAddServiceOperation as _;
+use operations::get_service::LifecycleStoreGetServiceOperation as _;
+use operations::list_service::LifecycleStoreListServiceOperation as _;
+use operations::remove_service::LifecycleStoreRemoveServiceOperation as _;
+use operations::update_service::LifecycleStoreUpdateServiceOperation as _;
+use operations::LifecycleStoreOperations;
+
+/// A database-backed LifecycleServiceStore, powered by [`Diesel`](https://crates.io/crates/diesel).
+pub struct DieselLifecycleStore<C: diesel::Connection + 'static> {
+    connection_pool: ConnectionPool<C>,
+}
+
+impl<C: diesel::Connection> DieselLifecycleStore<C> {
+    /// Creates a new ` DieselLifecycleStore`.
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: connection pool for the database
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
+        DieselLifecycleStore {
+            connection_pool: connection_pool.into(),
+        }
+    }
+
+    /// Create a new ` DieselLifecycleStore` with write exclusivity enabled.
+    ///
+    /// Write exclusivity is enforced by providing a connection pool that is wrapped in a
+    /// [`RwLock`]. This ensures that there may be only one writer, but many readers.
+    ///
+    /// # Arguments
+    ///
+    ///  * `connection_pool`: read-write lock-guarded connection pool for the database
+    pub fn new_with_write_exclusivity(
+        connection_pool: Arc<RwLock<Pool<ConnectionManager<C>>>>,
+    ) -> Self {
+        Self {
+            connection_pool: connection_pool.into(),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl Clone for DieselLifecycleStore<diesel::sqlite::SqliteConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Clone for DieselLifecycleStore<diesel::pg::PgConnection> {
+    fn clone(&self) -> Self {
+        Self {
+            connection_pool: self.connection_pool.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl LifecycleStore for DieselLifecycleStore<diesel::pg::PgConnection> {
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).add_service(service))
+    }
+
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).update_service(service))
+    }
+
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).remove_service(service_id))
+    }
+
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<LifecycleService>, LifecycleStoreError> {
+        self.connection_pool
+            .execute_read(|conn| LifecycleStoreOperations::new(conn).get_service(service_id))
+    }
+
+    // list services that have the provided LifecycleStatus
+    fn list_services(
+        &self,
+        status: &LifecycleStatus,
+    ) -> Result<Vec<LifecycleService>, LifecycleStoreError> {
+        self.connection_pool
+            .execute_read(|conn| LifecycleStoreOperations::new(conn).list_service(status))
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl DieselLifecycleStore<diesel::pg::PgConnection> {
+    pub fn clone_box(&self) -> Box<dyn LifecycleStore + Send> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl LifecycleStore for DieselLifecycleStore<diesel::sqlite::SqliteConnection> {
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).add_service(service))
+    }
+
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).update_service(service))
+    }
+
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError> {
+        self.connection_pool
+            .execute_write(|conn| LifecycleStoreOperations::new(conn).remove_service(service_id))
+    }
+
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<LifecycleService>, LifecycleStoreError> {
+        self.connection_pool
+            .execute_read(|conn| LifecycleStoreOperations::new(conn).get_service(service_id))
+    }
+
+    // list services that have the provided LifecycleStatus
+    fn list_services(
+        &self,
+        status: &LifecycleStatus,
+    ) -> Result<Vec<LifecycleService>, LifecycleStoreError> {
+        self.connection_pool
+            .execute_read(|conn| LifecycleStoreOperations::new(conn).list_service(status))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl DieselLifecycleStore<diesel::sqlite::SqliteConnection> {
+    pub fn clone_box(&self) -> Box<dyn LifecycleStore + Send> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+pub mod tests {
+    use super::*;
+
+    use diesel::{
+        r2d2::{ConnectionManager, Pool},
+        sqlite::SqliteConnection,
+    };
+
+    use crate::migrations::run_sqlite_migrations;
+    use crate::runtime::service::{LifecycleCommand, LifecycleServiceBuilder, LifecycleStatus};
+    use crate::service::ServiceType;
+
+    // Creates a connection pool for an in-memory SQLite database with only a single connection
+    /// available. Each connection is backed by a different in-memory SQLite database, so limiting
+    /// the pool to a single connection ensures that the same DB is used for all operations.
+    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+        let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
+        let pool = Pool::builder()
+            .max_size(1)
+            .build(connection_manager)
+            .expect("Failed to build connection pool");
+
+        run_sqlite_migrations(&*pool.get().expect("Failed to get connection for migrations"))
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    /// Verify that a service can be added to the store correctly and then fetched from the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselLifecycleStore
+    /// 3. Create a service
+    /// 4. Add service to store
+    /// 5. Fetch service from store
+    /// 6. Validate fetched service is the same as the service added
+    #[test]
+    fn test_add_get_service() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselLifecycleStore::new(pool);
+
+        let service = create_service();
+
+        store
+            .add_service(service.clone())
+            .expect("Unable to add service");
+
+        let fetched_service = store
+            .get_service(service.service_id())
+            .expect("Unable to get service")
+            .expect("Got None when expecting service");
+
+        assert_eq!(service, fetched_service);
+    }
+
+    /// Verify that a service can be updated correctly and then fetched from the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselLifecycleStore
+    /// 3. Create a service
+    /// 4. Add service to store
+    /// 5. Fetch service from store
+    /// 6. Validate fetched service is the same as the service added
+    /// 7. Update service to have status Initialized
+    /// 8. Validate new fetched service is the same as the updated service
+    #[test]
+    fn test_update_service() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselLifecycleStore::new(pool);
+
+        let service = create_service();
+
+        store
+            .add_service(service.clone())
+            .expect("Unable to add service");
+
+        let fetched_service = store
+            .get_service(service.service_id())
+            .expect("Unable to get service")
+            .expect("Got None when expecting service");
+
+        assert_eq!(service, fetched_service);
+
+        let updated_service = service
+            .into_builder()
+            .with_status(&LifecycleStatus::Complete)
+            .build()
+            .unwrap();
+
+        store
+            .update_service(updated_service.clone())
+            .expect("Unable to add service");
+
+        let fetched_service = store
+            .get_service(updated_service.service_id())
+            .expect("Unable to get service")
+            .expect("Got None when expecting service");
+
+        assert_eq!(updated_service, fetched_service);
+    }
+
+    /// Verify that a service can be updated correctly and then fetched from the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselLifecycleStore
+    /// 3. Create a service
+    /// 4. Add service to store
+    /// 5. Fetch service from store
+    /// 6. Validate fetched service is the same as the service added
+    /// 7. Remove the service
+    /// 8. Validate None is returned from the store when the service is attempted to be fetched
+    #[test]
+    fn test_remove_service() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselLifecycleStore::new(pool);
+
+        let service = create_service();
+
+        store
+            .add_service(service.clone())
+            .expect("Unable to add service");
+
+        let fetched_service = store
+            .get_service(service.service_id())
+            .expect("Unable to get service")
+            .expect("Got None when expecting service");
+
+        assert_eq!(service, fetched_service);
+
+        store
+            .remove_service(service.service_id())
+            .expect("Unable to add service");
+
+        let fetched_service = store
+            .get_service(service.service_id())
+            .expect("Unable to get service");
+
+        assert_eq!(None, fetched_service);
+    }
+
+    /// Verify that a service can be updated correctly and then fetched from the store
+    ///
+    /// 1. Run sqlite migrations
+    /// 2. Create DieselLifecycleStore
+    /// 3. Create a service
+    /// 4. Add service to store
+    /// 5. Fetch service from store
+    /// 6. Validate fetched service is the same as the service added
+    /// 7. Update service to have status Initialized
+    /// 8. Validate new fetched service is the same as the updated service
+    #[test]
+    fn test_list_service() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselLifecycleStore::new(pool);
+
+        let service_1 = create_service();
+
+        store
+            .add_service(service_1.clone())
+            .expect("Unable to add service");
+
+        let service_2 = create_service();
+
+        store
+            .add_service(service_2.clone())
+            .expect("Unable to add service");
+
+        let service_3 = create_service();
+
+        // update to initialized state
+        let service_3 = service_3
+            .into_builder()
+            .with_status(&LifecycleStatus::Complete)
+            .build()
+            .unwrap();
+
+        store
+            .add_service(service_3.clone())
+            .expect("Unable to add service");
+
+        let services = store
+            .list_services(&LifecycleStatus::New)
+            .expect("Unable to list services");
+
+        assert!(services.len() == 2);
+        assert!(services.contains(&service_1));
+        assert!(services.contains(&service_2));
+        assert!(!services.contains(&service_3));
+    }
+
+    fn create_service() -> LifecycleService {
+        let service_id = FullyQualifiedServiceId::new_random();
+        LifecycleServiceBuilder::new()
+            .with_service_id(&service_id)
+            .with_service_type(&ServiceType::new("test").unwrap())
+            .with_arguments(&[("arg1".into(), "1".into()), ("arg2".into(), "2".into())])
+            .with_command(&LifecycleCommand::Prepare)
+            .with_status(&LifecycleStatus::New)
+            .build()
+            .unwrap()
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/models.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/models.rs
@@ -1,0 +1,137 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+
+use crate::error::InternalError;
+use crate::runtime::service::{
+    LifecycleCommand, LifecycleService, LifecycleStatus, LifecycleStoreError,
+};
+
+use super::schema::{service_lifecycle_argument, service_lifecycle_status};
+
+/// Database model representation of `LifecycleService`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "service_lifecycle_status"]
+#[primary_key(circuit_id, service_id)]
+pub struct ServiceLifecycleStatusModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub service_type: String,
+    pub command: String,
+    pub status: String,
+}
+
+impl From<&LifecycleService> for ServiceLifecycleStatusModel {
+    fn from(service: &LifecycleService) -> Self {
+        ServiceLifecycleStatusModel {
+            circuit_id: service.service_id().circuit_id().as_str().into(),
+            service_id: service.service_id().service_id().as_str().into(),
+            service_type: service.service_type().to_string(),
+            command: service.command().into(),
+            status: service.status().into(),
+        }
+    }
+}
+
+/// Database model representation of the arguments in a `LifecycleService`
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "service_lifecycle_argument"]
+#[primary_key(circuit_id, service_id, key)]
+pub struct ServiceLifecycleArgumentModel {
+    pub circuit_id: String,
+    pub service_id: String,
+    pub key: String,
+    pub value: String,
+    pub position: i32,
+}
+
+impl TryFrom<&LifecycleService> for Vec<ServiceLifecycleArgumentModel> {
+    type Error = LifecycleStoreError;
+
+    fn try_from(service: &LifecycleService) -> Result<Self, Self::Error> {
+        let mut service_arguments = Vec::new();
+        service_arguments.extend(
+            service
+                .arguments()
+                .iter()
+                .enumerate()
+                .map(|(idx, (key, value))| {
+                    Ok(ServiceLifecycleArgumentModel {
+                        circuit_id: service.service_id().circuit_id().as_str().into(),
+                        service_id: service.service_id().service_id().as_str().into(),
+                        key: key.clone(),
+                        value: value.clone(),
+                        position: i32::try_from(idx).map_err(|_| {
+                            LifecycleStoreError::Internal(InternalError::with_message(
+                                "Unable to convert index into i32".to_string(),
+                            ))
+                        })?,
+                    })
+                })
+                .collect::<Result<Vec<ServiceLifecycleArgumentModel>, LifecycleStoreError>>()?,
+        );
+        Ok(service_arguments)
+    }
+}
+
+impl From<&LifecycleCommand> for String {
+    fn from(command: &LifecycleCommand) -> Self {
+        match *command {
+            LifecycleCommand::Prepare => "PREPARE".into(),
+            LifecycleCommand::Finalize => "FINALIZE".into(),
+            LifecycleCommand::Retire => "RETIRE".into(),
+            LifecycleCommand::Purge => "PURGE".into(),
+        }
+    }
+}
+
+impl TryFrom<&str> for LifecycleCommand {
+    type Error = LifecycleStoreError;
+
+    fn try_from(command: &str) -> Result<Self, Self::Error> {
+        match command {
+            "PREPARE" => Ok(LifecycleCommand::Prepare),
+            "FINALIZE" => Ok(LifecycleCommand::Finalize),
+            "RETIRE" => Ok(LifecycleCommand::Retire),
+            "PURGE" => Ok(LifecycleCommand::Purge),
+            _ => Err(LifecycleStoreError::Internal(InternalError::with_message(
+                format!("Unknown command {}", command),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<&str> for LifecycleStatus {
+    type Error = LifecycleStoreError;
+
+    fn try_from(status: &str) -> Result<Self, Self::Error> {
+        match status {
+            "NEW" => Ok(LifecycleStatus::New),
+            "COMPLETE" => Ok(LifecycleStatus::Complete),
+            _ => Err(LifecycleStoreError::Internal(InternalError::with_message(
+                format!("Unknown status {}", status),
+            ))),
+        }
+    }
+}
+
+impl From<&LifecycleStatus> for String {
+    fn from(status: &LifecycleStatus) -> Self {
+        match *status {
+            LifecycleStatus::New => "NEW".into(),
+            LifecycleStatus::Complete => "COMPLETE".into(),
+        }
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/add_service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/add_service.rs
@@ -1,0 +1,116 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "add service" operation for the `DieselLifecycleStore`.
+
+use std::convert::TryFrom;
+
+use diesel::{dsl::insert_into, prelude::*};
+
+use crate::error::{ConstraintViolationError, ConstraintViolationType};
+use crate::runtime::service::lifecycle_executor::store::{
+    diesel::{
+        models::{ServiceLifecycleArgumentModel, ServiceLifecycleStatusModel},
+        schema::{service_lifecycle_argument, service_lifecycle_status},
+    },
+    error::LifecycleStoreError,
+    LifecycleService,
+};
+
+use super::LifecycleStoreOperations;
+
+pub(in crate::runtime::service::lifecycle_executor::store::diesel) trait LifecycleStoreAddServiceOperation
+{
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LifecycleStoreAddServiceOperation
+    for LifecycleStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            if service_lifecycle_status::table
+                .filter(
+                    service_lifecycle_status::circuit_id
+                        .eq(service.service_id().circuit_id().as_str()),
+                )
+                .filter(
+                    service_lifecycle_status::service_id
+                        .eq(service.service_id().service_id().as_str()),
+                )
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .is_some()
+            {
+                return Err(LifecycleStoreError::ConstraintViolation(
+                    ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+                ));
+            }
+
+            // Create a `Model` from the `LifecycleService` to add to database
+            let service_model = ServiceLifecycleStatusModel::from(&service);
+            insert_into(service_lifecycle_status::table)
+                .values(service_model)
+                .execute(self.conn)?;
+
+            let service_arguments = Vec::<ServiceLifecycleArgumentModel>::try_from(&service)?;
+            insert_into(service_lifecycle_argument::table)
+                .values(&service_arguments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> LifecycleStoreAddServiceOperation
+    for LifecycleStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            if service_lifecycle_status::table
+                .filter(
+                    service_lifecycle_status::circuit_id
+                        .eq(service.service_id().circuit_id().as_str()),
+                )
+                .filter(
+                    service_lifecycle_status::service_id
+                        .eq(service.service_id().service_id().as_str()),
+                )
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .is_some()
+            {
+                return Err(LifecycleStoreError::ConstraintViolation(
+                    ConstraintViolationError::with_violation_type(ConstraintViolationType::Unique),
+                ));
+            }
+
+            // Create a `Model` from the `LifecycleService` to add to database
+            let service_model = ServiceLifecycleStatusModel::from(&service);
+            insert_into(service_lifecycle_status::table)
+                .values(service_model)
+                .execute(self.conn)?;
+
+            let service_arguments = Vec::<ServiceLifecycleArgumentModel>::try_from(&service)?;
+            insert_into(service_lifecycle_argument::table)
+                .values(&service_arguments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/get_service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/get_service.rs
@@ -1,0 +1,86 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "get service" operation for the `DieselLifecycleStore`.
+
+use std::convert::TryFrom;
+
+use diesel::prelude::*;
+
+use super::LifecycleStoreOperations;
+use crate::runtime::service::lifecycle_executor::store::{
+    diesel::{
+        models::{ServiceLifecycleArgumentModel, ServiceLifecycleStatusModel},
+        schema::{service_lifecycle_argument, service_lifecycle_status},
+    },
+    error::LifecycleStoreError,
+    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus,
+};
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+pub(in crate::runtime::service::lifecycle_executor::store::diesel) trait LifecycleStoreGetServiceOperation
+{
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<LifecycleService>, LifecycleStoreError>;
+}
+
+impl<'a, C> LifecycleStoreGetServiceOperation for LifecycleStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+{
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<LifecycleService>, LifecycleStoreError> {
+        self.conn.transaction::<Option<LifecycleService>, _, _>(|| {
+            // Fetch the `service` entry with the matching `service_id`.
+            // return None if the `service` does not exist
+            let service: ServiceLifecycleStatusModel = match service_lifecycle_status::table
+                .filter(service_lifecycle_status::circuit_id.eq(service_id.circuit_id().as_str()))
+                .filter(service_lifecycle_status::service_id.eq(service_id.service_id().as_str()))
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+            {
+                Some(service) => service,
+                None => return Ok(None),
+            };
+
+            // Collect the `service_arguments` entries with the associated `circuit_id` found
+            // in the `service` entry previously fetched and the provided `service_id`.
+            let arguments: Vec<(String, String)> = service_lifecycle_argument::table
+                .filter(service_lifecycle_argument::circuit_id.eq(service_id.circuit_id().as_str()))
+                .filter(service_lifecycle_argument::service_id.eq(service_id.service_id().as_str()))
+                .order(service_lifecycle_argument::position)
+                .load::<ServiceLifecycleArgumentModel>(self.conn)?
+                .iter()
+                .map(|arg| (arg.key.to_string(), arg.value.to_string()))
+                .collect();
+
+            let return_service = LifecycleServiceBuilder::new()
+                .with_service_id(service_id)
+                .with_service_type(&ServiceType::new(service.service_type)?)
+                .with_arguments(&arguments)
+                .with_command(&LifecycleCommand::try_from(service.command.as_str())?)
+                .with_status(&LifecycleStatus::try_from(service.status.as_str())?)
+                .build()
+                .map_err(LifecycleStoreError::InvalidState)?;
+
+            Ok(Some(return_service))
+        })
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/list_service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/list_service.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "list service" operation for the `DieselLifecycleStore`.
+use std::convert::TryFrom;
+
+use diesel::prelude::*;
+
+use crate::runtime::service::lifecycle_executor::store::{
+    diesel::{
+        models::{ServiceLifecycleArgumentModel, ServiceLifecycleStatusModel},
+        schema::{service_lifecycle_argument, service_lifecycle_status},
+    },
+    error::LifecycleStoreError,
+    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus,
+};
+use crate::service::{CircuitId, FullyQualifiedServiceId, ServiceId, ServiceType};
+
+use super::LifecycleStoreOperations;
+
+pub(in crate::runtime::service::lifecycle_executor::store::diesel) trait LifecycleStoreListServiceOperation
+{
+    fn list_service(
+        &self,
+        status: &LifecycleStatus,
+    ) -> Result<Vec<LifecycleService>, LifecycleStoreError>;
+}
+
+impl<'a, C> LifecycleStoreListServiceOperation for LifecycleStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    i32: diesel::deserialize::FromSql<diesel::sql_types::Integer, C::Backend>,
+{
+    fn list_service(
+        &self,
+        status: &LifecycleStatus,
+    ) -> Result<Vec<LifecycleService>, LifecycleStoreError> {
+        self.conn.transaction::<Vec<LifecycleService>, _, _>(|| {
+            // Fetch the `service` entry with the matching `service_id`.
+            // return None if the `service` does not exist
+            let services: Vec<ServiceLifecycleStatusModel> = service_lifecycle_status::table
+                .filter(service_lifecycle_status::status.eq(&String::from(status)))
+                .load::<ServiceLifecycleStatusModel>(self.conn)?;
+
+            let mut return_services = Vec::new();
+            for service in services {
+                // Collect the `service_arguments` entries with the associated `circuit_id` found
+                // in the `service` entry previously fetched and the provided `service_id`.
+                let arguments: Vec<(String, String)> = service_lifecycle_argument::table
+                    .filter(service_lifecycle_argument::circuit_id.eq(service.circuit_id.as_str()))
+                    .filter(service_lifecycle_argument::service_id.eq(service.service_id.as_str()))
+                    .order(service_lifecycle_argument::position)
+                    .load::<ServiceLifecycleArgumentModel>(self.conn)?
+                    .iter()
+                    .map(|arg| (arg.key.to_string(), arg.value.to_string()))
+                    .collect();
+
+                let return_service = LifecycleServiceBuilder::new()
+                    .with_service_id(&FullyQualifiedServiceId::new(
+                        CircuitId::new(service.circuit_id.as_str())?,
+                        ServiceId::new(service.service_id.as_str())?,
+                    ))
+                    .with_service_type(&ServiceType::new(service.service_type)?)
+                    .with_arguments(&arguments)
+                    .with_command(&LifecycleCommand::try_from(service.command.as_str())?)
+                    .with_status(&LifecycleStatus::try_from(service.status.as_str())?)
+                    .build()
+                    .map_err(LifecycleStoreError::InvalidState)?;
+
+                return_services.push(return_service);
+            }
+
+            Ok(return_services)
+        })
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/mod.rs
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod instance;
-#[cfg(feature = "service-lifecycle-executor")]
-mod lifecycle_executor;
+//! Provides database operations for the `DieselLifecycleStore`.
 
-#[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
-pub use lifecycle_executor::DieselLifecycleStore;
-#[cfg(feature = "service-lifecycle-executor")]
-pub use lifecycle_executor::{
-    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
-    LifecycleStoreError,
-};
+pub(super) mod add_service;
+pub(super) mod get_service;
+pub(super) mod list_service;
+pub(super) mod remove_service;
+pub(super) mod update_service;
+
+pub struct LifecycleStoreOperations<'a, C> {
+    conn: &'a C,
+}
+
+impl<'a, C: diesel::Connection> LifecycleStoreOperations<'a, C> {
+    pub fn new(conn: &'a C) -> Self {
+        LifecycleStoreOperations { conn }
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/remove_service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/remove_service.rs
@@ -1,0 +1,129 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "remove service" operation for the `DieselLifecycleStore`.
+
+use diesel::{dsl::delete, prelude::*};
+
+use crate::error::InvalidStateError;
+use crate::runtime::service::lifecycle_executor::store::{
+    diesel::{
+        models::ServiceLifecycleStatusModel,
+        schema::{service_lifecycle_argument, service_lifecycle_status},
+    },
+    error::LifecycleStoreError,
+};
+use crate::service::FullyQualifiedServiceId;
+
+use super::LifecycleStoreOperations;
+
+pub(in crate::runtime::service::lifecycle_executor::store::diesel) trait LifecycleStoreRemoveServiceOperation
+{
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LifecycleStoreRemoveServiceOperation
+    for LifecycleStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            service_lifecycle_status::table
+                .filter(service_lifecycle_status::circuit_id.eq(service_id.circuit_id().as_str()))
+                .filter(service_lifecycle_status::service_id.eq(service_id.service_id().as_str()))
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    LifecycleStoreError::InvalidState(InvalidStateError::with_message(
+                        String::from("Service does not exist in LifecycleStore"),
+                    ))
+                })?;
+
+            delete(
+                service_lifecycle_status::table
+                    .filter(
+                        service_lifecycle_status::circuit_id.eq(service_id.circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_status::service_id.eq(service_id.service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            delete(
+                service_lifecycle_argument::table
+                    .filter(
+                        service_lifecycle_argument::circuit_id.eq(service_id.circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_argument::service_id.eq(service_id.service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> LifecycleStoreRemoveServiceOperation
+    for LifecycleStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            service_lifecycle_status::table
+                .filter(service_lifecycle_status::circuit_id.eq(service_id.circuit_id().as_str()))
+                .filter(service_lifecycle_status::service_id.eq(service_id.service_id().as_str()))
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    LifecycleStoreError::InvalidState(InvalidStateError::with_message(
+                        String::from("Service does not exist in LifecycleStore"),
+                    ))
+                })?;
+
+            delete(
+                service_lifecycle_status::table
+                    .filter(
+                        service_lifecycle_status::circuit_id.eq(service_id.circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_status::service_id.eq(service_id.service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            delete(
+                service_lifecycle_argument::table
+                    .filter(
+                        service_lifecycle_argument::circuit_id.eq(service_id.circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_argument::service_id.eq(service_id.service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/update_service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/operations/update_service.rs
@@ -1,0 +1,169 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the "update service" operation for the `DieselLifecycleStore`.
+
+use std::convert::TryFrom;
+
+use diesel::{
+    dsl::{delete, insert_into},
+    prelude::*,
+};
+
+use crate::error::InvalidStateError;
+use crate::runtime::service::lifecycle_executor::store::{
+    diesel::{
+        models::{ServiceLifecycleArgumentModel, ServiceLifecycleStatusModel},
+        schema::{service_lifecycle_argument, service_lifecycle_status},
+    },
+    error::LifecycleStoreError,
+    LifecycleService,
+};
+
+use super::LifecycleStoreOperations;
+
+pub(in crate::runtime::service::lifecycle_executor::store::diesel) trait LifecycleStoreUpdateServiceOperation
+{
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError>;
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> LifecycleStoreUpdateServiceOperation
+    for LifecycleStoreOperations<'a, diesel::pg::PgConnection>
+{
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            service_lifecycle_status::table
+                .filter(
+                    service_lifecycle_status::circuit_id
+                        .eq(service.service_id().circuit_id().as_str()),
+                )
+                .filter(
+                    service_lifecycle_status::service_id
+                        .eq(service.service_id().service_id().as_str()),
+                )
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    LifecycleStoreError::InvalidState(InvalidStateError::with_message(
+                        String::from("Service does not exist in LifecycleStore"),
+                    ))
+                })?;
+
+            delete(
+                service_lifecycle_status::table
+                    .filter(
+                        service_lifecycle_status::circuit_id
+                            .eq(service.service_id().circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_status::service_id
+                            .eq(service.service_id().service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            delete(
+                service_lifecycle_argument::table
+                    .filter(
+                        service_lifecycle_argument::circuit_id
+                            .eq(service.service_id().circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_argument::service_id
+                            .eq(service.service_id().service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            // Create a `Model` from the `LifecycleService` to add to database
+            let service_model = ServiceLifecycleStatusModel::from(&service);
+            insert_into(service_lifecycle_status::table)
+                .values(service_model)
+                .execute(self.conn)?;
+
+            let service_arguments = Vec::<ServiceLifecycleArgumentModel>::try_from(&service)?;
+            insert_into(service_lifecycle_argument::table)
+                .values(&service_arguments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> LifecycleStoreUpdateServiceOperation
+    for LifecycleStoreOperations<'a, diesel::sqlite::SqliteConnection>
+{
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError> {
+        self.conn.transaction::<(), _, _>(|| {
+            service_lifecycle_status::table
+                .filter(
+                    service_lifecycle_status::circuit_id
+                        .eq(service.service_id().circuit_id().as_str()),
+                )
+                .filter(
+                    service_lifecycle_status::service_id
+                        .eq(service.service_id().service_id().as_str()),
+                )
+                .first::<ServiceLifecycleStatusModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    LifecycleStoreError::InvalidState(InvalidStateError::with_message(
+                        String::from("Service does not exist in LifecycleStore"),
+                    ))
+                })?;
+
+            delete(
+                service_lifecycle_status::table
+                    .filter(
+                        service_lifecycle_status::circuit_id
+                            .eq(service.service_id().circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_status::service_id
+                            .eq(service.service_id().service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            delete(
+                service_lifecycle_argument::table
+                    .filter(
+                        service_lifecycle_argument::circuit_id
+                            .eq(service.service_id().circuit_id().as_str()),
+                    )
+                    .filter(
+                        service_lifecycle_argument::service_id
+                            .eq(service.service_id().service_id().as_str()),
+                    ),
+            )
+            .execute(self.conn)?;
+
+            // Create a `Model` from the `LifecycleService` to add to database
+            let service_model = ServiceLifecycleStatusModel::from(&service);
+            insert_into(service_lifecycle_status::table)
+                .values(service_model)
+                .execute(self.conn)?;
+
+            let service_arguments = Vec::<ServiceLifecycleArgumentModel>::try_from(&service)?;
+            insert_into(service_lifecycle_argument::table)
+                .values(&service_arguments)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/schema.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/schema.rs
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod instance;
-#[cfg(feature = "service-lifecycle-executor")]
-mod lifecycle_executor;
+table! {
+    service_lifecycle_status (circuit_id, service_id) {
+        circuit_id -> Text,
+        service_id -> Text,
+        service_type -> Text,
+        command -> Text,
+        status -> Text,
+    }
+}
 
-#[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
-pub use lifecycle_executor::DieselLifecycleStore;
-#[cfg(feature = "service-lifecycle-executor")]
-pub use lifecycle_executor::{
-    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
-    LifecycleStoreError,
-};
+table! {
+    service_lifecycle_argument (circuit_id, service_id, key) {
+        circuit_id -> Text,
+        service_id -> Text,
+        key -> Text,
+        value -> Text,
+        position -> Integer,
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/error.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/error.rs
@@ -1,0 +1,112 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error types and logic for LifecycleStore.
+
+use std::error::Error;
+use std::fmt::Display;
+
+use crate::error::{
+    ConstraintViolationError, ConstraintViolationType, InternalError, InvalidArgumentError,
+    InvalidStateError, ResourceTemporarilyUnavailableError,
+};
+
+/// Error type for the LifecycleStore trait.
+#[derive(Debug)]
+pub enum LifecycleStoreError {
+    ConstraintViolation(ConstraintViolationError),
+    Internal(InternalError),
+    InvalidArgument(InvalidArgumentError),
+    InvalidState(InvalidStateError),
+    ResourceTemporarilyUnavailable(ResourceTemporarilyUnavailableError),
+}
+
+impl Display for LifecycleStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LifecycleStoreError::ConstraintViolation(e) => e.fmt(f),
+            LifecycleStoreError::Internal(e) => e.fmt(f),
+            LifecycleStoreError::InvalidArgument(e) => e.fmt(f),
+            LifecycleStoreError::InvalidState(e) => e.fmt(f),
+            LifecycleStoreError::ResourceTemporarilyUnavailable(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for LifecycleStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            LifecycleStoreError::ConstraintViolation(e) => Some(e),
+            LifecycleStoreError::Internal(e) => Some(e),
+            LifecycleStoreError::InvalidArgument(e) => Some(e),
+            LifecycleStoreError::InvalidState(e) => Some(e),
+            LifecycleStoreError::ResourceTemporarilyUnavailable(e) => Some(e),
+        }
+    }
+}
+
+impl From<InternalError> for LifecycleStoreError {
+    fn from(err: InternalError) -> Self {
+        LifecycleStoreError::Internal(err)
+    }
+}
+
+impl From<InvalidArgumentError> for LifecycleStoreError {
+    fn from(err: InvalidArgumentError) -> Self {
+        LifecycleStoreError::InvalidArgument(err)
+    }
+}
+
+impl From<InvalidStateError> for LifecycleStoreError {
+    fn from(err: InvalidStateError) -> Self {
+        LifecycleStoreError::InvalidState(err)
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::r2d2::PoolError> for LifecycleStoreError {
+    fn from(err: diesel::r2d2::PoolError) -> Self {
+        LifecycleStoreError::ResourceTemporarilyUnavailable(
+            ResourceTemporarilyUnavailableError::from_source(Box::new(err)),
+        )
+    }
+}
+
+#[cfg(feature = "diesel")]
+impl From<diesel::result::Error> for LifecycleStoreError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::DatabaseError(db_err_kind, _) => match db_err_kind {
+                diesel::result::DatabaseErrorKind::UniqueViolation => {
+                    LifecycleStoreError::ConstraintViolation(
+                        ConstraintViolationError::from_source_with_violation_type(
+                            ConstraintViolationType::Unique,
+                            Box::new(err),
+                        ),
+                    )
+                }
+                diesel::result::DatabaseErrorKind::ForeignKeyViolation => {
+                    LifecycleStoreError::ConstraintViolation(
+                        ConstraintViolationError::from_source_with_violation_type(
+                            ConstraintViolationType::ForeignKey,
+                            Box::new(err),
+                        ),
+                    )
+                }
+                _ => LifecycleStoreError::Internal(InternalError::from_source(Box::new(err))),
+            },
+            _ => LifecycleStoreError::Internal(InternalError::from_source(Box::new(err))),
+        }
+    }
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
@@ -45,3 +45,7 @@ pub trait LifecycleStore {
         status: &LifecycleStatus,
     ) -> Result<Vec<LifecycleService>, LifecycleStoreError>;
 }
+
+pub trait LifecycleStoreFactory<C>: Sync + Send {
+    fn new_store<'a>(&'a self, conn: &'a C) -> Box<dyn LifecycleStore + 'a>;
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stores required for lifecycle execution
+
+pub mod error;
+pub mod service;
+
+use crate::service::FullyQualifiedServiceId;
+
+use self::error::LifecycleStoreError;
+use self::service::{LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus};
+
+pub trait LifecycleStore {
+    fn add_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError>;
+
+    fn update_service(&self, service: LifecycleService) -> Result<(), LifecycleStoreError>;
+
+    fn remove_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), LifecycleStoreError>;
+
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<LifecycleService>, LifecycleStoreError>;
+
+    // list services that have the provided LifecycleStatus
+    fn list_services(
+        &self,
+        status: &LifecycleStatus,
+    ) -> Result<Vec<LifecycleService>, LifecycleStoreError>;
+}

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/mod.rs
@@ -14,6 +14,8 @@
 
 //! Stores required for lifecycle execution
 
+#[cfg(feature = "diesel")]
+pub mod diesel;
 pub mod error;
 pub mod service;
 

--- a/libsplinter/src/runtime/service/lifecycle_executor/store/service.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/service.rs
@@ -1,0 +1,234 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs for building services
+use std::fmt;
+
+use crate::error::InvalidStateError;
+use crate::service::{FullyQualifiedServiceId, ServiceType};
+
+/// Native representation of a service that is a part of circuit
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LifecycleService {
+    service_id: FullyQualifiedServiceId,
+    service_type: ServiceType<'static>,
+    arguments: Vec<(String, String)>,
+    command: LifecycleCommand,
+    status: LifecycleStatus,
+}
+
+impl LifecycleService {
+    /// Returns the ID of the service
+    pub fn service_id(&self) -> &FullyQualifiedServiceId {
+        &self.service_id
+    }
+
+    /// Returns the service type of the service
+    pub fn service_type(&self) -> &ServiceType {
+        &self.service_type
+    }
+
+    /// Returns the list of key/value arugments for the service
+    pub fn arguments(&self) -> &[(String, String)] {
+        &self.arguments
+    }
+
+    /// Returns lifecycle command of the service
+    pub fn command(&self) -> &LifecycleCommand {
+        &self.command
+    }
+
+    /// Returns lifecycle status of the service
+    pub fn status(&self) -> &LifecycleStatus {
+        &self.status
+    }
+
+    pub fn into_builder(self) -> LifecycleServiceBuilder {
+        LifecycleServiceBuilder::new()
+            .with_service_id(&self.service_id)
+            .with_service_type(&self.service_type)
+            .with_arguments(&self.arguments)
+            .with_command(&self.command)
+            .with_status(&self.status)
+    }
+}
+
+/// Builder for creating a `LifecycleService`
+#[derive(Default, Clone)]
+pub struct LifecycleServiceBuilder {
+    service_id: Option<FullyQualifiedServiceId>,
+    service_type: Option<ServiceType<'static>>,
+    arguments: Option<Vec<(String, String)>>,
+    command: Option<LifecycleCommand>,
+    status: Option<LifecycleStatus>,
+}
+
+impl LifecycleServiceBuilder {
+    /// Creates a new `LifecycleServiceBuilder`
+    pub fn new() -> Self {
+        LifecycleServiceBuilder::default()
+    }
+
+    /// Returns the service specific service ID
+    pub fn service_id(&self) -> Option<FullyQualifiedServiceId> {
+        self.service_id.clone()
+    }
+
+    /// Returns the service type
+    pub fn service_type(&self) -> Option<ServiceType> {
+        self.service_type.clone()
+    }
+
+    /// Returns lifecycle command of the service
+    pub fn command(&self) -> Option<LifecycleCommand> {
+        self.command.clone()
+    }
+
+    /// Returns lifecycle status of the service
+    pub fn status(&self) -> Option<LifecycleStatus> {
+        self.status.clone()
+    }
+
+    /// Returns the list of arguments for the service
+    pub fn arguments(&self) -> Option<Vec<(String, String)>> {
+        self.arguments.clone()
+    }
+
+    /// Sets the service ID
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_id` - The unique service ID for service
+    pub fn with_service_id(
+        mut self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> LifecycleServiceBuilder {
+        self.service_id = Some(service_id.clone());
+        self
+    }
+
+    /// Sets the service type
+    ///
+    /// # Arguments
+    ///
+    ///  * `service_type` - The service type of the service
+    pub fn with_service_type(
+        mut self,
+        service_type: &ServiceType<'static>,
+    ) -> LifecycleServiceBuilder {
+        self.service_type = Some(service_type.clone());
+        self
+    }
+
+    /// Sets the lifecycle command
+    ///
+    /// # Arguments
+    ///
+    ///  * `command` - The lifecycle command of the service
+    pub fn with_command(mut self, command: &LifecycleCommand) -> LifecycleServiceBuilder {
+        self.command = Some(command.clone());
+        self
+    }
+
+    /// Sets the lifecycle status
+    ///
+    /// # Arguments
+    ///
+    ///  * `status` - The lifecycle status of the service
+    pub fn with_status(mut self, status: &LifecycleStatus) -> LifecycleServiceBuilder {
+        self.status = Some(status.clone());
+        self
+    }
+
+    /// Sets the service arguments
+    ///
+    /// # Arguments
+    ///
+    ///  * `arguments` - A list of key-value pairs for the arguments for the service
+    pub fn with_arguments(mut self, arguments: &[(String, String)]) -> LifecycleServiceBuilder {
+        self.arguments = Some(arguments.to_vec());
+        self
+    }
+
+    /// Builds the `LifecycleService`
+    ///
+    /// Returns an error if the service ID, service_type, or allowed nodes is not set
+    pub fn build(self) -> Result<LifecycleService, InvalidStateError> {
+        let service_id = self.service_id.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "unable to build, missing field: `service_id`".to_string(),
+            )
+        })?;
+
+        let service_type = self.service_type.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "unable to build, missing field: `service_type`".to_string(),
+            )
+        })?;
+
+        let status = self.status.ok_or_else(|| {
+            InvalidStateError::with_message("unable to build, missing field: `status`".to_string())
+        })?;
+
+        let command = self.command.ok_or_else(|| {
+            InvalidStateError::with_message("unable to build, missing field: `command`".to_string())
+        })?;
+
+        let arguments = self.arguments.unwrap_or_default();
+
+        let service = LifecycleService {
+            service_id,
+            service_type,
+            command,
+            status,
+            arguments,
+        };
+
+        Ok(service)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LifecycleStatus {
+    New,
+    Complete,
+}
+
+impl fmt::Display for LifecycleStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LifecycleStatus::New => write!(f, "Status: New"),
+            LifecycleStatus::Complete => write!(f, "Status: Complete"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LifecycleCommand {
+    Prepare,
+    Finalize,
+    Retire,
+    Purge,
+}
+
+impl fmt::Display for LifecycleCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LifecycleCommand::Prepare => write!(f, "Command: Prepare"),
+            LifecycleCommand::Finalize => write!(f, "Command: Finalize"),
+            LifecycleCommand::Retire => write!(f, "Command: Retire"),
+            LifecycleCommand::Purge => write!(f, "Command: Purge"),
+        }
+    }
+}

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -24,6 +24,7 @@ pub use lifecycle_executor::PostgresLifecycleStoreFactory;
 pub use lifecycle_executor::SqliteLifecycleStoreFactory;
 #[cfg(feature = "service-lifecycle-executor")]
 pub use lifecycle_executor::{
-    LifecycleCommand, LifecycleCommandGenerator, LifecycleService, LifecycleServiceBuilder,
-    LifecycleStatus, LifecycleStore, LifecycleStoreError, LifecycleStoreFactory,
+    ExecutorAlarm, LifecycleCommand, LifecycleCommandGenerator, LifecycleExecutor,
+    LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
+    LifecycleStoreError, LifecycleStoreFactory,
 };

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -15,3 +15,9 @@
 pub mod instance;
 #[cfg(feature = "service-lifecycle-executor")]
 mod lifecycle_executor;
+
+#[cfg(feature = "service-lifecycle-executor")]
+pub use lifecycle_executor::{
+    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
+    LifecycleStoreError,
+};

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -18,8 +18,12 @@ mod lifecycle_executor;
 
 #[cfg(all(feature = "diesel", feature = "service-lifecycle-store"))]
 pub use lifecycle_executor::DieselLifecycleStore;
+#[cfg(all(feature = "service-lifecycle-store", feature = "postgres"))]
+pub use lifecycle_executor::PostgresLifecycleStoreFactory;
+#[cfg(all(feature = "service-lifecycle-store", feature = "sqlite"))]
+pub use lifecycle_executor::SqliteLifecycleStoreFactory;
 #[cfg(feature = "service-lifecycle-executor")]
 pub use lifecycle_executor::{
     LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
-    LifecycleStoreError,
+    LifecycleStoreError, LifecycleStoreFactory,
 };

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -24,6 +24,6 @@ pub use lifecycle_executor::PostgresLifecycleStoreFactory;
 pub use lifecycle_executor::SqliteLifecycleStoreFactory;
 #[cfg(feature = "service-lifecycle-executor")]
 pub use lifecycle_executor::{
-    LifecycleCommand, LifecycleService, LifecycleServiceBuilder, LifecycleStatus, LifecycleStore,
-    LifecycleStoreError, LifecycleStoreFactory,
+    LifecycleCommand, LifecycleCommandGenerator, LifecycleService, LifecycleServiceBuilder,
+    LifecycleStatus, LifecycleStore, LifecycleStoreError, LifecycleStoreFactory,
 };

--- a/libsplinter/src/service/service_type.rs
+++ b/libsplinter/src/service/service_type.rs
@@ -54,7 +54,7 @@ macro_rules! invalid_arg_error {
     };
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct ServiceType<'a>(ServiceTypeInner<'a>);
 
 impl<'a> ServiceType<'a> {
@@ -143,7 +143,7 @@ impl<'a> Display for ServiceType<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 enum ServiceTypeInner<'a> {
     Borrowed(&'a str),
     Owned(Box<str>),


### PR DESCRIPTION
The LifecycleExecutor will check the database for pending
services that need to be prepared, finalized, retired or purged.

It will check the database on a configured interval or can be
woken up by an alarm. When it finds a pending service, it will
get the commands from the Lifecycle implementation for the service
type and add its own command to update the Lifecycle store. It
then passes all commands to an executor.

The commands should all be very quick so the LifecycleExecutor
only has one thread.