### PR TITLE
Add consensus type to ScabbardService and add get_service to ScabbardStrore

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-160128_add_consensus/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-160128_add_consensus/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE scabbard_service DROP COLUMN consensus;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-160128_add_consensus/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-160128_add_consensus/up.sql
@@ -1,0 +1,18 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+CREATE TYPE scabbard_consensus AS ENUM ('2PC');
+
+ALTER TABLE scabbard_service
+  ADD COLUMN consensus scabbard_consensus NOT NULL Default '2PC';

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-160128_add_consensus/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-160128_add_consensus/down.sql
@@ -1,0 +1,32 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Rename old table
+ALTER TABLE scabbard_service RENAME TO _scabbard_service_old;
+
+-- create new table without consensus
+CREATE TABLE IF NOT EXISTS scabbard_service (
+    service_id       TEXT PRIMARY KEY NOT NULL,
+    status           TEXT NOT NULL
+    CHECK ( status IN ('PREPARED', 'FINALIZED', 'RETIRED') )
+);
+
+-- move data from old table
+INSERT INTO scabbard_service (service_id, status)
+  SELECT service_id, status
+  FROM _scabbard_service_old;
+
+-- drop old table
+DROP TABLE _scabbard_service_old;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-160128_add_consensus/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-160128_add_consensus/up.sql
@@ -1,0 +1,18 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE scabbard_service
+  ADD COLUMN consensus Text NOT NULL DEFAULT '2PC'
+  CHECK ( consensus IN ('2PC') );

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1036,6 +1036,7 @@ pub mod tests {
         let service = ScabbardServiceBuilder::default()
             .with_service_id(&service_fqsi)
             .with_peers(&[peer_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
             .with_status(&ServiceStatus::Finalized)
             .build()
             .expect("failed to build service");
@@ -1147,6 +1148,7 @@ pub mod tests {
         let service = ScabbardServiceBuilder::default()
             .with_service_id(&service_fqsi)
             .with_peers(&[peer_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
             .with_status(&ServiceStatus::Finalized)
             .build()
             .expect("failed to build service");
@@ -1204,6 +1206,7 @@ pub mod tests {
         let service = ScabbardServiceBuilder::default()
             .with_service_id(&service_fqsi)
             .with_peers(&[peer_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
             .with_status(&ServiceStatus::Finalized)
             .build()
             .expect("failed to build service");
@@ -1257,6 +1260,7 @@ pub mod tests {
         let service = ScabbardServiceBuilder::default()
             .with_service_id(&service_fqsi)
             .with_peers(&[peer_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
             .with_status(&ServiceStatus::Finalized)
             .build()
             .expect("failed to build service");
@@ -1315,6 +1319,7 @@ pub mod tests {
         let service = ScabbardServiceBuilder::default()
             .with_service_id(&service_fqsi)
             .with_peers(&[peer_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
             .with_status(&ServiceStatus::Prepared)
             .build()
             .expect("failed to build service");

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -46,6 +46,7 @@ use operations::add_consensus_context::AddContextOperation as _;
 use operations::add_consensus_event::AddEventOperation as _;
 use operations::add_service::AddServiceOperation as _;
 use operations::get_last_commit_entry::GetLastCommitEntryOperation as _;
+use operations::get_service::GetServiceOperation as _;
 use operations::list_consensus_actions::ListActionsOperation as _;
 use operations::list_consensus_events::ListEventsOperation as _;
 use operations::list_ready_services::ListReadyServicesOperation as _;
@@ -173,6 +174,15 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
         self.pool
             .execute_write(|conn| ScabbardStoreOperations::new(conn).update_service(service))
     }
+
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
+        self.pool
+            .execute_read(|conn| ScabbardStoreOperations::new(conn).get_service(service_id))
+    }
+
     /// Add a new consensus event
     fn add_consensus_event(
         &self,
@@ -308,6 +318,15 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
         self.pool
             .execute_write(|conn| ScabbardStoreOperations::new(conn).update_service(service))
     }
+
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
+        self.pool
+            .execute_read(|conn| ScabbardStoreOperations::new(conn).get_service(service_id))
+    }
+
     /// Add a new consensus event
     fn add_consensus_event(
         &self,
@@ -444,6 +463,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     fn update_service(&self, service: ScabbardService) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_service(service)
     }
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
+        ScabbardStoreOperations::new(self.connection).get_service(service_id)
+    }
     /// Add a new consensus event
     fn add_consensus_event(
         &self,
@@ -556,6 +581,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     fn update_service(&self, service: ScabbardService) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_service(service)
     }
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
+        ScabbardStoreOperations::new(self.connection).get_service(service_id)
+    }
     /// Add a new consensus event
     fn add_consensus_event(
         &self,
@@ -602,7 +633,7 @@ pub mod tests {
     use crate::store::scabbard_store::{
         commit::{CommitEntryBuilder, ConsensusDecision},
         context::{ContextBuilder, Participant},
-        service::{ScabbardServiceBuilder, ServiceStatus},
+        service::{ConsensusType, ScabbardServiceBuilder, ServiceStatus},
         state::Scabbard2pcState,
         two_phase::{
             action::{ConsensusAction, ConsensusActionNotification},
@@ -1009,6 +1040,45 @@ pub mod tests {
         assert!(store
             .update_consensus_action(&coordinator_fqsi, 1, action_id, SystemTime::now())
             .is_ok());
+    }
+
+    /// Test that the scabbard store `get_service` operation is successful.
+    ///
+    /// 1. Add a service in the finalized state to the database
+    /// 2. Fetch that service from the store
+    /// 3. Verify the correct service was returned
+    #[test]
+    fn scabbard_store_get_service() {
+        let pool = create_connection_pool_and_migrate();
+
+        let store = DieselScabbardStore::new(pool);
+
+        let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
+            .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
+
+        let peer_service_id = ServiceId::new_random();
+        let peer_service_id_second = ServiceId::new_random();
+
+        let mut peers = vec![peer_service_id, peer_service_id_second];
+        peers.sort_by(|a, b| a.as_str().partial_cmp(b.as_str()).unwrap());
+
+        // service with finalized status
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&service_fqsi)
+            .with_peers(&peers)
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        assert!(store.add_service(service.clone()).is_ok());
+
+        let fetched_service = store
+            .get_service(&service_fqsi)
+            .expect("Unable to fetch service")
+            .expect("Store should have returned a service");
+
+        assert_eq!(service, fetched_service);
     }
 
     /// Test that the scabbard store `list_ready_services` operation is successful.

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_service.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+
+use diesel::prelude::*;
+use splinter::error::{InternalError, InvalidArgumentError};
+use splinter::service::{FullyQualifiedServiceId, ServiceId};
+
+use crate::store::scabbard_store::diesel::models::{ScabbardPeerModel, ScabbardServiceModel};
+use crate::store::scabbard_store::diesel::schema::{scabbard_peer, scabbard_service};
+use crate::store::scabbard_store::{
+    service::{ConsensusType, ScabbardServiceBuilder, ServiceStatus},
+    ScabbardService, ScabbardStoreError,
+};
+
+use super::ScabbardStoreOperations;
+
+pub(in crate::store::scabbard_store::diesel) trait GetServiceOperation {
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError>;
+}
+
+impl<'a, C> GetServiceOperation for ScabbardStoreOperations<'a, C>
+where
+    C: diesel::Connection,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            let service_model: ScabbardServiceModel = match scabbard_service::table
+                .filter(scabbard_service::service_id.eq(&service_id.to_string()))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+            {
+                Some(service) => service,
+                None => return Ok(None),
+            };
+
+            let service_peers: Vec<ServiceId> = scabbard_peer::table
+                .filter(scabbard_peer::service_id.eq(&service_id.to_string()))
+                .order(scabbard_peer::peer_service_id.asc())
+                .load(self.conn)?
+                .into_iter()
+                .map(|peer: ScabbardPeerModel| ServiceId::new(peer.peer_service_id))
+                .collect::<Result<Vec<_>, InvalidArgumentError>>()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            let service = ScabbardServiceBuilder::default()
+                .with_service_id(service_id)
+                .with_consensus(&ConsensusType::try_from(service_model.consensus.as_str())?)
+                .with_status(&ServiceStatus::try_from(service_model.status.as_str())?)
+                .with_peers(service_peers.as_slice())
+                .build()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            Ok(Some(service))
+        })
+    }
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
@@ -18,6 +18,7 @@ pub(super) mod add_consensus_context;
 pub(super) mod add_consensus_event;
 pub(super) mod add_service;
 pub(super) mod get_last_commit_entry;
+pub(super) mod get_service;
 pub(super) mod list_consensus_actions;
 pub(super) mod list_consensus_events;
 pub(super) mod list_ready_services;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -15,6 +15,7 @@
 table! {
     scabbard_service (service_id) {
         service_id  -> Text,
+        consensus -> Text,
         status -> Text,
     }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -145,6 +145,15 @@ pub trait ScabbardStore {
     ///
     /// * `service` - The `ScabbardService` to be updated
     fn update_service(&self, service: ScabbardService) -> Result<(), ScabbardStoreError>;
+    /// Returns a scabbard service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` to be returned
+    fn get_service(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+    ) -> Result<Option<ScabbardService>, ScabbardStoreError>;
     /// Add a new consensus event
     ///
     /// # Arguments

--- a/services/scabbard/libscabbard/src/store/scabbard_store/service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/service.rs
@@ -21,6 +21,7 @@ use splinter::service::{FullyQualifiedServiceId, ServiceId};
 pub struct ScabbardService {
     service_id: FullyQualifiedServiceId,
     peers: Vec<ServiceId>,
+    consensus: ConsensusType,
     status: ServiceStatus,
 }
 
@@ -35,6 +36,11 @@ impl ScabbardService {
         &self.peers
     }
 
+    /// Returns the consensus type for the scabbard service
+    pub fn consensus(&self) -> &ConsensusType {
+        &self.consensus
+    }
+
     /// Returns the status of the scabbard service
     pub fn status(&self) -> &ServiceStatus {
         &self.status
@@ -44,6 +50,7 @@ impl ScabbardService {
         ScabbardServiceBuilder {
             service_id: Some(self.service_id),
             peers: Some(self.peers),
+            consensus: Some(self.consensus),
             status: Some(self.status),
         }
     }
@@ -53,6 +60,7 @@ impl ScabbardService {
 pub struct ScabbardServiceBuilder {
     service_id: Option<FullyQualifiedServiceId>,
     peers: Option<Vec<ServiceId>>,
+    consensus: Option<ConsensusType>,
     status: Option<ServiceStatus>,
 }
 
@@ -65,6 +73,11 @@ impl ScabbardServiceBuilder {
     /// Returns the peers for the service
     pub fn peers(&self) -> Option<Vec<ServiceId>> {
         self.peers.clone()
+    }
+
+    /// Returns the consensus type for the scabbard service
+    pub fn consensus(&self) -> Option<ConsensusType> {
+        self.consensus.clone()
     }
 
     /// Returns the peers for the service
@@ -95,6 +108,16 @@ impl ScabbardServiceBuilder {
         self
     }
 
+    /// Sets the consensus type
+    ///
+    /// # Arguments
+    ///
+    ///  * `consensus` - The consensus type for the scabbard service
+    pub fn with_consensus(mut self, consensus: &ConsensusType) -> ScabbardServiceBuilder {
+        self.consensus = Some(consensus.clone());
+        self
+    }
+
     /// Sets the status
     ///
     /// # Arguments
@@ -119,12 +142,19 @@ impl ScabbardServiceBuilder {
             InvalidStateError::with_message("unable to build, missing field: `peers`".to_string())
         })?;
 
+        let consensus = self.consensus.ok_or_else(|| {
+            InvalidStateError::with_message(
+                "unable to build, missing field: `consensus`".to_string(),
+            )
+        })?;
+
         let status = self.status.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `status`".to_string())
         })?;
 
         Ok(ScabbardService {
             service_id,
+            consensus,
             peers,
             status,
         })
@@ -144,6 +174,19 @@ impl fmt::Display for ServiceStatus {
             ServiceStatus::Prepared => write!(f, "Status: Prepared"),
             ServiceStatus::Finalized => write!(f, "Status: Finalized"),
             ServiceStatus::Retired => write!(f, "Status: Retired"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConsensusType {
+    TwoPC,
+}
+
+impl fmt::Display for ConsensusType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConsensusType::TwoPC => write!(f, "Consensus: Two Phase Commit"),
         }
     }
 }


### PR DESCRIPTION
A ScabbardService will be able to be run with different
types of consensus, configured from the circuit definition.

Currently, Scabbard V3 will support 2PC. This commit leaves
room for adding more supported consensus algorithms in the future.

Storing this in the scabbard service is required so the consensus
messages can be deserialized at runtime.