### PR TITLE
Fix single_match lint in rust 1.60

### DIFF
--- a/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
+++ b/libsplinter/src/network/auth/handlers/v1_handlers/mod.rs
@@ -446,21 +446,17 @@ impl Handler for AuthCompleteHandler {
             context.source_connection_id()
         );
 
-        match self
+        if let Err(err) = self
             .auth_manager
             .received_complete(context.source_connection_id())
         {
-            Err(err) => {
-                send_authorization_error(
-                    &self.auth_manager,
-                    context.source_id(),
-                    context.source_connection_id(),
-                    sender,
-                    &err.to_string(),
-                )?;
-                return Ok(());
-            }
-            Ok(()) => (),
+            send_authorization_error(
+                &self.auth_manager,
+                context.source_id(),
+                context.source_connection_id(),
+                sender,
+                &err.to_string(),
+            )?;
         }
 
         Ok(())


### PR DESCRIPTION
With the new edition of rust this new lint has been introduced. It
checks for match statements where only one match arm actually does
anything. The recommended fix is to replace it with an `if let` statement.

https://rust-lang.github.io/rust-clippy/master/index.html#single_match

Signed-off-by: Caleb Hill <hill@bitwise.io>