### PR TITLE
Add Timer to Splinterd

### DIFF
--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -106,6 +106,7 @@ experimental = [
     "https-bind",
     "node",
     "service-endpoint",
+    "service-timer-interval",
     "service2",
     "ws-transport",
 ]
@@ -156,6 +157,7 @@ oauth = [
 ]
 rest-api-cors = ["splinter/rest-api-cors"]
 service-endpoint = []
+service-timer-interval = []
 service2 = [
   "splinter/service-message-handler-dispatch",
   "splinter/service-message-sender-factory-peer",

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -161,7 +161,8 @@ service-timer-interval = []
 service2 = [
   "splinter/service-message-handler-dispatch",
   "splinter/service-message-sender-factory-peer",
-  "splinter/service-message-sender-factory"
+  "splinter/service-message-sender-factory",
+  "splinter/service-timer"
 ]
 trust-authorization = ["splinter/trust-authorization"]
 ws-transport = ["splinter/ws-transport"]

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -225,6 +225,10 @@ OPTIONS
 : Specifies where scabbard stores its internal state. Accepted values: `lmdb`,
   `database`
 
+`--service-timer-interval INTERVAL`
+: How often the service timer should be woken up, in seconds
+  (Default: 1)
+
 `--state-dir STATE-DIR`
 : Specifies the storage directory.
   (Default: `/var/lib/splinter`.)

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -431,6 +431,12 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.scabbard_state().map(|v| (v, p.source())))
                 .ok_or_else(|| ConfigError::MissingValue("scabbard_state".to_string()))?,
+            #[cfg(feature = "service2")]
+            service_timer_interval: self
+                .partial_configs
+                .iter()
+                .find_map(|p| p.service_timer_interval().map(|v| (v, p.source())))
+                .ok_or_else(|| ConfigError::MissingValue("service_timer_interval".to_string()))?,
         })
     }
 }

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 //! `PartialConfig` builder using values from splinterd command line arguments.
+#[cfg(feature = "service2")]
+use std::time::Duration;
 
 use crate::config::{ConfigError, ConfigSource, PartialConfig, PartialConfigBuilder};
 use clap::{ArgMatches, ErrorKind};
@@ -180,6 +182,13 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 .with_influx_url(self.matches.value_of("influx_url").map(String::from))
                 .with_influx_username(self.matches.value_of("influx_username").map(String::from))
                 .with_influx_password(self.matches.value_of("influx_password").map(String::from))
+        }
+
+        #[cfg(feature = "service-timer-interval")]
+        {
+            partial_config = partial_config.with_service_timer_interval(
+                parse_value(&self.matches, "service_timer_interval")?.map(Duration::from_secs),
+            )
         }
 
         partial_config =

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -56,6 +56,9 @@ const PEERING_KEY_NAME: &str = "splinterd";
 #[cfg(feature = "config-allow-keys")]
 const ALLOW_KEYS_FILE: &str = "allow_keys";
 
+#[cfg(feature = "service2")]
+const SERVICE_TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
 pub struct DefaultPartialConfigBuilder;
 
 impl DefaultPartialConfigBuilder {
@@ -196,6 +199,12 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
                 partial_config.with_allow_keys_file(Some(String::from(ALLOW_KEYS_FILE)))
         }
 
+        #[cfg(feature = "service2")]
+        {
+            partial_config =
+                partial_config.with_service_timer_interval(Some(SERVICE_TIMER_INTERVAL));
+        }
+
         Ok(partial_config)
     }
 }
