### PR TITLE
BACKPORT 0-6: Change publish-release GHA workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/0-6-publish-release.yaml
+++ b/.github/workflows/0-6-publish-release.yaml
@@ -28,11 +28,56 @@ jobs:
       - name: Run tests
         run: just ci-test
 
+  start_cluster:
+    if: github.repository == 'Cargill/splinter'
+    name: Start buildx cluster
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start_buildx_cluster.outputs.label }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - uses: actions/checkout@v2
+
+      - name: Start EC2 runner
+        id: start_buildx_cluster
+        uses: ./.github/actions/ec2-docker-buildx
+        with:
+          action: start
+          amd_ami_id: ${{ secrets.AMD_AMI_ID }}
+          amd_instance_type: ${{ secrets.AMD_INSTANCE_TYPE }}
+          arm_ami_id: ${{ secrets.ARM_AMI_ID }}
+          arm_instance_type: ${{ secrets.ARM_INSTANCE_TYPE }}
+          gh_personal_access_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          security_group_id: ${{ secrets.SECURITY_GROUP_ID }}
+          subnet: ${{ secrets.SUBNET }}
+
+      - name: Test output
+        run: echo ${{ steps.start_buildx_cluster.outputs.label }}
+
+      - name: Notify Slack of Failure
+        if: cancelled() || failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   publish_docker:
-    needs: unit_test_splinter
+    needs:
+      - start_cluster
+      - unit_test_splinter
     if: >-
       github.repository_owner == 'Cargill'
-    runs-on: ubuntu-18.04
+    runs-on: ${{ needs.start_cluster.outputs.label }}
     steps:
       - name: Display envvars
         run: env
@@ -58,6 +103,40 @@ jobs:
 
       - name: Notify Slack of Failure
         if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  stop_cluster:
+    name: Stop buildx cluster
+    needs:
+      - start_cluster
+      - publish_docker
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Cargill/splinter' && always() }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - uses: actions/checkout@v2
+
+      - name: Destroy cluster
+        uses: ./.github/actions/ec2-docker-buildx
+        with:
+          action: stop
+          label: ${{ needs.start_cluster.outputs.label }}
+
+      - name: Notify Slack of Failure
+        if: cancelled() || failure()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>