### PR TITLE
Add peers to ScabbardArguments

### DIFF
--- a/services/scabbard/libscabbard/src/service/v3/arguments.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments.rs
@@ -13,23 +13,42 @@
 // limitations under the License.
 
 use splinter::error::InvalidArgumentError;
+use splinter::service::ServiceId;
 
-pub struct ScabbardArguments {}
+pub struct ScabbardArguments {
+    peers: Vec<ServiceId>,
+}
 
 impl ScabbardArguments {
-    pub fn new() -> Result<Self, InvalidArgumentError> {
-        Ok(Self {})
+    pub fn new(peers: Vec<ServiceId>) -> Result<Self, InvalidArgumentError> {
+        Ok(Self { peers })
+    }
+
+    pub fn peers(&self) -> &Vec<ServiceId> {
+        &self.peers
     }
 }
 
-pub struct ScabbardArgumentsBuilder {}
+#[derive(Default)]
+pub struct ScabbardArgumentsBuilder {
+    peers: Option<Vec<ServiceId>>,
+}
 
 impl ScabbardArgumentsBuilder {
-    pub fn new() -> Result<Self, InvalidArgumentError> {
-        Ok(Self {})
+    pub fn new() -> Self {
+        Self { peers: None }
+    }
+
+    pub fn with_peers(mut self, peers: Vec<ServiceId>) -> Self {
+        self.peers = Some(peers);
+        self
     }
 
     pub fn build(self) -> Result<ScabbardArguments, InvalidArgumentError> {
-        ScabbardArguments::new()
+        let peers = self
+            .peers
+            .ok_or_else(|| InvalidArgumentError::new("peers", "must be set"))?;
+
+        ScabbardArguments::new(peers)
     }
 }

--- a/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
@@ -12,20 +12,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use splinter::{error::InternalError, service::ArgumentsConverter};
+use splinter::{
+    error::{InternalError, InvalidArgumentError},
+    service::{ArgumentsConverter, ServiceId},
+};
 
-use super::ScabbardArguments;
+use super::{ScabbardArguments, ScabbardArgumentsBuilder};
 
 pub struct ScabbardArgumentsVecConverter {}
 
 impl ArgumentsConverter<ScabbardArguments, Vec<(String, String)>>
     for ScabbardArgumentsVecConverter
 {
-    fn to_right(&self, _left: ScabbardArguments) -> Result<Vec<(String, String)>, InternalError> {
-        Ok(vec![])
+    fn to_right(&self, left: ScabbardArguments) -> Result<Vec<(String, String)>, InternalError> {
+        Ok(vec![(
+            "peer_services".to_string(),
+            left.peers()
+                .iter()
+                .map(|service_id| service_id.to_string())
+                .collect::<Vec<String>>()
+                .join(","),
+        )])
     }
 
-    fn to_left(&self, _right: Vec<(String, String)>) -> Result<ScabbardArguments, InternalError> {
-        ScabbardArguments::new().map_err(|e| InternalError::from_source(Box::new(e)))
+    fn to_left(&self, right: Vec<(String, String)>) -> Result<ScabbardArguments, InternalError> {
+        let mut arg_builder = ScabbardArgumentsBuilder::new();
+
+        for (key, value) in right {
+            match key.as_str() {
+                "peer_services" => {
+                    let peers: Vec<ServiceId> = parse_list(&value)
+                        .map_err(InternalError::with_message)?
+                        .iter()
+                        .map(ServiceId::new)
+                        .collect::<Result<Vec<ServiceId>, InvalidArgumentError>>()
+                        .map_err(|err| InternalError::from_source(Box::new(err)))?;
+                    arg_builder = arg_builder.with_peers(peers);
+                }
+                _ => {
+                    return Err(InternalError::with_message(format!(
+                        "Received unknown argument: {}",
+                        key
+                    )))
+                }
+            }
+        }
+
+        arg_builder
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}
+
+/// Parse a service argument into a list. Check if the argument is in json or csv format
+/// and return the list of strings. An error is returned if json fmt cannot be parsed.
+fn parse_list(values_list: &str) -> Result<Vec<String>, String> {
+    if values_list.starts_with('[') {
+        serde_json::from_str(values_list).map_err(|err| err.to_string())
+    } else {
+        Ok(values_list
+            .split(',')
+            .map(String::from)
+            .collect::<Vec<String>>())
     }
 }


### PR DESCRIPTION
Updates the ScabbardArguments, ScabbardArgumentsBuilder, as
well as the ArgumentConverter for adding peers to the arguments.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>