### PR TITLE
Move impl of StoreCommand over boxed trait

### DIFF
--- a/libsplinter/src/store/command/executor/mod.rs
+++ b/libsplinter/src/store/command/executor/mod.rs
@@ -36,11 +36,3 @@ pub trait StoreCommandExecutor {
         store_commands: Vec<C>,
     ) -> Result<(), InternalError>;
 }
-
-impl<C> StoreCommand for Box<dyn StoreCommand<Context = C>> {
-    type Context = C;
-
-    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
-        (&**self).execute(conn)
-    }
-}

--- a/libsplinter/src/store/command/mod.rs
+++ b/libsplinter/src/store/command/mod.rs
@@ -34,3 +34,11 @@ pub trait StoreCommand {
     /// * `conn` - Connection to the database being updated
     fn execute(&self, conn: &Self::Context) -> Result<(), InternalError>;
 }
+
+impl<C> StoreCommand for Box<dyn StoreCommand<Context = C>> {
+    type Context = C;
+
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        (&**self).execute(conn)
+    }
+}


### PR DESCRIPTION
This change moves the implementation of StoreCommand over a Boxed-dyn StoreCommand to the root splinter::store::command module. It is an unrelated item in the executor module.