### PR TITLE
Combine scabbard store consensus participant and coordinator

### DIFF
--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -81,7 +81,8 @@ experimental = [
   # The following features are experimental:
   "https",
   "scabbardv3",
-  "scabbardv3-consensus-action-runner"
+  "scabbardv3-consensus-action-runner",
+  "scabbardv3-store"
 ]
 
 authorization = ["splinter/authorization"]
@@ -98,6 +99,7 @@ scabbardv3-consensus-action-runner = [
     ]
 scabbardv3 = [
     "augrim",
+    "scabbardv3-store",
     "splinter/service-arguments-converter",
     "splinter/service-lifecycle",
     "splinter/service-message-converter",
@@ -110,5 +112,6 @@ scabbardv3 = [
     "splinter/service-timer-handler-factory",
     "splinter/service-type",
     ]
+scabbardv3-store = []
 splinter-service = ["log", "sawtooth"]
 sqlite = ["diesel/sqlite", "diesel_migrations", "log", "sawtooth/sqlite", "transact/sqlite"]

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,16 +13,10 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_2pc_coordinator_context;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_context;
+DROP TABLE IF EXISTS consensus_2pc_context_participant;
 DROP TABLE IF EXISTS consensus_2pc_action;
-DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_notification_action;
-DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action_participant;
-DROP TABLE IF EXISTS consensus_2pc_participant_context;
-DROP TABLE IF EXISTS consensus_2pc_participant_context_participant;
-DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action;
-DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action_participant;
-DROP TABLE IF EXISTS consensus_2pc_participant_send_message_action;
-DROP TABLE IF EXISTS consensus_2pc_participant_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_context_action;
+DROP TABLE IF EXISTS consensus_2pc_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_context_action_participant;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -13,32 +13,34 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TYPE coordinator_state AS ENUM ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT');
-CREATE TYPE coordinator_message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST');
-CREATE TYPE coordinator_notification_type AS ENUM ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
-CREATE TYPE participant_state AS ENUM ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE', 'VOTED', 'ABORT', 'COMMIT');
-CREATE TYPE participant_message_type AS ENUM ('VOTEREQUEST', 'COMMIT', 'ABORT', 'DECISIONREQUEST');
-CREATE TYPE participant_notification_type AS ENUM ('PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
+CREATE TYPE context_state AS ENUM ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED');
+CREATE TYPE message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST', 'VOTEREQUEST', 'COMMIT', 'ABORT');
+CREATE TYPE notification_type AS ENUM ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
-    state                     coordinator_state NOT NULL,
-    vote_timeout_start        BIGINT,
+    state                     context_state NOT NULL,
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -48,124 +50,62 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
-    state                     coordinator_state NOT NULL,
-    vote_timeout_start        BIGINT,
-    coordinator_action_alarm  BIGINT,
+    state                     context_state NOT NULL,
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     receiver_service_id       TEXT NOT NULL,
-    message_type              coordinator_message_type NOT NULL,
+    message_type              message_type NOT NULL,
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    notification_type         coordinator_notification_type NOT NULL,
-    dropped_message           TEXT
-    CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    vote                      TEXT
-    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_coordinator_context_action(action_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context (
-    service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
-    coordinator               TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    last_commit_epoch         BIGINT,
-    state                     participant_state NOT NULL,
-    vote                      TEXT
-    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    decision_timeout_start    BIGINT,
-    PRIMARY KEY (service_id, epoch)
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context_participant (
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
-    coordinator               TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    last_commit_epoch         BIGINT,
-    state                     participant_state NOT NULL,
-    vote                      TEXT
-    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR (state != 'VOTED') ),
-    decision_timeout_start    BIGINT,
-    participant_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action_participant (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_participant_context_action(action_id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_send_message_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    receiver_service_id       TEXT NOT NULL,
-    message_type              participant_message_type NOT NULL,
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
-    notification_type         participant_notification_type NOT NULL,
+    notification_type         notification_type NOT NULL,
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     request_for_vote_value    BYTEA
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action_participant (
+    action_id                 INTEGER PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_context_action(action_id) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BYTEA,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
@@ -56,5 +56,5 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/down.sql
@@ -13,16 +13,10 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-DROP TABLE IF EXISTS consensus_2pc_coordinator_context;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_context_participant;
+DROP TABLE IF EXISTS consensus_2pc_context;
+DROP TABLE IF EXISTS consensus_2pc_context_participant;
 DROP TABLE IF EXISTS consensus_2pc_action;
-DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_send_message_action;
-DROP TABLE IF EXISTS consensus_2pc_coordinator_notification_action;
-DROP TABLE IF EXISTS consensus_2pc_update_coordinator_context_action_participant;
-DROP TABLE IF EXISTS consensus_2pc_participant_context;
-DROP TABLE IF EXISTS consensus_2pc_participant_context_participant;
-DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action;
-DROP TABLE IF EXISTS consensus_2pc_update_participant_context_action_participant;
-DROP TABLE IF EXISTS consensus_2pc_participant_send_message_action;
-DROP TABLE IF EXISTS consensus_2pc_participant_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_context_action;
+DROP TABLE IF EXISTS consensus_2pc_send_message_action;
+DROP TABLE IF EXISTS consensus_2pc_notification_action;
+DROP TABLE IF EXISTS consensus_2pc_update_context_action_participant;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -13,26 +13,31 @@
 -- limitations under the License.
 -- -----------------------------------------------------------------------------
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context (
+CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
     state                     TEXT NOT NULL
-    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT') ),
-    vote_timeout_start        BIGINT,
+    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
     PRIMARY KEY (service_id, epoch)
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_context_participant (
+CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
     PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -42,10 +47,10 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     alarm                     BIGINT,
@@ -53,120 +58,54 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action (
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
     state                     TEXT NOT NULL
-    CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT') ),
-    vote_timeout_start        BIGINT,
-    coordinator_action_alarm  BIGINT,
+    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_send_message_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     receiver_service_id       TEXT NOT NULL,
     message_type              TEXT NOT NULL
-    CHECK ( message_type IN ('VOTERESPONSE', 'DECISIONREQUEST') ),
+    CHECK ( message_type IN ('VOTERESPONSE', 'DECISIONREQUEST', 'VOTEREQUEST', 'COMMIT', 'ABORT') ),
     vote_response             TEXT
     CHECK ( (vote_response IN ('TRUE', 'FALSE')) OR (message_type != 'VOTERESPONSE') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_coordinator_notification_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    notification_type         TEXT NOT NULL
-    CHECK ( notification_type IN ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED') ),
-    dropped_message           TEXT
-    CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_coordinator_context_action_participant (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    vote                      TEXT
-    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_coordinator_context_action(action_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context (
-    service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
-    coordinator               TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    last_commit_epoch         BIGINT,
-    state                     TEXT NOT NULL
-    CHECK ( state IN ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE', 'VOTED', 'ABORT', 'COMMIT') ),
-    vote                      TEXT
-    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    decision_timeout_start    BIGINT,
-    PRIMARY KEY (service_id, epoch)
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_context_participant (
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
-    coordinator               TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    last_commit_epoch         BIGINT,
-    state                     TEXT NOT NULL
-    CHECK ( state IN ('WAITINGFORVOTEREQUEST', 'WAITINGFORVOTE', 'VOTED', 'ABORT', 'COMMIT') ),
-    vote                      TEXT
-    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR (state != 'VOTED') ),
-    decision_timeout_start    BIGINT,
-    participant_action_alarm  BIGINT,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_update_participant_context_action_participant (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    process                   TEXT NOT NULL,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_participant_context_action(action_id) ON DELETE CASCADE,
-    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_send_message_action (
-    action_id                 INTEGER PRIMARY KEY,
-    service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
-    receiver_service_id       TEXT NOT NULL,
-    message_type              TEXT NOT NULL
-    CHECK ( message_type IN ('VOTEREQUEST', 'COMMIT', 'ABORT', 'DECISIONREQUEST') ),
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS consensus_2pc_participant_notification_action (
+CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     notification_type         TEXT NOT NULL
-    CHECK ( notification_type IN ('PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED') ),
+    CHECK ( notification_type IN ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED') ),
     dropped_message           TEXT
     CHECK ( (dropped_message IS NOT NULL) OR (notification_type != 'MESSAGEDROPPED') ),
     request_for_vote_value    BINARY
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_participant_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action_participant (
+    action_id                 INTEGER PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
+    FOREIGN KEY (action_id) REFERENCES consensus_2pc_update_context_action(action_id) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BINARY,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
@@ -55,5 +55,5 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_coordinator_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
@@ -318,7 +318,16 @@ mod tests {
             ContextBuilder::default()
                 .with_coordinator(&coordinator)
                 .with_epoch(1)
-                .with_participant_processes(service.peers().to_vec())
+                .with_participants(
+                    service
+                        .peers()
+                        .iter()
+                        .map(|participant| Participant {
+                            process: participant.clone(),
+                            vote: None,
+                        })
+                        .collect(),
+                )
                 .with_state(Scabbard2pcState::WaitingForVoteRequest)
                 .with_this_process(service.service_id().clone().service_id())
                 .build()

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -174,7 +174,10 @@ mod tests {
             .with_alarm(SystemTime::now())
             .with_coordinator(fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![peer_service1.clone()])
+            .with_participants(vec![Participant {
+                process: peer_service1.clone(),
+                vote: None,
+            }])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(fqsi2.clone().service_id())
             .build()
@@ -219,7 +222,10 @@ mod tests {
             .with_alarm(updated_alarm)
             .with_coordinator(fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![peer_service1.clone()])
+            .with_participants(vec![Participant {
+                process: peer_service1.clone(),
+                vote: None,
+            }])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(fqsi2.clone().service_id())
             .build()

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -19,7 +19,7 @@ mod command;
 mod commit_hash;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 pub(crate) mod pool;
-#[cfg(feature = "scabbardv3")]
+#[cfg(feature = "scabbardv3-store")]
 mod scabbard_store;
 
 #[cfg(feature = "scabbardv3")]
@@ -33,15 +33,15 @@ pub use commit_hash::diesel;
 pub use commit_hash::transact;
 pub use commit_hash::{CommitHashStore, CommitHashStoreError};
 
-#[cfg(all(feature = "scabbardv3", feature = "diesel"))]
+#[cfg(all(feature = "scabbardv3-store", feature = "diesel"))]
 pub use scabbard_store::diesel::DieselScabbardStore;
-#[cfg(feature = "scabbardv3")]
+#[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::PooledScabbardStoreFactory;
-#[cfg(feature = "scabbardv3")]
+#[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::{
     action, commit, context, event, service, two_phase, ScabbardStore, ScabbardStoreFactory,
 };
-#[cfg(all(feature = "scabbardv3", feature = "postgres"))]
+#[cfg(all(feature = "scabbardv3-store", feature = "postgres"))]
 pub use scabbard_store::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};
-#[cfg(all(feature = "scabbardv3", feature = "sqlite"))]
+#[cfg(all(feature = "scabbardv3-store", feature = "sqlite"))]
 pub use scabbard_store::{PooledSqliteScabbardStoreFactory, SqliteScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1508,7 +1508,8 @@ pub mod tests {
     ///
     /// 1. Add a valid participant context to the store
     /// 2. Attempt to add a valid event to the store and check that the operation was successful
-    /// 3. Attempt to add a coordinator specific event and check that an error is returned
+    /// 3. Attempt to add a an event for a service_id that does not exist check that an error is
+    ///    returned
     #[test]
     fn scabbard_store_add_event() {
         let pool = create_connection_pool_and_migrate();
@@ -1554,15 +1555,11 @@ pub mod tests {
         ));
 
         assert!(store
-            .add_consensus_event(&participant_fqsi, 1, event)
+            .add_consensus_event(&participant_fqsi, 1, event.clone())
             .is_ok());
 
-        let bad_event = ScabbardConsensusEvent::Scabbard2pcConsensusEvent(Scabbard2pcEvent::Start(
-            vec![1].into(),
-        ));
-
         assert!(store
-            .add_consensus_event(&participant_fqsi, 1, bad_event)
+            .add_consensus_event(&participant2_fqsi, 1, event)
             .is_err());
     }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1528,9 +1528,15 @@ pub mod tests {
             .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![
-                participant_fqsi.service_id().clone(),
-                participant2_fqsi.service_id().clone(),
+            .with_participants(vec![
+                Participant {
+                    process: participant_fqsi.service_id().clone(),
+                    vote: None,
+                },
+                Participant {
+                    process: participant2_fqsi.service_id().clone(),
+                    vote: None,
+                },
             ])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(participant_fqsi.clone().service_id())
@@ -1585,9 +1591,15 @@ pub mod tests {
             .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![
-                participant_fqsi.service_id().clone(),
-                participant2_fqsi.service_id().clone(),
+            .with_participants(vec![
+                Participant {
+                    process: participant_fqsi.service_id().clone(),
+                    vote: None,
+                },
+                Participant {
+                    process: participant2_fqsi.service_id().clone(),
+                    vote: None,
+                },
             ])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(participant_fqsi.clone().service_id())
@@ -1641,9 +1653,15 @@ pub mod tests {
             .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![
-                participant_fqsi.service_id().clone(),
-                participant2_fqsi.service_id().clone(),
+            .with_participants(vec![
+                Participant {
+                    process: participant_fqsi.service_id().clone(),
+                    vote: None,
+                },
+                Participant {
+                    process: participant2_fqsi.service_id().clone(),
+                    vote: None,
+                },
             ])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(participant_fqsi.clone().service_id())
@@ -1806,7 +1824,10 @@ pub mod tests {
             .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
-            .with_participant_processes(vec![participant_service_id.service_id().clone()])
+            .with_participants(vec![Participant {
+                process: participant_service_id.service_id().clone(),
+                vote: None,
+            }])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(participant_service_id.clone().service_id())
             .build()
@@ -1857,7 +1878,10 @@ pub mod tests {
             .with_alarm(alarm)
             .with_coordinator(participant_service_id.clone().service_id())
             .with_epoch(3)
-            .with_participant_processes(vec![coordinator_fqsi.service_id().clone()])
+            .with_participants(vec![Participant {
+                process: coordinator_fqsi.service_id().clone(),
+                vote: None,
+            }])
             .with_state(Scabbard2pcState::WaitingForVoteRequest)
             .with_this_process(coordinator_fqsi.clone().service_id())
             .build()

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -275,7 +275,7 @@ impl
                         })?
                 } else {
                     return Err(InternalError::with_message(
-                        "Failed to convert to ScabbardContext, context has state 'voting' but 
+                        "Failed to convert to ScabbardContext, context has state 'voting' but \
                         no vote timeout start time set"
                             .to_string(),
                     ));

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
@@ -19,18 +19,11 @@ use diesel::pg::PgConnection;
 #[cfg(feature = "sqlite")]
 use diesel::sqlite::SqliteConnection;
 use diesel::{dsl::insert_into, prelude::*};
-use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
-        CoordinatorContextParticipantList, ParticipantContextParticipantList,
-    },
-    schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
-        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
-    },
+    models::{Consensus2pcContextModel, ContextParticipantList},
+    schema::{consensus_2pc_context, consensus_2pc_context_participant},
 };
 use crate::store::scabbard_store::ScabbardContext;
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -55,41 +48,17 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ScabbardContext::Scabbard2pcContext(context) => {
-                    match Consensus2pcCoordinatorContextModel::try_from((&context, service_id)) {
-                        Ok(new_coordinator_context) => {
-                            let participants = CoordinatorContextParticipantList::try_from((
-                                &context, service_id,
-                            ))?
-                            .inner;
-                            insert_into(consensus_2pc_coordinator_context::table)
-                                .values(vec![new_coordinator_context])
-                                .execute(self.conn)?;
-                            insert_into(consensus_2pc_coordinator_context_participant::table)
-                                .values(participants)
-                                .execute(self.conn)?;
-                        }
-                        Err(_) => match Consensus2pcParticipantContextModel::try_from((
-                            &context, service_id,
-                        )) {
-                            Ok(new_participant_context) => {
-                                let participants = ParticipantContextParticipantList::try_from((
-                                    &context, service_id,
-                                ))?
-                                .inner;
-                                insert_into(consensus_2pc_participant_context::table)
-                                    .values(vec![new_participant_context])
-                                    .execute(self.conn)?;
-                                insert_into(consensus_2pc_participant_context_participant::table)
-                                    .values(participants)
-                                    .execute(self.conn)?;
-                            }
-                            Err(e) => {
-                                return Err(ScabbardStoreError::Internal(
-                                    InternalError::from_source(Box::new(e)),
-                                ))
-                            }
-                        },
-                    }
+                    let new_context = Consensus2pcContextModel::try_from((&context, service_id))?;
+                    let participants =
+                        ContextParticipantList::try_from((&context, service_id))?.inner;
+
+                    insert_into(consensus_2pc_context::table)
+                        .values(vec![new_context])
+                        .execute(self.conn)?;
+
+                    insert_into(consensus_2pc_context_participant::table)
+                        .values(participants)
+                        .execute(self.conn)?;
                 }
             }
             Ok(())
@@ -107,41 +76,17 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ScabbardContext::Scabbard2pcContext(context) => {
-                    match Consensus2pcCoordinatorContextModel::try_from((&context, service_id)) {
-                        Ok(new_coordinator_context) => {
-                            let participants = CoordinatorContextParticipantList::try_from((
-                                &context, service_id,
-                            ))?
-                            .inner;
-                            insert_into(consensus_2pc_coordinator_context::table)
-                                .values(vec![new_coordinator_context])
-                                .execute(self.conn)?;
-                            insert_into(consensus_2pc_coordinator_context_participant::table)
-                                .values(participants)
-                                .execute(self.conn)?;
-                        }
-                        Err(_) => match Consensus2pcParticipantContextModel::try_from((
-                            &context, service_id,
-                        )) {
-                            Ok(new_participant_context) => {
-                                let participants = ParticipantContextParticipantList::try_from((
-                                    &context, service_id,
-                                ))?
-                                .inner;
-                                insert_into(consensus_2pc_participant_context::table)
-                                    .values(vec![new_participant_context])
-                                    .execute(self.conn)?;
-                                insert_into(consensus_2pc_participant_context_participant::table)
-                                    .values(participants)
-                                    .execute(self.conn)?;
-                            }
-                            Err(e) => {
-                                return Err(ScabbardStoreError::Internal(
-                                    InternalError::from_source(Box::new(e)),
-                                ))
-                            }
-                        },
-                    }
+                    let new_context = Consensus2pcContextModel::try_from((&context, service_id))?;
+                    let participants =
+                        ContextParticipantList::try_from((&context, service_id))?.inner;
+
+                    insert_into(consensus_2pc_context::table)
+                        .values(vec![new_context])
+                        .execute(self.conn)?;
+
+                    insert_into(consensus_2pc_context_participant::table)
+                        .values(participants)
+                        .execute(self.conn)?;
                 }
             }
             Ok(())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -24,13 +24,12 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcDeliverEventModel,
-        Consensus2pcParticipantContextModel, Consensus2pcStartEventModel,
+        Consensus2pcContextModel, Consensus2pcDeliverEventModel, Consensus2pcStartEventModel,
         Consensus2pcVoteEventModel, InsertableConsensus2pcEventModel,
     },
     schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_deliver_event, consensus_2pc_event,
-        consensus_2pc_participant_context, consensus_2pc_start_event, consensus_2pc_vote_event,
+        consensus_2pc_context, consensus_2pc_deliver_event, consensus_2pc_event,
+        consensus_2pc_start_event, consensus_2pc_vote_event,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -63,21 +62,21 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
             let epoch = i64::try_from(epoch).map_err(|err| {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
-            // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_coordinator_context::table
-                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
-                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                .optional()?;
-
-            // check to see if a participant context with the given epoch and service_id exists
-            let participant_context = consensus_2pc_participant_context::table
-                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
-                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcParticipantContextModel>(self.conn)
-                .optional()?;
+            // check to see if a context with the given epoch and service_id exists
+            consensus_2pc_context::table
+                .filter(
+                    consensus_2pc_context::epoch
+                        .eq(epoch)
+                        .and(consensus_2pc_context::service_id.eq(format!("{}", service_id))),
+                )
+                .first::<Consensus2pcContextModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
+                        "Context with service ID {} and epoch {} does not exist",
+                        service_id, epoch,
+                    )))
+                })?;
 
             let position = consensus_2pc_event::table
                 .filter(
@@ -92,190 +91,84 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 .unwrap_or(0)
                 + 1;
 
-            if coordinator_context.is_some() {
-                // return an error if there is both a coordinator and a participant context for the
-                // given service_id and epoch
-                if participant_context.is_some() {
-                    return Err(ScabbardStoreError::InvalidState(
-                        InvalidStateError::with_message(format!(
-                            "Failed to add consensus event, contexts found for participant and 
-                            coordinator with service_id: {} epoch: {} ",
-                            service_id, epoch
-                        )),
-                    ));
+            let insertable_event = InsertableConsensus2pcEventModel {
+                service_id: format!("{}", service_id),
+                epoch,
+                executed_at: None,
+                position,
+                event_type: String::from(&event),
+            };
+
+            insert_into(consensus_2pc_event::table)
+                .values(vec![insertable_event])
+                .execute(self.conn)?;
+            let event_id = consensus_2pc_event::table
+                .order(consensus_2pc_event::id.desc())
+                .select(consensus_2pc_event::id)
+                .first::<i64>(self.conn)?;
+
+            match event {
+                Scabbard2pcEvent::Alarm() => Ok(event_id),
+                Scabbard2pcEvent::Deliver(receiving_process, message) => {
+                    let (message_type, vote_response, vote_request) = match message {
+                        Scabbard2pcMessage::DecisionRequest(_) => {
+                            (String::from(&message), None, None)
+                        }
+                        Scabbard2pcMessage::VoteResponse(_, true) => {
+                            (String::from(&message), Some("TRUE".to_string()), None)
+                        }
+                        Scabbard2pcMessage::VoteResponse(_, false) => {
+                            (String::from(&message), Some("FALSE".to_string()), None)
+                        }
+                        Scabbard2pcMessage::Commit(_) => (String::from(&message), None, None),
+                        Scabbard2pcMessage::Abort(_) => (String::from(&message), None, None),
+                        Scabbard2pcMessage::VoteRequest(_, ref value) => {
+                            (String::from(&message), None, Some(value.clone()))
+                        }
+                    };
+
+                    let deliver_event = Consensus2pcDeliverEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        receiver_service_id: format!("{}", receiving_process),
+                        message_type,
+                        vote_response,
+                        vote_request,
+                    };
+                    insert_into(consensus_2pc_deliver_event::table)
+                        .values(vec![deliver_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-
-                let insertable_event = InsertableConsensus2pcEventModel {
-                    service_id: format!("{}", service_id),
-                    epoch,
-                    executed_at: None,
-                    position,
-                    event_type: String::from(&event),
-                };
-
-                insert_into(consensus_2pc_event::table)
-                    .values(vec![insertable_event])
-                    .execute(self.conn)?;
-                let event_id = consensus_2pc_event::table
-                    .order(consensus_2pc_event::id.desc())
-                    .select(consensus_2pc_event::id)
-                    .first::<i64>(self.conn)?;
-
-                match event {
-                    Scabbard2pcEvent::Alarm() => Ok(event_id),
-                    Scabbard2pcEvent::Deliver(receiving_process, message) => {
-                        let (message_type, vote_response) = match message {
-                            Scabbard2pcMessage::DecisionRequest(_) => {
-                                (String::from(&message), None)
-                            }
-                            Scabbard2pcMessage::VoteResponse(_, true) => {
-                                (String::from(&message), Some("TRUE".to_string()))
-                            }
-                            Scabbard2pcMessage::VoteResponse(_, false) => {
-                                (String::from(&message), Some("FALSE".to_string()))
-                            }
-                            _ => {
-                                return Err(ScabbardStoreError::InvalidState(
-                                    InvalidStateError::with_message(format!(
-                                        "Failed to add consensus deliver event, invalid coordinator 
-                                        message type {}",
-                                        String::from(&message)
-                                    )),
-                                ))
-                            }
-                        };
-
-                        let deliver_event = Consensus2pcDeliverEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            receiver_service_id: format!("{}", receiving_process),
-                            message_type,
-                            vote_response,
-                            vote_request: None,
-                        };
-                        insert_into(consensus_2pc_deliver_event::table)
-                            .values(vec![deliver_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Start(value) => {
-                        let start_event = Consensus2pcStartEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            value,
-                        };
-                        insert_into(consensus_2pc_start_event::table)
-                            .values(vec![start_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Vote(vote) => {
-                        let vote = match vote {
-                            true => String::from("TRUE"),
-                            false => String::from("FALSE"),
-                        };
-                        let vote_event = Consensus2pcVoteEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            vote,
-                        };
-                        insert_into(consensus_2pc_vote_event::table)
-                            .values(vec![vote_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
+                Scabbard2pcEvent::Start(value) => {
+                    let start_event = Consensus2pcStartEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        value,
+                    };
+                    insert_into(consensus_2pc_start_event::table)
+                        .values(vec![start_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-            } else if participant_context.is_some() {
-                let insertable_event = InsertableConsensus2pcEventModel {
-                    service_id: format!("{}", service_id),
-                    epoch,
-                    executed_at: None,
-                    position,
-                    event_type: String::from(&event),
-                };
-
-                insert_into(consensus_2pc_event::table)
-                    .values(vec![insertable_event])
-                    .execute(self.conn)?;
-                let event_id = consensus_2pc_event::table
-                    .order(consensus_2pc_event::id.desc())
-                    .select(consensus_2pc_event::id)
-                    .first::<i64>(self.conn)?;
-
-                match event {
-                    Scabbard2pcEvent::Alarm() => Ok(event_id),
-                    Scabbard2pcEvent::Deliver(receiving_process, message) => {
-                        let (message_type, vote_request) = match &message {
-                            Scabbard2pcMessage::DecisionRequest(_) => {
-                                (String::from(&message), None)
-                            }
-                            Scabbard2pcMessage::Commit(_) => (String::from(&message), None),
-                            Scabbard2pcMessage::Abort(_) => (String::from(&message), None),
-                            Scabbard2pcMessage::VoteRequest(_, value) => {
-                                (String::from(&message), Some(value.clone()))
-                            }
-                            _ => {
-                                return Err(ScabbardStoreError::InvalidState(
-                                    InvalidStateError::with_message(format!(
-                                        "Failed to add consensus deliver event, invalid participant 
-                                        message type {}",
-                                        String::from(&message)
-                                    )),
-                                ))
-                            }
-                        };
-
-                        let deliver_event = Consensus2pcDeliverEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            receiver_service_id: format!("{}", receiving_process),
-                            message_type,
-                            vote_response: None,
-                            vote_request,
-                        };
-                        insert_into(consensus_2pc_deliver_event::table)
-                            .values(vec![deliver_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Vote(vote) => {
-                        let vote = match vote {
-                            true => String::from("TRUE"),
-                            false => String::from("FALSE"),
-                        };
-                        let vote_event = Consensus2pcVoteEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            vote,
-                        };
-                        insert_into(consensus_2pc_vote_event::table)
-                            .values(vec![vote_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    _ => {
-                        return Err(ScabbardStoreError::InvalidState(
-                            InvalidStateError::with_message(format!(
-                                "Failed to add consensus event, invalid participant event 
-                            type {}",
-                                String::from(&event)
-                            )),
-                        ))
-                    }
+                Scabbard2pcEvent::Vote(vote) => {
+                    let vote = match vote {
+                        true => String::from("TRUE"),
+                        false => String::from("FALSE"),
+                    };
+                    let vote_event = Consensus2pcVoteEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        vote,
+                    };
+                    insert_into(consensus_2pc_vote_event::table)
+                        .values(vec![vote_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-            } else {
-                Err(ScabbardStoreError::InvalidState(
-                    InvalidStateError::with_message(format!(
-                        "Failed to add consensus event, a context with service_id: {} and epoch: {} 
-                        does not exist",
-                        service_id, epoch
-                    )),
-                ))
             }
         })
     }
@@ -294,21 +187,21 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
             let epoch = i64::try_from(epoch).map_err(|err| {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
-            // check to see if a coordinator context with the given epoch and service_id exists
-            let coordinator_context = consensus_2pc_coordinator_context::table
-                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
-                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                .optional()?;
-
-            // check to see if a participant context with the given epoch and service_id exists
-            let participant_context = consensus_2pc_participant_context::table
-                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
-                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcParticipantContextModel>(self.conn)
-                .optional()?;
+            // check to see if a context with the given epoch and service_id exists
+            consensus_2pc_context::table
+                .filter(
+                    consensus_2pc_context::epoch
+                        .eq(epoch)
+                        .and(consensus_2pc_context::service_id.eq(format!("{}", service_id))),
+                )
+                .first::<Consensus2pcContextModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
+                        "Context with service ID {} and epoch {} does not exist",
+                        service_id, epoch,
+                    )))
+                })?;
 
             let position = consensus_2pc_event::table
                 .filter(
@@ -323,184 +216,81 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 .unwrap_or(0)
                 + 1;
 
-            if coordinator_context.is_some() {
-                // return an error if there is both a coordinator and a participant context for the
-                // given service_id and epoch
-                if participant_context.is_some() {
-                    return Err(ScabbardStoreError::InvalidState(
-                        InvalidStateError::with_message(format!(
-                            "Failed to add consensus event, contexts found for participant and 
-                            coordinator with service_id: {} epoch: {} ",
-                            service_id, epoch
-                        )),
-                    ));
+            let insertable_event = InsertableConsensus2pcEventModel {
+                service_id: format!("{}", service_id),
+                epoch,
+                executed_at: None,
+                position,
+                event_type: String::from(&event),
+            };
+
+            let event_id: i64 = insert_into(consensus_2pc_event::table)
+                .values(vec![insertable_event])
+                .returning(consensus_2pc_event::id)
+                .get_result(self.conn)?;
+
+            match event {
+                Scabbard2pcEvent::Alarm() => Ok(event_id),
+                Scabbard2pcEvent::Deliver(receiving_process, message) => {
+                    let (message_type, vote_response, vote_request) = match message {
+                        Scabbard2pcMessage::DecisionRequest(_) => {
+                            (String::from(&message), None, None)
+                        }
+                        Scabbard2pcMessage::VoteResponse(_, true) => {
+                            (String::from(&message), Some("TRUE".to_string()), None)
+                        }
+                        Scabbard2pcMessage::VoteResponse(_, false) => {
+                            (String::from(&message), Some("FALSE".to_string()), None)
+                        }
+                        Scabbard2pcMessage::Commit(_) => (String::from(&message), None, None),
+                        Scabbard2pcMessage::Abort(_) => (String::from(&message), None, None),
+                        Scabbard2pcMessage::VoteRequest(_, ref value) => {
+                            (String::from(&message), None, Some(value.clone()))
+                        }
+                    };
+
+                    let deliver_event = Consensus2pcDeliverEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        receiver_service_id: format!("{}", receiving_process),
+                        message_type,
+                        vote_response,
+                        vote_request,
+                    };
+                    insert_into(consensus_2pc_deliver_event::table)
+                        .values(vec![deliver_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-
-                let insertable_event = InsertableConsensus2pcEventModel {
-                    service_id: format!("{}", service_id),
-                    epoch,
-                    executed_at: None,
-                    position,
-                    event_type: String::from(&event),
-                };
-
-                let event_id: i64 = insert_into(consensus_2pc_event::table)
-                    .values(vec![insertable_event])
-                    .returning(consensus_2pc_event::id)
-                    .get_result(self.conn)?;
-
-                match event {
-                    Scabbard2pcEvent::Alarm() => Ok(event_id),
-                    Scabbard2pcEvent::Deliver(receiving_process, message) => {
-                        let (message_type, vote_response) = match message {
-                            Scabbard2pcMessage::DecisionRequest(_) => {
-                                (String::from(&message), None)
-                            }
-                            Scabbard2pcMessage::VoteResponse(_, true) => {
-                                (String::from(&message), Some("TRUE".to_string()))
-                            }
-                            Scabbard2pcMessage::VoteResponse(_, false) => {
-                                (String::from(&message), Some("FALSE".to_string()))
-                            }
-                            _ => {
-                                return Err(ScabbardStoreError::InvalidState(
-                                    InvalidStateError::with_message(format!(
-                                        "Failed to add consensus deliver event, invalid 
-                                            coordinator message type {}",
-                                        String::from(&message)
-                                    )),
-                                ))
-                            }
-                        };
-
-                        let deliver_event = Consensus2pcDeliverEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            receiver_service_id: format!("{}", receiving_process),
-                            message_type,
-                            vote_response,
-                            vote_request: None,
-                        };
-                        insert_into(consensus_2pc_deliver_event::table)
-                            .values(vec![deliver_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Start(value) => {
-                        let start_event = Consensus2pcStartEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            value,
-                        };
-                        insert_into(consensus_2pc_start_event::table)
-                            .values(vec![start_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Vote(vote) => {
-                        let vote = match vote {
-                            true => String::from("TRUE"),
-                            false => String::from("FALSE"),
-                        };
-                        let vote_event = Consensus2pcVoteEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            vote,
-                        };
-                        insert_into(consensus_2pc_vote_event::table)
-                            .values(vec![vote_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
+                Scabbard2pcEvent::Start(value) => {
+                    let start_event = Consensus2pcStartEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        value,
+                    };
+                    insert_into(consensus_2pc_start_event::table)
+                        .values(vec![start_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-            } else if participant_context.is_some() {
-                let insertable_event = InsertableConsensus2pcEventModel {
-                    service_id: format!("{}", service_id),
-                    epoch,
-                    executed_at: None,
-                    position,
-                    event_type: String::from(&event),
-                };
-
-                let event_id: i64 = insert_into(consensus_2pc_event::table)
-                    .values(vec![insertable_event])
-                    .returning(consensus_2pc_event::id)
-                    .get_result(self.conn)?;
-
-                match event {
-                    Scabbard2pcEvent::Alarm() => Ok(event_id),
-                    Scabbard2pcEvent::Deliver(receiving_process, message) => {
-                        let (message_type, vote_request) = match &message {
-                            Scabbard2pcMessage::DecisionRequest(_) => {
-                                (String::from(&message), None)
-                            }
-                            Scabbard2pcMessage::Commit(_) => (String::from(&message), None),
-                            Scabbard2pcMessage::Abort(_) => (String::from(&message), None),
-                            Scabbard2pcMessage::VoteRequest(_, value) => {
-                                (String::from(&message), Some(value.clone()))
-                            }
-                            _ => {
-                                return Err(ScabbardStoreError::InvalidState(
-                                    InvalidStateError::with_message(format!(
-                                        "Failed to add consensus deliver event, invalid 
-                                            participant message type {}",
-                                        String::from(&message)
-                                    )),
-                                ))
-                            }
-                        };
-
-                        let deliver_event = Consensus2pcDeliverEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            receiver_service_id: format!("{}", receiving_process),
-                            message_type,
-                            vote_response: None,
-                            vote_request,
-                        };
-                        insert_into(consensus_2pc_deliver_event::table)
-                            .values(vec![deliver_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    Scabbard2pcEvent::Vote(vote) => {
-                        let vote = match vote {
-                            true => String::from("TRUE"),
-                            false => String::from("FALSE"),
-                        };
-                        let vote_event = Consensus2pcVoteEventModel {
-                            event_id,
-                            service_id: format!("{}", service_id),
-                            epoch,
-                            vote,
-                        };
-                        insert_into(consensus_2pc_vote_event::table)
-                            .values(vec![vote_event])
-                            .execute(self.conn)?;
-                        Ok(event_id)
-                    }
-                    _ => {
-                        return Err(ScabbardStoreError::InvalidState(
-                            InvalidStateError::with_message(format!(
-                                "Failed to add consensus event, invalid participant event 
-                                type {}",
-                                String::from(&event)
-                            )),
-                        ))
-                    }
+                Scabbard2pcEvent::Vote(vote) => {
+                    let vote = match vote {
+                        true => String::from("TRUE"),
+                        false => String::from("FALSE"),
+                    };
+                    let vote_event = Consensus2pcVoteEventModel {
+                        event_id,
+                        service_id: format!("{}", service_id),
+                        epoch,
+                        vote,
+                    };
+                    insert_into(consensus_2pc_vote_event::table)
+                        .values(vec![vote_event])
+                        .execute(self.conn)?;
+                    Ok(event_id)
                 }
-            } else {
-                Err(ScabbardStoreError::InvalidState(
-                    InvalidStateError::with_message(format!(
-                        "Failed to add consensus event, a context with service_id: {} and epoch: {} 
-                        does not exist",
-                        service_id, epoch
-                    )),
-                ))
             }
         })
     }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -12,22 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
 use std::convert::TryFrom;
 
 use diesel::prelude::*;
-use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcCoordinatorContextParticipantModel,
-        Consensus2pcParticipantContextModel, Consensus2pcParticipantContextParticipantModel,
-    },
-    schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
-        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
-    },
+    models::{Consensus2pcContextModel, Consensus2pcContextParticipantModel},
+    schema::{consensus_2pc_context, consensus_2pc_context_participant},
 };
 use crate::store::scabbard_store::{context::ScabbardContext, ScabbardStoreError};
 
@@ -51,135 +43,25 @@ where
         service_id: &FullyQualifiedServiceId,
     ) -> Result<Option<ScabbardContext>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            let coordinator_context = consensus_2pc_coordinator_context::table
-                .filter(consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_coordinator_context::epoch.desc())
-                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
+            let context = consensus_2pc_context::table
+                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .order(consensus_2pc_context::epoch.desc())
+                .first::<Consensus2pcContextModel>(self.conn)
                 .optional()?;
 
-            let participant_context = consensus_2pc_participant_context::table
-                .filter(consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_participant_context::epoch.desc())
-                .first::<Consensus2pcParticipantContextModel>(self.conn)
-                .optional()?;
+            if let Some(context) = context {
+                let participants: Vec<Consensus2pcContextParticipantModel> =
+                    consensus_2pc_context_participant::table
+                        .filter(
+                            consensus_2pc_context_participant::service_id
+                                .eq(format!("{}", service_id))
+                                .and(consensus_2pc_context_participant::epoch.eq(context.epoch)),
+                        )
+                        .load::<Consensus2pcContextParticipantModel>(self.conn)?;
 
-            match (coordinator_context, participant_context) {
-                // If both a coordinator and a participant contexts exist for the given service ID
-                // get the context with the largest epoch
-                (Some(coordinator_context), Some(participant_context)) => {
-                    match coordinator_context.epoch.cmp(&participant_context.epoch) {
-                        // If both a coordinator and a participant context exists for the given
-                        // service ID and they have the same epoch value, return an error
-                        Ordering::Equal => {
-                            return Err(ScabbardStoreError::InvalidState(
-                                InvalidStateError::with_message(format!(
-                                    "Failed to add consensus action, contexts found for both
-                                        participant and coordinator with service_id: {} epoch: {} ",
-                                    service_id, participant_context.epoch
-                                )),
-                            ));
-                        }
-                        Ordering::Greater => {
-                            let coordinator_participants: Vec<
-                                Consensus2pcCoordinatorContextParticipantModel,
-                            > = consensus_2pc_coordinator_context_participant::table
-                                .filter(
-                                    consensus_2pc_coordinator_context_participant::service_id
-                                        .eq(format!("{}", service_id))
-                                        .and(
-                                            consensus_2pc_coordinator_context_participant::epoch
-                                                .eq(coordinator_context.epoch),
-                                        ),
-                                )
-                                .load::<Consensus2pcCoordinatorContextParticipantModel>(
-                                    self.conn,
-                                )?;
-                            Ok(Some(
-                                ScabbardContext::try_from((
-                                    &coordinator_context,
-                                    coordinator_participants,
-                                ))
-                                .map_err(|err| {
-                                    ScabbardStoreError::Internal(InternalError::from_source(
-                                        Box::new(err),
-                                    ))
-                                })?,
-                            ))
-                        }
-                        Ordering::Less => {
-                            let participant_participants: Vec<
-                                Consensus2pcParticipantContextParticipantModel,
-                            > = consensus_2pc_participant_context_participant::table
-                                .filter(
-                                    consensus_2pc_participant_context_participant::service_id
-                                        .eq(format!("{}", service_id))
-                                        .and(
-                                            consensus_2pc_participant_context_participant::epoch
-                                                .eq(participant_context.epoch),
-                                        ),
-                                )
-                                .load::<Consensus2pcParticipantContextParticipantModel>(
-                                    self.conn,
-                                )?;
-                            Ok(Some(
-                                ScabbardContext::try_from((
-                                    &participant_context,
-                                    participant_participants,
-                                ))
-                                .map_err(|err| {
-                                    ScabbardStoreError::Internal(InternalError::from_source(
-                                        Box::new(err),
-                                    ))
-                                })?,
-                            ))
-                        }
-                    }
-                }
-                (Some(coordinator_context), None) => {
-                    let coordinator_participants: Vec<
-                        Consensus2pcCoordinatorContextParticipantModel,
-                    > = consensus_2pc_coordinator_context_participant::table
-                        .filter(
-                            consensus_2pc_coordinator_context_participant::service_id
-                                .eq(format!("{}", service_id))
-                                .and(
-                                    consensus_2pc_coordinator_context_participant::epoch
-                                        .eq(coordinator_context.epoch),
-                                ),
-                        )
-                        .load::<Consensus2pcCoordinatorContextParticipantModel>(self.conn)?;
-                    Ok(Some(
-                        ScabbardContext::try_from((&coordinator_context, coordinator_participants))
-                            .map_err(|err| {
-                                ScabbardStoreError::Internal(InternalError::from_source(Box::new(
-                                    err,
-                                )))
-                            })?,
-                    ))
-                }
-                (None, Some(participant_context)) => {
-                    let participant_participants: Vec<
-                        Consensus2pcParticipantContextParticipantModel,
-                    > = consensus_2pc_participant_context_participant::table
-                        .filter(
-                            consensus_2pc_participant_context_participant::service_id
-                                .eq(format!("{}", service_id))
-                                .and(
-                                    consensus_2pc_participant_context_participant::epoch
-                                        .eq(participant_context.epoch),
-                                ),
-                        )
-                        .load::<Consensus2pcParticipantContextParticipantModel>(self.conn)?;
-                    Ok(Some(
-                        ScabbardContext::try_from((&participant_context, participant_participants))
-                            .map_err(|err| {
-                                ScabbardStoreError::Internal(InternalError::from_source(Box::new(
-                                    err,
-                                )))
-                            })?,
-                    ))
-                }
-                (None, None) => Ok(None),
+                Ok(Some(ScabbardContext::try_from((&context, participants))?))
+            } else {
+                Ok(None)
             }
         })
     }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -395,7 +395,13 @@ where
                             ScabbardStoreError::Internal(
                                 InternalError::from_source(Box::new(err))
                             )
-                        })?;
+                        })?
+                        .into_iter()
+                        .map(|process| Participant {
+                            process,
+                            vote: None,
+                        })
+                        .collect::<Vec<Participant>>();
 
                     let state = match update_context.state.as_str() {
                         "WAITINGFORVOTE" => Scabbard2pcState::WaitingForStart,
@@ -463,7 +469,7 @@ where
                             },
                         )?)
                         .with_epoch(update_context.epoch as u64)
-                        .with_participant_processes(participants)
+                        .with_participants(participants)
                         .with_state(state)
                         .with_this_process(
                             FullyQualifiedServiceId::new_from_string(update_context.service_id)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
@@ -21,8 +21,7 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::operations::get_service::GetServiceOperation;
 use crate::store::scabbard_store::diesel::schema::{
-    consensus_2pc_coordinator_context, consensus_2pc_participant_context, scabbard_peer,
-    scabbard_service, scabbard_v3_commit_history,
+    consensus_2pc_context, scabbard_peer, scabbard_service, scabbard_v3_commit_history,
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -61,14 +60,8 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, SqliteConnection
                 //
                 // delete cascade will remove the remaining associated consensus components
                 delete(
-                    consensus_2pc_coordinator_context::table
-                        .filter(consensus_2pc_coordinator_context::service_id.eq(&service_id)),
-                )
-                .execute(self.conn)?;
-
-                delete(
-                    consensus_2pc_participant_context::table
-                        .filter(consensus_2pc_participant_context::service_id.eq(&service_id)),
+                    consensus_2pc_context::table
+                        .filter(consensus_2pc_context::service_id.eq(&service_id)),
                 )
                 .execute(self.conn)?;
 
@@ -105,14 +98,8 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, PgConnection> {
                     //
                     // delete cascade will remove the remaining associated consensus components
                     delete(
-                        consensus_2pc_coordinator_context::table
-                            .filter(consensus_2pc_coordinator_context::service_id.eq(&service_id)),
-                    )
-                    .execute(self.conn)?;
-
-                    delete(
-                        consensus_2pc_participant_context::table
-                            .filter(consensus_2pc_participant_context::service_id.eq(&service_id)),
+                        consensus_2pc_context::table
+                            .filter(consensus_2pc_context::service_id.eq(&service_id)),
                     )
                     .execute(self.conn)?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -23,14 +23,8 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{
-        Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel,
-        CoordinatorContextParticipantList, ParticipantContextParticipantList,
-    },
-    schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_coordinator_context_participant,
-        consensus_2pc_participant_context, consensus_2pc_participant_context_participant,
-    },
+    models::{Consensus2pcContextModel, ContextParticipantList},
+    schema::{consensus_2pc_context, consensus_2pc_context_participant},
 };
 use crate::store::scabbard_store::ScabbardContext;
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -58,150 +52,57 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                     let epoch = i64::try_from(*context.epoch()).map_err(|err| {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
-                    // check to make sure the context exists
-                    let coordinator_context = consensus_2pc_coordinator_context::table
+                    // check to see if a context with the given epoch and service_id exists
+                    consensus_2pc_context::table
                         .filter(
-                            consensus_2pc_coordinator_context::epoch
-                                .eq(epoch)
-                                .and(
-                                    consensus_2pc_coordinator_context::service_id
-                                        .eq(format!("{}", service_id)),
-                                )
-                                .and(
-                                    consensus_2pc_coordinator_context::coordinator
-                                        .eq(format!("{}", context.coordinator())),
+                            consensus_2pc_context::epoch.eq(epoch).and(
+                                consensus_2pc_context::service_id.eq(format!("{}", service_id)),
+                            ),
+                        )
+                        .first::<Consensus2pcContextModel>(self.conn)
+                        .optional()?
+                        .ok_or_else(|| {
+                            ScabbardStoreError::InvalidState(InvalidStateError::with_message(
+                                format!(
+                                    "Context with service ID {} and epoch {} does not exist",
+                                    service_id, epoch,
                                 ),
-                        )
-                        .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                        .optional()?;
+                            ))
+                        })?;
 
-                    let participant_context = consensus_2pc_participant_context::table
-                        .filter(
-                            consensus_2pc_participant_context::epoch
-                                .eq(epoch)
-                                .and(
-                                    consensus_2pc_participant_context::service_id
-                                        .eq(format!("{}", service_id)),
-                                )
-                                .and(
-                                    consensus_2pc_participant_context::coordinator
-                                        .eq(format!("{}", context.coordinator())),
-                                ),
-                        )
-                        .first::<Consensus2pcParticipantContextModel>(self.conn)
-                        .optional()?;
+                    let update_context =
+                        Consensus2pcContextModel::try_from((&context, service_id))?;
 
-                    if coordinator_context.is_some() {
-                        // return an error if there is both a coordinator and a participant context
-                        // for the given service_id and epoch
-                        if participant_context.is_some() {
-                            return Err(ScabbardStoreError::InvalidState(
-                                InvalidStateError::with_message(format!(
-                                    "Failed to update consensus action, contexts found for
-                                        participant and coordinator with service_id: {} epoch: {} ",
-                                    service_id, epoch
-                                )),
-                            ));
-                        }
-
-                        let update_coordinator_context =
-                            Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
-
-                        delete(
-                            consensus_2pc_coordinator_context::table.filter(
-                                consensus_2pc_coordinator_context::epoch
-                                    .eq(epoch)
-                                    .and(
-                                        consensus_2pc_coordinator_context::service_id
-                                            .eq(format!("{}", service_id)),
-                                    )
-                                    .and(
-                                        consensus_2pc_coordinator_context::coordinator
-                                            .eq(format!("{}", context.coordinator())),
-                                    ),
+                    delete(
+                        consensus_2pc_context::table.filter(
+                            consensus_2pc_context::epoch.eq(epoch).and(
+                                consensus_2pc_context::service_id.eq(format!("{}", service_id)),
                             ),
-                        )
+                        ),
+                    )
+                    .execute(self.conn)?;
+
+                    insert_into(consensus_2pc_context::table)
+                        .values(vec![update_context])
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_coordinator_context::table)
-                            .values(vec![update_coordinator_context])
-                            .execute(self.conn)?;
+                    let updated_participants =
+                        ContextParticipantList::try_from((&context, service_id))?.inner;
 
-                        let updated_participants =
-                            CoordinatorContextParticipantList::try_from((&context, service_id))?
-                                .inner;
+                    delete(
+                        consensus_2pc_context_participant::table.filter(
+                            consensus_2pc_context_participant::service_id
+                                .eq(format!("{}", service_id))
+                                .and(consensus_2pc_context_participant::epoch.eq(epoch)),
+                        ),
+                    )
+                    .execute(self.conn)?;
 
-                        delete(
-                            consensus_2pc_coordinator_context_participant::table.filter(
-                                consensus_2pc_coordinator_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_2pc_coordinator_context_participant::epoch
-                                            .eq(epoch),
-                                    ),
-                            ),
-                        )
+                    insert_into(consensus_2pc_context_participant::table)
+                        .values(updated_participants)
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_coordinator_context_participant::table)
-                            .values(updated_participants)
-                            .execute(self.conn)?;
-
-                        Ok(())
-                    } else if participant_context.is_some() {
-                        let update_participant_context =
-                            Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
-
-                        delete(
-                            consensus_2pc_participant_context::table.filter(
-                                consensus_2pc_participant_context::epoch
-                                    .eq(epoch)
-                                    .and(
-                                        consensus_2pc_participant_context::service_id
-                                            .eq(format!("{}", service_id)),
-                                    )
-                                    .and(
-                                        consensus_2pc_participant_context::coordinator
-                                            .eq(format!("{}", context.coordinator())),
-                                    ),
-                            ),
-                        )
-                        .execute(self.conn)?;
-
-                        insert_into(consensus_2pc_participant_context::table)
-                            .values(vec![update_participant_context])
-                            .execute(self.conn)?;
-
-                        let updated_participants =
-                            ParticipantContextParticipantList::try_from((&context, service_id))?
-                                .inner;
-
-                        delete(
-                            consensus_2pc_participant_context_participant::table.filter(
-                                consensus_2pc_participant_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_2pc_participant_context_participant::epoch
-                                            .eq(epoch),
-                                    ),
-                            ),
-                        )
-                        .execute(self.conn)?;
-
-                        insert_into(consensus_2pc_participant_context_participant::table)
-                            .values(updated_participants)
-                            .execute(self.conn)?;
-
-                        Ok(())
-                    } else {
-                        Err(ScabbardStoreError::InvalidState(
-                            InvalidStateError::with_message(format!(
-                                "Faild to update context, a context with service_id: {} and \
-                                epoch: {} does not exist",
-                                service_id, epoch
-                            )),
-                        ))
-                    }
+                    Ok(())
                 }
             }
         })
@@ -221,144 +122,57 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                     let epoch = i64::try_from(*context.epoch()).map_err(|err| {
                         ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
                     })?;
-                    // check to make sure the context exists
-                    let coordinator_context = consensus_2pc_coordinator_context::table
+                    // check to see if a context with the given epoch and service_id exists
+                    consensus_2pc_context::table
                         .filter(
-                            consensus_2pc_coordinator_context::epoch
-                                .eq(epoch)
-                                .and(
-                                    consensus_2pc_coordinator_context::service_id
-                                        .eq(format!("{}", service_id)),
-                                )
-                                .and(
-                                    consensus_2pc_coordinator_context::coordinator
-                                        .eq(format!("{}", context.coordinator())),
+                            consensus_2pc_context::epoch.eq(epoch).and(
+                                consensus_2pc_context::service_id.eq(format!("{}", service_id)),
+                            ),
+                        )
+                        .first::<Consensus2pcContextModel>(self.conn)
+                        .optional()?
+                        .ok_or_else(|| {
+                            ScabbardStoreError::InvalidState(InvalidStateError::with_message(
+                                format!(
+                                    "Context with service ID {} and epoch {} does not exist",
+                                    service_id, epoch,
                                 ),
-                        )
-                        .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                        .optional()?;
+                            ))
+                        })?;
 
-                    let participant_context = consensus_2pc_participant_context::table
-                        .filter(
-                            consensus_2pc_participant_context::epoch.eq(epoch).and(
-                                consensus_2pc_participant_context::service_id
-                                    .eq(format!("{}", service_id)),
+                    let update_context =
+                        Consensus2pcContextModel::try_from((&context, service_id))?;
+
+                    delete(
+                        consensus_2pc_context::table.filter(
+                            consensus_2pc_context::epoch.eq(epoch).and(
+                                consensus_2pc_context::service_id.eq(format!("{}", service_id)),
                             ),
-                        )
-                        .first::<Consensus2pcParticipantContextModel>(self.conn)
-                        .optional()?;
+                        ),
+                    )
+                    .execute(self.conn)?;
 
-                    if coordinator_context.is_some() {
-                        // return an error if there is both a coordinator and a participant context
-                        // for the given service_id and epoch
-                        if participant_context.is_some() {
-                            return Err(ScabbardStoreError::InvalidState(
-                                InvalidStateError::with_message(format!(
-                                    "Failed to update consensus action, contexts found for
-                                        participant and coordinator with service_id: {} epoch: {} ",
-                                    service_id, epoch
-                                )),
-                            ));
-                        }
-
-                        let update_coordinator_context =
-                            Consensus2pcCoordinatorContextModel::try_from((&context, service_id))?;
-
-                        delete(
-                            consensus_2pc_coordinator_context::table.filter(
-                                consensus_2pc_coordinator_context::epoch
-                                    .eq(epoch)
-                                    .and(
-                                        consensus_2pc_coordinator_context::service_id
-                                            .eq(format!("{}", service_id)),
-                                    )
-                                    .and(
-                                        consensus_2pc_coordinator_context::coordinator
-                                            .eq(format!("{}", context.coordinator())),
-                                    ),
-                            ),
-                        )
+                    insert_into(consensus_2pc_context::table)
+                        .values(vec![update_context])
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_coordinator_context::table)
-                            .values(vec![update_coordinator_context])
-                            .execute(self.conn)?;
+                    let updated_participants =
+                        ContextParticipantList::try_from((&context, service_id))?.inner;
 
-                        let updated_participants =
-                            CoordinatorContextParticipantList::try_from((&context, service_id))?
-                                .inner;
+                    delete(
+                        consensus_2pc_context_participant::table.filter(
+                            consensus_2pc_context_participant::service_id
+                                .eq(format!("{}", service_id))
+                                .and(consensus_2pc_context_participant::epoch.eq(epoch)),
+                        ),
+                    )
+                    .execute(self.conn)?;
 
-                        delete(
-                            consensus_2pc_coordinator_context_participant::table.filter(
-                                consensus_2pc_coordinator_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_2pc_coordinator_context_participant::epoch
-                                            .eq(epoch),
-                                    ),
-                            ),
-                        )
+                    insert_into(consensus_2pc_context_participant::table)
+                        .values(updated_participants)
                         .execute(self.conn)?;
 
-                        insert_into(consensus_2pc_coordinator_context_participant::table)
-                            .values(updated_participants)
-                            .execute(self.conn)?;
-
-                        Ok(())
-                    } else if participant_context.is_some() {
-                        let update_participant_context =
-                            Consensus2pcParticipantContextModel::try_from((&context, service_id))?;
-
-                        delete(
-                            consensus_2pc_participant_context::table.filter(
-                                consensus_2pc_participant_context::epoch
-                                    .eq(epoch)
-                                    .and(
-                                        consensus_2pc_participant_context::service_id
-                                            .eq(format!("{}", service_id)),
-                                    )
-                                    .and(
-                                        consensus_2pc_participant_context::coordinator
-                                            .eq(format!("{}", context.coordinator())),
-                                    ),
-                            ),
-                        )
-                        .execute(self.conn)?;
-
-                        insert_into(consensus_2pc_participant_context::table)
-                            .values(vec![update_participant_context])
-                            .execute(self.conn)?;
-
-                        let updated_participants =
-                            ParticipantContextParticipantList::try_from((&context, service_id))?
-                                .inner;
-
-                        delete(
-                            consensus_2pc_participant_context_participant::table.filter(
-                                consensus_2pc_participant_context_participant::service_id
-                                    .eq(format!("{}", service_id))
-                                    .and(
-                                        consensus_2pc_participant_context_participant::epoch
-                                            .eq(epoch),
-                                    ),
-                            ),
-                        )
-                        .execute(self.conn)?;
-
-                        insert_into(consensus_2pc_participant_context_participant::table)
-                            .values(updated_participants)
-                            .execute(self.conn)?;
-
-                        Ok(())
-                    } else {
-                        Err(ScabbardStoreError::InvalidState(
-                            InvalidStateError::with_message(format!(
-                                "Faild to update context, a context with service_id: {} and \
-                                epoch: {} does not exist",
-                                service_id, epoch
-                            )),
-                        ))
-                    }
+                    Ok(())
                 }
             }
         })

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -20,10 +20,8 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{Consensus2pcCoordinatorContextModel, Consensus2pcParticipantContextModel},
-    schema::{
-        consensus_2pc_coordinator_context, consensus_2pc_event, consensus_2pc_participant_context,
-    },
+    models::Consensus2pcContextModel,
+    schema::{consensus_2pc_context, consensus_2pc_event},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -56,32 +54,21 @@ where
             let epoch = i64::try_from(epoch).map_err(|err| {
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
-            // check to see if a context exists with the given service_id and epoch
-            let coordinator_context = consensus_2pc_coordinator_context::table
-                .filter(consensus_2pc_coordinator_context::epoch.eq(epoch).and(
-                    consensus_2pc_coordinator_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcCoordinatorContextModel>(self.conn)
-                .optional()?;
-
-            let participant_context = consensus_2pc_participant_context::table
-                .filter(consensus_2pc_participant_context::epoch.eq(epoch).and(
-                    consensus_2pc_participant_context::service_id.eq(format!("{}", service_id)),
-                ))
-                .first::<Consensus2pcParticipantContextModel>(self.conn)
-                .optional()?;
-
-            // return an error if there is both a coordinator and a participant context for the
-            // given service_id and epoch
-            if coordinator_context.is_some() && participant_context.is_some() {
-                return Err(ScabbardStoreError::InvalidState(
-                    InvalidStateError::with_message(format!(
-                        "Failed to update event, contexts found for both participant and
-                        coordinator with service_id: {} epoch: {} ",
-                        service_id, epoch
-                    )),
-                ));
-            }
+            // check to see if a context with the given epoch and service_id exists
+            consensus_2pc_context::table
+                .filter(
+                    consensus_2pc_context::epoch
+                        .eq(epoch)
+                        .and(consensus_2pc_context::service_id.eq(format!("{}", service_id))),
+                )
+                .first::<Consensus2pcContextModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
+                        "Context with service ID {} and epoch {} does not exist",
+                        service_id, epoch,
+                    )))
+                })?;
 
             let update_executed_at = i64::try_from(
                 executed_at
@@ -95,28 +82,18 @@ where
                 ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
             })?;
 
-            if coordinator_context.is_some() || participant_context.is_some() {
-                update(consensus_2pc_event::table)
-                    .filter(
-                        consensus_2pc_event::id
-                            .eq(event_id)
-                            .and(consensus_2pc_event::service_id.eq(format!("{}", service_id)))
-                            .and(consensus_2pc_event::epoch.eq(epoch)),
-                    )
-                    .set(consensus_2pc_event::executed_at.eq(Some(update_executed_at)))
-                    .execute(self.conn)
-                    .map(|_| ())
-                    .map_err(|err| InternalError::from_source(Box::new(err)))?;
-                Ok(())
-            } else {
-                Err(ScabbardStoreError::InvalidState(
-                    InvalidStateError::with_message(format!(
-                        "Failed to update 'executed at' time for consensus event, a context with
-                        service_id: {} and epoch: {} does not exist",
-                        service_id, epoch
-                    )),
-                ))
-            }
+            update(consensus_2pc_event::table)
+                .filter(
+                    consensus_2pc_event::id
+                        .eq(event_id)
+                        .and(consensus_2pc_event::service_id.eq(format!("{}", service_id)))
+                        .and(consensus_2pc_event::epoch.eq(epoch)),
+                )
+                .set(consensus_2pc_event::executed_at.eq(Some(update_executed_at)))
+                .execute(self.conn)
+                .map(|_| ())
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            Ok(())
         })
     }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -37,7 +37,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_coordinator_context (service_id, epoch) {
+    consensus_2pc_context (service_id, epoch) {
         service_id -> Text,
         alarm -> Nullable<BigInt>,
         coordinator -> Text,
@@ -45,11 +45,13 @@ table! {
         last_commit_epoch -> Nullable<BigInt>,
         state -> Text,
         vote_timeout_start -> Nullable<BigInt>,
+        vote -> Nullable<Text>,
+        decision_timeout_start -> Nullable<BigInt>,
     }
 }
 
 table! {
-    consensus_2pc_coordinator_context_participant (service_id, epoch, process) {
+    consensus_2pc_context_participant (service_id, epoch, process) {
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,
@@ -58,28 +60,30 @@ table! {
 }
 
 table! {
-    consensus_2pc_coordinator_notification_action (action_id) {
+    consensus_2pc_notification_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
         notification_type -> Text,
         dropped_message -> Nullable<Text>,
+        request_for_vote_value -> Nullable<Binary>,
     }
 }
 
 table! {
-    consensus_2pc_coordinator_send_message_action (action_id) {
+    consensus_2pc_send_message_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
         receiver_service_id -> Text,
         message_type -> Text,
         vote_response -> Nullable<Text>,
+        vote_request -> Nullable<Binary>,
     }
 }
 
 table! {
-    consensus_2pc_update_coordinator_context_action (action_id) {
+    consensus_2pc_update_context_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
         alarm -> Nullable<BigInt>,
@@ -88,12 +92,14 @@ table! {
         last_commit_epoch -> Nullable<BigInt>,
         state -> Text,
         vote_timeout_start -> Nullable<BigInt>,
-        coordinator_action_alarm -> Nullable<BigInt>,
+        vote -> Nullable<Text>,
+        decision_timeout_start -> Nullable<BigInt>,
+        action_alarm -> Nullable<BigInt>,
     }
 }
 
 table! {
-    consensus_2pc_update_coordinator_context_action_participant (action_id) {
+    consensus_2pc_update_context_action_participant (action_id) {
         action_id -> Int8,
         service_id -> Text,
         epoch -> BigInt,
@@ -110,73 +116,6 @@ table! {
         created_at -> Timestamp,
         executed_at -> Nullable<BigInt>,
         position -> Integer,
-    }
-}
-
-table! {
-    consensus_2pc_participant_context (service_id, epoch) {
-        service_id -> Text,
-        alarm -> Nullable<BigInt>,
-        coordinator -> Text,
-        epoch -> BigInt,
-        last_commit_epoch -> Nullable<BigInt>,
-        state -> Text,
-        vote -> Nullable<Text>,
-        decision_timeout_start -> Nullable<BigInt>,
-    }
-}
-
-table! {
-    consensus_2pc_participant_context_participant (service_id, epoch, process) {
-        service_id -> Text,
-        epoch -> BigInt,
-        process -> Text,
-    }
-}
-
-table! {
-    consensus_2pc_participant_notification_action (action_id) {
-        action_id -> Int8,
-        service_id -> Text,
-        epoch -> BigInt,
-        notification_type -> Text,
-        dropped_message -> Nullable<Text>,
-        request_for_vote_value -> Nullable<Binary>,
-    }
-}
-
-table! {
-    consensus_2pc_participant_send_message_action (action_id) {
-        action_id -> Int8,
-        service_id -> Text,
-        epoch -> BigInt,
-        receiver_service_id -> Text,
-        message_type -> Text,
-        vote_request -> Nullable<Binary>,
-    }
-}
-
-table! {
-    consensus_2pc_update_participant_context_action (action_id) {
-        action_id -> Int8,
-        service_id -> Text,
-        alarm -> Nullable<BigInt>,
-        coordinator -> Text,
-        epoch -> BigInt,
-        last_commit_epoch -> Nullable<BigInt>,
-        state -> Text,
-        vote -> Nullable<Text>,
-        decision_timeout_start -> Nullable<BigInt>,
-        participant_action_alarm -> Nullable<BigInt>,
-    }
-}
-
-table! {
-    consensus_2pc_update_participant_context_action_participant (action_id) {
-        action_id -> Int8,
-        service_id -> Text,
-        epoch -> BigInt,
-        process -> Text,
     }
 }
 
@@ -222,34 +161,24 @@ table! {
     }
 }
 
-joinable!(consensus_2pc_coordinator_notification_action -> consensus_2pc_action (action_id));
-joinable!(consensus_2pc_coordinator_send_message_action -> consensus_2pc_action (action_id));
-joinable!(consensus_2pc_update_coordinator_context_action -> consensus_2pc_action (action_id));
-joinable!(consensus_2pc_update_coordinator_context_action_participant -> consensus_2pc_update_coordinator_context_action (action_id));
-joinable!(consensus_2pc_update_coordinator_context_action_participant -> consensus_2pc_action (action_id));
-
-joinable!(consensus_2pc_participant_notification_action -> consensus_2pc_action (action_id));
-joinable!(consensus_2pc_participant_send_message_action -> consensus_2pc_action (action_id));
-joinable!(consensus_2pc_update_participant_context_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_notification_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_send_message_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_update_context_action -> consensus_2pc_action (action_id));
+joinable!(consensus_2pc_update_context_action_participant -> consensus_2pc_update_context_action (action_id));
+joinable!(consensus_2pc_update_context_action_participant -> consensus_2pc_action (action_id));
 
 joinable!(consensus_2pc_deliver_event -> consensus_2pc_event(event_id));
 joinable!(consensus_2pc_start_event -> consensus_2pc_event(event_id));
 joinable!(consensus_2pc_vote_event -> consensus_2pc_event(event_id));
 
 allow_tables_to_appear_in_same_query!(
-    consensus_2pc_coordinator_context,
-    consensus_2pc_coordinator_context_participant,
+    consensus_2pc_context,
+    consensus_2pc_context_participant,
     consensus_2pc_action,
-    consensus_2pc_update_coordinator_context_action,
-    consensus_2pc_coordinator_send_message_action,
-    consensus_2pc_coordinator_notification_action,
-    consensus_2pc_update_coordinator_context_action_participant,
-    consensus_2pc_participant_context,
-    consensus_2pc_participant_context_participant,
-    consensus_2pc_update_participant_context_action,
-    consensus_2pc_update_participant_context_action_participant,
-    consensus_2pc_participant_send_message_action,
-    consensus_2pc_participant_notification_action,
+    consensus_2pc_update_context_action,
+    consensus_2pc_send_message_action,
+    consensus_2pc_notification_action,
+    consensus_2pc_update_context_action_participant,
     consensus_2pc_event,
     consensus_2pc_deliver_event,
     consensus_2pc_start_event,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/state.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/two_phase/state.rs
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
 use std::time::SystemTime;
-
-use splinter::error::InvalidStateError;
-
-use super::context::{CoordinatorState, ParticipantState};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Scabbard2pcState {
@@ -33,80 +28,4 @@ pub enum Scabbard2pcState {
     WaitingForStart,
     WaitingForVoteRequest,
     WaitingForVote,
-}
-
-impl TryFrom<Scabbard2pcState> for CoordinatorState {
-    type Error = InvalidStateError;
-
-    fn try_from(state: Scabbard2pcState) -> Result<Self, InvalidStateError> {
-        match state {
-            Scabbard2pcState::Abort => Ok(CoordinatorState::Abort),
-            Scabbard2pcState::Commit => Ok(CoordinatorState::Commit),
-            Scabbard2pcState::Voting { vote_timeout_start } => {
-                Ok(CoordinatorState::Voting { vote_timeout_start })
-            }
-            Scabbard2pcState::WaitingForStart => Ok(CoordinatorState::WaitingForStart),
-            Scabbard2pcState::WaitingForVote => Ok(CoordinatorState::WaitingForVote),
-            _ => Err(InvalidStateError::with_message(format!(
-                "invalid state for coordinator: {:?}",
-                state
-            ))),
-        }
-    }
-}
-
-impl TryFrom<Scabbard2pcState> for ParticipantState {
-    type Error = InvalidStateError;
-
-    fn try_from(state: Scabbard2pcState) -> Result<Self, InvalidStateError> {
-        match state {
-            Scabbard2pcState::Abort => Ok(ParticipantState::Abort),
-            Scabbard2pcState::Commit => Ok(ParticipantState::Commit),
-            Scabbard2pcState::Voted {
-                vote,
-                decision_timeout_start,
-            } => Ok(ParticipantState::Voted {
-                vote,
-                decision_timeout_start,
-            }),
-            Scabbard2pcState::WaitingForVoteRequest => Ok(ParticipantState::WaitingForVoteRequest),
-            Scabbard2pcState::WaitingForVote => Ok(ParticipantState::WaitingForVote),
-            _ => Err(InvalidStateError::with_message(format!(
-                "invalid state for participant: {:?}",
-                state
-            ))),
-        }
-    }
-}
-
-impl From<CoordinatorState> for Scabbard2pcState {
-    fn from(state: CoordinatorState) -> Self {
-        match state {
-            CoordinatorState::Abort => Scabbard2pcState::Abort,
-            CoordinatorState::Commit => Scabbard2pcState::Commit,
-            CoordinatorState::Voting { vote_timeout_start } => {
-                Scabbard2pcState::Voting { vote_timeout_start }
-            }
-            CoordinatorState::WaitingForStart => Scabbard2pcState::WaitingForStart,
-            CoordinatorState::WaitingForVote => Scabbard2pcState::WaitingForVote,
-        }
-    }
-}
-
-impl From<ParticipantState> for Scabbard2pcState {
-    fn from(state: ParticipantState) -> Self {
-        match state {
-            ParticipantState::Abort => Scabbard2pcState::Abort,
-            ParticipantState::Commit => Scabbard2pcState::Commit,
-            ParticipantState::Voted {
-                vote,
-                decision_timeout_start,
-            } => Scabbard2pcState::Voted {
-                vote,
-                decision_timeout_start,
-            },
-            ParticipantState::WaitingForVoteRequest => Scabbard2pcState::WaitingForVoteRequest,
-            ParticipantState::WaitingForVote => Scabbard2pcState::WaitingForVote,
-        }
-    }
 }


### PR DESCRIPTION
This PR combines the participant and coordinator tables for consensus contexts and actions in the diesel backed `ScabbardStore` implementation.