### PR TITLE
Update scabbard store consensus table and struct names

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,8 +13,8 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context;
-DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_context;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_context_participant;
 DROP TABLE IF EXISTS consensus_2pc_action;
 DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
 DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -20,7 +20,7 @@ CREATE TYPE participant_state AS ENUM ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE'
 CREATE TYPE participant_message_type AS ENUM ('VOTEREQUEST', 'COMMIT', 'ABORT', 'DECISIONREQUEST');
 CREATE TYPE participant_notification_type AS ENUM ('PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -31,14 +31,14 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
     vote_timeout_start        BIGINT,
     coordinator_action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/down.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS two_pc_consensus_event;
-DROP TABLE IF EXISTS two_pc_consensus_deliver_event;
-DROP TABLE IF EXISTS two_pc_consensus_start_event;
-DROP TABLE IF EXISTS two_pc_consensus_vote_event;
+DROP TABLE IF EXISTS consensus_2pc_event;
+DROP TABLE IF EXISTS consensus_2pc_deliver_event;
+DROP TABLE IF EXISTS consensus_2pc_start_event;
+DROP TABLE IF EXISTS consensus_2pc_vote_event;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BYTEA,
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
@@ -56,5 +56,5 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -16,7 +16,7 @@
 CREATE TYPE event_type AS ENUM ('ALARM', 'DELIVER', 'START', 'VOTE');
 CREATE TYPE deliver_event_message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST', 'VOTEREQUEST', 'COMMIT', 'ABORT');
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_event (
     id                        BIGSERIAL PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_event (
     event_type                event_type NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -36,25 +36,25 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     value                     BYTEA,
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,8 +13,8 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context;
-DROP TABLE IF EXISTS consensus_2pc_consensus_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_context;
+DROP TABLE IF EXISTS consensus_2pc_coordinator_context_participant;
 DROP TABLE IF EXISTS consensus_2pc_action;
 DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
 DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
@@ -25,14 +25,14 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context (
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_consensus_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
     vote_timeout_start        BIGINT,
     coordinator_action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/down.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS two_pc_consensus_event;
-DROP TABLE IF EXISTS two_pc_consensus_deliver_event;
-DROP TABLE IF EXISTS two_pc_consensus_start_event;
-DROP TABLE IF EXISTS two_pc_consensus_vote_event;
+DROP TABLE IF EXISTS consensus_2pc_event;
+DROP TABLE IF EXISTS consensus_2pc_deliver_event;
+DROP TABLE IF EXISTS consensus_2pc_start_event;
+DROP TABLE IF EXISTS consensus_2pc_vote_event;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_event (
     id                        INTEGER PRIMARY KEY AUTOINCREMENT,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_event (
     CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
@@ -35,25 +35,25 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     value                     BINARY,
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
+CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
-    FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
+    FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_deliver_event (
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BINARY,
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
@@ -55,5 +55,5 @@ CREATE TABLE IF NOT EXISTS two_pc_consensus_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES two_pc_consensus_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_consensus_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -34,14 +34,15 @@ use crate::store::scabbard_store::{
 use super::schema::{
     consensus_2pc_action, consensus_2pc_coordinator_context,
     consensus_2pc_coordinator_context_participant, consensus_2pc_coordinator_notification_action,
-    consensus_2pc_coordinator_send_message_action, consensus_2pc_participant_context,
+    consensus_2pc_coordinator_send_message_action, consensus_2pc_deliver_event,
+    consensus_2pc_event, consensus_2pc_participant_context,
     consensus_2pc_participant_context_participant, consensus_2pc_participant_notification_action,
-    consensus_2pc_participant_send_message_action, consensus_2pc_update_coordinator_context_action,
+    consensus_2pc_participant_send_message_action, consensus_2pc_start_event,
+    consensus_2pc_update_coordinator_context_action,
     consensus_2pc_update_coordinator_context_action_participant,
     consensus_2pc_update_participant_context_action,
-    consensus_2pc_update_participant_context_action_participant, scabbard_peer, scabbard_service,
-    scabbard_v3_commit_history, two_pc_consensus_deliver_event, two_pc_consensus_event,
-    two_pc_consensus_start_event, two_pc_consensus_vote_event,
+    consensus_2pc_update_participant_context_action_participant, consensus_2pc_vote_event,
+    scabbard_peer, scabbard_service, scabbard_v3_commit_history,
 };
 
 /// Database model representation of `ScabbardService`
@@ -1090,7 +1091,7 @@ impl From<&Scabbard2pcMessage> for String {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "two_pc_consensus_event"]
+#[table_name = "consensus_2pc_event"]
 #[primary_key(id)]
 pub struct TwoPcConsensusEventModel {
     pub id: i64,
@@ -1103,7 +1104,7 @@ pub struct TwoPcConsensusEventModel {
 }
 
 #[derive(Debug, PartialEq, Insertable)]
-#[table_name = "two_pc_consensus_event"]
+#[table_name = "consensus_2pc_event"]
 pub struct InsertableTwoPcConsensusEventModel {
     pub service_id: String,
     pub epoch: i64,
@@ -1124,7 +1125,7 @@ impl From<&Scabbard2pcEvent> for String {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "two_pc_consensus_deliver_event"]
+#[table_name = "consensus_2pc_deliver_event"]
 #[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
 pub struct TwoPcConsensusDeliverEventModel {
@@ -1138,7 +1139,7 @@ pub struct TwoPcConsensusDeliverEventModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "two_pc_consensus_start_event"]
+#[table_name = "consensus_2pc_start_event"]
 #[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
 pub struct TwoPcConsensusStartEventModel {
@@ -1149,7 +1150,7 @@ pub struct TwoPcConsensusStartEventModel {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "two_pc_consensus_vote_event"]
+#[table_name = "consensus_2pc_vote_event"]
 #[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
 pub struct TwoPcConsensusVoteEventModel {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -32,12 +32,11 @@ use crate::store::scabbard_store::{
 };
 
 use super::schema::{
-    consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
-    consensus_2pc_consensus_coordinator_context_participant,
-    consensus_2pc_coordinator_notification_action, consensus_2pc_coordinator_send_message_action,
-    consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
-    consensus_2pc_participant_notification_action, consensus_2pc_participant_send_message_action,
-    consensus_2pc_update_coordinator_context_action,
+    consensus_2pc_action, consensus_2pc_coordinator_context,
+    consensus_2pc_coordinator_context_participant, consensus_2pc_coordinator_notification_action,
+    consensus_2pc_coordinator_send_message_action, consensus_2pc_participant_context,
+    consensus_2pc_participant_context_participant, consensus_2pc_participant_notification_action,
+    consensus_2pc_participant_send_message_action, consensus_2pc_update_coordinator_context_action,
     consensus_2pc_update_coordinator_context_action_participant,
     consensus_2pc_update_participant_context_action,
     consensus_2pc_update_participant_context_action_participant, scabbard_peer, scabbard_service,
@@ -208,7 +207,7 @@ impl From<&ConsensusDecision> for String {
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_2pc_consensus_coordinator_context"]
+#[table_name = "consensus_2pc_coordinator_context"]
 #[primary_key(service_id, epoch)]
 pub struct Consensus2pcCoordinatorContextModel {
     pub service_id: String,
@@ -365,7 +364,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcCoordinatorCo
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
-#[table_name = "consensus_2pc_consensus_coordinator_context_participant"]
+#[table_name = "consensus_2pc_coordinator_context_participant"]
 #[primary_key(service_id, epoch, process)]
 pub struct Consensus2pcCoordinatorContextParticipantModel {
     pub service_id: String,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -1093,7 +1093,7 @@ impl From<&Scabbard2pcMessage> for String {
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_event"]
 #[primary_key(id)]
-pub struct TwoPcConsensusEventModel {
+pub struct Consensus2pcEventModel {
     pub id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -1105,7 +1105,7 @@ pub struct TwoPcConsensusEventModel {
 
 #[derive(Debug, PartialEq, Insertable)]
 #[table_name = "consensus_2pc_event"]
-pub struct InsertableTwoPcConsensusEventModel {
+pub struct InsertableConsensus2pcEventModel {
     pub service_id: String,
     pub epoch: i64,
     pub executed_at: Option<i64>,
@@ -1126,9 +1126,9 @@ impl From<&Scabbard2pcEvent> for String {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_deliver_event"]
-#[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
+#[belongs_to(Consensus2pcEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
-pub struct TwoPcConsensusDeliverEventModel {
+pub struct Consensus2pcDeliverEventModel {
     pub event_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -1140,9 +1140,9 @@ pub struct TwoPcConsensusDeliverEventModel {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_start_event"]
-#[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
+#[belongs_to(Consensus2pcEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
-pub struct TwoPcConsensusStartEventModel {
+pub struct Consensus2pcStartEventModel {
     pub event_id: i64,
     pub service_id: String,
     pub epoch: i64,
@@ -1151,9 +1151,9 @@ pub struct TwoPcConsensusStartEventModel {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_vote_event"]
-#[belongs_to(TwoPcConsensusEventModel, foreign_key = "event_id")]
+#[belongs_to(Consensus2pcEventModel, foreign_key = "event_id")]
 #[primary_key(event_id)]
-pub struct TwoPcConsensusVoteEventModel {
+pub struct Consensus2pcVoteEventModel {
     pub event_id: i64,
     pub service_id: String,
     pub epoch: i64,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
@@ -34,7 +34,7 @@ use crate::store::scabbard_store::diesel::{
         UpdateParticipantContextActionParticipantList,
     },
     schema::{
-        consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_action, consensus_2pc_coordinator_context,
         consensus_2pc_coordinator_notification_action,
         consensus_2pc_coordinator_send_message_action, consensus_2pc_participant_context,
         consensus_2pc_participant_notification_action,
@@ -79,15 +79,10 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 
@@ -379,15 +374,10 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
@@ -28,9 +28,8 @@ use crate::store::scabbard_store::diesel::{
         CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
-        consensus_2pc_consensus_coordinator_context,
-        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
-        consensus_2pc_participant_context_participant,
+        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
+        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::ScabbardContext;
@@ -62,14 +61,12 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                                 &context, service_id,
                             ))?
                             .inner;
-                            insert_into(consensus_2pc_consensus_coordinator_context::table)
+                            insert_into(consensus_2pc_coordinator_context::table)
                                 .values(vec![new_coordinator_context])
                                 .execute(self.conn)?;
-                            insert_into(
-                                consensus_2pc_consensus_coordinator_context_participant::table,
-                            )
-                            .values(participants)
-                            .execute(self.conn)?;
+                            insert_into(consensus_2pc_coordinator_context_participant::table)
+                                .values(participants)
+                                .execute(self.conn)?;
                         }
                         Err(_) => match Consensus2pcParticipantContextModel::try_from((
                             &context, service_id,
@@ -116,14 +113,12 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
                                 &context, service_id,
                             ))?
                             .inner;
-                            insert_into(consensus_2pc_consensus_coordinator_context::table)
+                            insert_into(consensus_2pc_coordinator_context::table)
                                 .values(vec![new_coordinator_context])
                                 .execute(self.conn)?;
-                            insert_into(
-                                consensus_2pc_consensus_coordinator_context_participant::table,
-                            )
-                            .values(participants)
-                            .execute(self.conn)?;
+                            insert_into(consensus_2pc_coordinator_context_participant::table)
+                                .values(participants)
+                                .execute(self.conn)?;
                         }
                         Err(_) => match Consensus2pcParticipantContextModel::try_from((
                             &context, service_id,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -24,9 +24,9 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
-        InsertableTwoPcConsensusEventModel, TwoPcConsensusDeliverEventModel,
-        TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcDeliverEventModel,
+        Consensus2pcParticipantContextModel, Consensus2pcStartEventModel,
+        Consensus2pcVoteEventModel, InsertableConsensus2pcEventModel,
     },
     schema::{
         consensus_2pc_coordinator_context, consensus_2pc_deliver_event, consensus_2pc_event,
@@ -105,7 +105,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     ));
                 }
 
-                let insertable_event = InsertableTwoPcConsensusEventModel {
+                let insertable_event = InsertableConsensus2pcEventModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -145,7 +145,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             }
                         };
 
-                        let deliver_event = TwoPcConsensusDeliverEventModel {
+                        let deliver_event = Consensus2pcDeliverEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -160,7 +160,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                         Ok(event_id)
                     }
                     Scabbard2pcEvent::Start(value) => {
-                        let start_event = TwoPcConsensusStartEventModel {
+                        let start_event = Consensus2pcStartEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -176,7 +176,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             true => String::from("TRUE"),
                             false => String::from("FALSE"),
                         };
-                        let vote_event = TwoPcConsensusVoteEventModel {
+                        let vote_event = Consensus2pcVoteEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -189,7 +189,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     }
                 }
             } else if participant_context.is_some() {
-                let insertable_event = InsertableTwoPcConsensusEventModel {
+                let insertable_event = InsertableConsensus2pcEventModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -228,7 +228,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             }
                         };
 
-                        let deliver_event = TwoPcConsensusDeliverEventModel {
+                        let deliver_event = Consensus2pcDeliverEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -247,7 +247,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             true => String::from("TRUE"),
                             false => String::from("FALSE"),
                         };
-                        let vote_event = TwoPcConsensusVoteEventModel {
+                        let vote_event = Consensus2pcVoteEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -336,7 +336,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     ));
                 }
 
-                let insertable_event = InsertableTwoPcConsensusEventModel {
+                let insertable_event = InsertableConsensus2pcEventModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -373,7 +373,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             }
                         };
 
-                        let deliver_event = TwoPcConsensusDeliverEventModel {
+                        let deliver_event = Consensus2pcDeliverEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -388,7 +388,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                         Ok(event_id)
                     }
                     Scabbard2pcEvent::Start(value) => {
-                        let start_event = TwoPcConsensusStartEventModel {
+                        let start_event = Consensus2pcStartEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -404,7 +404,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             true => String::from("TRUE"),
                             false => String::from("FALSE"),
                         };
-                        let vote_event = TwoPcConsensusVoteEventModel {
+                        let vote_event = Consensus2pcVoteEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -417,7 +417,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     }
                 }
             } else if participant_context.is_some() {
-                let insertable_event = InsertableTwoPcConsensusEventModel {
+                let insertable_event = InsertableConsensus2pcEventModel {
                     service_id: format!("{}", service_id),
                     epoch,
                     executed_at: None,
@@ -453,7 +453,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             }
                         };
 
-                        let deliver_event = TwoPcConsensusDeliverEventModel {
+                        let deliver_event = Consensus2pcDeliverEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,
@@ -472,7 +472,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             true => String::from("TRUE"),
                             false => String::from("FALSE"),
                         };
-                        let vote_event = TwoPcConsensusVoteEventModel {
+                        let vote_event = Consensus2pcVoteEventModel {
                             event_id,
                             service_id: format!("{}", service_id),
                             epoch,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -29,9 +29,8 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
-        two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
-        two_pc_consensus_vote_event,
+        consensus_2pc_coordinator_context, consensus_2pc_deliver_event, consensus_2pc_event,
+        consensus_2pc_participant_context, consensus_2pc_start_event, consensus_2pc_vote_event,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -80,14 +79,14 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 .first::<Consensus2pcParticipantContextModel>(self.conn)
                 .optional()?;
 
-            let position = two_pc_consensus_event::table
+            let position = consensus_2pc_event::table
                 .filter(
-                    two_pc_consensus_event::service_id
+                    consensus_2pc_event::service_id
                         .eq(format!("{}", service_id))
-                        .and(two_pc_consensus_event::epoch.eq(epoch)),
+                        .and(consensus_2pc_event::epoch.eq(epoch)),
                 )
-                .order(two_pc_consensus_event::position.desc())
-                .select(two_pc_consensus_event::position)
+                .order(consensus_2pc_event::position.desc())
+                .select(consensus_2pc_event::position)
                 .first::<i32>(self.conn)
                 .optional()?
                 .unwrap_or(0)
@@ -114,12 +113,12 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     event_type: String::from(&event),
                 };
 
-                insert_into(two_pc_consensus_event::table)
+                insert_into(consensus_2pc_event::table)
                     .values(vec![insertable_event])
                     .execute(self.conn)?;
-                let event_id = two_pc_consensus_event::table
-                    .order(two_pc_consensus_event::id.desc())
-                    .select(two_pc_consensus_event::id)
+                let event_id = consensus_2pc_event::table
+                    .order(consensus_2pc_event::id.desc())
+                    .select(consensus_2pc_event::id)
                     .first::<i64>(self.conn)?;
 
                 match event {
@@ -155,7 +154,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             vote_response,
                             vote_request: None,
                         };
-                        insert_into(two_pc_consensus_deliver_event::table)
+                        insert_into(consensus_2pc_deliver_event::table)
                             .values(vec![deliver_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -167,7 +166,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             epoch,
                             value,
                         };
-                        insert_into(two_pc_consensus_start_event::table)
+                        insert_into(consensus_2pc_start_event::table)
                             .values(vec![start_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -183,7 +182,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             epoch,
                             vote,
                         };
-                        insert_into(two_pc_consensus_vote_event::table)
+                        insert_into(consensus_2pc_vote_event::table)
                             .values(vec![vote_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -198,12 +197,12 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     event_type: String::from(&event),
                 };
 
-                insert_into(two_pc_consensus_event::table)
+                insert_into(consensus_2pc_event::table)
                     .values(vec![insertable_event])
                     .execute(self.conn)?;
-                let event_id = two_pc_consensus_event::table
-                    .order(two_pc_consensus_event::id.desc())
-                    .select(two_pc_consensus_event::id)
+                let event_id = consensus_2pc_event::table
+                    .order(consensus_2pc_event::id.desc())
+                    .select(consensus_2pc_event::id)
                     .first::<i64>(self.conn)?;
 
                 match event {
@@ -238,7 +237,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             vote_response: None,
                             vote_request,
                         };
-                        insert_into(two_pc_consensus_deliver_event::table)
+                        insert_into(consensus_2pc_deliver_event::table)
                             .values(vec![deliver_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -254,7 +253,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             epoch,
                             vote,
                         };
-                        insert_into(two_pc_consensus_vote_event::table)
+                        insert_into(consensus_2pc_vote_event::table)
                             .values(vec![vote_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -311,14 +310,14 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 .first::<Consensus2pcParticipantContextModel>(self.conn)
                 .optional()?;
 
-            let position = two_pc_consensus_event::table
+            let position = consensus_2pc_event::table
                 .filter(
-                    two_pc_consensus_event::service_id
+                    consensus_2pc_event::service_id
                         .eq(format!("{}", service_id))
-                        .and(two_pc_consensus_event::epoch.eq(epoch)),
+                        .and(consensus_2pc_event::epoch.eq(epoch)),
                 )
-                .order(two_pc_consensus_event::position.desc())
-                .select(two_pc_consensus_event::position)
+                .order(consensus_2pc_event::position.desc())
+                .select(consensus_2pc_event::position)
                 .first::<i32>(self.conn)
                 .optional()?
                 .unwrap_or(0)
@@ -345,9 +344,9 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     event_type: String::from(&event),
                 };
 
-                let event_id: i64 = insert_into(two_pc_consensus_event::table)
+                let event_id: i64 = insert_into(consensus_2pc_event::table)
                     .values(vec![insertable_event])
-                    .returning(two_pc_consensus_event::id)
+                    .returning(consensus_2pc_event::id)
                     .get_result(self.conn)?;
 
                 match event {
@@ -383,7 +382,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             vote_response,
                             vote_request: None,
                         };
-                        insert_into(two_pc_consensus_deliver_event::table)
+                        insert_into(consensus_2pc_deliver_event::table)
                             .values(vec![deliver_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -395,7 +394,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             epoch,
                             value,
                         };
-                        insert_into(two_pc_consensus_start_event::table)
+                        insert_into(consensus_2pc_start_event::table)
                             .values(vec![start_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -411,7 +410,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             epoch,
                             vote,
                         };
-                        insert_into(two_pc_consensus_vote_event::table)
+                        insert_into(consensus_2pc_vote_event::table)
                             .values(vec![vote_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -426,9 +425,9 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     event_type: String::from(&event),
                 };
 
-                let event_id: i64 = insert_into(two_pc_consensus_event::table)
+                let event_id: i64 = insert_into(consensus_2pc_event::table)
                     .values(vec![insertable_event])
-                    .returning(two_pc_consensus_event::id)
+                    .returning(consensus_2pc_event::id)
                     .get_result(self.conn)?;
 
                 match event {
@@ -463,7 +462,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             vote_response: None,
                             vote_request,
                         };
-                        insert_into(two_pc_consensus_deliver_event::table)
+                        insert_into(consensus_2pc_deliver_event::table)
                             .values(vec![deliver_event])
                             .execute(self.conn)?;
                         Ok(event_id)
@@ -479,7 +478,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                             epoch,
                             vote,
                         };
-                        insert_into(two_pc_consensus_vote_event::table)
+                        insert_into(consensus_2pc_vote_event::table)
                             .values(vec![vote_event])
                             .execute(self.conn)?;
                         Ok(event_id)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -29,7 +29,7 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusStartEventModel, TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
+        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
         two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
         two_pc_consensus_vote_event,
     },
@@ -65,15 +65,10 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 
@@ -301,15 +296,10 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -25,9 +25,8 @@ use crate::store::scabbard_store::diesel::{
         Consensus2pcParticipantContextModel, Consensus2pcParticipantContextParticipantModel,
     },
     schema::{
-        consensus_2pc_consensus_coordinator_context,
-        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
-        consensus_2pc_participant_context_participant,
+        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
+        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::{context::ScabbardContext, ScabbardStoreError};
@@ -52,9 +51,9 @@ where
         service_id: &FullyQualifiedServiceId,
     ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(consensus_2pc_consensus_coordinator_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_consensus_coordinator_context::epoch.desc())
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_2pc_coordinator_context::epoch.desc())
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 
@@ -83,12 +82,12 @@ where
                         Ordering::Greater => {
                             let coordinator_participants: Vec<
                                 Consensus2pcCoordinatorContextParticipantModel,
-                            > = consensus_2pc_consensus_coordinator_context_participant::table
+                            > = consensus_2pc_coordinator_context_participant::table
                                 .filter(
-                                    consensus_2pc_consensus_coordinator_context_participant::service_id
+                                    consensus_2pc_coordinator_context_participant::service_id
                                         .eq(format!("{}", service_id))
                                         .and(
-                                            consensus_2pc_consensus_coordinator_context_participant::epoch
+                                            consensus_2pc_coordinator_context_participant::epoch
                                                 .eq(coordinator_context.epoch),
                                         ),
                                 )
@@ -139,12 +138,12 @@ where
                 (Some(coordinator_context), None) => {
                     let coordinator_participants: Vec<
                         Consensus2pcCoordinatorContextParticipantModel,
-                    > = consensus_2pc_consensus_coordinator_context_participant::table
+                    > = consensus_2pc_coordinator_context_participant::table
                         .filter(
-                            consensus_2pc_consensus_coordinator_context_participant::service_id
+                            consensus_2pc_coordinator_context_participant::service_id
                                 .eq(format!("{}", service_id))
                                 .and(
-                                    consensus_2pc_consensus_coordinator_context_participant::epoch
+                                    consensus_2pc_coordinator_context_participant::epoch
                                         .eq(coordinator_context.epoch),
                                 ),
                         )

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -31,7 +31,7 @@ use crate::store::scabbard_store::diesel::{
         Consensus2pcUpdateParticipantContextActionModel,
     },
     schema::{
-        consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
+        consensus_2pc_action, consensus_2pc_coordinator_context,
         consensus_2pc_coordinator_notification_action,
         consensus_2pc_coordinator_send_message_action, consensus_2pc_participant_context,
         consensus_2pc_participant_notification_action,
@@ -82,9 +82,9 @@ where
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
             let coordinator_context =
-                consensus_2pc_consensus_coordinator_context::table
-                    .filter(consensus_2pc_consensus_coordinator_context::epoch.eq(epoch).and(
-                        consensus_2pc_consensus_coordinator_context::service_id.eq(format!("{}", service_id)),
+                consensus_2pc_coordinator_context::table
+                    .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                        consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
                     ))
                     .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                     .optional()?;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
@@ -27,9 +27,8 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
-        two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
-        two_pc_consensus_vote_event,
+        consensus_2pc_coordinator_context, consensus_2pc_deliver_event, consensus_2pc_event,
+        consensus_2pc_participant_context, consensus_2pc_start_event, consensus_2pc_vote_event,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -81,18 +80,18 @@ where
                 .first::<Consensus2pcParticipantContextModel>(self.conn)
                 .optional()?;
 
-            let consensus_events = two_pc_consensus_event::table
+            let consensus_events = consensus_2pc_event::table
                 .filter(
-                    two_pc_consensus_event::service_id
+                    consensus_2pc_event::service_id
                         .eq(format!("{}", service_id))
-                        .and(two_pc_consensus_event::epoch.eq(epoch))
-                        .and(two_pc_consensus_event::executed_at.is_null()),
+                        .and(consensus_2pc_event::epoch.eq(epoch))
+                        .and(consensus_2pc_event::executed_at.is_null()),
                 )
-                .order(two_pc_consensus_event::position.desc())
+                .order(consensus_2pc_event::position.desc())
                 .select((
-                    two_pc_consensus_event::id,
-                    two_pc_consensus_event::position,
-                    two_pc_consensus_event::event_type,
+                    consensus_2pc_event::id,
+                    consensus_2pc_event::position,
+                    consensus_2pc_event::event_type,
                 ))
                 .load::<(i64, i32, String)>(self.conn)?;
 
@@ -126,16 +125,16 @@ where
 
             all_events.append(&mut alarm_events);
 
-            let deliver_events = two_pc_consensus_deliver_event::table
-                .filter(two_pc_consensus_deliver_event::event_id.eq_any(&event_ids))
+            let deliver_events = consensus_2pc_deliver_event::table
+                .filter(consensus_2pc_deliver_event::event_id.eq_any(&event_ids))
                 .load::<TwoPcConsensusDeliverEventModel>(self.conn)?;
 
-            let start_events = two_pc_consensus_start_event::table
-                .filter(two_pc_consensus_start_event::event_id.eq_any(&event_ids))
+            let start_events = consensus_2pc_start_event::table
+                .filter(consensus_2pc_start_event::event_id.eq_any(&event_ids))
                 .load::<TwoPcConsensusStartEventModel>(self.conn)?;
 
-            let vote_events = two_pc_consensus_vote_event::table
-                .filter(two_pc_consensus_vote_event::event_id.eq_any(&event_ids))
+            let vote_events = consensus_2pc_vote_event::table
+                .filter(consensus_2pc_vote_event::event_id.eq_any(&event_ids))
                 .load::<TwoPcConsensusVoteEventModel>(self.conn)?;
 
             if coordinator_context.is_some() {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
@@ -27,7 +27,7 @@ use crate::store::scabbard_store::diesel::{
         TwoPcConsensusVoteEventModel,
     },
     schema::{
-        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
+        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
         two_pc_consensus_deliver_event, two_pc_consensus_event, two_pc_consensus_start_event,
         two_pc_consensus_vote_event,
     },
@@ -66,15 +66,10 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_events.rs
@@ -22,9 +22,9 @@ use splinter::service::ServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
-        TwoPcConsensusDeliverEventModel, TwoPcConsensusStartEventModel,
-        TwoPcConsensusVoteEventModel,
+        Consensus2pcCoordinatorContextModel, Consensus2pcDeliverEventModel,
+        Consensus2pcParticipantContextModel, Consensus2pcStartEventModel,
+        Consensus2pcVoteEventModel,
     },
     schema::{
         consensus_2pc_coordinator_context, consensus_2pc_deliver_event, consensus_2pc_event,
@@ -127,15 +127,15 @@ where
 
             let deliver_events = consensus_2pc_deliver_event::table
                 .filter(consensus_2pc_deliver_event::event_id.eq_any(&event_ids))
-                .load::<TwoPcConsensusDeliverEventModel>(self.conn)?;
+                .load::<Consensus2pcDeliverEventModel>(self.conn)?;
 
             let start_events = consensus_2pc_start_event::table
                 .filter(consensus_2pc_start_event::event_id.eq_any(&event_ids))
-                .load::<TwoPcConsensusStartEventModel>(self.conn)?;
+                .load::<Consensus2pcStartEventModel>(self.conn)?;
 
             let vote_events = consensus_2pc_vote_event::table
                 .filter(consensus_2pc_vote_event::event_id.eq_any(&event_ids))
-                .load::<TwoPcConsensusVoteEventModel>(self.conn)?;
+                .load::<Consensus2pcVoteEventModel>(self.conn)?;
 
             if coordinator_context.is_some() {
                 // return an error if there is both a coordinator and a participant context for the

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
@@ -20,8 +20,8 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::schema::{
-    consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
-    consensus_2pc_participant_context, scabbard_service,
+    consensus_2pc_action, consensus_2pc_coordinator_context, consensus_2pc_participant_context,
+    scabbard_service,
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -49,13 +49,13 @@ where
             let current_time = get_timestamp(Some(SystemTime::now()))?;
 
             // get the service IDs of coordinators for which the alarm has passed
-            let mut ready_services = consensus_2pc_consensus_coordinator_context::table
+            let mut ready_services = consensus_2pc_coordinator_context::table
                 .filter(
-                    consensus_2pc_consensus_coordinator_context::service_id
+                    consensus_2pc_coordinator_context::service_id
                         .eq_any(&finalized_services)
-                        .and(consensus_2pc_consensus_coordinator_context::alarm.le(current_time)),
+                        .and(consensus_2pc_coordinator_context::alarm.le(current_time)),
                 )
-                .select(consensus_2pc_consensus_coordinator_context::service_id)
+                .select(consensus_2pc_coordinator_context::service_id)
                 .load::<String>(self.conn)?
                 .into_iter()
                 .collect::<Vec<String>>();

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
@@ -21,7 +21,7 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::operations::get_service::GetServiceOperation;
 use crate::store::scabbard_store::diesel::schema::{
-    consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context, scabbard_peer,
+    consensus_2pc_coordinator_context, consensus_2pc_participant_context, scabbard_peer,
     scabbard_service, scabbard_v3_commit_history,
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -60,9 +60,10 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, SqliteConnection
                 // delete all consensus state associated with the services
                 //
                 // delete cascade will remove the remaining associated consensus components
-                delete(consensus_2pc_consensus_coordinator_context::table.filter(
-                    consensus_2pc_consensus_coordinator_context::service_id.eq(&service_id),
-                ))
+                delete(
+                    consensus_2pc_coordinator_context::table
+                        .filter(consensus_2pc_coordinator_context::service_id.eq(&service_id)),
+                )
                 .execute(self.conn)?;
 
                 delete(
@@ -103,9 +104,10 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, PgConnection> {
                     // delete all consensus state associated with the services
                     //
                     // delete cascade will remove the remaining associated consensus components
-                    delete(consensus_2pc_consensus_coordinator_context::table.filter(
-                        consensus_2pc_consensus_coordinator_context::service_id.eq(&service_id),
-                    ))
+                    delete(
+                        consensus_2pc_coordinator_context::table
+                            .filter(consensus_2pc_coordinator_context::service_id.eq(&service_id)),
+                    )
                     .execute(self.conn)?;
 
                     delete(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -22,8 +22,7 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{
-        consensus_2pc_action, consensus_2pc_consensus_coordinator_context,
-        consensus_2pc_participant_context,
+        consensus_2pc_action, consensus_2pc_coordinator_context, consensus_2pc_participant_context,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -58,15 +57,10 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if action a context exists with the given service_id and epoch
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -28,9 +28,8 @@ use crate::store::scabbard_store::diesel::{
         CoordinatorContextParticipantList, ParticipantContextParticipantList,
     },
     schema::{
-        consensus_2pc_consensus_coordinator_context,
-        consensus_2pc_consensus_coordinator_context_participant, consensus_2pc_participant_context,
-        consensus_2pc_participant_context_participant,
+        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
+        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
     },
 };
 use crate::store::scabbard_store::ScabbardContext;
@@ -60,16 +59,16 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
                     // check to make sure the context exists
-                    let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                    let coordinator_context = consensus_2pc_coordinator_context::table
                         .filter(
-                            consensus_2pc_consensus_coordinator_context::epoch
+                            consensus_2pc_coordinator_context::epoch
                                 .eq(epoch)
                                 .and(
-                                    consensus_2pc_consensus_coordinator_context::service_id
+                                    consensus_2pc_coordinator_context::service_id
                                         .eq(format!("{}", service_id)),
                                 )
                                 .and(
-                                    consensus_2pc_consensus_coordinator_context::coordinator
+                                    consensus_2pc_coordinator_context::coordinator
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
@@ -109,22 +108,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                             Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_2pc_consensus_coordinator_context::table.filter(
-                                consensus_2pc_consensus_coordinator_context::epoch
+                            consensus_2pc_coordinator_context::table.filter(
+                                consensus_2pc_coordinator_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context::service_id
+                                        consensus_2pc_coordinator_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context::coordinator
+                                        consensus_2pc_coordinator_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_consensus_coordinator_context::table)
+                        insert_into(consensus_2pc_coordinator_context::table)
                             .values(vec![update_coordinator_context])
                             .execute(self.conn)?;
 
@@ -133,17 +132,18 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                 .inner;
 
                         delete(
-                            consensus_2pc_consensus_coordinator_context_participant::table.filter(
-                                consensus_2pc_consensus_coordinator_context_participant::service_id
+                            consensus_2pc_coordinator_context_participant::table.filter(
+                                consensus_2pc_coordinator_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_coordinator_context_participant::epoch
+                                            .eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_consensus_coordinator_context_participant::table)
+                        insert_into(consensus_2pc_coordinator_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 
@@ -181,7 +181,8 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                 consensus_2pc_participant_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_2pc_participant_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_participant_context_participant::epoch
+                                            .eq(epoch),
                                     ),
                             ),
                         )
@@ -221,16 +222,16 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
                     // check to make sure the context exists
-                    let coordinator_context = consensus_2pc_consensus_coordinator_context::table
+                    let coordinator_context = consensus_2pc_coordinator_context::table
                         .filter(
-                            consensus_2pc_consensus_coordinator_context::epoch
+                            consensus_2pc_coordinator_context::epoch
                                 .eq(epoch)
                                 .and(
-                                    consensus_2pc_consensus_coordinator_context::service_id
+                                    consensus_2pc_coordinator_context::service_id
                                         .eq(format!("{}", service_id)),
                                 )
                                 .and(
-                                    consensus_2pc_consensus_coordinator_context::coordinator
+                                    consensus_2pc_coordinator_context::coordinator
                                         .eq(format!("{}", context.coordinator())),
                                 ),
                         )
@@ -238,9 +239,12 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         .optional()?;
 
                     let participant_context = consensus_2pc_participant_context::table
-                        .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
-                            consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
-                        ))
+                        .filter(
+                            consensus_2pc_participant_context::epoch.eq(epoch).and(
+                                consensus_2pc_participant_context::service_id
+                                    .eq(format!("{}", service_id)),
+                            ),
+                        )
                         .first::<Consensus2pcParticipantContextModel>(self.conn)
                         .optional()?;
 
@@ -261,22 +265,22 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                             Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
 
                         delete(
-                            consensus_2pc_consensus_coordinator_context::table.filter(
-                                consensus_2pc_consensus_coordinator_context::epoch
+                            consensus_2pc_coordinator_context::table.filter(
+                                consensus_2pc_coordinator_context::epoch
                                     .eq(epoch)
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context::service_id
+                                        consensus_2pc_coordinator_context::service_id
                                             .eq(format!("{}", service_id)),
                                     )
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context::coordinator
+                                        consensus_2pc_coordinator_context::coordinator
                                             .eq(format!("{}", context.coordinator())),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_consensus_coordinator_context::table)
+                        insert_into(consensus_2pc_coordinator_context::table)
                             .values(vec![update_coordinator_context])
                             .execute(self.conn)?;
 
@@ -285,17 +289,18 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                 .inner;
 
                         delete(
-                            consensus_2pc_consensus_coordinator_context_participant::table.filter(
-                                consensus_2pc_consensus_coordinator_context_participant::service_id
+                            consensus_2pc_coordinator_context_participant::table.filter(
+                                consensus_2pc_coordinator_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_2pc_consensus_coordinator_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_coordinator_context_participant::epoch
+                                            .eq(epoch),
                                     ),
                             ),
                         )
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_consensus_coordinator_context_participant::table)
+                        insert_into(consensus_2pc_coordinator_context_participant::table)
                             .values(updated_participants)
                             .execute(self.conn)?;
 
@@ -333,7 +338,8 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                 consensus_2pc_participant_context_participant::service_id
                                     .eq(format!("{}", service_id))
                                     .and(
-                                        consensus_2pc_participant_context_participant::epoch.eq(epoch),
+                                        consensus_2pc_participant_context_participant::epoch
+                                            .eq(epoch),
                                     ),
                             ),
                         )

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -22,8 +22,7 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
-        two_pc_consensus_event,
+        consensus_2pc_coordinator_context, consensus_2pc_event, consensus_2pc_participant_context,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -97,14 +96,14 @@ where
             })?;
 
             if coordinator_context.is_some() || participant_context.is_some() {
-                update(two_pc_consensus_event::table)
+                update(consensus_2pc_event::table)
                     .filter(
-                        two_pc_consensus_event::id
+                        consensus_2pc_event::id
                             .eq(event_id)
-                            .and(two_pc_consensus_event::service_id.eq(format!("{}", service_id)))
-                            .and(two_pc_consensus_event::epoch.eq(epoch)),
+                            .and(consensus_2pc_event::service_id.eq(format!("{}", service_id)))
+                            .and(consensus_2pc_event::epoch.eq(epoch)),
                     )
-                    .set(two_pc_consensus_event::executed_at.eq(Some(update_executed_at)))
+                    .set(consensus_2pc_event::executed_at.eq(Some(update_executed_at)))
                     .execute(self.conn)
                     .map(|_| ())
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -22,7 +22,7 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
     schema::{
-        consensus_2pc_consensus_coordinator_context, consensus_2pc_participant_context,
+        consensus_2pc_coordinator_context, consensus_2pc_participant_context,
         two_pc_consensus_event,
     },
 };
@@ -58,15 +58,10 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
             // check to see if a context exists with the given service_id and epoch
-            let coordinator_context = consensus_2pc_consensus_coordinator_context::table
-                .filter(
-                    consensus_2pc_consensus_coordinator_context::epoch
-                        .eq(epoch)
-                        .and(
-                            consensus_2pc_consensus_coordinator_context::service_id
-                                .eq(format!("{}", service_id)),
-                        ),
-                )
+            let coordinator_context = consensus_2pc_coordinator_context::table
+                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
+                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
+                ))
                 .first::<Consensus2pcCoordinatorContextModel>(self.conn)
                 .optional()?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -181,7 +181,7 @@ table! {
 }
 
 table! {
-    two_pc_consensus_event (id) {
+    consensus_2pc_event (id) {
         id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -193,7 +193,7 @@ table! {
 }
 
 table! {
-    two_pc_consensus_deliver_event (event_id) {
+    consensus_2pc_deliver_event (event_id) {
         event_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -205,7 +205,7 @@ table! {
 }
 
 table! {
-    two_pc_consensus_start_event (event_id) {
+    consensus_2pc_start_event (event_id) {
         event_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -214,7 +214,7 @@ table! {
 }
 
 table! {
-    two_pc_consensus_vote_event (event_id) {
+    consensus_2pc_vote_event (event_id) {
         event_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -232,9 +232,9 @@ joinable!(consensus_2pc_participant_notification_action -> consensus_2pc_action 
 joinable!(consensus_2pc_participant_send_message_action -> consensus_2pc_action (action_id));
 joinable!(consensus_2pc_update_participant_context_action -> consensus_2pc_action (action_id));
 
-joinable!(two_pc_consensus_deliver_event -> two_pc_consensus_event(event_id));
-joinable!(two_pc_consensus_start_event -> two_pc_consensus_event(event_id));
-joinable!(two_pc_consensus_vote_event -> two_pc_consensus_event(event_id));
+joinable!(consensus_2pc_deliver_event -> consensus_2pc_event(event_id));
+joinable!(consensus_2pc_start_event -> consensus_2pc_event(event_id));
+joinable!(consensus_2pc_vote_event -> consensus_2pc_event(event_id));
 
 allow_tables_to_appear_in_same_query!(
     consensus_2pc_coordinator_context,
@@ -250,10 +250,10 @@ allow_tables_to_appear_in_same_query!(
     consensus_2pc_update_participant_context_action_participant,
     consensus_2pc_participant_send_message_action,
     consensus_2pc_participant_notification_action,
-    two_pc_consensus_event,
-    two_pc_consensus_deliver_event,
-    two_pc_consensus_start_event,
-    two_pc_consensus_vote_event,
+    consensus_2pc_event,
+    consensus_2pc_deliver_event,
+    consensus_2pc_start_event,
+    consensus_2pc_vote_event,
 );
 
 allow_tables_to_appear_in_same_query!(scabbard_peer, scabbard_service, scabbard_v3_commit_history,);

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -37,7 +37,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_consensus_coordinator_context (service_id, epoch) {
+    consensus_2pc_coordinator_context (service_id, epoch) {
         service_id -> Text,
         alarm -> Nullable<BigInt>,
         coordinator -> Text,
@@ -49,7 +49,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_consensus_coordinator_context_participant (service_id, epoch, process) {
+    consensus_2pc_coordinator_context_participant (service_id, epoch, process) {
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,
@@ -237,8 +237,8 @@ joinable!(two_pc_consensus_start_event -> two_pc_consensus_event(event_id));
 joinable!(two_pc_consensus_vote_event -> two_pc_consensus_event(event_id));
 
 allow_tables_to_appear_in_same_query!(
-    consensus_2pc_consensus_coordinator_context,
-    consensus_2pc_consensus_coordinator_context_participant,
+    consensus_2pc_coordinator_context,
+    consensus_2pc_coordinator_context_participant,
     consensus_2pc_action,
     consensus_2pc_update_coordinator_context_action,
     consensus_2pc_coordinator_send_message_action,


### PR DESCRIPTION
- Fix the coordinator context and coordinator context participant table names to remove the unintentional extra "consensus"
`consensus_2pc_consensus_coordinator_context` -> `consensus_2pc_coordinator_context`
`consensus_2pc_consensus_coordinator_context_participant` -> `consensus_2pc_coordinator_context_participant`
- Update the scabbard consensus event table names to replace the `two_pc_consensus` prefix with `consensus_2pc`
- Replace the `TwoPcConsensus` prefix on event model structs with `Consensus2pc`