### PR TITLE
Backport 0-6: Rename Service::peer_id to ::local_peer_id

### DIFF
--- a/libsplinter/src/circuit/component.rs
+++ b/libsplinter/src/circuit/component.rs
@@ -99,11 +99,11 @@ impl ServiceInstances for RoutingTableServiceInstances {
             return Err(ServiceAddInstanceError::NotAllowed);
         }
 
-        if service.peer_id().is_some() {
+        if service.local_peer_id().is_some() {
             return Err(ServiceAddInstanceError::AlreadyRegistered);
         }
 
-        service.set_peer_id(PeerTokenPair::new(
+        service.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id(&component_id),
             PeerAuthorizationToken::from_peer_id(&self.node_id),
         ));
@@ -132,11 +132,11 @@ impl ServiceInstances for RoutingTableServiceInstances {
             })?
             .ok_or(ServiceRemoveInstanceError::NotRegistered)?;
 
-        if service.peer_id().is_none() {
+        if service.local_peer_id().is_none() {
             return Err(ServiceRemoveInstanceError::NotRegistered);
         }
 
-        service.remove_peer_id();
+        service.remove_local_peer_id();
 
         let mut writer = self.routing_table_writer.clone();
         writer.add_service(service_id, service).map_err(|err| {
@@ -222,7 +222,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .expect("Missing service");
-        service.set_peer_id(PeerTokenPair::new(
+        service.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
@@ -271,7 +271,7 @@ mod tests {
                 .get_service(&id)
                 .expect("cannot check if it has the service")
                 .expect("no service returned")
-                .peer_id(),
+                .local_peer_id(),
             &Some(PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("my_component"),
                 PeerAuthorizationToken::from_peer_id("123"),
@@ -324,7 +324,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .expect("Missing service");
-        service.set_peer_id(PeerTokenPair::new(
+        service.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
@@ -344,7 +344,7 @@ mod tests {
             .get_service(&id)
             .expect("cannot check if it has the service")
             .expect("no service returned")
-            .peer_id()
+            .local_peer_id()
             .is_none());
     }
 

--- a/libsplinter/src/circuit/handlers/circuit_error.rs
+++ b/libsplinter/src/circuit/handlers/circuit_error.rs
@@ -55,7 +55,7 @@ impl Handler for CircuitErrorHandler {
                 let node_id = service.node_id();
                 if node_id == self.node_id {
                     // If the service is connected to this node, send the error to the service
-                    match service.peer_id() {
+                    match service.local_peer_id() {
                         Some(peer_id) => peer_id.clone(),
                         None => {
                             // This should never happen, as a peer id will always
@@ -205,11 +205,11 @@ mod tests {
 
         let abc_id = ServiceId::new("alpha".into(), "abc".into());
         let def_id = ServiceId::new("alpha".into(), "def".into());
-        service_abc.set_peer_id(PeerTokenPair::new(
+        service_abc.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
-        service_def.set_peer_id(PeerTokenPair::new(
+        service_def.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
             PeerAuthorizationToken::from_peer_id("345"),
         ));
@@ -310,11 +310,11 @@ mod tests {
 
         let abc_id = ServiceId::new("alpha".into(), "abc".into());
         let def_id = ServiceId::new("alpha".into(), "def".into());
-        service_abc.set_peer_id(PeerTokenPair::new(
+        service_abc.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
-        service_def.set_peer_id(PeerTokenPair::new(
+        service_def.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
             PeerAuthorizationToken::from_peer_id("345"),
         ));

--- a/libsplinter/src/circuit/handlers/direct_message.rs
+++ b/libsplinter/src/circuit/handlers/direct_message.rs
@@ -147,7 +147,7 @@ impl Handler for CircuitDirectMessageHandler {
 
                             (network_msg_bytes, node_peer_id)
                         } else {
-                            let peer_id: PeerId = match service.peer_id() {
+                            let peer_id: PeerId = match service.local_peer_id() {
                                 Some(peer_id) => peer_id.clone().into(),
                                 None => {
                                     // This should never happen, as a peer id will always
@@ -275,11 +275,11 @@ mod tests {
             vec![],
         );
 
-        service_abc.set_peer_id(PeerTokenPair::new(
+        service_abc.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
-        service_def.set_peer_id(PeerTokenPair::new(
+        service_def.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
             PeerAuthorizationToken::from_peer_id("345"),
         ));
@@ -373,11 +373,11 @@ mod tests {
             vec![],
         );
 
-        service_abc.set_peer_id(PeerTokenPair::new(
+        service_abc.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
-        service_def.set_peer_id(PeerTokenPair::new(
+        service_def.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
             PeerAuthorizationToken::from_peer_id("345"),
         ));
@@ -465,7 +465,7 @@ mod tests {
             vec![],
         );
 
-        service_abc.set_peer_id(PeerTokenPair::new(
+        service_abc.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("abc_network"),
             PeerAuthorizationToken::from_peer_id("123"),
         ));
@@ -554,7 +554,7 @@ mod tests {
             vec![],
         );
 
-        service_def.set_peer_id(PeerTokenPair::new(
+        service_def.set_local_peer_id(PeerTokenPair::new(
             PeerAuthorizationToken::from_peer_id("def_network"),
             PeerAuthorizationToken::from_peer_id("345"),
         ));

--- a/libsplinter/src/circuit/handlers/service_handlers.rs
+++ b/libsplinter/src/circuit/handlers/service_handlers.rs
@@ -95,7 +95,7 @@ impl Handler for ServiceConnectRequestHandler {
 
                 // If the circuit exists and has the service in the roster but the service is already
                 // connected, return an error response
-                if service.peer_id().is_some() {
+                if service.local_peer_id().is_some() {
                     response.set_status(
                         ServiceConnectResponse_Status::ERROR_SERVICE_ALREADY_REGISTERED,
                     );
@@ -105,7 +105,8 @@ impl Handler for ServiceConnectRequestHandler {
                     response.set_status(ServiceConnectResponse_Status::ERROR_NOT_AN_ALLOWED_NODE);
                     response.set_error_message(format!("{} is not allowed on this node", unique_id))
                 } else {
-                    service.set_peer_id(PeerTokenPair::from(context.source_peer_id().clone()));
+                    service
+                        .set_local_peer_id(PeerTokenPair::from(context.source_peer_id().clone()));
                     let mut writer = self.routing_table_writer.clone();
                     writer
                         .add_service(unique_id, service)
@@ -214,8 +215,8 @@ impl Handler for ServiceDisconnectRequestHandler {
                         DispatchError::HandleError(format!("Unable to get service {}", service_id))
                     })?;
 
-                if service.peer_id().is_some() {
-                    service.remove_peer_id();
+                if service.local_peer_id().is_some() {
+                    service.remove_local_peer_id();
                     let mut writer = self.routing_table_writer.clone();
                     writer
                         .add_service(unique_id, service)
@@ -482,7 +483,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .unwrap();
-        service.set_peer_id(
+        service.set_local_peer_id(
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
                 PeerAuthorizationToken::from_peer_id("123"),
@@ -664,7 +665,7 @@ mod tests {
             .get_service(&id)
             .expect("Unable to get service")
             .unwrap();
-        service.set_peer_id(
+        service.set_local_peer_id(
             PeerTokenPair::new(
                 PeerAuthorizationToken::from_peer_id("abc_network"),
                 PeerAuthorizationToken::from_peer_id("123"),

--- a/libsplinter/src/circuit/routing/memory/mod.rs
+++ b/libsplinter/src/circuit/routing/memory/mod.rs
@@ -430,7 +430,7 @@ mod test {
                 service_type: "test".to_string(),
                 node_id: format!("endpoint_{}", x),
                 arguments: vec![("peer_services".to_string(), "node-000".to_string())],
-                peer_id: None,
+                local_peer_id: None,
             };
             roster.push(service.clone());
             nodes.push(node.clone());
@@ -587,7 +587,7 @@ mod test {
             service_type: "test".to_string(),
             node_id: "endpoint_0".to_string(),
             arguments: vec![("peer_services".to_string(), "node-000".to_string())],
-            peer_id: None,
+            local_peer_id: None,
         };
         let node1 = CircuitNode {
             node_id: "node-1".to_string(),
@@ -599,7 +599,7 @@ mod test {
             service_type: "test".to_string(),
             node_id: "endpoint_1".to_string(),
             arguments: vec![("peer_services".to_string(), "node-000".to_string())],
-            peer_id: None,
+            local_peer_id: None,
         };
         let circuit = Circuit {
             circuit_id: "012-abc".to_string(),

--- a/libsplinter/src/circuit/routing/mod.rs
+++ b/libsplinter/src/circuit/routing/mod.rs
@@ -309,7 +309,7 @@ pub struct Service {
     service_type: String,
     node_id: String,
     arguments: Vec<(String, String)>,
-    peer_id: Option<PeerTokenPair>,
+    local_peer_id: Option<PeerTokenPair>,
 }
 
 impl Service {
@@ -332,7 +332,7 @@ impl Service {
             service_type,
             node_id,
             arguments,
-            peer_id: None,
+            local_peer_id: None,
         }
     }
 
@@ -357,16 +357,28 @@ impl Service {
     }
 
     /// Returns the local peer ID for the service
+    pub fn local_peer_id(&self) -> &Option<PeerTokenPair> {
+        &self.local_peer_id
+    }
+
+    pub fn set_local_peer_id(&mut self, peer_id: PeerTokenPair) {
+        self.local_peer_id = Some(peer_id)
+    }
+
+    pub fn remove_local_peer_id(&mut self) {
+        self.local_peer_id = None
+    }
+
     pub fn peer_id(&self) -> &Option<PeerTokenPair> {
-        &self.peer_id
+        self.local_peer_id()
     }
 
     pub fn set_peer_id(&mut self, peer_id: PeerTokenPair) {
-        self.peer_id = Some(peer_id)
+        self.set_local_peer_id(peer_id)
     }
 
     pub fn remove_peer_id(&mut self) {
-        self.peer_id = None
+        self.remove_local_peer_id()
     }
 }
 


### PR DESCRIPTION
Backport of #1864 