### PR TITLE
BACKPORT: Adjust sqlite, postgres feature to work in isolation

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -132,7 +132,7 @@ experimental = [
 # used for turning benchmark tests on
 benchmark = []
 
-admin-service = []
+admin-service = ["store"]
 admin-service-client = ["admin-service"]
 admin-service-event-client = ["admin-service-client" ]
 admin-service-event-client-actix-web-client = [
@@ -159,7 +159,7 @@ https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]
 node-id-store = []
 oauth = ["biome", "base64", "oauth2", "reqwest", "rest-api"]
-postgres = ["diesel/postgres", "diesel_migrations", "store"]
+postgres = ["diesel/postgres", "diesel_migrations"]
 registry = []
 registry-client = ["registry"]
 registry-client-reqwest = ["registry-client", "reqwest"]
@@ -175,7 +175,7 @@ rest-api-actix-web-1 = [
 ]
 rest-api-actix-web-3 = ["actix-web-3", "futures-0-3", "actix-0-10", "actix-service-1-0", "https-bind"]
 rest-api-cors = []
-sqlite = ["diesel/sqlite", "diesel_migrations", "store"]
+sqlite = ["diesel/sqlite", "diesel_migrations"]
 store = []
 store-factory = ["store"]
 tap = ["chrono", "futures-0-3", "influxdb", "metrics", "tokio-1"]

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -23,7 +23,7 @@ extern crate serde_derive;
 #[cfg(feature = "rest-api-actix-web-1")]
 extern crate serde_json;
 #[macro_use]
-#[cfg(feature = "diesel")]
+#[cfg(all(feature = "diesel", feature = "store"))]
 extern crate diesel;
 #[macro_use]
 #[cfg(feature = "diesel")]


### PR DESCRIPTION
Backport of #1924 

This removes "store" from sqlite, postgres and then uses "store" to
guard "extern diesel", which caused a clippy error when not enabled with
a store command. This also adds "store" to "admin-service", which
depends on "store", which was exposed by removing it from sqlite and
postgres.