### PR TITLE
Add `Action` and `Message` structs/enums to scabbard store

### DIFF
--- a/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
@@ -1,0 +1,21 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::store::scabbard_store::two_phase::action::ConsensusAction;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum ScabbardConsensusAction {
+    Scabbard2pcConsensusAction(ConsensusAction),
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod action;
 pub mod commit;
 pub mod context;
 mod error;
 pub mod service;
 pub mod state;
+pub mod two_phase;
 
 pub(crate) use error::ScabbardStoreError;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/action.rs
@@ -1,0 +1,39 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::SystemTime;
+
+use splinter::service::ServiceId;
+
+use super::message::Scabbard2pcMessage;
+use crate::store::scabbard_store::context::ScabbardContext;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum ConsensusAction {
+    Update(ScabbardContext, Option<SystemTime>),
+    SendMessage(ServiceId, Scabbard2pcMessage),
+    Notify(ConsensusActionNotification),
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub enum ConsensusActionNotification {
+    Abort(),
+    Commit(),
+    MessageDropped(String),
+    RequestForStart(),
+    CoordinatorRequestForVote(),
+    ParticipantRequestForVote(Vec<u8>),
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/message.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/message.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum Scabbard2pcMessage {
+    VoteRequest(u64, Vec<u8>),
+    Commit(u64),
+    Abort(u64),
+    DecisionRequest(u64),
+    VoteResponse(u64, bool),
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/mod.rs
@@ -1,0 +1,18 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs and enums specific to the two phase commit consensus algorithm
+
+pub mod action;
+pub mod message;


### PR DESCRIPTION
Add Action and Message sub-modules to the scabbard_store module which contain structs used for storing consensus related information in the scabbard store.

These structs and enums are currently behind `#[allow(dead_code)]` to avoid clippy lint, this will be removed in the future when they are put to use.