### PR TITLE
0-6 Backport: Set initial state root properly on start up of Scabbard

### DIFF
--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -113,10 +113,18 @@ impl ScabbardState {
             let initial_state_root = merkle_state
                 .get_initial_state_root()
                 .map_err(|err| ScabbardStateError(err.to_string()))?;
-            merkle_state.commit(
+
+            let new_state_root = merkle_state.commit(
                 &initial_state_root,
                 vec![admin_keys_state_change].as_slice(),
-            )?
+            )?;
+
+            // store the new state root to the commit store
+            commit_hash_store
+                .set_current_commit_hash(&new_state_root)
+                .map_err(|err| ScabbardStateError(err.to_string()))?;
+
+            new_state_root
         };
 
         // Initialize transact


### PR DESCRIPTION
Previously, Scabbard did not set the initial state root
hash in the commit store on start. This caused the
`state migrate` command to fail if a scabbard circuit
was created but never used.

Scabbard will now properly set the state root on start.
If the state was not set previously, it will be set on
restart.

backport of #1888 