### PR TITLE
Remove old dependency from "scabbardv3" feature

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -89,7 +89,6 @@ rest-api = ["futures", "splinter/rest-api"]
 rest-api-actix-web-1 = ["actix-web", "rest-api", "splinter/rest-api-actix-web-1"]
 scabbardv3 = [
     "splinter/service-arguments-converter",
-    "splinter/service-id",
     "splinter/service-lifecycle",
     "splinter/service-message-converter",
     "splinter/service-message-handler",


### PR DESCRIPTION
Remove the "splinter/service-id" dependency as it was removed from
splinter when the feature was stabilized.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>