### PR TITLE
Change From impl to new constructor

### DIFF
--- a/rest_api/actix_web_1/src/admin/mod.rs
+++ b/rest_api/actix_web_1/src/admin/mod.rs
@@ -45,8 +45,8 @@ pub struct AdminServiceRestProvider {
     resources: Vec<Resource>,
 }
 
-impl From<&AdminService> for AdminServiceRestProvider {
-    fn from(source: &AdminService) -> Self {
+impl AdminServiceRestProvider {
+    pub fn new(source: &AdminService) -> Self {
         let resources = vec![
             ws_register_type::make_application_handler_registration_route(source.commands()),
             submit::make_submit_route(source.commands()),

--- a/splinterd/src/daemon/mod.rs
+++ b/splinterd/src/daemon/mod.rs
@@ -659,7 +659,7 @@ impl SplinterDaemon {
         let mut rest_api_builder = RestApiBuilder::new()
             .with_bind(bind)
             .add_resources(registry.resources())
-            .add_resources(AdminServiceRestProvider::from(&admin_service).resources())
+            .add_resources(AdminServiceRestProvider::new(&admin_service).resources())
             .add_resources(orchestrator_resources)
             .add_resources(circuit_resource_provider.resources());
 

--- a/splinterd/src/node/runnable/admin.rs
+++ b/splinterd/src/node/runnable/admin.rs
@@ -151,7 +151,7 @@ impl RunnableAdminSubsystem {
 
         let mut actix1_resources = vec![];
 
-        actix1_resources.append(&mut AdminServiceRestProvider::from(&admin_service).resources());
+        actix1_resources.append(&mut AdminServiceRestProvider::new(&admin_service).resources());
         actix1_resources.append(&mut circuit_resource_provider.resources());
         actix1_resources.append(&mut registry.resources());
         actix1_resources.append(&mut orchestrator_resources);


### PR DESCRIPTION
The `From` trait documentation states that the trait is "Used to do
value-to-value conversions while consuming the input value." the
implementation this commit replaces did not consume the `&AdminService`.

This commit replaces the `from` method with a `pub new` method that does
exactly the same thing while more strictly adhering to the spirit of
the `From` trait.

Signed-off-by: Caleb Hill <hill@bitwise.io>