@@ -262,6 +271,11 @@ mod tests {
         assert_eq!(config.state_dir(), Some(String::from(STATE_DIR)));
         assert_eq!(config.tls_insecure(), Some(false));
         assert_eq!(config.no_tls(), Some(false));
+        #[cfg(feature = "service2")]
+        assert_eq!(
+            config.service_timer_interval(),
+            Some(SERVICE_TIMER_INTERVAL)
+        );
         // Assert the source is correctly identified for this `PartialConfig` object.
         assert_eq!(config.source(), ConfigSource::Default);
     }

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -109,6 +109,8 @@ pub struct Config {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: (String, ConfigSource),
     scabbard_state: (ScabbardState, ConfigSource),
+    #[cfg(feature = "service2")]
+    service_timer_interval: (Duration, ConfigSource),
 }
 
 impl Config {
@@ -342,6 +344,11 @@ impl Config {
 
     pub fn peering_key(&self) -> &str {
         &self.peering_key.0
+    }
+
+    #[cfg(feature = "service2")]
+    pub fn service_timer_interval(&self) -> Duration {
+        self.service_timer_interval.0
     }
 
     pub fn config_dir_source(&self) -> &ConfigSource {
@@ -620,6 +627,11 @@ impl Config {
 
     pub fn scabbard_state_source(&self) -> &ConfigSource {
         &self.scabbard_state.1
+    }
+
+    #[cfg(feature = "service2")]
+    pub fn service_timer_interval_source(&self) -> &ConfigSource {
+        &self.service_timer_interval.1
     }
 
     #[allow(clippy::cognitive_complexity)]

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -900,6 +900,15 @@ impl Config {
             self.scabbard_state(),
             self.scabbard_state_source()
         );
+
+        #[cfg(feature = "service2")]
+        {
+            debug!(
+                "Config: service_timer_interval: {:?}, (source: {:?})",
+                self.service_timer_interval(),
+                self.service_timer_interval_source(),
+            );
+        }
     }
 
     #[cfg(feature = "rest-api-cors")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -100,6 +100,8 @@ pub struct PartialConfig {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: Option<String>,
     scabbard_state: Option<ScabbardState>,
+    #[cfg(feature = "service2")]
+    service_timer_interval: Option<Duration>,
 }
 
 impl PartialConfig {
@@ -170,6 +172,8 @@ impl PartialConfig {
             #[cfg(feature = "config-allow-keys")]
             allow_keys_file: None,
             scabbard_state: None,
+            #[cfg(feature = "service2")]
+            service_timer_interval: None,
         }
     }
 
@@ -376,6 +380,11 @@ impl PartialConfig {
 
     pub fn scabbard_state(&self) -> Option<ScabbardState> {
         self.scabbard_state
+    }
+
+    #[cfg(feature = "service2")]
+    pub fn service_timer_interval(&self) -> Option<Duration> {
+        self.service_timer_interval
     }
 
     /// Adds a `config_dir` value to the `PartialConfig` object.
@@ -910,6 +919,12 @@ impl PartialConfig {
     ///
     pub fn with_scabbard_state(mut self, scabbard_state: Option<ScabbardState>) -> Self {
         self.scabbard_state = scabbard_state;
+        self
+    }
+
+    #[cfg(feature = "service2")]
+    pub fn with_service_timer_interval(mut self, service_timer_interval: Option<Duration>) -> Self {
+        self.service_timer_interval = service_timer_interval;
         self
     }
 }

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -22,6 +22,8 @@ use serde::Deserialize as DeserializeTrait;
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::convert::TryInto;
+#[cfg(feature = "service2")]
+use std::time::Duration;
 
 use super::logging::{default_pattern, UnnamedAppenderConfig, UnnamedLoggerConfig};
 use super::ScabbardState;
@@ -207,6 +209,8 @@ struct TomlConfig {
     scabbard_state: Option<ScabbardStateToml>,
     config_dir: Option<String>,
     state_dir: Option<String>,
+    #[cfg(feature = "service-timer-interval")]
+    service_timer_interval: Option<u64>,
 
     // Deprecated values
     cert_dir: Option<String>,
@@ -330,6 +334,15 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
                 .with_influx_url(self.toml_config.influx_url)
                 .with_influx_username(self.toml_config.influx_username)
                 .with_influx_password(self.toml_config.influx_password)
+        }
+
+        #[cfg(feature = "service-timer-interval")]
+        {
+            partial_config = partial_config.with_service_timer_interval(
+                self.toml_config
+                    .service_timer_interval
+                    .map(Duration::from_secs),
+            )
         }
 
         if let Some(mut loggers) = self.toml_config.loggers {

--- a/splinterd/src/daemon/builder.rs
+++ b/splinterd/src/daemon/builder.rs
@@ -66,6 +66,8 @@ pub struct SplinterDaemonBuilder {
     signers: Option<Vec<Box<dyn Signer>>>,
     peering_token: Option<PeerAuthorizationToken>,
     enable_lmdb_state: bool,
+    #[cfg(feature = "service2")]
+    service_timer_interval: Option<Duration>,
 }
 
 impl SplinterDaemonBuilder {
@@ -244,6 +246,12 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    #[cfg(feature = "service2")]
+    pub fn with_service_timer_interval(mut self, service_timer_interval: Duration) -> Self {
+        self.service_timer_interval = Some(service_timer_interval);
+        self
+    }
+
     pub fn build(self) -> Result<SplinterDaemon, CreateError> {
         let heartbeat = self.heartbeat.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: heartbeat".to_string())
@@ -346,6 +354,11 @@ impl SplinterDaemonBuilder {
 
         let peering_token = self.peering_token.ok_or_else(|| {
             CreateError::MissingRequiredField("Missing field: peering_token".to_string())
+        })?;
+
+        #[cfg(feature = "service2")]
+        let service_timer_interval = self.service_timer_interval.ok_or_else(|| {
+            CreateError::MissingRequiredField("Missing field: service_timer_interval".to_string())
         })?;
 
         Ok(SplinterDaemon {

--- a/splinterd/src/daemon/builder.rs
+++ b/splinterd/src/daemon/builder.rs
@@ -404,6 +404,8 @@ impl SplinterDaemonBuilder {
             signers,
             peering_token,
             enable_lmdb_state: self.enable_lmdb_state,
+            #[cfg(feature = "service2")]
+            service_timer_interval,
         })
     }
 }

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -490,6 +490,18 @@ fn main() {
                 .takes_value(true),
         );
 
+    #[cfg(feature = "service-timer-interval")]
+    let app = app.arg(
+        Arg::with_name("service_timer_interval")
+            .long("service-timer-interval")
+            .value_name("interval")
+            .long_help(
+                "How often the service timer should be woken up, in seconds; \
+                    defaults to 1 second",
+            )
+            .takes_value(true),
+    );
+
     let app = app.arg(
         Arg::with_name("scabbard_state")
             .long("scabbard-state")

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -707,6 +707,12 @@ fn start_daemon(matches: ArgMatches, log_handle: Handle) -> Result<(), UserError
         .with_signers(signers)
         .with_peering_token(peering_token);
 
+    #[cfg(feature = "service2")]
+    {
+        daemon_builder =
+            daemon_builder.with_service_timer_interval(config.service_timer_interval());
+    }
+
     let mut node = daemon_builder.build().map_err(|err| {
         UserError::daemon_err_with_source("unable to build the Splinter daemon", Box::new(err))
     })?;


### PR DESCRIPTION
This change adds the Timer (without filters or handlers) to the splinter
daemon struct.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>