### PR TITLE
Stop unit tests from different PRs cancelling each other

### DIFF
--- a/.github/workflows/unit-test-splinter-self-hosted.yaml
+++ b/.github/workflows/unit-test-splinter-self-hosted.yaml
@@ -7,7 +7,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: "${{ github.ref }}-${{ github.workflow }}"
+  group: "${{ github.head_ref }}-${{ github.workflow }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
GHA events with the `pull_request_target` event run in the context of the base
of the PR rather than the merge commit. This causes the concurrency group to
always match even though the jobs are not related.

After this change the concurrency group will use the branch name rather than
"refs/heads/main" which is similar behavior to the workflows triggered by
`pull_request`.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>