### PR TITLE
Common auth exports

### DIFF
--- a/rest_api/common/Cargo.toml
+++ b/rest_api/common/Cargo.toml
@@ -40,3 +40,5 @@ experimental = [
     "stable",
     # The following features are experimental:
 ]
+
+authorization = ["splinter/authorization"]

--- a/rest_api/common/Cargo.toml
+++ b/rest_api/common/Cargo.toml
@@ -24,7 +24,7 @@ description = """\
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-splinter = { path = "../../libsplinter" }
+splinter = { path = "../../libsplinter", features = ["rest-api"] }
 
 [features]
 default = []

--- a/rest_api/common/src/auth/authorization.rs
+++ b/rest_api/common/src/auth/authorization.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "authorization")]
-pub mod authorization;
+pub use splinter::rest_api::auth::authorization::{
+    AuthorizationHandler, AuthorizationHandlerResult, Method, Permission, PermissionMap,
+};

--- a/rest_api/common/src/auth/identity.rs
+++ b/rest_api/common/src/auth/identity.rs
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "authorization")]
-pub mod authorization;
-pub mod identity;
+pub use splinter::rest_api::auth::identity::IdentityProvider;

--- a/rest_api/common/src/auth/mod.rs
+++ b/rest_api/common/src/auth/mod.rs
@@ -11,7 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-pub mod auth;
-pub mod error;
-pub mod paging;

--- a/rest_api/common/src/auth/mod.rs
+++ b/rest_api/common/src/auth/mod.rs
@@ -15,3 +15,5 @@
 #[cfg(feature = "authorization")]
 pub mod authorization;
 pub mod identity;
+
+pub use splinter::rest_api::auth::AuthorizationHeader;


### PR DESCRIPTION
Changes related to being able to implement an auth service in actix_web_4 without breaking all of libsplinter and splinterd.