### PR TITLE
Stabilize service-id feature by removing it

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -127,7 +127,6 @@ experimental = [
     "registry-client-reqwest",
     "rest-api-actix-web-3",
     "service-arguments-converter",
-    "service-id",
     "service-lifecycle",
     "service-lifecycle-executor",
     "service-lifecycle-store",
@@ -194,27 +193,25 @@ rest-api-actix-web-1 = [
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
 service-arguments-converter = []
-service-id = []
-service-lifecycle = ["service-arguments-converter", "service-id", "store-command"]
+service-lifecycle = ["service-arguments-converter", "store-command"]
 service-lifecycle-executor = ["service-lifecycle", "service-lifecycle-store"]
 service-lifecycle-store = ["service-lifecycle"]
 service-message-converter = []
-service-message-handler = ["service-id", "service-message-converter", "service-message-sender"]
+service-message-handler = ["service-message-converter", "service-message-sender"]
 service-message-handler-factory = ["service-message-handler"]
-service-message-sender = ["service-id", "service-message-converter"]
+service-message-sender = ["service-message-converter"]
 service-message-sender-factory = ["service-message-sender"]
 service-network = []
 service-routable = ["service-type"]
 service-timer =[
-  "service-id",
   "service-message-sender-factory",
   "service-routable",
   "service-timer-filter",
   "service-timer-handler",
   "service-timer-handler-factory"
 ]
-service-timer-filter = ["service-id"]
-service-timer-handler = ["service-id", "service-message-converter", "service-message-sender"]
+service-timer-filter = []
+service-timer-handler = ["service-message-converter", "service-message-sender"]
 service-timer-handler-factory = ["service-timer-handler"]
 service-type = []
 sqlite = ["diesel/sqlite", "diesel_migrations", "store"]

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -37,7 +37,6 @@
 
 #[cfg(feature = "service-arguments-converter")]
 mod arguments_converter;
-#[cfg(feature = "service-id")]
 mod id;
 pub mod instance;
 #[cfg(feature = "service-lifecycle")]
@@ -67,7 +66,6 @@ mod timer_handler_factory;
 
 #[cfg(feature = "service-arguments-converter")]
 pub use arguments_converter::ArgumentsConverter;
-#[cfg(feature = "service-id")]
 pub use id::{CircuitId, FullyQualifiedServiceId, ServiceId};
 #[cfg(feature = "service-lifecycle")]
 pub use lifecycle::Lifecycle;


### PR DESCRIPTION
The service-id feature guards service and circuit identifier structs.

This feature guard is removed because it is a foundational set of
structs within libsplinter. This feature relies on a single dependency,
cylinder, which is already non-optional.
