### PR TITLE
Remove service::routable::Typed

### DIFF
--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -84,7 +84,7 @@ pub use message_sender::MessageSender;
 #[cfg(feature = "service-message-sender-factory")]
 pub use message_sender_factory::MessageSenderFactory;
 #[cfg(feature = "service-routable")]
-pub use routable::{Routable, Typed};
+pub use routable::Routable;
 #[cfg(feature = "service-type")]
 pub use service_type::ServiceType;
 #[cfg(feature = "service-timer-filter")]

--- a/libsplinter/src/service/routable.rs
+++ b/libsplinter/src/service/routable.rs
@@ -17,7 +17,3 @@ use super::ServiceType;
 pub trait Routable {
     fn service_types(&self) -> &[ServiceType];
 }
-
-pub trait Typed {
-    fn service_type(&self) -> &str;
-}


### PR DESCRIPTION
This change removes `Typed`, in favor of the `Routable` trait.