### PR TITLE
Update Dockerfile to copy more than Cargo.tomls

### DIFF
--- a/examples/gameroom/daemon/Dockerfile-installed-focal
+++ b/examples/gameroom/daemon/Dockerfile-installed-focal
@@ -47,6 +47,9 @@ COPY examples/gameroom/daemon/ /build/examples/gameroom/daemon
 COPY libsplinter /build/libsplinter
 COPY splinterd /build/splinterd
 COPY services/scabbard/libscabbard /build/services/scabbard/libscabbard
+COPY rest_api/actix_web_1/ /build/rest_api/actix_web_1/
+COPY rest_api/actix_web_4/ /build/rest_api/actix_web_4/
+COPY rest_api/common/ /build/rest_api/common/
 
 # Build the gameroomd package
 ARG REPO_VERSION

--- a/splinterd/Dockerfile-installed-focal
+++ b/splinterd/Dockerfile-installed-focal
@@ -49,6 +49,9 @@ COPY rest_api/actix_web_1/ /build/rest_api/actix_web_1/
 COPY rest_api/common/ /build/rest_api/common/
 COPY splinterd/ /build/splinterd
 COPY services/scabbard/libscabbard /build/services/scabbard/libscabbard
+COPY rest_api/actix_web_1/ /build/rest_api/actix_web_1/
+COPY rest_api/actix_web_4/ /build/rest_api/actix_web_4/
+COPY rest_api/common/ /build/rest_api/common/
 
 # Build splinterd
 ARG REPO_VERSION

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -25,7 +25,7 @@ COPY libsplinter /build/libsplinter
 COPY splinterd /build/splinterd
 COPY cli /build/cli
 COPY rest_api/actix_web_1/ /build/rest_api/actix_web_1/
-COPY rest_api/actix_web_4/Cargo.toml /build/rest_api/actix_web_4/Cargo.toml
+COPY rest_api/actix_web_4/ /build/rest_api/actix_web_4/
 COPY rest_api/common/ /build/rest_api/common/
 COPY services/scabbard/cli /build/services/scabbard/cli
 COPY services/scabbard/libscabbard /build/services/scabbard/libscabbard


### PR DESCRIPTION
The Dockerfile-installed-focal, and tests/Dockerfile copy just the
Cargo.tomls for the rest_api crates. Which is fine as long as no other
crates depend on those rest_api crates. As soon as splinterd pulls in
the actix_web_1 or 4 crates cargo won't be able to find those local
dependencies.

This commit updates the dockerfiles to copy the entire actix_web_1,
actix_web_4, and common rest_api crates into the build directory.

Signed-off-by: Caleb Hill <hill@bitwise.io>