### PR TITLE
Update lifecylce commands for scabbard store 

### DIFF
--- a/services/scabbard/libscabbard/src/service/v3/arguments.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments.rs
@@ -17,15 +17,17 @@ use std::convert::TryFrom;
 use splinter::error::InvalidArgumentError;
 use splinter::service::ServiceId;
 
+use crate::store::service::ConsensusType;
+
 pub struct ScabbardArguments {
     peers: Vec<ServiceId>,
-    consensus: ScabbardConsensus,
+    consensus: ConsensusType,
 }
 
 impl ScabbardArguments {
     pub fn new(
         peers: Vec<ServiceId>,
-        consensus: ScabbardConsensus,
+        consensus: ConsensusType,
     ) -> Result<Self, InvalidArgumentError> {
         Ok(Self { peers, consensus })
     }
@@ -34,7 +36,7 @@ impl ScabbardArguments {
         &self.peers
     }
 
-    pub fn consensus(&self) -> &ScabbardConsensus {
+    pub fn consensus(&self) -> &ConsensusType {
         &self.consensus
     }
 }
@@ -42,7 +44,7 @@ impl ScabbardArguments {
 #[derive(Default)]
 pub struct ScabbardArgumentsBuilder {
     peers: Option<Vec<ServiceId>>,
-    consensus: Option<ScabbardConsensus>,
+    consensus: Option<ConsensusType>,
 }
 
 impl ScabbardArgumentsBuilder {
@@ -58,7 +60,7 @@ impl ScabbardArgumentsBuilder {
         self
     }
 
-    pub fn with_consensus(mut self, consensus: ScabbardConsensus) -> Self {
+    pub fn with_consensus(mut self, consensus: ConsensusType) -> Self {
         self.consensus = Some(consensus);
         self
     }
@@ -69,22 +71,18 @@ impl ScabbardArgumentsBuilder {
             .ok_or_else(|| InvalidArgumentError::new("peers", "must be set"))?;
 
         // currently defaults to TwoPC if none is provided
-        let consensus = self.consensus.unwrap_or(ScabbardConsensus::TwoPC);
+        let consensus = self.consensus.unwrap_or(ConsensusType::TwoPC);
 
         ScabbardArguments::new(peers, consensus)
     }
 }
 
-pub enum ScabbardConsensus {
-    TwoPC,
-}
-
-impl TryFrom<String> for ScabbardConsensus {
+impl TryFrom<String> for ConsensusType {
     type Error = InvalidArgumentError;
 
     fn try_from(consensus: String) -> Result<Self, Self::Error> {
         match consensus.as_str() {
-            "2PC" => Ok(ScabbardConsensus::TwoPC),
+            "2PC" => Ok(ConsensusType::TwoPC),
             _ => Err(InvalidArgumentError::new(
                 "consensus",
                 "provided consensus type is not supported",

--- a/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
@@ -19,7 +19,9 @@ use splinter::{
     service::{ArgumentsConverter, ServiceId},
 };
 
-use super::{ScabbardArguments, ScabbardArgumentsBuilder, ScabbardConsensus};
+use crate::store::service::ConsensusType;
+
+use super::{ScabbardArguments, ScabbardArgumentsBuilder};
 
 pub struct ScabbardArgumentsVecConverter {}
 
@@ -52,7 +54,7 @@ impl ArgumentsConverter<ScabbardArguments, Vec<(String, String)>>
                     arg_builder = arg_builder.with_peers(peers);
                 }
                 "consensus" => {
-                    let consensus = ScabbardConsensus::try_from(value)
+                    let consensus = ConsensusType::try_from(value)
                         .map_err(|err| InternalError::from_source(Box::new(err)))?;
                     arg_builder = arg_builder.with_consensus(consensus);
                 }

--- a/services/scabbard/libscabbard/src/service/v3/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/mod.rs
@@ -22,7 +22,7 @@ mod timer_filter;
 mod timer_handler;
 mod timer_handler_factory;
 
-pub use arguments::{ScabbardArguments, ScabbardArgumentsBuilder, ScabbardConsensus};
+pub use arguments::{ScabbardArguments, ScabbardArgumentsBuilder};
 pub use arguments_converter::ScabbardArgumentsVecConverter;
 pub use lifecycle::ScabbardLifecycle;
 pub use message_converter::ScabbardMessageByteConverter;

--- a/services/scabbard/libscabbard/src/store/command/prepare_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/prepare_service.rs
@@ -12,20 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
+use std::sync::Arc;
 
-use log::info;
-use splinter::{error::InternalError, store::command::StoreCommand};
+use splinter::{error::InternalError, service::ServiceId, store::command::StoreCommand};
 
-#[derive(Default)]
+use crate::store::{
+    context::{Context, ContextBuilder, Participant, ScabbardContext},
+    service::ScabbardService,
+    state::Scabbard2pcState,
+    ScabbardStoreFactory,
+};
+
 pub struct ScabbardPrepareServiceCommand<C> {
-    _store_factory: PhantomData<C>,
+    store_factory: Arc<dyn ScabbardStoreFactory<C>>,
+    scabbard_service: ScabbardService,
 }
 
 impl<C> ScabbardPrepareServiceCommand<C> {
-    pub fn new() -> Self {
+    pub fn new(
+        store_factory: Arc<dyn ScabbardStoreFactory<C>>,
+        scabbard_service: ScabbardService,
+    ) -> Self {
         Self {
-            _store_factory: PhantomData,
+            store_factory,
+            scabbard_service,
         }
     }
 }
@@ -33,8 +43,69 @@ impl<C> ScabbardPrepareServiceCommand<C> {
 impl<C> StoreCommand for ScabbardPrepareServiceCommand<C> {
     type Context = C;
 
-    fn execute(&self, _conn: &Self::Context) -> Result<(), InternalError> {
-        info!("executing prepare service command");
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        let context = create_context(&self.scabbard_service)?;
+
+        let store = self.store_factory.new_store(conn);
+
+        store
+            .add_service(self.scabbard_service.clone())
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        store
+            .add_consensus_context(
+                self.scabbard_service.service_id(),
+                ScabbardContext::Scabbard2pcContext(context),
+            )
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
         Ok(())
     }
+}
+
+fn create_context(service: &ScabbardService) -> Result<Context, InternalError> {
+    let mut peers = service.peers().to_vec();
+
+    peers.push(service.service_id().service_id().clone());
+
+    let coordinator = get_coordinator(peers).ok_or_else(|| {
+        InternalError::with_message(format!(
+            "Unable to get coordinator service ID for service {}",
+            service.service_id()
+        ))
+    })?;
+
+    if service.service_id().service_id() == &coordinator {
+        ContextBuilder::default()
+            .with_coordinator(&coordinator)
+            .with_epoch(1)
+            .with_participants(
+                service
+                    .peers()
+                    .iter()
+                    .map(|participant| Participant {
+                        process: participant.clone(),
+                        vote: None,
+                    })
+                    .collect(),
+            )
+            .with_state(Scabbard2pcState::WaitingForStart)
+            .with_this_process(service.service_id().clone().service_id())
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    } else {
+        ContextBuilder::default()
+            .with_coordinator(&coordinator)
+            .with_epoch(1)
+            .with_participant_processes(service.peers().to_vec())
+            .with_state(Scabbard2pcState::WaitingForVoteRequest)
+            .with_this_process(service.service_id().clone().service_id())
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}
+
+/// Gets the ID of the coordinator. The coordinator is the node with the lowest ID in the set of
+/// verifiers.
+fn get_coordinator(peers: Vec<ServiceId>) -> Option<ServiceId> {
+    peers.into_iter().min_by(|x, y| x.as_str().cmp(y.as_str()))
 }

--- a/services/scabbard/libscabbard/src/store/command/retire_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/retire_service.rs
@@ -12,20 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
+use std::sync::Arc;
 
-use log::info;
-use splinter::{error::InternalError, store::command::StoreCommand};
+use splinter::{
+    error::InternalError, service::FullyQualifiedServiceId, store::command::StoreCommand,
+};
 
-#[derive(Default)]
+use crate::store::{service::ServiceStatus, ScabbardStoreFactory};
+
 pub struct ScabbardRetireServiceCommand<C> {
-    _store_factory: PhantomData<C>,
+    store_factory: Arc<dyn ScabbardStoreFactory<C>>,
+    service_id: FullyQualifiedServiceId,
 }
 
 impl<C> ScabbardRetireServiceCommand<C> {
-    pub fn new() -> Self {
+    pub fn new(
+        store_factory: Arc<dyn ScabbardStoreFactory<C>>,
+        service_id: FullyQualifiedServiceId,
+    ) -> Self {
         Self {
-            _store_factory: PhantomData,
+            store_factory,
+            service_id,
         }
     }
 }
@@ -33,8 +40,24 @@ impl<C> ScabbardRetireServiceCommand<C> {
 impl<C> StoreCommand for ScabbardRetireServiceCommand<C> {
     type Context = C;
 
-    fn execute(&self, _conn: &Self::Context) -> Result<(), InternalError> {
-        info!("executing retire service command");
+    fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
+        let store = self.store_factory.new_store(conn);
+
+        let service = store
+            .get_service(&self.service_id)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?
+            .ok_or_else(|| {
+                InternalError::with_message(format!("Unable to fetch service {}", self.service_id))
+            })?
+            .into_builder()
+            .with_status(&ServiceStatus::Retired)
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        store
+            .update_service(service)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
         Ok(())
     }
 }

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -35,11 +35,13 @@ pub use commit_hash::{CommitHashStore, CommitHashStoreError};
 
 #[cfg(all(feature = "scabbardv3", feature = "diesel"))]
 pub use scabbard_store::diesel::DieselScabbardStore;
-#[cfg(all(feature = "scabbardv3", feature = "postgres"))]
-pub use scabbard_store::PooledPgScabbardStoreFactory;
 #[cfg(feature = "scabbardv3")]
 pub use scabbard_store::PooledScabbardStoreFactory;
-#[cfg(all(feature = "scabbardv3", feature = "sqlite"))]
-pub use scabbard_store::PooledSqliteScabbardStoreFactory;
 #[cfg(feature = "scabbardv3")]
-pub use scabbard_store::{action, context, service, state, two_phase, ScabbardStore};
+pub use scabbard_store::{
+    action, context, service, state, two_phase, ScabbardStore, ScabbardStoreFactory,
+};
+#[cfg(all(feature = "scabbardv3", feature = "postgres"))]
+pub use scabbard_store::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};
+#[cfg(all(feature = "scabbardv3", feature = "sqlite"))]
+pub use scabbard_store::{PooledSqliteScabbardStoreFactory, SqliteScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/scabbard_store/context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/context.rs
@@ -59,6 +59,34 @@ impl Context {
     pub fn this_process(&self) -> &ServiceId {
         &self.this_process
     }
+
+    pub fn into_builder(self) -> ContextBuilder {
+        let mut builder = ContextBuilder::default()
+            .with_coordinator(&self.coordinator)
+            .with_epoch(self.epoch)
+            .with_this_process(&self.this_process);
+
+        match self.role_context.inner {
+            InnerContext::Participant(context) => {
+                builder = builder.with_participant_processes(context.participant_processes);
+                builder = builder.with_state(context.state.into());
+            }
+            InnerContext::Coordinator(context) => {
+                builder = builder.with_participants(context.participants);
+                builder = builder.with_state(context.state.into());
+            }
+        }
+
+        if let Some(alarm) = self.alarm {
+            builder = builder.with_alarm(alarm);
+        }
+
+        if let Some(last_commit_epoch) = self.last_commit_epoch {
+            builder = builder.with_last_commit_epoch(last_commit_epoch);
+        }
+
+        builder
+    }
 }
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
Updates the skeleton commands to properly update the
service state.

Prepare: Add the scabbard service with prepared state and a
	context for two phase

Finalize: Update scabbard state to finalized and add an alarm
	to the context

Retire: Update the service state to retired

Purge: Remove the service and all associated consensus and commit
	state