### PR TITLE
Scabbard Store - move alarm out of context

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -19,7 +19,6 @@ CREATE TYPE notification_type AS ENUM ('REQUESTFORSTART', 'COORDINATORREQUESTFOR
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
@@ -56,7 +55,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-05-05-142800-create-scabbard-alarm-table/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-05-05-142800-create-scabbard-alarm-table/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS scabbard_alarm;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-05-05-142800-create-scabbard-alarm-table/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-05-05-142800-create-scabbard-alarm-table/up.sql
@@ -1,0 +1,24 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TYPE alarm_type AS ENUM ('TWOPHASECOMMIT');
+
+CREATE TABLE IF NOT EXISTS scabbard_alarm (
+    service_id                TEXT NOT NULL,
+    alarm_type                alarm_type NOT NULL,
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (service_id) REFERENCES scabbard_service(service_id) ON DELETE CASCADE,
+    PRIMARY KEY (service_id, alarm_type)
+);

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -15,7 +15,6 @@
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
@@ -53,7 +52,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     action_id                 INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    alarm                     BIGINT,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-05-05-142800-create-scabbard-alarm-table/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-05-05-142800-create-scabbard-alarm-table/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS scabbard_alarm;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-05-05-142800-create-scabbard-alarm-table/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-05-05-142800-create-scabbard-alarm-table/up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scabbard_alarm (
+    service_id                TEXT NOT NULL,
+    alarm_type                TEXT NOT NULL
+    CHECK ( alarm_type IN ('TWOPHASECOMMIT')),
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (service_id) REFERENCES scabbard_service(service_id) ON DELETE CASCADE,
+    PRIMARY KEY (service_id, alarm_type)
+);

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/store.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/store.rs
@@ -56,11 +56,12 @@ impl<C: 'static> ContextUpdater<C> for ScabbardStoreContextUpdater<C> {
         &self,
         context: ConsensusContext,
         service_id: &FullyQualifiedServiceId,
-        _alarm: Option<SystemTime>,
+        alarm: Option<SystemTime>,
     ) -> Result<Vec<Box<dyn StoreCommand<Context = C>>>, InternalError> {
         Ok(vec![Box::new(UpdateContextCommand::new(
             context,
             service_id.clone(),
+            alarm,
             self.store_factory.clone(),
         ))])
     }

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -129,7 +129,6 @@ mod tests {
         store.add_service(service2).expect("failed to add service2");
 
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(SystemTime::now())
             .with_coordinator(fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -169,7 +168,6 @@ mod tests {
         assert!(ids.contains(&fqsi));
 
         let participant_context = ContextBuilder::default()
-            .with_alarm(SystemTime::now())
             .with_coordinator(fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -209,48 +207,10 @@ mod tests {
         assert!(ids.contains(&fqsi));
         assert!(ids.contains(&fqsi2));
 
-        let updated_alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(604800))
-            .expect("failed to get alarm time");
-
-        let update_context2 = ContextBuilder::default()
-            .with_alarm(updated_alarm)
-            .with_coordinator(fqsi.clone().service_id())
-            .with_epoch(1)
-            .with_participants(vec![Participant {
-                process: peer_service1.clone(),
-                vote: None,
-            }])
-            .with_state(State::WaitingForVoteRequest)
-            .with_this_process(fqsi2.clone().service_id())
-            .build()
-            .expect("failed to build context");
-
         // reset the alarms for both services to far in the future
-        store
-            .update_consensus_context(&fqsi2, ConsensusContext::TwoPhaseCommit(update_context2))
-            .expect("failed to update context");
-
         let updated_alarm = SystemTime::now()
             .checked_add(Duration::from_secs(604800))
             .expect("failed to get alarm time");
-
-        let update_context1 = ContextBuilder::default()
-            .with_alarm(updated_alarm)
-            .with_coordinator(fqsi.clone().service_id())
-            .with_epoch(1)
-            .with_participants(vec![Participant {
-                process: peer_service1.clone(),
-                vote: None,
-            }])
-            .with_state(State::WaitingForStart)
-            .with_this_process(fqsi.clone().service_id())
-            .build()
-            .expect("failed to build context");
-
-        store
-            .update_consensus_context(&fqsi, ConsensusContext::TwoPhaseCommit(update_context1))
-            .expect("failed to update context");
 
         // update the second service's action's executed_at time so that it appears to have
         // been executed

--- a/services/scabbard/libscabbard/src/store/command/finalize_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/finalize_service.rs
@@ -55,9 +55,6 @@ impl<C> StoreCommand for ScabbardFinalizeServiceCommand<C> {
             .build()
             .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
-        // set alarm to current time so it will be considered passed next time the timer runs
-        let alarm = SystemTime::now();
-
         let mut context = store
             .get_current_consensus_context(&self.service_id)
             .map_err(|err| InternalError::from_source(Box::new(err)))?
@@ -69,7 +66,6 @@ impl<C> StoreCommand for ScabbardFinalizeServiceCommand<C> {
             ConsensusContext::TwoPhaseCommit(context) => ConsensusContext::TwoPhaseCommit(
                 context
                     .into_builder()
-                    .with_alarm(alarm)
                     .build()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?,
             ),

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -39,7 +39,8 @@ pub use scabbard_store::diesel::DieselScabbardStore;
 pub use scabbard_store::PooledScabbardStoreFactory;
 #[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::{
-    action, commit, context, event, service, two_phase_commit, ScabbardStore, ScabbardStoreFactory,
+    action, alarm, commit, context, event, service, two_phase_commit, ScabbardStore,
+    ScabbardStoreFactory,
 };
 #[cfg(all(feature = "scabbardv3-store", feature = "postgres"))]
 pub use scabbard_store::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/scabbard_store/alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/alarm.rs
@@ -1,0 +1,18 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum AlarmType {
+    TwoPhaseCommit,
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -269,4 +269,19 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     ) -> Result<(), ScabbardStoreError> {
         (&**self).set_alarm(service_id, alarm_type, alarm)
     }
+
+    /// Unset a scabbard alarm of a specified type for a given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` that the alarm
+    ///   will be unset for
+    /// * `alarm_type` - The type of alarm being unset
+    fn unset_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<(), ScabbardStoreError> {
+        (&**self).unset_alarm(service_id, alarm_type)
+    }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -284,4 +284,19 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     ) -> Result<(), ScabbardStoreError> {
         (&**self).unset_alarm(service_id, alarm_type)
     }
+
+    /// Get the scabbard alarm of a specified type for the given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` to retrieve the
+    ///    alarm for
+    /// * `alarm_type` - The type of alarm to retrieve
+    fn get_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<Option<SystemTime>, ScabbardStoreError> {
+        (&**self).get_alarm(service_id, alarm_type)
+    }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -19,6 +19,7 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
     action::IdentifiedConsensusAction,
+    alarm::AlarmType,
     commit::CommitEntry,
     event::{ConsensusEvent, IdentifiedConsensusEvent},
     service::ScabbardService,
@@ -250,5 +251,22 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         service_id: &FullyQualifiedServiceId,
     ) -> Result<(), ScabbardStoreError> {
         (&**self).remove_service(service_id)
+    }
+
+    /// Set a scabbard alarm for a given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` that the alarm
+    ///   will be set for
+    /// * `alarm` - The time that the alarm will go off
+    /// * `alarm_type` - The type of alarm being set
+    fn set_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+        alarm: SystemTime,
+    ) -> Result<(), ScabbardStoreError> {
+        (&**self).set_alarm(service_id, alarm_type, alarm)
     }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -725,12 +725,7 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -748,7 +743,6 @@ pub mod tests {
             .is_ok());
 
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -782,12 +776,7 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -828,19 +817,7 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
-        let alarm = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_secs(
-                SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .expect("failed to get alarm time")
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("failed to get duration since UNIX EPOCH")
-                    .as_secs(),
-            ))
-            .unwrap();
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -872,7 +849,6 @@ pub mod tests {
             .unwrap();
 
         let update_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -901,7 +877,6 @@ pub mod tests {
             .expect("failed to list all actions");
 
         let expected_update_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -950,12 +925,7 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -984,7 +954,6 @@ pub mod tests {
             .unwrap();
 
         let update_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1004,7 +973,6 @@ pub mod tests {
             .is_ok());
 
         let bad_update_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(0)
             .with_participants(vec![Participant {
@@ -1041,12 +1009,7 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1075,7 +1038,6 @@ pub mod tests {
             .unwrap();
 
         let update_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1172,7 +1134,6 @@ pub mod tests {
         assert!(store.add_service(service).is_ok());
 
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(SystemTime::now())
             .with_coordinator(service_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1205,7 +1166,6 @@ pub mod tests {
             .expect("failed to get alarm time");
 
         let update_context = ContextBuilder::default()
-            .with_alarm(updated_alarm)
             .with_coordinator(service_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1453,7 +1413,6 @@ pub mod tests {
         assert!(store.add_service(service.clone()).is_ok());
 
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(SystemTime::now())
             .with_coordinator(service_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1511,12 +1470,7 @@ pub mod tests {
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let participant_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![
@@ -1570,12 +1524,7 @@ pub mod tests {
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let participant_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![
@@ -1632,12 +1581,7 @@ pub mod tests {
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
 
-        let alarm = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("failed to get alarm time");
-
         let participant_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![
@@ -1772,19 +1716,7 @@ pub mod tests {
 
         store.add_service(service).expect("faield to add service");
 
-        let alarm = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_secs(
-                SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .expect("failed to get alarm time")
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("failed to get duration since UNIX EPOCH")
-                    .as_secs(),
-            ))
-            .unwrap();
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1802,7 +1734,6 @@ pub mod tests {
             .expect("failed to add context");
 
         let participant_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {
@@ -1832,7 +1763,6 @@ pub mod tests {
         assert_eq!(current_context, Some(context2));
 
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(2)
             .with_participants(vec![Participant {
@@ -1856,7 +1786,6 @@ pub mod tests {
         assert_eq!(current_context, Some(context3));
 
         let participant_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(participant_service_id.clone().service_id())
             .with_epoch(3)
             .with_participants(vec![Participant {
@@ -1910,19 +1839,7 @@ pub mod tests {
             .add_service(service.clone())
             .expect("failed to add service");
 
-        let alarm = SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_secs(
-                SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .expect("failed to get alarm time")
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .expect("failed to get duration since UNIX EPOCH")
-                    .as_secs(),
-            ))
-            .unwrap();
-
         let coordinator_context = ContextBuilder::default()
-            .with_alarm(alarm)
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
             .with_participants(vec![Participant {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1197,6 +1197,10 @@ pub mod tests {
             .add_consensus_context(&service_fqsi, context)
             .expect("failed to add context to store");
 
+        store
+            .set_alarm(&service_fqsi, &AlarmType::TwoPhaseCommit, SystemTime::now())
+            .expect("failed to add alarm to store");
+
         let ready_services = store
             .list_ready_services()
             .expect("failed to list ready services");
@@ -1211,25 +1215,10 @@ pub mod tests {
             .checked_add(Duration::from_secs(604800))
             .expect("failed to get alarm time");
 
-        let update_context = ContextBuilder::default()
-            .with_coordinator(service_fqsi.clone().service_id())
-            .with_epoch(1)
-            .with_participants(vec![Participant {
-                process: peer_service_id.clone(),
-                vote: None,
-            }])
-            .with_state(State::WaitingForStart)
-            .with_this_process(service_fqsi.clone().service_id())
-            .build()
-            .expect("failed to build context");
-
         // update the context to have an alarm far in the future
         store
-            .update_consensus_context(
-                &service_fqsi,
-                ConsensusContext::TwoPhaseCommit(update_context),
-            )
-            .expect("failed to update context");
+            .set_alarm(&service_fqsi, &AlarmType::TwoPhaseCommit, updated_alarm)
+            .expect("failed to add alarm to store");
 
         // add an action for the service
         let action_id = store
@@ -1475,6 +1464,10 @@ pub mod tests {
         store
             .add_consensus_context(&service_fqsi, context)
             .expect("failed to add context to store");
+
+        store
+            .set_alarm(&service_fqsi, &AlarmType::TwoPhaseCommit, SystemTime::now())
+            .expect("failed to add alarm to store");
 
         let ready_services = store
             .list_ready_services()
@@ -1901,6 +1894,14 @@ pub mod tests {
         store
             .add_consensus_context(&coordinator_fqsi, context.clone())
             .expect("failed to add context");
+
+        store
+            .set_alarm(
+                &coordinator_fqsi,
+                &AlarmType::TwoPhaseCommit,
+                SystemTime::now(),
+            )
+            .expect("failed to add alarm to store");
 
         let fetched_service = store
             .get_service(&coordinator_fqsi)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -19,6 +19,7 @@ use splinter::error::InternalError;
 use splinter::service::{FullyQualifiedServiceId, ServiceId};
 
 use crate::store::scabbard_store::{
+    alarm::AlarmType,
     commit::{CommitEntry, CommitEntryBuilder, ConsensusDecision},
     context::ConsensusContext,
     service::{ConsensusType, ScabbardService, ServiceStatus},
@@ -771,4 +772,12 @@ pub struct Consensus2pcVoteEventModel {
     pub service_id: String,
     pub epoch: i64,
     pub vote: String, // TRUE or FALSE
+}
+
+impl From<&AlarmType> for String {
+    fn from(status: &AlarmType) -> Self {
+        match *status {
+            AlarmType::TwoPhaseCommit => "TWOPHASECOMMIT".into(),
+        }
+    }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -30,7 +30,8 @@ use super::schema::{
     consensus_2pc_deliver_event, consensus_2pc_event, consensus_2pc_notification_action,
     consensus_2pc_send_message_action, consensus_2pc_start_event,
     consensus_2pc_update_context_action, consensus_2pc_update_context_action_participant,
-    consensus_2pc_vote_event, scabbard_peer, scabbard_service, scabbard_v3_commit_history,
+    consensus_2pc_vote_event, scabbard_alarm, scabbard_peer, scabbard_service,
+    scabbard_v3_commit_history,
 };
 
 /// Database model representation of `ScabbardService`
@@ -199,6 +200,15 @@ impl From<&ConsensusDecision> for String {
             ConsensusDecision::Commit => "COMMIT".into(),
         }
     }
+}
+
+#[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
+#[table_name = "scabbard_alarm"]
+#[primary_key(service_id, alarm_type)]
+pub struct ScabbardAlarmModel {
+    pub service_id: String,
+    pub alarm_type: String,
+    pub alarm: i64, // timestamp, when to wake up
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
@@ -1,0 +1,126 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Duration, SystemTime};
+
+#[cfg(feature = "postgres")]
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+#[cfg(feature = "sqlite")]
+use diesel::sqlite::SqliteConnection;
+use splinter::error::{InternalError, InvalidStateError};
+use splinter::service::FullyQualifiedServiceId;
+
+use crate::store::alarm::AlarmType;
+use crate::store::scabbard_store::diesel::{
+    models::ScabbardServiceModel,
+    schema::{scabbard_alarm, scabbard_service},
+};
+use crate::store::scabbard_store::ScabbardStoreError;
+
+use super::ScabbardStoreOperations;
+
+pub(in crate::store::scabbard_store::diesel) trait GetAlarmOperation {
+    fn get_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<Option<SystemTime>, ScabbardStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
+    fn get_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<Option<SystemTime>, ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to get scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .select(scabbard_alarm::alarm)
+                .first::<i64>(self.conn)
+                .optional()?
+                .map(|t| {
+                    SystemTime::UNIX_EPOCH
+                        .checked_add(Duration::from_secs(t as u64))
+                        .ok_or_else(|| {
+                            ScabbardStoreError::Internal(InternalError::with_message(
+                                "'alarm' timestamp could not be represented as a `SystemTime`"
+                                    .to_string(),
+                            ))
+                        })
+                })
+                .transpose()
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
+    fn get_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<Option<SystemTime>, ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to get scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .select(scabbard_alarm::alarm)
+                .first::<i64>(self.conn)
+                .optional()?
+                .map(|t| {
+                    SystemTime::UNIX_EPOCH
+                        .checked_add(Duration::from_secs(t as u64))
+                        .ok_or_else(|| {
+                            ScabbardStoreError::Internal(InternalError::with_message(
+                                "'alarm' timestamp could not be represented as a `SystemTime`"
+                                    .to_string(),
+                            ))
+                        })
+                })
+                .transpose()
+        })
+    }
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -216,13 +216,6 @@ where
                 };
 
                 let mut context = ContextBuilder::default()
-                    .with_alarm(get_system_time(update_context.alarm)?.ok_or_else(|| {
-                        ScabbardStoreError::Internal(InternalError::with_message(
-                            "failed to get update context action with status 'voting', no vote \
-                            timeout start time set"
-                                .to_string(),
-                        ))
-                    })?)
                     .with_coordinator(&ServiceId::new(&update_context.coordinator).map_err(
                         |err| {
                             ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
@@ -19,8 +19,9 @@ use diesel::prelude::*;
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
+use crate::store::alarm::AlarmType;
 use crate::store::scabbard_store::diesel::schema::{
-    consensus_2pc_action, consensus_2pc_context, consensus_2pc_event, scabbard_service,
+    consensus_2pc_action, consensus_2pc_event, scabbard_alarm, scabbard_service,
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -44,6 +45,23 @@ where
                 .load::<String>(self.conn)?
                 .into_iter()
                 .collect();
+
+            let current_time = get_timestamp(SystemTime::now())?;
+
+            // get the service IDs of services with alarms which have passed
+            let mut ready_services = scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq_any(&finalized_services)
+                        .and(
+                            scabbard_alarm::alarm_type.eq(String::from(&AlarmType::TwoPhaseCommit)),
+                        )
+                        .and(scabbard_alarm::alarm.le(current_time)),
+                )
+                .select(scabbard_alarm::service_id)
+                .load::<String>(self.conn)?
+                .into_iter()
+                .collect::<Vec<String>>();
 
             // get the service IDs of any finalized services that have unexecuted actions
             ready_services.append(
@@ -83,20 +101,11 @@ where
     }
 }
 
-fn get_timestamp(time: Option<SystemTime>) -> Result<Option<i64>, ScabbardStoreError> {
-    match time {
-        Some(time) => Ok(Some(
-            i64::try_from(
-                time.duration_since(SystemTime::UNIX_EPOCH)
-                    .map_err(|err| {
-                        ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
-                    })?
-                    .as_secs(),
-            )
-            .map_err(|err| {
-                ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
-            })?,
-        )),
-        None => Ok(None),
-    }
+fn get_timestamp(time: SystemTime) -> Result<i64, ScabbardStoreError> {
+    i64::try_from(
+        time.duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|err| ScabbardStoreError::Internal(InternalError::from_source(Box::new(err))))?
+            .as_secs(),
+    )
+    .map_err(|err| ScabbardStoreError::Internal(InternalError::from_source(Box::new(err))))
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
@@ -45,20 +45,6 @@ where
                 .into_iter()
                 .collect();
 
-            let current_time = get_timestamp(Some(SystemTime::now()))?;
-
-            // get the service IDs of services with alarms which have passed
-            let mut ready_services = consensus_2pc_context::table
-                .filter(
-                    consensus_2pc_context::service_id
-                        .eq_any(&finalized_services)
-                        .and(consensus_2pc_context::alarm.le(current_time)),
-                )
-                .select(consensus_2pc_context::service_id)
-                .load::<String>(self.conn)?
-                .into_iter()
-                .collect::<Vec<String>>();
-
             // get the service IDs of any finalized services that have unexecuted actions
             ready_services.append(
                 &mut consensus_2pc_action::table

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
@@ -17,6 +17,7 @@ pub(super) mod add_consensus_action;
 pub(super) mod add_consensus_context;
 pub(super) mod add_consensus_event;
 pub(super) mod add_service;
+pub(super) mod get_alarm;
 pub(super) mod get_current_consensus_context;
 pub(super) mod get_last_commit_entry;
 pub(super) mod get_service;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
@@ -25,6 +25,7 @@ pub(super) mod list_consensus_events;
 pub(super) mod list_ready_services;
 pub(super) mod remove_service;
 pub(super) mod set_alarm;
+pub(super) mod unset_alarm;
 pub(super) mod update_commit_entry;
 pub(super) mod update_consensus_action;
 pub(super) mod update_consensus_context;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/mod.rs
@@ -24,6 +24,7 @@ pub(super) mod list_consensus_actions;
 pub(super) mod list_consensus_events;
 pub(super) mod list_ready_services;
 pub(super) mod remove_service;
+pub(super) mod set_alarm;
 pub(super) mod update_commit_entry;
 pub(super) mod update_consensus_action;
 pub(super) mod update_consensus_context;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
@@ -1,0 +1,163 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+use std::time::SystemTime;
+
+#[cfg(feature = "postgres")]
+use diesel::pg::PgConnection;
+#[cfg(feature = "sqlite")]
+use diesel::sqlite::SqliteConnection;
+use diesel::{delete, dsl::insert_into, prelude::*};
+use splinter::error::{InternalError, InvalidStateError};
+use splinter::service::FullyQualifiedServiceId;
+
+use crate::store::alarm::AlarmType;
+use crate::store::scabbard_store::diesel::{
+    models::{ScabbardAlarmModel, ScabbardServiceModel},
+    schema::{scabbard_alarm, scabbard_service},
+};
+use crate::store::scabbard_store::ScabbardStoreError;
+
+use super::ScabbardStoreOperations;
+
+pub(in crate::store::scabbard_store::diesel) trait SetAlarmOperation {
+    fn set_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+        alarm: SystemTime,
+    ) -> Result<(), ScabbardStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
+    fn set_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+        alarm: SystemTime,
+    ) -> Result<(), ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to set scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            let current_alarm = scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .first::<ScabbardAlarmModel>(self.conn)
+                .optional()?;
+
+            let new_alarm = ScabbardAlarmModel {
+                service_id: format!("{}", service_id),
+                alarm_type: String::from(alarm_type),
+                alarm: get_timestamp(alarm)?,
+            };
+
+            if current_alarm.is_some() {
+                // delete the current alarm
+                delete(
+                    scabbard_alarm::table.filter(
+                        scabbard_alarm::service_id
+                            .eq(format!("{}", service_id))
+                            .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                    ),
+                )
+                .execute(self.conn)?;
+            }
+
+            insert_into(scabbard_alarm::table)
+                .values(vec![new_alarm])
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
+    fn set_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+        alarm: SystemTime,
+    ) -> Result<(), ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to set scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            let current_alarm = scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .first::<ScabbardAlarmModel>(self.conn)
+                .optional()?;
+
+            let new_alarm = ScabbardAlarmModel {
+                service_id: format!("{}", service_id),
+                alarm_type: String::from(alarm_type),
+                alarm: get_timestamp(alarm)?,
+            };
+
+            if current_alarm.is_some() {
+                // delete the current alarm
+                delete(
+                    scabbard_alarm::table.filter(
+                        scabbard_alarm::service_id
+                            .eq(format!("{}", service_id))
+                            .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                    ),
+                )
+                .execute(self.conn)?;
+            }
+
+            insert_into(scabbard_alarm::table)
+                .values(vec![new_alarm])
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+fn get_timestamp(time: SystemTime) -> Result<i64, ScabbardStoreError> {
+    i64::try_from(
+        time.duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|err| ScabbardStoreError::Internal(InternalError::from_source(Box::new(err))))?
+            .as_secs(),
+    )
+    .map_err(|err| ScabbardStoreError::Internal(InternalError::from_source(Box::new(err))))
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
@@ -1,0 +1,128 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "postgres")]
+use diesel::pg::PgConnection;
+#[cfg(feature = "sqlite")]
+use diesel::sqlite::SqliteConnection;
+use diesel::{delete, prelude::*};
+use splinter::error::InvalidStateError;
+use splinter::service::FullyQualifiedServiceId;
+
+use crate::store::alarm::AlarmType;
+use crate::store::scabbard_store::diesel::{
+    models::{ScabbardAlarmModel, ScabbardServiceModel},
+    schema::{scabbard_alarm, scabbard_service},
+};
+use crate::store::scabbard_store::ScabbardStoreError;
+
+use super::ScabbardStoreOperations;
+
+pub(in crate::store::scabbard_store::diesel) trait UnsetAlarmOperation {
+    fn unset_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<(), ScabbardStoreError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
+    fn unset_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<(), ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to unset scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            let current_alarm = scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .first::<ScabbardAlarmModel>(self.conn)
+                .optional()?;
+
+            if current_alarm.is_some() {
+                // delete the current alarm
+                delete(
+                    scabbard_alarm::table.filter(
+                        scabbard_alarm::service_id
+                            .eq(format!("{}", service_id))
+                            .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                    ),
+                )
+                .execute(self.conn)?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
+    fn unset_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<(), ScabbardStoreError> {
+        self.conn.transaction::<_, _, _>(|| {
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
+                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .first::<ScabbardServiceModel>(self.conn)
+                .optional()?
+                .ok_or_else(|| {
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Failed to unset scabbard alarm, service does not exist",
+                    )))
+                })?;
+
+            let current_alarm = scabbard_alarm::table
+                .filter(
+                    scabbard_alarm::service_id
+                        .eq(format!("{}", service_id))
+                        .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                )
+                .first::<ScabbardAlarmModel>(self.conn)
+                .optional()?;
+
+            if current_alarm.is_some() {
+                // delete the current alarm
+                delete(
+                    scabbard_alarm::table.filter(
+                        scabbard_alarm::service_id
+                            .eq(format!("{}", service_id))
+                            .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
+                    ),
+                )
+                .execute(self.conn)?;
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -37,6 +37,14 @@ table! {
 }
 
 table! {
+    scabbard_alarm (service_id, alarm_type) {
+        service_id -> Text,
+        alarm_type -> Text,
+        alarm -> BigInt,
+    }
+}
+
+table! {
     consensus_2pc_context (service_id, epoch) {
         service_id -> Text,
         coordinator -> Text,
@@ -183,4 +191,9 @@ allow_tables_to_appear_in_same_query!(
     consensus_2pc_vote_event,
 );
 
-allow_tables_to_appear_in_same_query!(scabbard_peer, scabbard_service, scabbard_v3_commit_history,);
+allow_tables_to_appear_in_same_query!(
+    scabbard_peer,
+    scabbard_service,
+    scabbard_v3_commit_history,
+    scabbard_alarm
+);

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -39,7 +39,6 @@ table! {
 table! {
     consensus_2pc_context (service_id, epoch) {
         service_id -> Text,
-        alarm -> Nullable<BigInt>,
         coordinator -> Text,
         epoch -> BigInt,
         last_commit_epoch -> Nullable<BigInt>,
@@ -86,7 +85,6 @@ table! {
     consensus_2pc_update_context_action (action_id) {
         action_id -> Int8,
         service_id -> Text,
-        alarm -> Nullable<BigInt>,
         coordinator -> Text,
         epoch -> BigInt,
         last_commit_epoch -> Nullable<BigInt>,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod action;
+pub mod alarm;
 mod boxed;
 pub mod commit;
 pub mod context;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -261,4 +261,17 @@ pub trait ScabbardStore {
         service_id: &FullyQualifiedServiceId,
         alarm_type: &AlarmType,
     ) -> Result<(), ScabbardStoreError>;
+
+    /// Get the scabbard alarm of a specified type for the given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` to retrieve the
+    ///    alarm for
+    /// * `alarm_type` - The type of alarm to retrieve
+    fn get_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<Option<SystemTime>, ScabbardStoreError>;
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -30,6 +30,7 @@ use std::time::SystemTime;
 pub(crate) use error::ScabbardStoreError;
 
 use action::{ConsensusAction, IdentifiedConsensusAction};
+use alarm::AlarmType;
 use commit::CommitEntry;
 use context::ConsensusContext;
 use event::{ConsensusEvent, IdentifiedConsensusEvent};
@@ -231,5 +232,20 @@ pub trait ScabbardStore {
     fn remove_service(
         &self,
         service_id: &FullyQualifiedServiceId,
+    ) -> Result<(), ScabbardStoreError>;
+
+    /// Set a scabbard alarm for a given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` that the alarm
+    ///   will be set for
+    /// * `alarm` - The time that the alarm will go off
+    /// * `alarm_type` - The type of alarm being set
+    fn set_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+        alarm: SystemTime,
     ) -> Result<(), ScabbardStoreError>;
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -248,4 +248,17 @@ pub trait ScabbardStore {
         alarm_type: &AlarmType,
         alarm: SystemTime,
     ) -> Result<(), ScabbardStoreError>;
+
+    /// Unset a scabbard alarm of a specified type for a given service
+    ///
+    /// # Arguments
+    ///
+    /// * `service_id` - The fully qualified service id for the `ScabbardService` that the alarm
+    ///   will be unset for
+    /// * `alarm_type` - The type of alarm being unset
+    fn unset_alarm(
+        &self,
+        service_id: &FullyQualifiedServiceId,
+        alarm_type: &AlarmType,
+    ) -> Result<(), ScabbardStoreError>;
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/two_phase_commit/context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/two_phase_commit/context.rs
@@ -14,6 +14,7 @@
 
 #[cfg(feature = "scabbardv3-consensus")]
 use std::convert::{TryFrom, TryInto as _};
+#[cfg(feature = "scabbardv3-consensus")]
 use std::time::SystemTime;
 
 #[cfg(feature = "scabbardv3-consensus")]
@@ -34,7 +35,6 @@ use crate::service::v3::ScabbardProcess;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Context {
-    alarm: Option<SystemTime>,
     coordinator: ServiceId,
     epoch: u64,
     last_commit_epoch: Option<u64>,
@@ -44,10 +44,6 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn alarm(&self) -> Option<SystemTime> {
-        self.alarm
-    }
-
     pub fn coordinator(&self) -> &ServiceId {
         &self.coordinator
     }
@@ -80,10 +76,6 @@ impl Context {
             .with_state(self.state)
             .with_participants(self.participants);
 
-        if let Some(alarm) = self.alarm {
-            builder = builder.with_alarm(alarm);
-        }
-
         if let Some(last_commit_epoch) = self.last_commit_epoch {
             builder = builder.with_last_commit_epoch(last_commit_epoch);
         }
@@ -94,7 +86,6 @@ impl Context {
 
 #[derive(Default, Clone)]
 pub struct ContextBuilder {
-    alarm: Option<SystemTime>,
     coordinator: Option<ServiceId>,
     epoch: Option<u64>,
     last_commit_epoch: Option<u64>,
@@ -104,11 +95,6 @@ pub struct ContextBuilder {
 }
 
 impl ContextBuilder {
-    pub fn with_alarm(mut self, alarm: SystemTime) -> ContextBuilder {
-        self.alarm = Some(alarm);
-        self
-    }
-
     pub fn with_coordinator(mut self, coordinator: &ServiceId) -> ContextBuilder {
         self.coordinator = Some(coordinator.clone());
         self
@@ -167,7 +153,6 @@ impl ContextBuilder {
         })?;
 
         Ok(Context {
-            alarm: self.alarm,
             coordinator,
             epoch,
             last_commit_epoch: self.last_commit_epoch,


### PR DESCRIPTION
Move the alarm out of context and into its own table in the scabbard store 