### PR TITLE
Update splinter-dev publishing to use OIDC for AWS creds

### DIFF
--- a/.github/workflows/splinter-dev.yaml
+++ b/.github/workflows/splinter-dev.yaml
@@ -9,13 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start_buildx_cluster.outputs.label }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 
       - uses: actions/checkout@v2
 
@@ -84,13 +86,15 @@ jobs:
       - build_splinter_dev
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'Cargill/splinter' && always() }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The developers of the `configure-aws-credentials` action now recommend
using OIDC instead of an IAM user with credentials stored in GitHub secrets.

https://github.com/aws-actions/configure-aws-credentials

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>