### PR TITLE
Add dry-run to state migrate command

### DIFF
--- a/cli/man/splinter-state-migrate.1.md
+++ b/cli/man/splinter-state-migrate.1.md
@@ -31,6 +31,10 @@ running.
 
 FLAGS
 =====
+`--dry-run`
+: Check that the in and out databases are available and that the in database
+  has a commit hash. The command will not attempt to move the state
+
 `-f`, `--force`
 : Always attempt to move state, regardless of if there is existing data in the
   out database

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -967,7 +967,12 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                                 .short("y")
                                 .long("yes")
                                 .help("Do not prompt for confirmation"),
-                        ),
+                        )
+                        .arg(Arg::with_name("dry_run").long("dry-run").long_help(
+                            "Check that the in and out databases are available and that \
+                            the in database has a commit hash. The command will not \
+                            attempt to move the state",
+                        )),
                 ),
         );
     }


### PR DESCRIPTION
Add an option to dry-run the state migrate command.
Check that the in and out databases are available and that the in database
has a commit hash. The command will not attempt to move the state

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>