### PR TITLE
Stop unit tests from different PRs cancelling each other

### DIFF
--- a/.github/workflows/unit-test-splinter.yaml
+++ b/.github/workflows/unit-test-splinter.yaml
@@ -7,7 +7,7 @@ env:
   CARGO_TERM_COLOR: always
 
 concurrency:
-  group: "${{ github.ref }}-${{ github.workflow }}"
+  group: "${{ github.head_ref }}-${{ github.workflow }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This was originally fixed in 8a9bd91e but overwritten in a subsequent PR.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>