### PR TITLE
Scabbard store updates

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,16 +13,16 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_coordinator_context;
-DROP TABLE IF EXISTS consensus_coordinator_context_participant;
-DROP TABLE IF EXISTS consensus_action;
-DROP TABLE IF EXISTS consensus_update_coordinator_context_action;
-DROP TABLE IF EXISTS consensus_coordinator_send_message_action;
-DROP TABLE IF EXISTS consensus_coordinator_notification_action;
-DROP TABLE IF EXISTS consensus_update_coordinator_context_action_participant;
-DROP TABLE IF EXISTS consensus_participant_context;
-DROP TABLE IF EXISTS consensus_participant_context_participant;
-DROP TABLE IF EXISTS consensus_update_participant_context_action;
-DROP TABLE IF EXISTS consensus_update_participant_context_action_participant;
-DROP TABLE IF EXISTS consensus_participant_send_message_action;
-DROP TABLE IF EXISTS consensus_participant_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context;
+DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_action;
+DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action_participant;
+DROP TABLE IF EXISTS consensus_2pc_participant_context;
+DROP TABLE IF EXISTS consensus_2pc_participant_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action;
+DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action_participant;
+DROP TABLE IF EXISTS consensus_2pc_participant_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_participant_notification_action;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -20,7 +20,7 @@ CREATE TYPE participant_state AS ENUM ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE'
 CREATE TYPE participant_message_type AS ENUM ('VOTEREQUEST', 'COMMIT', 'ABORT', 'DECISIONREQUEST');
 CREATE TYPE participant_notification_type AS ENUM ('PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -31,27 +31,27 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     id                        BIGSERIAL PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
@@ -61,11 +61,11 @@ CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action (
     state                     coordinator_state NOT NULL,
     vote_timeout_start        BIGINT,
     coordinator_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -73,33 +73,33 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_send_message_action (
     message_type              coordinator_message_type NOT NULL,
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     notification_type         coordinator_notification_type NOT NULL,
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_update_coordinator_context_action(action_id) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_coordinator_context_action(action_id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -112,15 +112,15 @@ CREATE TABLE IF NOT EXISTS consensus_participant_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
@@ -132,20 +132,20 @@ CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action (
     CHECK ( (vote IN ('TRUE' , 'FALSE')) OR (state != 'VOTED') ),
     decision_timeout_start    BIGINT,
     participant_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action_participant (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
-    FOREIGN KEY (action_id) REFERENCES consensus_update_participant_context_action(action_id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_participant_context_action(action_id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -153,11 +153,11 @@ CREATE TABLE IF NOT EXISTS consensus_participant_send_message_action (
     message_type              participant_message_type NOT NULL,
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -166,6 +166,6 @@ CREATE TABLE IF NOT EXISTS consensus_participant_notification_action (
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     request_for_vote_value    BYTEA
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -99,8 +99,6 @@ CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action_participa
     FOREIGN KEY (action_id) REFERENCES consensus_update_coordinator_context_action(action_id) ON DELETE CASCADE
 );
 
--- participant tables ----------------------------------------------------------
-
 CREATE TABLE IF NOT EXISTS consensus_participant_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TYPE coordinator_state AS ENUM ('WAITINGFORSTART', 'VOTING', 'WAITINGFORCOORDINATORVOTE', 'ABORT', 'COMMIT');
+CREATE TYPE coordinator_state AS ENUM ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT');
 CREATE TYPE coordinator_message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST');
 CREATE TYPE coordinator_notification_type AS ENUM ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
 CREATE TYPE participant_state AS ENUM ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE', 'VOTED', 'ABORT', 'COMMIT');

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BYTEA,
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
@@ -56,5 +56,5 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,16 +13,16 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_coordinator_context;
-DROP TABLE IF EXISTS consensus_coordinator_context_participant;
-DROP TABLE IF EXISTS consensus_action;
-DROP TABLE IF EXISTS consensus_update_coordinator_context_action;
-DROP TABLE IF EXISTS consensus_coordinator_send_message_action;
-DROP TABLE IF EXISTS consensus_coordinator_notification_action;
-DROP TABLE IF EXISTS consensus_update_coordinator_context_action_participant;
-DROP TABLE IF EXISTS consensus_participant_context;
-DROP TABLE IF EXISTS consensus_participant_context_participant;
-DROP TABLE IF EXISTS consensus_update_participant_context_action;
-DROP TABLE IF EXISTS consensus_update_participant_context_action_participant;
-DROP TABLE IF EXISTS consensus_participant_send_message_action;
-DROP TABLE IF EXISTS consensus_participant_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context;
+DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_action;
+DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action_participant;
+DROP TABLE IF EXISTS consensus_2pc_participant_context;
+DROP TABLE IF EXISTS consensus_2pc_participant_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action;
+DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action_participant;
+DROP TABLE IF EXISTS consensus_2pc_participant_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_participant_notification_action;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -96,8 +96,6 @@ CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action_participa
     FOREIGN KEY (action_id) REFERENCES consensus_update_coordinator_context_action(action_id) ON DELETE CASCADE
 );
 
--- participant tables ----------------------------------------------------------
-
 CREATE TABLE IF NOT EXISTS consensus_participant_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_context (
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
     state                     TEXT NOT NULL
-    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORCOORDINATORVOTE', 'ABORT', 'COMMIT') ),
+    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT') ),
     vote_timeout_start        BIGINT,
     PRIMARY KEY (service_id, epoch)
 );
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action (
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
     state                     TEXT NOT NULL
-    CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORCOORDINATORVOTE', 'ABORT', 'COMMIT') ),
+    CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT') ),
     vote_timeout_start        BIGINT,
     coordinator_action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -25,27 +25,27 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     id                        INTEGER PRIMARY KEY AUTOINCREMENT,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
@@ -56,11 +56,11 @@ CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action (
     CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT') ),
     vote_timeout_start        BIGINT,
     coordinator_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -69,11 +69,11 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_send_message_action (
     CHECK ( message_type IN ('VOTERESPONSE', 'DECISIONREQUEST') ),
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_coordinator_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -81,22 +81,22 @@ CREATE TABLE IF NOT EXISTS consensus_coordinator_notification_action (
     CHECK ( notification_type IN ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED') ),
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_coordinator_context_action_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_update_coordinator_context_action(action_id) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_coordinator_context_action(action_id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -110,15 +110,15 @@ CREATE TABLE IF NOT EXISTS consensus_participant_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
@@ -131,20 +131,20 @@ CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action (
     CHECK ( (vote IN ('TRUE' , 'FALSE')) OR (state != 'VOTED') ),
     decision_timeout_start    BIGINT,
     participant_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_update_participant_context_action_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action_participant (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
-    FOREIGN KEY (action_id) REFERENCES consensus_update_participant_context_action(action_id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_participant_context_action(action_id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -153,11 +153,11 @@ CREATE TABLE IF NOT EXISTS consensus_participant_send_message_action (
     CHECK ( message_type IN ('VOTEREQUEST', 'COMMIT', 'ABORT', 'DECISIONREQUEST') ),
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_participant_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_participant_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -167,6 +167,6 @@ CREATE TABLE IF NOT EXISTS consensus_participant_notification_action (
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     request_for_vote_value    BINARY
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BINARY,
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
@@ -55,5 +55,5 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
@@ -18,3 +18,9 @@ use crate::store::scabbard_store::two_phase::action::ConsensusAction;
 pub enum ScabbardConsensusAction {
     Scabbard2pcConsensusAction(ConsensusAction),
 }
+
+// A scabbard consensus action that includes the action ID associated with the action
+#[derive(Debug, PartialEq, Clone)]
+pub enum IdentifiedScabbardConsensusAction {
+    Scabbard2pcConsensusAction(i64, ConsensusAction),
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -46,6 +46,7 @@ use operations::add_consensus_action::AddActionOperation as _;
 use operations::add_consensus_context::AddContextOperation as _;
 use operations::add_consensus_event::AddEventOperation as _;
 use operations::add_service::AddServiceOperation as _;
+use operations::get_current_consensus_context::GetCurrentContextAction as _;
 use operations::get_last_commit_entry::GetLastCommitEntryOperation as _;
 use operations::get_service::GetServiceOperation as _;
 use operations::list_consensus_actions::ListActionsOperation as _;
@@ -222,6 +223,15 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
             ScabbardStoreOperations::new(conn).list_consensus_events(service_id, epoch)
         })
     }
+    /// Get the current context for a given service
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
+        self.pool.execute_write(|conn| {
+            ScabbardStoreOperations::new(conn).get_current_consensus_context(service_id)
+        })
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -366,6 +376,15 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
             ScabbardStoreOperations::new(conn).list_consensus_events(service_id, epoch)
         })
     }
+    /// Get the current context for a given service
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
+        self.pool.execute_write(|conn| {
+            ScabbardStoreOperations::new(conn).get_current_consensus_context(service_id)
+        })
+    }
 }
 
 pub struct DieselConnectionScabbardStore<'a, C>
@@ -502,6 +521,13 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     ) -> Result<Vec<ReturnedScabbardConsensusEvent>, ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id, epoch)
     }
+    /// Get the current context for a given service
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
+        ScabbardStoreOperations::new(self.connection).get_current_consensus_context(service_id)
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -619,6 +645,13 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
         epoch: u64,
     ) -> Result<Vec<ReturnedScabbardConsensusEvent>, ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id, epoch)
+    }
+    /// Get the current context for a given service
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
+        ScabbardStoreOperations::new(self.connection).get_current_consensus_context(service_id)
     }
 }
 
@@ -1660,6 +1693,154 @@ pub mod tests {
                 Scabbard2pcEvent::Alarm()
             ),
         );
+    }
+
+    /// Test that the scabbard store `get_current_consensus_context` operation is successful.
+    ///
+    /// 1. Add two services to the database
+    /// 2. Add a coordinator context for the first service
+    /// 3. Add a participant context for the second service
+    /// 4. Call `get_current_consensus_context` with the first service ID and check that the
+    ///    coordinator context is returned
+    /// 5. Call `get_current_consensus_context` with the second service ID and check that the
+    ///    participant context is returned
+    /// 6. Add a second coordinator context for the first service with a larger epoch
+    /// 7. Call `get_current_consensus_context` with the first service ID and check that the
+    ///    coordinator context with the larger epoch is returned
+    /// 8. Add a participant context with a larger epoch for the first service
+    /// 9. Call `get_current_consensus_context` with the first service ID and check that the
+    ///    participant context that was most recently added is returned
+    #[test]
+    fn scabbard_store_get_current_context() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselScabbardStore::new(pool);
+
+        let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
+            .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
+
+        let participant_service_id = FullyQualifiedServiceId::new_random();
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.service_id().clone()])
+            .with_status(&ServiceStatus::Finalized)
+            .with_consensus(&ConsensusType::TwoPC)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("faield to add service");
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&participant_service_id)
+            .with_peers(&[coordinator_fqsi.service_id().clone()])
+            .with_status(&ServiceStatus::Finalized)
+            .with_consensus(&ConsensusType::TwoPC)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("faield to add service");
+
+        let alarm = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_secs(
+                SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .expect("failed to get alarm time")
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("failed to get duration since UNIX EPOCH")
+                    .as_secs(),
+            ))
+            .unwrap();
+
+        let coordinator_context = ContextBuilder::default()
+            .with_alarm(alarm)
+            .with_coordinator(coordinator_fqsi.clone().service_id())
+            .with_epoch(1)
+            .with_participants(vec![Participant {
+                process: participant_service_id.service_id().clone(),
+                vote: None,
+            }])
+            .with_state(Scabbard2pcState::WaitingForStart)
+            .with_this_process(coordinator_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+        let context = ScabbardContext::Scabbard2pcContext(coordinator_context);
+
+        store
+            .add_consensus_context(&coordinator_fqsi, context.clone())
+            .expect("failed to add context");
+
+        let participant_context = ContextBuilder::default()
+            .with_alarm(alarm)
+            .with_coordinator(coordinator_fqsi.clone().service_id())
+            .with_epoch(1)
+            .with_participant_processes(vec![participant_service_id.service_id().clone()])
+            .with_state(Scabbard2pcState::WaitingForVoteRequest)
+            .with_this_process(participant_service_id.clone().service_id())
+            .build()
+            .expect("failed to build context");
+        let context2 = ScabbardContext::Scabbard2pcContext(participant_context);
+
+        store
+            .add_consensus_context(&participant_service_id.clone(), context2.clone())
+            .expect("failed to add context");
+
+        let current_context = store
+            .get_current_consensus_context(&coordinator_fqsi)
+            .expect("failed to get current context");
+
+        assert_eq!(current_context, Some(context));
+
+        let current_context = store
+            .get_current_consensus_context(&participant_service_id)
+            .expect("failed to get current context");
+
+        assert_eq!(current_context, Some(context2));
+
+        let coordinator_context = ContextBuilder::default()
+            .with_alarm(alarm)
+            .with_coordinator(coordinator_fqsi.clone().service_id())
+            .with_epoch(2)
+            .with_participants(vec![Participant {
+                process: participant_service_id.service_id().clone(),
+                vote: None,
+            }])
+            .with_state(Scabbard2pcState::WaitingForStart)
+            .with_this_process(coordinator_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+        let context3 = ScabbardContext::Scabbard2pcContext(coordinator_context);
+
+        store
+            .add_consensus_context(&coordinator_fqsi, context3.clone())
+            .expect("failed to add context");
+
+        let current_context = store
+            .get_current_consensus_context(&coordinator_fqsi)
+            .expect("failed to get current context");
+
+        assert_eq!(current_context, Some(context3));
+
+        let participant_context = ContextBuilder::default()
+            .with_alarm(alarm)
+            .with_coordinator(participant_service_id.clone().service_id())
+            .with_epoch(3)
+            .with_participant_processes(vec![coordinator_fqsi.service_id().clone()])
+            .with_state(Scabbard2pcState::WaitingForVoteRequest)
+            .with_this_process(coordinator_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+        let context4 = ScabbardContext::Scabbard2pcContext(participant_context);
+
+        store
+            .add_consensus_context(&coordinator_fqsi.clone(), context4.clone())
+            .expect("failed to add context");
+
+        let current_context = store
+            .get_current_consensus_context(&coordinator_fqsi)
+            .expect("failed to get current context");
+
+        assert_eq!(current_context, Some(context4));
     }
 
     fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -206,8 +206,6 @@ impl From<&ConsensusDecision> for String {
     }
 }
 
-/// --- coordinator tables ------------------------------------------------------
-
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_coordinator_context"]
 #[primary_key(service_id, epoch)]

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -209,7 +209,7 @@ impl From<&ConsensusDecision> for String {
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_coordinator_context"]
 #[primary_key(service_id, epoch)]
-pub struct CoordinatorContextModel {
+pub struct Consensus2pcCoordinatorContextModel {
     pub service_id: String,
     pub alarm: Option<i64>, // timestamp, when to wake up
     pub coordinator: String,
@@ -221,16 +221,16 @@ pub struct CoordinatorContextModel {
 
 impl
     TryFrom<(
-        &CoordinatorContextModel,
-        Vec<CoordinatorContextParticipantModel>,
+        &Consensus2pcCoordinatorContextModel,
+        Vec<Consensus2pcCoordinatorContextParticipantModel>,
     )> for ScabbardContext
 {
     type Error = InternalError;
 
     fn try_from(
         (context, participants): (
-            &CoordinatorContextModel,
-            Vec<CoordinatorContextParticipantModel>,
+            &Consensus2pcCoordinatorContextModel,
+            Vec<Consensus2pcCoordinatorContextParticipantModel>,
         ),
     ) -> Result<Self, Self::Error> {
         let epoch = u64::try_from(context.epoch)
@@ -309,7 +309,7 @@ impl
     }
 }
 
-impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextModel {
+impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcCoordinatorContextModel {
     type Error = InternalError;
 
     fn try_from(
@@ -348,7 +348,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextModel {
                     .map_err(|err| InternalError::from_source(Box::new(err)))?
                     .transpose()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
-                Ok(CoordinatorContextModel {
+                Ok(Consensus2pcCoordinatorContextModel {
                     service_id: format!("{}", service_id),
                     alarm,
                     coordinator: format!("{}", context.coordinator()),
@@ -366,7 +366,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextModel {
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_coordinator_context_participant"]
 #[primary_key(service_id, epoch, process)]
-pub struct CoordinatorContextParticipantModel {
+pub struct Consensus2pcCoordinatorContextParticipantModel {
     pub service_id: String,
     pub epoch: i64,
     pub process: String,
@@ -378,11 +378,11 @@ pub struct CoordinatorParticipantList {
     pub inner: Vec<Participant>,
 }
 
-impl TryFrom<Vec<CoordinatorContextParticipantModel>> for CoordinatorParticipantList {
+impl TryFrom<Vec<Consensus2pcCoordinatorContextParticipantModel>> for CoordinatorParticipantList {
     type Error = InternalError;
 
     fn try_from(
-        participants: Vec<CoordinatorContextParticipantModel>,
+        participants: Vec<Consensus2pcCoordinatorContextParticipantModel>,
     ) -> Result<Self, Self::Error> {
         let mut all_participants = Vec::new();
         for p in participants {
@@ -413,7 +413,7 @@ impl TryFrom<Vec<CoordinatorContextParticipantModel>> for CoordinatorParticipant
 
 #[derive(Debug, PartialEq)]
 pub struct CoordinatorContextParticipantList {
-    pub inner: Vec<CoordinatorContextParticipantModel>,
+    pub inner: Vec<Consensus2pcCoordinatorContextParticipantModel>,
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextParticipantList {
@@ -432,7 +432,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextPartici
                         true => "TRUE".to_string(),
                         false => "FALSE".to_string(),
                     });
-                    coordinator_participants.push(CoordinatorContextParticipantModel {
+                    coordinator_participants.push(Consensus2pcCoordinatorContextParticipantModel {
                         service_id: format!("{}", service_id),
                         epoch,
                         process: format!("{}", participant.process),
@@ -450,9 +450,9 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextPartici
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_update_coordinator_context_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct UpdateCoordinatorContextActionModel {
+pub struct Consensus2pcUpdateCoordinatorContextActionModel {
     pub action_id: i64,
     pub service_id: String,
     pub alarm: Option<i64>,
@@ -465,7 +465,7 @@ pub struct UpdateCoordinatorContextActionModel {
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
-    for UpdateCoordinatorContextActionModel
+    for Consensus2pcUpdateCoordinatorContextActionModel
 {
     type Error = InternalError;
 
@@ -510,7 +510,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
                     .map_err(|err| InternalError::from_source(Box::new(err)))?
                     .transpose()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
-                Ok(UpdateCoordinatorContextActionModel {
+                Ok(Consensus2pcUpdateCoordinatorContextActionModel {
                     action_id: *action_id,
                     service_id: format!("{}", service_id),
                     alarm,
@@ -529,10 +529,13 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_update_coordinator_context_action_participant"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
-#[belongs_to(UpdateCoordinatorContextActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
+#[belongs_to(
+    Consensus2pcUpdateCoordinatorContextActionModel,
+    foreign_key = "action_id"
+)]
 #[primary_key(action_id, process)]
-pub struct UpdateCoordinatorContextActionParticipantModel {
+pub struct Consensus2pcUpdateCoordinatorContextActionParticipantModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -542,7 +545,7 @@ pub struct UpdateCoordinatorContextActionParticipantModel {
 
 #[derive(Debug, PartialEq)]
 pub struct UpdateCoordinatorContextActionParticipantList {
-    pub inner: Vec<UpdateCoordinatorContextActionParticipantModel>,
+    pub inner: Vec<Consensus2pcUpdateCoordinatorContextActionParticipantModel>,
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
@@ -563,13 +566,15 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
                         true => "TRUE".to_string(),
                         false => "FALSE".to_string(),
                     });
-                    coordinator_participants.push(UpdateCoordinatorContextActionParticipantModel {
-                        action_id: *action_id,
-                        service_id: format!("{}", service_id),
-                        epoch,
-                        process: format!("{}", participant.process),
-                        vote,
-                    })
+                    coordinator_participants.push(
+                        Consensus2pcUpdateCoordinatorContextActionParticipantModel {
+                            action_id: *action_id,
+                            service_id: format!("{}", service_id),
+                            epoch,
+                            process: format!("{}", participant.process),
+                            vote,
+                        },
+                    )
                 }
                 Ok(UpdateCoordinatorContextActionParticipantList {
                     inner: coordinator_participants,
@@ -582,9 +587,9 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_coordinator_send_message_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct CoordinatorSendMessageActionModel {
+pub struct Consensus2pcCoordinatorSendMessageActionModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -595,9 +600,9 @@ pub struct CoordinatorSendMessageActionModel {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_coordinator_notification_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct CoordinatorNotificationModel {
+pub struct Consensus2pcCoordinatorNotificationModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -619,9 +624,9 @@ impl From<&CoordinatorState> for String {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_action"]
-#[belongs_to(CoordinatorContextModel, foreign_key = "service_id")]
+#[belongs_to(Consensus2pcCoordinatorContextModel, foreign_key = "service_id")]
 #[primary_key(id)]
-pub struct ConsensusActionModel {
+pub struct Consensus2pcActionModel {
     pub id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -632,7 +637,7 @@ pub struct ConsensusActionModel {
 
 #[derive(Debug, PartialEq, Insertable)]
 #[table_name = "consensus_action"]
-pub struct InsertableConsensusActionModel {
+pub struct InsertableConsensus2pcActionModel {
     pub service_id: String,
     pub epoch: i64,
     pub executed_at: Option<i64>,
@@ -642,7 +647,7 @@ pub struct InsertableConsensusActionModel {
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_participant_context"]
 #[primary_key(service_id, epoch)]
-pub struct ParticipantContextModel {
+pub struct Consensus2pcParticipantContextModel {
     pub service_id: String,
     pub alarm: Option<i64>,
     pub coordinator: String,
@@ -655,16 +660,16 @@ pub struct ParticipantContextModel {
 
 impl
     TryFrom<(
-        &ParticipantContextModel,
-        Vec<ParticipantContextParticipantModel>,
+        &Consensus2pcParticipantContextModel,
+        Vec<Consensus2pcParticipantContextParticipantModel>,
     )> for ScabbardContext
 {
     type Error = InternalError;
 
     fn try_from(
         (context, participants): (
-            &ParticipantContextModel,
-            Vec<ParticipantContextParticipantModel>,
+            &Consensus2pcParticipantContextModel,
+            Vec<Consensus2pcParticipantContextParticipantModel>,
         ),
     ) -> Result<Self, Self::Error> {
         let epoch = u64::try_from(context.epoch)
@@ -776,7 +781,7 @@ impl
     }
 }
 
-impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextModel {
+impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcParticipantContextModel {
     type Error = InternalError;
 
     fn try_from(
@@ -821,7 +826,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextModel {
                     .map_err(|err| InternalError::from_source(Box::new(err)))?
                     .transpose()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
-                Ok(ParticipantContextModel {
+                Ok(Consensus2pcParticipantContextModel {
                     service_id: format!("{}", service_id),
                     alarm,
                     coordinator: format!("{}", context.coordinator()),
@@ -840,7 +845,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextModel {
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_participant_context_participant"]
 #[primary_key(service_id, epoch, process)]
-pub struct ParticipantContextParticipantModel {
+pub struct Consensus2pcParticipantContextParticipantModel {
     pub service_id: String,
     pub epoch: i64,
     pub process: String,
@@ -848,7 +853,7 @@ pub struct ParticipantContextParticipantModel {
 
 #[derive(Debug, PartialEq)]
 pub struct ParticipantContextParticipantList {
-    pub inner: Vec<ParticipantContextParticipantModel>,
+    pub inner: Vec<Consensus2pcParticipantContextParticipantModel>,
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextParticipantList {
@@ -863,7 +868,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextPartici
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
                 let mut participants = Vec::new();
                 for participant in participant_context.participant_processes {
-                    participants.push(ParticipantContextParticipantModel {
+                    participants.push(Consensus2pcParticipantContextParticipantModel {
                         service_id: format!("{}", service_id),
                         epoch,
                         process: format!("{}", participant),
@@ -880,9 +885,9 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextPartici
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_update_participant_context_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct UpdateParticipantContextActionModel {
+pub struct Consensus2pcUpdateParticipantContextActionModel {
     pub action_id: i64,
     pub service_id: String,
     pub alarm: Option<i64>,
@@ -896,7 +901,7 @@ pub struct UpdateParticipantContextActionModel {
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
-    for UpdateParticipantContextActionModel
+    for Consensus2pcUpdateParticipantContextActionModel
 {
     type Error = InternalError;
 
@@ -947,7 +952,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
                     .map_err(|err| InternalError::from_source(Box::new(err)))?
                     .transpose()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
-                Ok(UpdateParticipantContextActionModel {
+                Ok(Consensus2pcUpdateParticipantContextActionModel {
                     action_id: *action_id,
                     service_id: format!("{}", service_id),
                     alarm,
@@ -967,10 +972,13 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_update_participant_context_action_participant"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
-#[belongs_to(UpdateParticipantContextActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
+#[belongs_to(
+    Consensus2pcUpdateParticipantContextActionModel,
+    foreign_key = "action_id"
+)]
 #[primary_key(action_id, process)]
-pub struct UpdateParticipantContextActionParticipantModel {
+pub struct Consensus2pcUpdateParticipantContextActionParticipantModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -979,7 +987,7 @@ pub struct UpdateParticipantContextActionParticipantModel {
 
 #[derive(Debug, PartialEq)]
 pub struct UpdateParticipantContextActionParticipantList {
-    pub inner: Vec<UpdateParticipantContextActionParticipantModel>,
+    pub inner: Vec<Consensus2pcUpdateParticipantContextActionParticipantModel>,
 }
 
 impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
@@ -996,12 +1004,14 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
                 let mut participant_participants = Vec::new();
                 for participant in participant_context.participant_processes {
-                    participant_participants.push(UpdateParticipantContextActionParticipantModel {
-                        action_id: *action_id,
-                        service_id: format!("{}", service_id),
-                        epoch,
-                        process: format!("{}", participant),
-                    })
+                    participant_participants.push(
+                        Consensus2pcUpdateParticipantContextActionParticipantModel {
+                            action_id: *action_id,
+                            service_id: format!("{}", service_id),
+                            epoch,
+                            process: format!("{}", participant),
+                        },
+                    )
                 }
                 Ok(UpdateParticipantContextActionParticipantList {
                     inner: participant_participants,
@@ -1014,9 +1024,9 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_participant_send_message_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct ParticipantSendMessageActionModel {
+pub struct Consensus2pcParticipantSendMessageActionModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -1027,9 +1037,9 @@ pub struct ParticipantSendMessageActionModel {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_participant_notification_action"]
-#[belongs_to(ConsensusActionModel, foreign_key = "action_id")]
+#[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
-pub struct ParticipantNotificationModel {
+pub struct Consensus2pcParticipantNotificationModel {
     pub action_id: i64,
     pub service_id: String,
     pub epoch: i64,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -32,14 +32,15 @@ use crate::store::scabbard_store::{
 };
 
 use super::schema::{
-    consensus_action, consensus_coordinator_context, consensus_coordinator_context_participant,
-    consensus_coordinator_notification_action, consensus_coordinator_send_message_action,
-    consensus_participant_context, consensus_participant_context_participant,
-    consensus_participant_notification_action, consensus_participant_send_message_action,
-    consensus_update_coordinator_context_action,
-    consensus_update_coordinator_context_action_participant,
-    consensus_update_participant_context_action,
-    consensus_update_participant_context_action_participant, scabbard_peer, scabbard_service,
+    consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
+    consensus_2pc_consensus_coordinator_context_participant,
+    consensus_2pc_coordinator_notification_action, consensus_2pc_coordinator_send_message_action,
+    consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
+    consensus_2pc_participant_notification_action, consensus_2pc_participant_send_message_action,
+    consensus_2pc_update_coordinator_context_action,
+    consensus_2pc_update_coordinator_context_action_participant,
+    consensus_2pc_update_participant_context_action,
+    consensus_2pc_update_participant_context_action_participant, scabbard_peer, scabbard_service,
     scabbard_v3_commit_history, two_pc_consensus_deliver_event, two_pc_consensus_event,
     two_pc_consensus_start_event, two_pc_consensus_vote_event,
 };
@@ -207,7 +208,7 @@ impl From<&ConsensusDecision> for String {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_coordinator_context"]
+#[table_name = "consensus_2pc_consensus_coordinator_context"]
 #[primary_key(service_id, epoch)]
 pub struct Consensus2pcCoordinatorContextModel {
     pub service_id: String,
@@ -364,7 +365,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcCoordinatorCo
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_coordinator_context_participant"]
+#[table_name = "consensus_2pc_consensus_coordinator_context_participant"]
 #[primary_key(service_id, epoch, process)]
 pub struct Consensus2pcCoordinatorContextParticipantModel {
     pub service_id: String,
@@ -449,7 +450,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for CoordinatorContextPartici
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_update_coordinator_context_action"]
+#[table_name = "consensus_2pc_update_coordinator_context_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcUpdateCoordinatorContextActionModel {
@@ -528,7 +529,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_update_coordinator_context_action_participant"]
+#[table_name = "consensus_2pc_update_coordinator_context_action_participant"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[belongs_to(
     Consensus2pcUpdateCoordinatorContextActionModel,
@@ -586,7 +587,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_coordinator_send_message_action"]
+#[table_name = "consensus_2pc_coordinator_send_message_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcCoordinatorSendMessageActionModel {
@@ -599,7 +600,7 @@ pub struct Consensus2pcCoordinatorSendMessageActionModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_coordinator_notification_action"]
+#[table_name = "consensus_2pc_coordinator_notification_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcCoordinatorNotificationModel {
@@ -623,7 +624,7 @@ impl From<&CoordinatorState> for String {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_action"]
+#[table_name = "consensus_2pc_action"]
 #[belongs_to(Consensus2pcCoordinatorContextModel, foreign_key = "service_id")]
 #[primary_key(id)]
 pub struct Consensus2pcActionModel {
@@ -636,7 +637,7 @@ pub struct Consensus2pcActionModel {
 }
 
 #[derive(Debug, PartialEq, Insertable)]
-#[table_name = "consensus_action"]
+#[table_name = "consensus_2pc_action"]
 pub struct InsertableConsensus2pcActionModel {
     pub service_id: String,
     pub epoch: i64,
@@ -645,7 +646,7 @@ pub struct InsertableConsensus2pcActionModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_participant_context"]
+#[table_name = "consensus_2pc_participant_context"]
 #[primary_key(service_id, epoch)]
 pub struct Consensus2pcParticipantContextModel {
     pub service_id: String,
@@ -843,7 +844,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcParticipantCo
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_participant_context_participant"]
+#[table_name = "consensus_2pc_participant_context_participant"]
 #[primary_key(service_id, epoch, process)]
 pub struct Consensus2pcParticipantContextParticipantModel {
     pub service_id: String,
@@ -884,7 +885,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for ParticipantContextPartici
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_update_participant_context_action"]
+#[table_name = "consensus_2pc_update_participant_context_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcUpdateParticipantContextActionModel {
@@ -971,7 +972,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64, &Option<i64>)>
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_update_participant_context_action_participant"]
+#[table_name = "consensus_2pc_update_participant_context_action_participant"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[belongs_to(
     Consensus2pcUpdateParticipantContextActionModel,
@@ -1023,7 +1024,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId, &i64)>
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_participant_send_message_action"]
+#[table_name = "consensus_2pc_participant_send_message_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcParticipantSendMessageActionModel {
@@ -1036,7 +1037,7 @@ pub struct Consensus2pcParticipantSendMessageActionModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_participant_notification_action"]
+#[table_name = "consensus_2pc_participant_notification_action"]
 #[belongs_to(Consensus2pcActionModel, foreign_key = "action_id")]
 #[primary_key(action_id)]
 pub struct Consensus2pcParticipantNotificationModel {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
@@ -25,10 +25,12 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, CoordinatorNotificationModel, CoordinatorSendMessageActionModel,
-        InsertableConsensusActionModel, ParticipantContextModel, ParticipantNotificationModel,
-        ParticipantSendMessageActionModel, UpdateCoordinatorContextActionModel,
-        UpdateCoordinatorContextActionParticipantList, UpdateParticipantContextActionModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcCoordinatorNotificationModel,
+        Consensus2pcCoordinatorSendMessageActionModel, Consensus2pcParticipantContextModel,
+        Consensus2pcParticipantNotificationModel, Consensus2pcParticipantSendMessageActionModel,
+        Consensus2pcUpdateCoordinatorContextActionModel,
+        Consensus2pcUpdateParticipantContextActionModel, InsertableConsensus2pcActionModel,
+        UpdateCoordinatorContextActionParticipantList,
         UpdateParticipantContextActionParticipantList,
     },
     schema::{
@@ -80,7 +82,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -89,7 +91,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let position = consensus_action::table
@@ -118,7 +120,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     ));
                 }
 
-                let insertable_action = InsertableConsensusActionModel {
+                let insertable_action = InsertableConsensus2pcActionModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -139,7 +141,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             let coordinator_action_alarm = get_timestamp(alarm)?;
 
                             let update_context_action =
-                                UpdateCoordinatorContextActionModel::try_from((
+                                Consensus2pcUpdateCoordinatorContextActionModel::try_from((
                                     &context,
                                     service_id,
                                     &action_id,
@@ -186,7 +188,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             }
                         };
 
-                        let send_message_action = CoordinatorSendMessageActionModel {
+                        let send_message_action = Consensus2pcCoordinatorSendMessageActionModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -216,7 +218,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             _ => (String::from(&notification), None),
                         };
 
-                        let notification_action = CoordinatorNotificationModel {
+                        let notification_action = Consensus2pcCoordinatorNotificationModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -230,7 +232,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     }
                 }
             } else if participant_context.is_some() {
-                let insertable_action = InsertableConsensusActionModel {
+                let insertable_action = InsertableConsensus2pcActionModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -251,7 +253,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             let participant_action_alarm = get_timestamp(alarm)?;
 
                             let update_context_action =
-                                UpdateParticipantContextActionModel::try_from((
+                                Consensus2pcUpdateParticipantContextActionModel::try_from((
                                     &context,
                                     service_id,
                                     &action_id,
@@ -296,7 +298,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             }
                         };
 
-                        let send_message_action = ParticipantSendMessageActionModel {
+                        let send_message_action = Consensus2pcParticipantSendMessageActionModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -331,7 +333,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                                 _ => (String::from(&notification), None, None),
                             };
 
-                        let notification_action = ParticipantNotificationModel {
+                        let notification_action = Consensus2pcParticipantNotificationModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -377,7 +379,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -386,7 +388,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let position = consensus_action::table
@@ -415,7 +417,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                     ));
                 }
 
-                let insertable_action = InsertableConsensusActionModel {
+                let insertable_action = InsertableConsensus2pcActionModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -433,7 +435,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                             let coordinator_action_alarm = get_timestamp(alarm)?;
 
                             let update_context_action =
-                                UpdateCoordinatorContextActionModel::try_from((
+                                Consensus2pcUpdateCoordinatorContextActionModel::try_from((
                                     &context,
                                     service_id,
                                     &action_id,
@@ -480,7 +482,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                             }
                         };
 
-                        let send_message_action = CoordinatorSendMessageActionModel {
+                        let send_message_action = Consensus2pcCoordinatorSendMessageActionModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -510,7 +512,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                             _ => (String::from(&notification), None),
                         };
 
-                        let notification_action = CoordinatorNotificationModel {
+                        let notification_action = Consensus2pcCoordinatorNotificationModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -524,7 +526,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                     }
                 }
             } else if participant_context.is_some() {
-                let insertable_action = InsertableConsensusActionModel {
+                let insertable_action = InsertableConsensus2pcActionModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -542,7 +544,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                             let participant_action_alarm = get_timestamp(alarm)?;
 
                             let update_context_action =
-                                UpdateParticipantContextActionModel::try_from((
+                                Consensus2pcUpdateParticipantContextActionModel::try_from((
                                     &context,
                                     service_id,
                                     &action_id,
@@ -587,7 +589,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                             }
                         };
 
-                        let send_message_action = ParticipantSendMessageActionModel {
+                        let send_message_action = Consensus2pcParticipantSendMessageActionModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -622,7 +624,7 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                                 _ => (String::from(&notification), None, None),
                             };
 
-                        let notification_action = ParticipantNotificationModel {
+                        let notification_action = Consensus2pcParticipantNotificationModel {
                             action_id,
                             service_id: format!("{}", service_id),
                             epoch,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
@@ -24,8 +24,8 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, CoordinatorContextParticipantList, ParticipantContextModel,
-        ParticipantContextParticipantList,
+        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
+        CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
         consensus_coordinator_context, consensus_coordinator_context_participant,
@@ -55,7 +55,7 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ScabbardContext::Scabbard2pcContext(context) => {
-                    match CoordinatorContextModel::try_from((&context, service_id)) {
+                    match Consensus2pcCoordinatorContextModel::try_from((&context, service_id)) {
                         Ok(new_coordinator_context) => {
                             let participants = CoordinatorContextParticipantList::try_from((
                                 &context, service_id,
@@ -68,7 +68,9 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                                 .values(participants)
                                 .execute(self.conn)?;
                         }
-                        Err(_) => match ParticipantContextModel::try_from((&context, service_id)) {
+                        Err(_) => match Consensus2pcParticipantContextModel::try_from((
+                            &context, service_id,
+                        )) {
                             Ok(new_participant_context) => {
                                 let participants = ParticipantContextParticipantList::try_from((
                                     &context, service_id,
@@ -105,7 +107,7 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ScabbardContext::Scabbard2pcContext(context) => {
-                    match CoordinatorContextModel::try_from((&context, service_id)) {
+                    match Consensus2pcCoordinatorContextModel::try_from((&context, service_id)) {
                         Ok(new_coordinator_context) => {
                             let participants = CoordinatorContextParticipantList::try_from((
                                 &context, service_id,
@@ -118,7 +120,9 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
                                 .values(participants)
                                 .execute(self.conn)?;
                         }
-                        Err(_) => match ParticipantContextModel::try_from((&context, service_id)) {
+                        Err(_) => match Consensus2pcParticipantContextModel::try_from((
+                            &context, service_id,
+                        )) {
                             Ok(new_participant_context) => {
                                 let participants = ParticipantContextParticipantList::try_from((
                                     &context, service_id,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
@@ -28,8 +28,9 @@ use crate::store::scabbard_store::diesel::{
         CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
-        consensus_coordinator_context, consensus_coordinator_context_participant,
-        consensus_participant_context, consensus_participant_context_participant,
+        consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
+        consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::ScabbardContext;
@@ -61,12 +62,14 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                                 &context, service_id,
                             ))?
                             .inner;
-                            insert_into(consensus_coordinator_context::table)
+                            insert_into(consensus_2pc_consensus_coordinator_context::table)
                                 .values(vec![new_coordinator_context])
                                 .execute(self.conn)?;
-                            insert_into(consensus_coordinator_context_participant::table)
-                                .values(participants)
-                                .execute(self.conn)?;
+                            insert_into(
+                                consensus_2pc_consensus_coordinator_context_participant::table,
+                            )
+                            .values(participants)
+                            .execute(self.conn)?;
                         }
                         Err(_) => match Consensus2pcParticipantContextModel::try_from((
                             &context, service_id,
@@ -76,10 +79,10 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                                     &context, service_id,
                                 ))?
                                 .inner;
-                                insert_into(consensus_participant_context::table)
+                                insert_into(consensus_2pc_participant_context::table)
                                     .values(vec![new_participant_context])
                                     .execute(self.conn)?;
-                                insert_into(consensus_participant_context_participant::table)
+                                insert_into(consensus_2pc_participant_context_participant::table)
                                     .values(participants)
                                     .execute(self.conn)?;
                             }
@@ -113,12 +116,14 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
                                 &context, service_id,
                             ))?
                             .inner;
-                            insert_into(consensus_coordinator_context::table)
+                            insert_into(consensus_2pc_consensus_coordinator_context::table)
                                 .values(vec![new_coordinator_context])
                                 .execute(self.conn)?;
-                            insert_into(consensus_coordinator_context_participant::table)
-                                .values(participants)
-                                .execute(self.conn)?;
+                            insert_into(
+                                consensus_2pc_consensus_coordinator_context_participant::table,
+                            )
+                            .values(participants)
+                            .execute(self.conn)?;
                         }
                         Err(_) => match Consensus2pcParticipantContextModel::try_from((
                             &context, service_id,
@@ -128,10 +133,10 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
                                     &context, service_id,
                                 ))?
                                 .inner;
-                                insert_into(consensus_participant_context::table)
+                                insert_into(consensus_2pc_participant_context::table)
                                     .values(vec![new_participant_context])
                                     .execute(self.conn)?;
-                                insert_into(consensus_participant_context_participant::table)
+                                insert_into(consensus_2pc_participant_context_participant::table)
                                     .values(participants)
                                     .execute(self.conn)?;
                             }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -29,7 +29,7 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_coordinator_context, consensus_participant_context,
+        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
         two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
         two_pc_consensus_vote_event,
     },
@@ -65,22 +65,25 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context =
-                consensus_coordinator_context::table
-                    .filter(consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                    .optional()?;
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(
+                    consensus_2pc_consensus_coordinator_context::epoch
+                        .eq(epoch)
+                        .and(
+                            consensus_2pc_consensus_coordinator_context::service_id
+                                .eq(format!("{}", service_id)),
+                        ),
+                )
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+                .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
-            let participant_context =
-                consensus_participant_context::table
-                    .filter(consensus_participant_context::epoch.eq(epoch).and(
-                        consensus_participant_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcParticipantContextModel>(self.conn)
-                    .optional()?;
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
+                ))
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
+                .optional()?;
 
             let position = two_pc_consensus_event::table
                 .filter(
@@ -298,22 +301,25 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context =
-                consensus_coordinator_context::table
-                    .filter(consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                    .optional()?;
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(
+                    consensus_2pc_consensus_coordinator_context::epoch
+                        .eq(epoch)
+                        .and(
+                            consensus_2pc_consensus_coordinator_context::service_id
+                                .eq(format!("{}", service_id)),
+                        ),
+                )
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+                .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
-            let participant_context =
-                consensus_participant_context::table
-                    .filter(consensus_participant_context::epoch.eq(epoch).and(
-                        consensus_participant_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcParticipantContextModel>(self.conn)
-                    .optional()?;
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
+                ))
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
+                .optional()?;
 
             let position = two_pc_consensus_event::table
                 .filter(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -24,9 +24,9 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, InsertableTwoPcConsensusEventModel, ParticipantContextModel,
-        TwoPcConsensusDeliverEventModel, TwoPcConsensusStartEventModel,
-        TwoPcConsensusVoteEventModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
+        InsertableTwoPcConsensusEventModel, TwoPcConsensusDeliverEventModel,
+        TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
     },
     schema::{
         consensus_coordinator_context, consensus_participant_context,
@@ -70,7 +70,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -79,7 +79,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let position = two_pc_consensus_event::table
@@ -303,7 +303,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -312,7 +312,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let position = two_pc_consensus_event::table

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -1,0 +1,178 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+
+use diesel::prelude::*;
+use splinter::error::{InternalError, InvalidStateError};
+use splinter::service::FullyQualifiedServiceId;
+
+use crate::store::scabbard_store::diesel::{
+    models::{
+        CoordinatorContextModel, CoordinatorContextParticipantModel, ParticipantContextModel,
+        ParticipantContextParticipantModel,
+    },
+    schema::{
+        consensus_coordinator_context, consensus_coordinator_context_participant,
+        consensus_participant_context, consensus_participant_context_participant,
+    },
+};
+use crate::store::scabbard_store::{context::ScabbardContext, ScabbardStoreError};
+
+use super::ScabbardStoreOperations;
+
+pub(in crate::store::scabbard_store::diesel) trait GetCurrentContextAction {
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError>;
+}
+
+impl<'a, C> GetCurrentContextAction for ScabbardStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            let coordinator_context = consensus_coordinator_context::table
+                .filter(consensus_coordinator_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_coordinator_context::epoch.desc())
+                .first::<CoordinatorContextModel>(self.conn)
+                .optional()?;
+
+            let participant_context = consensus_participant_context::table
+                .filter(consensus_participant_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_participant_context::epoch.desc())
+                .first::<ParticipantContextModel>(self.conn)
+                .optional()?;
+
+            match (coordinator_context, participant_context) {
+                // If both a coordinator and a participant contexts exist for the given service ID
+                // get the context with the largest epoch
+                (Some(coordinator_context), Some(participant_context)) => {
+                    match coordinator_context.epoch.cmp(&participant_context.epoch) {
+                        // If both a coordinator and a participant context exists for the given
+                        // service ID and they have the same epoch value, return an error
+                        Ordering::Equal => {
+                            return Err(ScabbardStoreError::InvalidState(
+                                InvalidStateError::with_message(format!(
+                                    "Failed to add consensus action, contexts found for both
+                                        participant and coordinator with service_id: {} epoch: {} ",
+                                    service_id, participant_context.epoch
+                                )),
+                            ));
+                        }
+                        Ordering::Greater => {
+                            let coordinator_participants: Vec<CoordinatorContextParticipantModel> =
+                                consensus_coordinator_context_participant::table
+                                    .filter(
+                                        consensus_coordinator_context_participant::service_id
+                                            .eq(format!("{}", service_id))
+                                            .and(
+                                                consensus_coordinator_context_participant::epoch
+                                                    .eq(coordinator_context.epoch),
+                                            ),
+                                    )
+                                    .load::<CoordinatorContextParticipantModel>(self.conn)?;
+                            Ok(Some(
+                                ScabbardContext::try_from((
+                                    &coordinator_context,
+                                    coordinator_participants,
+                                ))
+                                .map_err(|err| {
+                                    ScabbardStoreError::Internal(InternalError::from_source(
+                                        Box::new(err),
+                                    ))
+                                })?,
+                            ))
+                        }
+                        Ordering::Less => {
+                            let participant_participants: Vec<ParticipantContextParticipantModel> =
+                                consensus_participant_context_participant::table
+                                    .filter(
+                                        consensus_participant_context_participant::service_id
+                                            .eq(format!("{}", service_id))
+                                            .and(
+                                                consensus_participant_context_participant::epoch
+                                                    .eq(participant_context.epoch),
+                                            ),
+                                    )
+                                    .load::<ParticipantContextParticipantModel>(self.conn)?;
+                            Ok(Some(
+                                ScabbardContext::try_from((
+                                    &participant_context,
+                                    participant_participants,
+                                ))
+                                .map_err(|err| {
+                                    ScabbardStoreError::Internal(InternalError::from_source(
+                                        Box::new(err),
+                                    ))
+                                })?,
+                            ))
+                        }
+                    }
+                }
+                (Some(coordinator_context), None) => {
+                    let coordinator_participants: Vec<CoordinatorContextParticipantModel> =
+                        consensus_coordinator_context_participant::table
+                            .filter(
+                                consensus_coordinator_context_participant::service_id
+                                    .eq(format!("{}", service_id))
+                                    .and(
+                                        consensus_coordinator_context_participant::epoch
+                                            .eq(coordinator_context.epoch),
+                                    ),
+                            )
+                            .load::<CoordinatorContextParticipantModel>(self.conn)?;
+                    Ok(Some(
+                        ScabbardContext::try_from((&coordinator_context, coordinator_participants))
+                            .map_err(|err| {
+                                ScabbardStoreError::Internal(InternalError::from_source(Box::new(
+                                    err,
+                                )))
+                            })?,
+                    ))
+                }
+                (None, Some(participant_context)) => {
+                    let participant_participants: Vec<ParticipantContextParticipantModel> =
+                        consensus_participant_context_participant::table
+                            .filter(
+                                consensus_participant_context_participant::service_id
+                                    .eq(format!("{}", service_id))
+                                    .and(
+                                        consensus_participant_context_participant::epoch
+                                            .eq(participant_context.epoch),
+                                    ),
+                            )
+                            .load::<ParticipantContextParticipantModel>(self.conn)?;
+                    Ok(Some(
+                        ScabbardContext::try_from((&participant_context, participant_participants))
+                            .map_err(|err| {
+                                ScabbardStoreError::Internal(InternalError::from_source(Box::new(
+                                    err,
+                                )))
+                            })?,
+                    ))
+                }
+                (None, None) => Ok(None),
+            }
+        })
+    }
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -25,8 +25,9 @@ use crate::store::scabbard_store::diesel::{
         Consensus2pcParticipantContextModel, Consensus2pcParticipantContextParticipantModel,
     },
     schema::{
-        consensus_coordinator_context, consensus_coordinator_context_participant,
-        consensus_participant_context, consensus_participant_context_participant,
+        consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
+        consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::{context::ScabbardContext, ScabbardStoreError};
@@ -51,15 +52,15 @@ where
         service_id: &FullyQualifiedServiceId,
     ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            let coordinator_context = consensus_coordinator_context::table
-                .filter(consensus_coordinator_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_coordinator_context::epoch.desc())
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(consensus_2pc_consensus_coordinator_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_2pc_consensus_coordinator_context::epoch.desc())
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 
-            let participant_context = consensus_participant_context::table
-                .filter(consensus_participant_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_participant_context::epoch.desc())
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_2pc_participant_context::epoch.desc())
                 .first::<Consensus2pcParticipantContextModel>(self.conn)
                 .optional()?;
 
@@ -82,12 +83,12 @@ where
                         Ordering::Greater => {
                             let coordinator_participants: Vec<
                                 Consensus2pcCoordinatorContextParticipantModel,
-                            > = consensus_coordinator_context_participant::table
+                            > = consensus_2pc_consensus_coordinator_context_participant::table
                                 .filter(
-                                    consensus_coordinator_context_participant::service_id
+                                    consensus_2pc_consensus_coordinator_context_participant::service_id
                                         .eq(format!("{}", service_id))
                                         .and(
-                                            consensus_coordinator_context_participant::epoch
+                                            consensus_2pc_consensus_coordinator_context_participant::epoch
                                                 .eq(coordinator_context.epoch),
                                         ),
                                 )
@@ -109,12 +110,12 @@ where
                         Ordering::Less => {
                             let participant_participants: Vec<
                                 Consensus2pcParticipantContextParticipantModel,
-                            > = consensus_participant_context_participant::table
+                            > = consensus_2pc_participant_context_participant::table
                                 .filter(
-                                    consensus_participant_context_participant::service_id
+                                    consensus_2pc_participant_context_participant::service_id
                                         .eq(format!("{}", service_id))
                                         .and(
-                                            consensus_participant_context_participant::epoch
+                                            consensus_2pc_participant_context_participant::epoch
                                                 .eq(participant_context.epoch),
                                         ),
                                 )
@@ -138,12 +139,12 @@ where
                 (Some(coordinator_context), None) => {
                     let coordinator_participants: Vec<
                         Consensus2pcCoordinatorContextParticipantModel,
-                    > = consensus_coordinator_context_participant::table
+                    > = consensus_2pc_consensus_coordinator_context_participant::table
                         .filter(
-                            consensus_coordinator_context_participant::service_id
+                            consensus_2pc_consensus_coordinator_context_participant::service_id
                                 .eq(format!("{}", service_id))
                                 .and(
-                                    consensus_coordinator_context_participant::epoch
+                                    consensus_2pc_consensus_coordinator_context_participant::epoch
                                         .eq(coordinator_context.epoch),
                                 ),
                         )
@@ -160,12 +161,12 @@ where
                 (None, Some(participant_context)) => {
                     let participant_participants: Vec<
                         Consensus2pcParticipantContextParticipantModel,
-                    > = consensus_participant_context_participant::table
+                    > = consensus_2pc_participant_context_participant::table
                         .filter(
-                            consensus_participant_context_participant::service_id
+                            consensus_2pc_participant_context_participant::service_id
                                 .eq(format!("{}", service_id))
                                 .and(
-                                    consensus_participant_context_participant::epoch
+                                    consensus_2pc_participant_context_participant::epoch
                                         .eq(participant_context.epoch),
                                 ),
                         )

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -21,8 +21,8 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, CoordinatorContextParticipantModel, ParticipantContextModel,
-        ParticipantContextParticipantModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcCoordinatorContextParticipantModel,
+        Consensus2pcParticipantContextModel, Consensus2pcParticipantContextParticipantModel,
     },
     schema::{
         consensus_coordinator_context, consensus_coordinator_context_participant,
@@ -54,13 +54,13 @@ where
             let coordinator_context = consensus_coordinator_context::table
                 .filter(consensus_coordinator_context::service_id.eq(format!("{}", service_id)))
                 .order(consensus_coordinator_context::epoch.desc())
-                .first::<CoordinatorContextModel>(self.conn)
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 
             let participant_context = consensus_participant_context::table
                 .filter(consensus_participant_context::service_id.eq(format!("{}", service_id)))
                 .order(consensus_participant_context::epoch.desc())
-                .first::<ParticipantContextModel>(self.conn)
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
                 .optional()?;
 
             match (coordinator_context, participant_context) {
@@ -80,17 +80,20 @@ where
                             ));
                         }
                         Ordering::Greater => {
-                            let coordinator_participants: Vec<CoordinatorContextParticipantModel> =
-                                consensus_coordinator_context_participant::table
-                                    .filter(
-                                        consensus_coordinator_context_participant::service_id
-                                            .eq(format!("{}", service_id))
-                                            .and(
-                                                consensus_coordinator_context_participant::epoch
-                                                    .eq(coordinator_context.epoch),
-                                            ),
-                                    )
-                                    .load::<CoordinatorContextParticipantModel>(self.conn)?;
+                            let coordinator_participants: Vec<
+                                Consensus2pcCoordinatorContextParticipantModel,
+                            > = consensus_coordinator_context_participant::table
+                                .filter(
+                                    consensus_coordinator_context_participant::service_id
+                                        .eq(format!("{}", service_id))
+                                        .and(
+                                            consensus_coordinator_context_participant::epoch
+                                                .eq(coordinator_context.epoch),
+                                        ),
+                                )
+                                .load::<Consensus2pcCoordinatorContextParticipantModel>(
+                                    self.conn,
+                                )?;
                             Ok(Some(
                                 ScabbardContext::try_from((
                                     &coordinator_context,
@@ -104,17 +107,20 @@ where
                             ))
                         }
                         Ordering::Less => {
-                            let participant_participants: Vec<ParticipantContextParticipantModel> =
-                                consensus_participant_context_participant::table
-                                    .filter(
-                                        consensus_participant_context_participant::service_id
-                                            .eq(format!("{}", service_id))
-                                            .and(
-                                                consensus_participant_context_participant::epoch
-                                                    .eq(participant_context.epoch),
-                                            ),
-                                    )
-                                    .load::<ParticipantContextParticipantModel>(self.conn)?;
+                            let participant_participants: Vec<
+                                Consensus2pcParticipantContextParticipantModel,
+                            > = consensus_participant_context_participant::table
+                                .filter(
+                                    consensus_participant_context_participant::service_id
+                                        .eq(format!("{}", service_id))
+                                        .and(
+                                            consensus_participant_context_participant::epoch
+                                                .eq(participant_context.epoch),
+                                        ),
+                                )
+                                .load::<Consensus2pcParticipantContextParticipantModel>(
+                                    self.conn,
+                                )?;
                             Ok(Some(
                                 ScabbardContext::try_from((
                                     &participant_context,
@@ -130,17 +136,18 @@ where
                     }
                 }
                 (Some(coordinator_context), None) => {
-                    let coordinator_participants: Vec<CoordinatorContextParticipantModel> =
-                        consensus_coordinator_context_participant::table
-                            .filter(
-                                consensus_coordinator_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_coordinator_context_participant::epoch
-                                            .eq(coordinator_context.epoch),
-                                    ),
-                            )
-                            .load::<CoordinatorContextParticipantModel>(self.conn)?;
+                    let coordinator_participants: Vec<
+                        Consensus2pcCoordinatorContextParticipantModel,
+                    > = consensus_coordinator_context_participant::table
+                        .filter(
+                            consensus_coordinator_context_participant::service_id
+                                .eq(format!("{}", service_id))
+                                .and(
+                                    consensus_coordinator_context_participant::epoch
+                                        .eq(coordinator_context.epoch),
+                                ),
+                        )
+                        .load::<Consensus2pcCoordinatorContextParticipantModel>(self.conn)?;
                     Ok(Some(
                         ScabbardContext::try_from((&coordinator_context, coordinator_participants))
                             .map_err(|err| {
@@ -151,17 +158,18 @@ where
                     ))
                 }
                 (None, Some(participant_context)) => {
-                    let participant_participants: Vec<ParticipantContextParticipantModel> =
-                        consensus_participant_context_participant::table
-                            .filter(
-                                consensus_participant_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_participant_context_participant::epoch
-                                            .eq(participant_context.epoch),
-                                    ),
-                            )
-                            .load::<ParticipantContextParticipantModel>(self.conn)?;
+                    let participant_participants: Vec<
+                        Consensus2pcParticipantContextParticipantModel,
+                    > = consensus_participant_context_participant::table
+                        .filter(
+                            consensus_participant_context_participant::service_id
+                                .eq(format!("{}", service_id))
+                                .and(
+                                    consensus_participant_context_participant::epoch
+                                        .eq(participant_context.epoch),
+                                ),
+                        )
+                        .load::<Consensus2pcParticipantContextParticipantModel>(self.conn)?;
                     Ok(Some(
                         ScabbardContext::try_from((&participant_context, participant_participants))
                             .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -599,8 +599,7 @@ fn get_system_time(time: Option<i64>) -> Result<Option<SystemTime>, ScabbardStor
                 .checked_add(Duration::from_secs(time as u64))
                 .ok_or_else(|| {
                     InternalError::with_message(
-                        "'sent_at' timestamp could not be represented as a `SystemTime`"
-                            .to_string(),
+                        "timestamp could not be represented as a `SystemTime`".to_string(),
                     )
                 })?,
         )),

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -24,9 +24,11 @@ use splinter::service::ServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, CoordinatorNotificationModel, CoordinatorSendMessageActionModel,
-        ParticipantContextModel, ParticipantNotificationModel, ParticipantSendMessageActionModel,
-        UpdateCoordinatorContextActionModel, UpdateParticipantContextActionModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcCoordinatorNotificationModel,
+        Consensus2pcCoordinatorSendMessageActionModel, Consensus2pcParticipantContextModel,
+        Consensus2pcParticipantNotificationModel, Consensus2pcParticipantSendMessageActionModel,
+        Consensus2pcUpdateCoordinatorContextActionModel,
+        Consensus2pcUpdateParticipantContextActionModel,
     },
     schema::{
         consensus_action, consensus_coordinator_context, consensus_coordinator_notification_action,
@@ -82,7 +84,7 @@ where
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -91,7 +93,7 @@ where
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let all_actions = consensus_action::table
@@ -130,19 +132,19 @@ where
                     .filter(
                         consensus_update_coordinator_context_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<UpdateCoordinatorContextActionModel>(self.conn)?;
+                    .load::<Consensus2pcUpdateCoordinatorContextActionModel>(self.conn)?;
 
                 let send_message_actions = consensus_coordinator_send_message_action::table
                     .filter(
                         consensus_coordinator_send_message_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<CoordinatorSendMessageActionModel>(self.conn)?;
+                    .load::<Consensus2pcCoordinatorSendMessageActionModel>(self.conn)?;
 
                 let notification_actions = consensus_coordinator_notification_action::table
                     .filter(
                         consensus_coordinator_notification_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<CoordinatorNotificationModel>(self.conn)?;
+                    .load::<Consensus2pcCoordinatorNotificationModel>(self.conn)?;
 
                 for update_context in update_context_actions {
                     let position = actions_map.get(&update_context.action_id).ok_or_else(|| {
@@ -353,19 +355,19 @@ where
                     .filter(
                         consensus_update_participant_context_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<UpdateParticipantContextActionModel>(self.conn)?;
+                    .load::<Consensus2pcUpdateParticipantContextActionModel>(self.conn)?;
 
                 let send_message_actions = consensus_participant_send_message_action::table
                     .filter(
                         consensus_participant_send_message_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<ParticipantSendMessageActionModel>(self.conn)?;
+                    .load::<Consensus2pcParticipantSendMessageActionModel>(self.conn)?;
 
                 let notification_actions = consensus_participant_notification_action::table
                     .filter(
                         consensus_participant_notification_action::action_id.eq_any(&action_ids),
                     )
-                    .load::<ParticipantNotificationModel>(self.conn)?;
+                    .load::<Consensus2pcParticipantNotificationModel>(self.conn)?;
 
                 for update_context in update_context_actions {
                     let position = actions_map.get(&update_context.action_id).ok_or_else(|| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -46,7 +46,7 @@ use crate::store::scabbard_store::{
         action::{ConsensusAction, ConsensusActionNotification},
         message::Scabbard2pcMessage,
     },
-    ScabbardConsensusAction, ScabbardContext,
+    IdentifiedScabbardConsensusAction, ScabbardContext,
 };
 
 use super::ScabbardStoreOperations;
@@ -56,7 +56,7 @@ pub(in crate::store::scabbard_store::diesel) trait ListActionsOperation {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<ScabbardConsensusAction>, ScabbardStoreError>;
+    ) -> Result<Vec<IdentifiedScabbardConsensusAction>, ScabbardStoreError>;
 }
 
 impl<'a, C> ListActionsOperation for ScabbardStoreOperations<'a, C>
@@ -71,7 +71,7 @@ where
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<ScabbardConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<IdentifiedScabbardConsensusAction>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
             let epoch = i64::try_from(epoch).map_err(|err| {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
@@ -247,7 +247,8 @@ where
 
                     let coordinator_action_alarm =
                         get_system_time(update_context.coordinator_action_alarm)?;
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        update_context.action_id,
                         ConsensusAction::Update(
                             ScabbardContext::Scabbard2pcContext(context),
                             coordinator_action_alarm,
@@ -305,7 +306,8 @@ where
                             ))
                         }
                     };
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        send_message.action_id,
                         ConsensusAction::SendMessage(service_id, message),
                     );
                     all_actions.push((position, action));
@@ -340,7 +342,8 @@ where
                             )))
                         }
                     };
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        notification.action_id,
                         ConsensusAction::Notify(coordinator_notification),
                     );
                     all_actions.push((position, action));
@@ -478,7 +481,8 @@ where
 
                     let participant_action_alarm =
                         get_system_time(update_context.participant_action_alarm)?;
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        update_context.action_id,
                         ConsensusAction::Update(
                             ScabbardContext::Scabbard2pcContext(context),
                             participant_action_alarm,
@@ -521,7 +525,8 @@ where
                             ))
                         }
                     };
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        send_message.action_id,
                         ConsensusAction::SendMessage(service_id, message),
                     );
                     all_actions.push((position, action));
@@ -564,7 +569,8 @@ where
                             )))
                         }
                     };
-                    let action = ScabbardConsensusAction::Scabbard2pcConsensusAction(
+                    let action = IdentifiedScabbardConsensusAction::Scabbard2pcConsensusAction(
+                        notification.action_id,
                         ConsensusAction::Notify(participant_notification),
                     );
                     all_actions.push((position, action));

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
@@ -27,7 +27,7 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_coordinator_context, consensus_participant_context,
+        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
         two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
         two_pc_consensus_vote_event,
     },
@@ -66,22 +66,25 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context =
-                consensus_coordinator_context::table
-                    .filter(consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                    .optional()?;
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(
+                    consensus_2pc_consensus_coordinator_context::epoch
+                        .eq(epoch)
+                        .and(
+                            consensus_2pc_consensus_coordinator_context::service_id
+                                .eq(format!("{}", service_id)),
+                        ),
+                )
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+                .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
-            let participant_context =
-                consensus_participant_context::table
-                    .filter(consensus_participant_context::epoch.eq(epoch).and(
-                        consensus_participant_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcParticipantContextModel>(self.conn)
-                    .optional()?;
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
+                ))
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
+                .optional()?;
 
             let consensus_events = two_pc_consensus_event::table
                 .filter(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
@@ -22,8 +22,9 @@ use splinter::service::ServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, ParticipantContextModel, TwoPcConsensusDeliverEventModel,
-        TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
+        TwoPcConsensusDeliverEventModel, TwoPcConsensusStartEventModel,
+        TwoPcConsensusVoteEventModel,
     },
     schema::{
         consensus_coordinator_context, consensus_participant_context,
@@ -70,7 +71,7 @@ where
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             // check to see if a participant context with the given epoch and service_id exists
@@ -79,7 +80,7 @@ where
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let consensus_events = two_pc_consensus_event::table

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
@@ -17,6 +17,7 @@ pub(super) mod add_consensus_action;
 pub(super) mod add_consensus_context;
 pub(super) mod add_consensus_event;
 pub(super) mod add_service;
+pub(super) mod get_current_consensus_context;
 pub(super) mod get_last_commit_entry;
 pub(super) mod get_service;
 pub(super) mod list_consensus_actions;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -20,7 +20,7 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{CoordinatorContextModel, ParticipantContextModel},
+    models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{consensus_action, consensus_coordinator_context, consensus_participant_context},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -60,7 +60,7 @@ where
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             let participant_context =
@@ -68,7 +68,7 @@ where
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             let update_executed_at = i64::try_from(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -21,7 +21,10 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
-    schema::{consensus_action, consensus_coordinator_context, consensus_participant_context},
+    schema::{
+        consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_participant_context,
+    },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -55,21 +58,24 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if action a context exists with the given service_id and epoch
-            let coordinator_context =
-                consensus_coordinator_context::table
-                    .filter(consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                    .optional()?;
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(
+                    consensus_2pc_consensus_coordinator_context::epoch
+                        .eq(epoch)
+                        .and(
+                            consensus_2pc_consensus_coordinator_context::service_id
+                                .eq(format!("{}", service_id)),
+                        ),
+                )
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+                .optional()?;
 
-            let participant_context =
-                consensus_participant_context::table
-                    .filter(consensus_participant_context::epoch.eq(epoch).and(
-                        consensus_participant_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcParticipantContextModel>(self.conn)
-                    .optional()?;
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
+                ))
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
+                .optional()?;
 
             let update_executed_at = i64::try_from(
                 executed_at
@@ -84,14 +90,14 @@ where
             })?;
 
             if coordinator_context.is_some() || participant_context.is_some() {
-                update(consensus_action::table)
+                update(consensus_2pc_action::table)
                     .filter(
-                        consensus_action::id
+                        consensus_2pc_action::id
                             .eq(action_id)
-                            .and(consensus_action::service_id.eq(format!("{}", service_id)))
-                            .and(consensus_action::epoch.eq(epoch)),
+                            .and(consensus_2pc_action::service_id.eq(format!("{}", service_id)))
+                            .and(consensus_2pc_action::epoch.eq(epoch)),
                     )
-                    .set(consensus_action::executed_at.eq(Some(update_executed_at)))
+                    .set(consensus_2pc_action::executed_at.eq(Some(update_executed_at)))
                     .execute(self.conn)
                     .map(|_| ())
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -28,8 +28,9 @@ use crate::store::scabbard_store::diesel::{
         CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
-        consensus_coordinator_context, consensus_coordinator_context_participant,
-        consensus_participant_context, consensus_participant_context_participant,
+        consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
+        consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::ScabbardContext;
@@ -59,32 +60,32 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
                     // check to make sure the context exists
-                    let coordinator_context = consensus_coordinator_context::table
+                    let coordinator_context = consensus_2pc_consensus_coordinator_context::table
                         .filter(
-                            consensus_coordinator_context::epoch
+                            consensus_2pc_consensus_coordinator_context::epoch
                                 .eq(epoch)
                                 .and(
-                                    consensus_coordinator_context::service_id
+                                    consensus_2pc_consensus_coordinator_context::service_id
                                         .eq(format!("{}", service_id)),
                                 )
                                 .and(
-                                    consensus_coordinator_context::coordinator
+                                    consensus_2pc_consensus_coordinator_context::coordinator
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
                         .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                         .optional()?;
 
-                    let participant_context = consensus_participant_context::table
+                    let participant_context = consensus_2pc_participant_context::table
                         .filter(
-                            consensus_participant_context::epoch
+                            consensus_2pc_participant_context::epoch
                                 .eq(epoch)
                                 .and(
-                                    consensus_participant_context::service_id
+                                    consensus_2pc_participant_context::service_id
                                         .eq(format!("{}", service_id)),
                                 )
                                 .and(
-                                    consensus_participant_context::coordinator
+                                    consensus_2pc_participant_context::coordinator
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
@@ -108,22 +109,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                             Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_coordinator_context::table.filter(
-                                consensus_coordinator_context::epoch
+                            consensus_2pc_consensus_coordinator_context::table.filter(
+                                consensus_2pc_consensus_coordinator_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_coordinator_context::service_id
+                                        consensus_2pc_consensus_coordinator_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_coordinator_context::coordinator
+                                        consensus_2pc_consensus_coordinator_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_coordinator_context::table)
+                        insert_into(consensus_2pc_consensus_coordinator_context::table)
                             .values(vec![update_coordinator_context])
                             .execute(self.conn)?;
 
@@ -132,17 +133,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                 .inner;
 
                         delete(
-                            consensus_coordinator_context_participant::table.filter(
-                                consensus_coordinator_context_participant::service_id
+                            consensus_2pc_consensus_coordinator_context_participant::table.filter(
+                                consensus_2pc_consensus_coordinator_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_coordinator_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_consensus_coordinator_context_participant::epoch.eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_coordinator_context_participant::table)
+                        insert_into(consensus_2pc_consensus_coordinator_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 
@@ -152,22 +153,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                             Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_participant_context::table.filter(
-                                consensus_participant_context::epoch
+                            consensus_2pc_participant_context::table.filter(
+                                consensus_2pc_participant_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_participant_context::service_id
+                                        consensus_2pc_participant_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_participant_context::coordinator
+                                        consensus_2pc_participant_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_participant_context::table)
+                        insert_into(consensus_2pc_participant_context::table)
                             .values(vec![update_participant_context])
                             .execute(self.conn)?;
 
@@ -176,17 +177,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                 .inner;
 
                         delete(
-                            consensus_participant_context_participant::table.filter(
-                                consensus_participant_context_participant::service_id
+                            consensus_2pc_participant_context_participant::table.filter(
+                                consensus_2pc_participant_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_participant_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_participant_context_participant::epoch.eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_participant_context_participant::table)
+                        insert_into(consensus_2pc_participant_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 
@@ -220,25 +221,25 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
                     // check to make sure the context exists
-                    let coordinator_context = consensus_coordinator_context::table
+                    let coordinator_context = consensus_2pc_consensus_coordinator_context::table
                         .filter(
-                            consensus_coordinator_context::epoch
+                            consensus_2pc_consensus_coordinator_context::epoch
                                 .eq(epoch)
                                 .and(
-                                    consensus_coordinator_context::service_id
+                                    consensus_2pc_consensus_coordinator_context::service_id
                                         .eq(format!("{}", service_id)),
                                 )
                                 .and(
-                                    consensus_coordinator_context::coordinator
+                                    consensus_2pc_consensus_coordinator_context::coordinator
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
                         .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                         .optional()?;
 
-                    let participant_context = consensus_participant_context::table
-                        .filter(consensus_participant_context::epoch.eq(epoch).and(
-                            consensus_participant_context::service_id.eq(format!("{}", service_id)),
+                    let participant_context = consensus_2pc_participant_context::table
+                        .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                            consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
                         ))
                         .first::<Consensus2pcParticipantContextModel>(self.conn)
                         .optional()?;
@@ -260,22 +261,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                             Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_coordinator_context::table.filter(
-                                consensus_coordinator_context::epoch
+                            consensus_2pc_consensus_coordinator_context::table.filter(
+                                consensus_2pc_consensus_coordinator_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_coordinator_context::service_id
+                                        consensus_2pc_consensus_coordinator_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_coordinator_context::coordinator
+                                        consensus_2pc_consensus_coordinator_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_coordinator_context::table)
+                        insert_into(consensus_2pc_consensus_coordinator_context::table)
                             .values(vec![update_coordinator_context])
                             .execute(self.conn)?;
 
@@ -284,17 +285,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                 .inner;
 
                         delete(
-                            consensus_coordinator_context_participant::table.filter(
-                                consensus_coordinator_context_participant::service_id
+                            consensus_2pc_consensus_coordinator_context_participant::table.filter(
+                                consensus_2pc_consensus_coordinator_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_coordinator_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_consensus_coordinator_context_participant::epoch.eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_coordinator_context_participant::table)
+                        insert_into(consensus_2pc_consensus_coordinator_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 
@@ -304,22 +305,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                             Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_participant_context::table.filter(
-                                consensus_participant_context::epoch
+                            consensus_2pc_participant_context::table.filter(
+                                consensus_2pc_participant_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_participant_context::service_id
+                                        consensus_2pc_participant_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_participant_context::coordinator
+                                        consensus_2pc_participant_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_participant_context::table)
+                        insert_into(consensus_2pc_participant_context::table)
                             .values(vec![update_participant_context])
                             .execute(self.conn)?;
 
@@ -328,17 +329,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                 .inner;
 
                         delete(
-                            consensus_participant_context_participant::table.filter(
-                                consensus_participant_context_participant::service_id
+                            consensus_2pc_participant_context_participant::table.filter(
+                                consensus_2pc_participant_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_participant_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_participant_context_participant::epoch.eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_participant_context_participant::table)
+                        insert_into(consensus_2pc_participant_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -24,8 +24,8 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        CoordinatorContextModel, CoordinatorContextParticipantList, ParticipantContextModel,
-        ParticipantContextParticipantList,
+        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
+        CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
         consensus_coordinator_context, consensus_coordinator_context_participant,
@@ -72,7 +72,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
-                        .first::<CoordinatorContextModel>(self.conn)
+                        .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                         .optional()?;
 
                     let participant_context = consensus_participant_context::table
@@ -88,7 +88,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
-                        .first::<ParticipantContextModel>(self.conn)
+                        .first::<Consensus2pcParticipantContextModel>(self.conn)
                         .optional()?;
 
                     if coordinator_context.is_some() {
@@ -105,7 +105,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         }
 
                         let update_coordinator_context =
-                            CoordinatorContextModel::try_from((&context, service_id))?;
+                            Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
                             consensus_coordinator_context::table.filter(
@@ -149,7 +149,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         Ok(())
                     } else if participant_context.is_some() {
                         let update_participant_context =
-                            ParticipantContextModel::try_from((&context, service_id))?;
+                            Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
 
                         delete(
                             consensus_participant_context::table.filter(
@@ -233,14 +233,14 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
-                        .first::<CoordinatorContextModel>(self.conn)
+                        .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                         .optional()?;
 
                     let participant_context = consensus_participant_context::table
                         .filter(consensus_participant_context::epoch.eq(epoch).and(
                             consensus_participant_context::service_id.eq(format!("{}", service_id)),
                         ))
-                        .first::<ParticipantContextModel>(self.conn)
+                        .first::<Consensus2pcParticipantContextModel>(self.conn)
                         .optional()?;
 
                     if coordinator_context.is_some() {
@@ -257,7 +257,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         }
 
                         let update_coordinator_context =
-                            CoordinatorContextModel::try_from((&context, service_id))?;
+                            Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
                             consensus_coordinator_context::table.filter(
@@ -301,7 +301,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         Ok(())
                     } else if participant_context.is_some() {
                         let update_participant_context =
-                            ParticipantContextModel::try_from((&context, service_id))?;
+                            Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
 
                         delete(
                             consensus_participant_context::table.filter(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -20,7 +20,7 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{CoordinatorContextModel, ParticipantContextModel},
+    models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{
         consensus_coordinator_context, consensus_participant_context, two_pc_consensus_event,
     },
@@ -62,7 +62,7 @@ where
                     .filter(consensus_coordinator_context::epoch.eq(epoch).and(
                         consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<CoordinatorContextModel>(self.conn)
+                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;
 
             let participant_context =
@@ -70,7 +70,7 @@ where
                     .filter(consensus_participant_context::epoch.eq(epoch).and(
                         consensus_participant_context::service_id.eq(format!("{}", service_id)),
                     ))
-                    .first::<ParticipantContextModel>(self.conn)
+                    .first::<Consensus2pcParticipantContextModel>(self.conn)
                     .optional()?;
 
             // return an error if there is both a coordinator and a participant context for the

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -22,7 +22,8 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{
-        consensus_coordinator_context, consensus_participant_context, two_pc_consensus_event,
+        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
+        two_pc_consensus_event,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -57,21 +58,24 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a context exists with the given service_id and epoch
-            let coordinator_context =
-                consensus_coordinator_context::table
-                    .filter(consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                    .optional()?;
+            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                .filter(
+                    consensus_2pc_consensus_coordinator_context::epoch
+                        .eq(epoch)
+                        .and(
+                            consensus_2pc_consensus_coordinator_context::service_id
+                                .eq(format!("{}", service_id)),
+                        ),
+                )
+                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+                .optional()?;
 
-            let participant_context =
-                consensus_participant_context::table
-                    .filter(consensus_participant_context::epoch.eq(epoch).and(
-                        consensus_participant_context::service_id.eq(format!("{}", service_id)),
-                    ))
-                    .first::<Consensus2pcParticipantContextModel>(self.conn)
-                    .optional()?;
+            let participant_context = consensus_2pc_participant_context::table
+                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
+                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
+                ))
+                .first::<Consensus2pcParticipantContextModel>(self.conn)
+                .optional()?;
 
             // return an error if there is both a coordinator and a participant context for the
             // given service_id and epoch

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -37,7 +37,7 @@ table! {
 }
 
 table! {
-    consensus_coordinator_context (service_id, epoch) {
+    consensus_2pc_consensus_coordinator_context (service_id, epoch) {
         service_id -> Text,
         alarm -> Nullable<BigInt>,
         coordinator -> Text,
@@ -49,7 +49,7 @@ table! {
 }
 
 table! {
-    consensus_coordinator_context_participant (service_id, epoch, process) {
+    consensus_2pc_consensus_coordinator_context_participant (service_id, epoch, process) {
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,
@@ -58,7 +58,7 @@ table! {
 }
 
 table! {
-    consensus_coordinator_notification_action (action_id) {
+    consensus_2pc_coordinator_notification_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -68,7 +68,7 @@ table! {
 }
 
 table! {
-    consensus_coordinator_send_message_action (action_id) {
+    consensus_2pc_coordinator_send_message_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -79,7 +79,7 @@ table! {
 }
 
 table! {
-    consensus_update_coordinator_context_action (action_id) {
+    consensus_2pc_update_coordinator_context_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         alarm -> Nullable<BigInt>,
@@ -93,7 +93,7 @@ table! {
 }
 
 table! {
-    consensus_update_coordinator_context_action_participant (action_id) {
+    consensus_2pc_update_coordinator_context_action_participant (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -103,7 +103,7 @@ table! {
 }
 
 table! {
-    consensus_action (id) {
+    consensus_2pc_action (id) {
         id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -114,7 +114,7 @@ table! {
 }
 
 table! {
-    consensus_participant_context (service_id, epoch) {
+    consensus_2pc_participant_context (service_id, epoch) {
         service_id -> Text,
         alarm -> Nullable<BigInt>,
         coordinator -> Text,
@@ -127,7 +127,7 @@ table! {
 }
 
 table! {
-    consensus_participant_context_participant (service_id, epoch, process) {
+    consensus_2pc_participant_context_participant (service_id, epoch, process) {
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,
@@ -135,7 +135,7 @@ table! {
 }
 
 table! {
-    consensus_participant_notification_action (action_id) {
+    consensus_2pc_participant_notification_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -146,7 +146,7 @@ table! {
 }
 
 table! {
-    consensus_participant_send_message_action (action_id) {
+    consensus_2pc_participant_send_message_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -157,7 +157,7 @@ table! {
 }
 
 table! {
-    consensus_update_participant_context_action (action_id) {
+    consensus_2pc_update_participant_context_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         alarm -> Nullable<BigInt>,
@@ -172,7 +172,7 @@ table! {
 }
 
 table! {
-    consensus_update_participant_context_action_participant (action_id) {
+    consensus_2pc_update_participant_context_action_participant (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -222,34 +222,34 @@ table! {
     }
 }
 
-joinable!(consensus_coordinator_notification_action -> consensus_action (action_id));
-joinable!(consensus_coordinator_send_message_action -> consensus_action (action_id));
-joinable!(consensus_update_coordinator_context_action -> consensus_action (action_id));
-joinable!(consensus_update_coordinator_context_action_participant -> consensus_update_coordinator_context_action (action_id));
-joinable!(consensus_update_coordinator_context_action_participant -> consensus_action (action_id));
+joinable!(consensus_2pc_coordinator_notification_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_coordinator_send_message_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_update_coordinator_context_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_update_coordinator_context_action_participant -> consensus_2pc_update_coordinator_context_action (action_id));
+joinable!(consensus_2pc_update_coordinator_context_action_participant -> consensus_2pc_action (action_id));
 
-joinable!(consensus_participant_notification_action -> consensus_action (action_id));
-joinable!(consensus_participant_send_message_action -> consensus_action (action_id));
-joinable!(consensus_update_participant_context_action -> consensus_action (action_id));
+joinable!(consensus_2pc_participant_notification_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_participant_send_message_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_update_participant_context_action -> consensus_2pc_action (action_id));
 
 joinable!(two_pc_consensus_deliver_event -> two_pc_consensus_event(event_id));
 joinable!(two_pc_consensus_start_event -> two_pc_consensus_event(event_id));
 joinable!(two_pc_consensus_vote_event -> two_pc_consensus_event(event_id));
 
 allow_tables_to_appear_in_same_query!(
-    consensus_coordinator_context,
-    consensus_coordinator_context_participant,
-    consensus_action,
-    consensus_update_coordinator_context_action,
-    consensus_coordinator_send_message_action,
-    consensus_coordinator_notification_action,
-    consensus_update_coordinator_context_action_participant,
-    consensus_participant_context,
-    consensus_participant_context_participant,
-    consensus_update_participant_context_action,
-    consensus_update_participant_context_action_participant,
-    consensus_participant_send_message_action,
-    consensus_participant_notification_action,
+    consensus_2pc_consensus_coordinator_context,
+    consensus_2pc_consensus_coordinator_context_participant,
+    consensus_2pc_action,
+    consensus_2pc_update_coordinator_context_action,
+    consensus_2pc_coordinator_send_message_action,
+    consensus_2pc_coordinator_notification_action,
+    consensus_2pc_update_coordinator_context_action_participant,
+    consensus_2pc_participant_context,
+    consensus_2pc_participant_context_participant,
+    consensus_2pc_update_participant_context_action,
+    consensus_2pc_update_participant_context_action_participant,
+    consensus_2pc_participant_send_message_action,
+    consensus_2pc_participant_notification_action,
     two_pc_consensus_event,
     two_pc_consensus_deliver_event,
     two_pc_consensus_start_event,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -196,4 +196,14 @@ pub trait ScabbardStore {
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
     ) -> Result<Vec<ReturnedScabbardConsensusEvent>, ScabbardStoreError>;
+    /// Get the current context for a given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service for which the
+    ///    current context should be retrieved
+    fn get_current_consensus_context(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardContext>, ScabbardStoreError>;
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -28,7 +28,7 @@ use std::time::SystemTime;
 
 pub(crate) use error::ScabbardStoreError;
 
-use action::ScabbardConsensusAction;
+use action::{IdentifiedScabbardConsensusAction, ScabbardConsensusAction};
 use commit::CommitEntry;
 use context::ScabbardContext;
 use event::{ReturnedScabbardConsensusEvent, ScabbardConsensusEvent};
@@ -108,7 +108,7 @@ pub trait ScabbardStore {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<ScabbardConsensusAction>, ScabbardStoreError>;
+    ) -> Result<Vec<IdentifiedScabbardConsensusAction>, ScabbardStoreError>;
     /// List ready services
     fn list_ready_services(&self) -> Result<Vec<FullyQualifiedServiceId>, ScabbardStoreError>;
     /// Add a new scabbard service


### PR DESCRIPTION
This PR makes a few updates to the scabbard store:
- Update the `list_consensus_actions` method return type so that the the associated `action_id` is returned with the actions
- Add a `get_current_consensus_context` method to the ScabbardStore trait and diesel backed implementations
- Fix an old state type in the scabbard store migrations
- Remove unnecessary comments
- Fix an incorrect error message