### PR TITLE
Make use of ServiceDispatcher in splinterd 

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -106,6 +106,7 @@ experimental = [
     "https-bind",
     "node",
     "service-endpoint",
+    "service2",
     "ws-transport",
 ]
 
@@ -145,6 +146,8 @@ node = [
     "splinter/rest-api-actix-web-3",
     "splinter/registry-client",
     "splinter/registry-client-reqwest",
+    "splinter/service-message-handler-dispatch",
+    "splinter/service-message-sender-factory-peer",
     "splinter/biome-client",
     "splinter/biome-client-reqwest",
 ]
@@ -153,6 +156,11 @@ oauth = [
 ]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-endpoint = []
+service2 = [
+  "splinter/service-message-handler-dispatch",
+  "splinter/service-message-sender-factory-peer",
+  "splinter/service-message-sender-factory"
+]
 trust-authorization = ["splinter/trust-authorization"]
 ws-transport = ["splinter/ws-transport"]
 

--- a/splinterd/src/daemon/error.rs
+++ b/splinterd/src/daemon/error.rs
@@ -15,6 +15,7 @@
 use std::error::Error;
 use std::fmt;
 
+use splinter::error::InternalError;
 use splinter::rest_api::RestApiServerError;
 use splinter::transport::{AcceptError, ConnectError, ListenError};
 
@@ -50,6 +51,7 @@ pub enum StartError {
     HealthServiceError(String),
     OrchestratorError(String),
     UserError(String),
+    InternalError(String),
 }
 
 impl Error for StartError {}
@@ -75,6 +77,7 @@ impl fmt::Display for StartError {
             StartError::UserError(msg) => {
                 write!(f, "there has been a user error: {}", msg)
             }
+            StartError::InternalError(err) => f.write_str(err),
         }
     }
 }
@@ -112,5 +115,11 @@ impl From<ConnectError> for StartError {
 impl From<protobuf::ProtobufError> for StartError {
     fn from(err: protobuf::ProtobufError) -> Self {
         StartError::ProtocolError(err.to_string())
+    }
+}
+
+impl From<InternalError> for StartError {
+    fn from(err: InternalError) -> Self {
+        StartError::InternalError(err.to_string())
     }
 }


### PR DESCRIPTION
Adds ServiceDispatcher to the CircuitDirectMessageHandler.

No message handlers are currently provided to the dispatcher.