### PR TITLE
Replace the use of admin shared with store in ProposalStore

### DIFF
--- a/libsplinter/src/admin/service/builder.rs
+++ b/libsplinter/src/admin/service/builder.rs
@@ -224,7 +224,7 @@ impl AdminServiceBuilder {
             lifecycle_dispatch,
             service_arg_validators,
             peer_connector.clone(),
-            admin_store,
+            admin_store.clone(),
             signature_verifier,
             key_verifier,
             key_permission_manager,
@@ -241,6 +241,7 @@ impl AdminServiceBuilder {
             consensus: None,
             peer_connector,
             peer_notification_run_state: None,
+            admin_store,
         })
     }
 }

--- a/libsplinter/src/admin/service/mod.rs
+++ b/libsplinter/src/admin/service/mod.rs
@@ -143,8 +143,8 @@ pub struct AdminService {
     coordinator_timeout: Duration,
     consensus: Option<AdminConsensusManager>,
     peer_connector: PeerManagerConnector,
-
     peer_notification_run_state: Option<(usize, JoinHandle<()>)>,
+    admin_store: Box<dyn AdminServiceStore>,
 }
 
 impl AdminService {
@@ -193,7 +193,7 @@ impl AdminService {
     }
 
     pub fn proposal_store_factory(&self) -> impl ProposalStoreFactory {
-        AdminServiceProposalsFactory::new(&self.admin_service_shared)
+        AdminServiceProposalsFactory::new(self.admin_store.clone())
     }
 
     /// On restart of a splinter node, all services that this node should run on the existing

--- a/libsplinter/src/admin/service/proposal_store/admin_service_proposals_factory.rs
+++ b/libsplinter/src/admin/service/proposal_store/admin_service_proposals_factory.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
-
-use crate::admin::service::shared::AdminServiceShared;
+use crate::admin::store::AdminServiceStore;
 
 use super::admin_service_proposals::AdminServiceProposals;
 use super::factory::ProposalStoreFactory;
@@ -22,19 +20,17 @@ use super::store::ProposalStore;
 
 #[derive(Clone)]
 pub struct AdminServiceProposalsFactory {
-    admin_service_shared: Arc<Mutex<AdminServiceShared>>,
+    admin_store: Box<dyn AdminServiceStore>,
 }
 
 impl ProposalStoreFactory for AdminServiceProposalsFactory {
     fn new_proposal_store<'a>(&'a self) -> Box<dyn ProposalStore + 'a> {
-        Box::new(AdminServiceProposals::new(&self.admin_service_shared))
+        Box::new(AdminServiceProposals::new(self.admin_store.clone()))
     }
 }
 
 impl AdminServiceProposalsFactory {
-    pub fn new(admin_service_shared: &Arc<Mutex<AdminServiceShared>>) -> Self {
-        Self {
-            admin_service_shared: Arc::clone(admin_service_shared),
-        }
+    pub fn new(admin_store: Box<dyn AdminServiceStore>) -> Self {
+        Self { admin_store }
     }
 }

--- a/libsplinter/src/admin/service/proposal_store/error.rs
+++ b/libsplinter/src/admin/service/proposal_store/error.rs
@@ -15,7 +15,7 @@
 #[derive(Debug)]
 pub struct ProposalStoreError {
     context: String,
-    source: Option<Box<dyn std::error::Error + Send + 'static>>,
+    source: Option<Box<dyn std::error::Error + 'static>>,
 }
 
 impl std::error::Error for ProposalStoreError {}
@@ -28,7 +28,7 @@ impl ProposalStoreError {
         }
     }
 
-    pub fn from_source<T: std::error::Error + Send + 'static>(context: &str, source: T) -> Self {
+    pub fn from_source<T: std::error::Error + 'static>(context: &str, source: T) -> Self {
         Self {
             context: context.into(),
             source: Some(Box::new(source)),


### PR DESCRIPTION
There is no reason the ProposalStore needs to wrap the entire
AdminServiceShared. It can instead just use the AdminServiceStore
directly. The AdminServiceStore will handle it's own locking and
removes some lock contention around AdminServiceShared.

This changes requires removing the Send requirement on the
ProposalStoreError.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>