### PR TITLE
Switch primary docker publishing to ghcr.io

### DIFF
--- a/.github/workflows/publish-docker-branch.yaml
+++ b/.github/workflows/publish-docker-branch.yaml
@@ -82,6 +82,8 @@ jobs:
         env:
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
       - name: Notify Slack of Failure
         if: failure()
@@ -191,6 +193,8 @@ jobs:
         env:
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
       - name: Notify Slack of Failure
         if: failure()

--- a/.github/workflows/publish-docker-branch.yaml
+++ b/.github/workflows/publish-docker-branch.yaml
@@ -79,7 +79,6 @@ jobs:
       - name: Publish branch to dockerhub
         run: docker buildx ls && ./ci/publish-docker main
         env:
-          NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
 
@@ -188,7 +187,6 @@ jobs:
       - name: Publish branch to dockerhub
         run: docker buildx ls && ./ci/publish-docker experimental
         env:
-          NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
 

--- a/.github/workflows/publish-docker-branch.yaml
+++ b/.github/workflows/publish-docker-branch.yaml
@@ -66,11 +66,12 @@ jobs:
       - name: Display envvars
         run: env
 
-      - name: Login to DockerHub
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: splintercommunity
+          password: ${{ secrets.SPLINTERCOMMUNITY_GH_PAT }}
 
       - uses: actions/checkout@v2
         with:
@@ -174,11 +175,12 @@ jobs:
       - name: Display envvars
         run: env
 
-      - name: Login to DockerHub
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: splintercommunity
+          password: ${{ secrets.SPLINTERCOMMUNITY_GH_PAT }}
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -100,6 +100,8 @@ jobs:
         env:
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
       - name: Notify Slack of Failure
         if: failure()

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -82,11 +82,12 @@ jobs:
       - name: Display envvars
         run: env
 
-      - name: Login to DockerHub
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: splintercommunity
+          password: ${{ secrets.SPLINTERCOMMUNITY_GH_PAT }}
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -97,7 +97,6 @@ jobs:
           git fetch --tags --force
           ./ci/publish-docker
         env:
-          NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
           VERSION: AUTO_STRICT
           CARGO_TERM_COLOR: always
 

--- a/.github/workflows/splinter-dev.yaml
+++ b/.github/workflows/splinter-dev.yaml
@@ -66,8 +66,6 @@ jobs:
           fetch-depth: 0
 
       - name: Docker build
-        env:
-          NAMESPACE: ${{ secrets.DOCKER_HUB_NAMESPACE }}/
         run: ./ci/splinter-dev-buildx
 
       - name: Notify Slack of Failure

--- a/.github/workflows/splinter-dev.yaml
+++ b/.github/workflows/splinter-dev.yaml
@@ -55,11 +55,12 @@ jobs:
       - name: Buildx ls
         run: docker buildx ls
 
-      - name: Login to DockerHub
+      - name: Login to ghcr.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: splintercommunity
+          password: ${{ secrets.SPLINTERCOMMUNITY_GH_PAT }}
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/splinter-dev.yaml
+++ b/.github/workflows/splinter-dev.yaml
@@ -68,6 +68,9 @@ jobs:
 
       - name: Docker build
         run: ./ci/splinter-dev-buildx
+        env:
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
       - name: Notify Slack of Failure
         if: cancelled() || failure()

--- a/ci/docker-bake.hcl
+++ b/ci/docker-bake.hcl
@@ -39,14 +39,6 @@ variable "ISOLATION_ID" {
     default = "latest"
 }
 
-variable "NAMESPACE" {
-    default = ""
-}
-
-variable "REGISTRY" {
-    default = ""
-}
-
 variable "REPO_VERSION" {
     default = "0.7.1-dev"
 }
@@ -64,19 +56,19 @@ target "all" {
 target "scabbard-cli" {
     inherits = ["all"]
     dockerfile = "services/scabbard/cli/Dockerfile-installed-${DISTRO}"
-    tags = ["${REGISTRY}${NAMESPACE}scabbard-cli:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/scabbard-cli:${ISOLATION_ID}"]
 }
 
 target "splinter-cli" {
     inherits = ["all"]
     dockerfile = "cli/Dockerfile-installed-${DISTRO}"
-    tags = ["${REGISTRY}${NAMESPACE}splinter-cli:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/splinter-cli:${ISOLATION_ID}"]
 }
 
 target "splinterd" {
     inherits = ["all"]
     dockerfile = "splinterd/Dockerfile-installed-${DISTRO}"
-    tags = ["${REGISTRY}${NAMESPACE}splinterd:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/splinterd:${ISOLATION_ID}"]
 }
 
 # --== gameroom ==--
@@ -84,32 +76,32 @@ target "splinterd" {
 target "gameroomd" {
     inherits = ["all"]
     dockerfile = "examples/gameroom/daemon/Dockerfile-installed-${DISTRO}"
-    tags = ["${REGISTRY}${NAMESPACE}gameroomd:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/gameroomd:${ISOLATION_ID}"]
 }
 
 target "gameroom-app-acme" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "acme"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["${REGISTRY}${NAMESPACE}gameroom-app-acme:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/gameroom-app-acme:${ISOLATION_ID}"]
 }
 
 target "gameroom-app-bubba" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "bubba"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["${REGISTRY}${NAMESPACE}gameroom-app-bubba:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/gameroom-app-bubba:${ISOLATION_ID}"]
 }
 
 target "gameroom-app" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "generic"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["${REGISTRY}${NAMESPACE}gameroom-app:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/gameroom-app:${ISOLATION_ID}"]
 }
 
 target "gameroom-database" {
     inherits = ["all"]
     dockerfile = "examples/gameroom/database/Dockerfile-installed"
-    tags = ["${REGISTRY}${NAMESPACE}gameroom-database:${ISOLATION_ID}"]
+    tags = ["docker.io/splintercommunity/gameroom-database:${ISOLATION_ID}"]
 }

--- a/ci/docker-bake.hcl
+++ b/ci/docker-bake.hcl
@@ -56,19 +56,19 @@ target "all" {
 target "scabbard-cli" {
     inherits = ["all"]
     dockerfile = "services/scabbard/cli/Dockerfile-installed-${DISTRO}"
-    tags = ["docker.io/splintercommunity/scabbard-cli:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/scabbard-cli:${ISOLATION_ID}"]
 }
 
 target "splinter-cli" {
     inherits = ["all"]
     dockerfile = "cli/Dockerfile-installed-${DISTRO}"
-    tags = ["docker.io/splintercommunity/splinter-cli:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/splinter-cli:${ISOLATION_ID}"]
 }
 
 target "splinterd" {
     inherits = ["all"]
     dockerfile = "splinterd/Dockerfile-installed-${DISTRO}"
-    tags = ["docker.io/splintercommunity/splinterd:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/splinterd:${ISOLATION_ID}"]
 }
 
 # --== gameroom ==--
@@ -76,32 +76,32 @@ target "splinterd" {
 target "gameroomd" {
     inherits = ["all"]
     dockerfile = "examples/gameroom/daemon/Dockerfile-installed-${DISTRO}"
-    tags = ["docker.io/splintercommunity/gameroomd:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/gameroomd:${ISOLATION_ID}"]
 }
 
 target "gameroom-app-acme" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "acme"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["docker.io/splintercommunity/gameroom-app-acme:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/gameroom-app-acme:${ISOLATION_ID}"]
 }
 
 target "gameroom-app-bubba" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "bubba"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["docker.io/splintercommunity/gameroom-app-bubba:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/gameroom-app-bubba:${ISOLATION_ID}"]
 }
 
 target "gameroom-app" {
     inherits = ["all"]
     args = {VUE_APP_BRAND = "generic"}
     dockerfile = "examples/gameroom/gameroom-app/Dockerfile-installed"
-    tags = ["docker.io/splintercommunity/gameroom-app:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/gameroom-app:${ISOLATION_ID}"]
 }
 
 target "gameroom-database" {
     inherits = ["all"]
     dockerfile = "examples/gameroom/database/Dockerfile-installed"
-    tags = ["docker.io/splintercommunity/gameroom-database:${ISOLATION_ID}"]
+    tags = ["ghcr.io/splintercommunity/gameroom-database:${ISOLATION_ID}"]
 }

--- a/ci/publish-docker
+++ b/ci/publish-docker
@@ -39,6 +39,19 @@ build_docker() {
     done
 }
 
+mirror_docker() {
+    for SERVICE in $SERVICES
+    do
+        docker run quay.io/skopeo/stable \
+          copy \
+          --dest-username "${DOCKER_HUB_USERNAME}" \
+          --dest-password "${DOCKER_HUB_ACCESS_TOKEN}" \
+          --multi-arch all \
+          "docker://ghcr.io/splintercommunity/$SERVICE:$ISOLATION_ID" \
+          "docker://docker.io/splintercommunity/$SERVICE:$ISOLATION_ID"
+    done
+}
+
 if [[ $GITHUB_REF = *tags* ]];
 then
     # Runs on tagged builds
@@ -70,3 +83,5 @@ echo "Publishing main images for an untagged build"
 echo "ISOLATION_ID is: $ISOLATION_ID"
 
 build_docker
+
+mirror_docker

--- a/ci/publish-docker
+++ b/ci/publish-docker
@@ -20,8 +20,6 @@ top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 export VERSION=AUTO_STRICT
 export REPO_VERSION=$($top_dir/bin/get_version)
 
-export NAMESPACE=${NAMESPACE}
-
 SERVICES="
     scabbard-cli
     splinter-cli

--- a/ci/splinter-dev-buildx
+++ b/ci/splinter-dev-buildx
@@ -20,3 +20,10 @@ docker buildx build \
   -t ghcr.io/splintercommunity/splinter-dev:v11 \
   -f ci/splinter-dev.dockerfile \
   --push .
+
+docker run quay.io/skopeo/stable \
+  copy \
+  --dest-creds "${DOCKER_HUB_USERNAME}:${DOCKER_HUB_ACCESS_TOKEN}" \
+  --multi-arch all \
+  "docker://ghcr.io/splintercommunity/splinter-dev:v11" \
+  "docker://docker.io/splintercommunity/splinter-dev:v11"

--- a/ci/splinter-dev-buildx
+++ b/ci/splinter-dev-buildx
@@ -17,6 +17,6 @@ set -e
 
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t ${NAMESPACE}splinter-dev:v11 \
+  -t docker.io/splintercommunity/splinter-dev:v11 \
   -f ci/splinter-dev.dockerfile \
   --push .

--- a/ci/splinter-dev-buildx
+++ b/ci/splinter-dev-buildx
@@ -17,6 +17,6 @@ set -e
 
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  -t docker.io/splintercommunity/splinter-dev:v11 \
+  -t ghcr.io/splintercommunity/splinter-dev:v11 \
   -f ci/splinter-dev.dockerfile \
   --push .

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -23,7 +23,7 @@ services:
       args:
       - CARGO_ARGS=${CARGO_ARGS}
       - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}scabbard-cli:${ISOLATION_ID}
+    image: scabbard-cli:${ISOLATION_ID}
     container_name: scabbard-cli
 
   splinter-cli:
@@ -33,7 +33,7 @@ services:
       args:
       - CARGO_ARGS=${CARGO_ARGS}
       - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}splinter-cli:${ISOLATION_ID}
+    image: splinter-cli:${ISOLATION_ID}
     container_name: splinter-cli
 
   splinterd:
@@ -43,7 +43,7 @@ services:
       args:
       - CARGO_ARGS=${CARGO_ARGS}
       - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}splinterd:${ISOLATION_ID}
+    image: splinterd:${ISOLATION_ID}
     container_name: splinterd
 
 # ---==== gameroom components ====---
@@ -55,7 +55,7 @@ services:
       args:
       - CARGO_ARGS=${CARGO_ARGS}
       - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}gameroomd:${ISOLATION_ID}
+    image: gameroomd:${ISOLATION_ID}
     container_name: gameroomd
 
   gameroom-app-acme:
@@ -65,7 +65,7 @@ services:
       args:
         - VUE_APP_BRAND=acme
         - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}gameroom-app-acme:${ISOLATION_ID}
+    image: gameroom-app-acme:${ISOLATION_ID}
     container_name: gameroom-app-acme
 
   gameroom-app-bubba:
@@ -75,7 +75,7 @@ services:
       args:
         - VUE_APP_BRAND=bubba
         - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}gameroom-app-bubba:${ISOLATION_ID}
+    image: gameroom-app-bubba:${ISOLATION_ID}
     container_name: gameroom-app-bubba
 
   gameroom-app:
@@ -85,7 +85,7 @@ services:
       args:
         - VUE_APP_BRAND=generic
         - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}gameroom-app:${ISOLATION_ID}
+    image: gameroom-app:${ISOLATION_ID}
     container_name: gameroom-app
 
   gameroom-database:
@@ -94,5 +94,5 @@ services:
       dockerfile: examples/gameroom/database/Dockerfile-installed
       args:
       - REPO_VERSION=${REPO_VERSION}
-    image: ${REGISTRY}${NAMESPACE}gameroom-database:${ISOLATION_ID}
+    image: gameroom-database:${ISOLATION_ID}
     container_name: gameroom-database


### PR DESCRIPTION
This PR switches primary publishing from docker.io(Docker Hub) to ghcr.io (GitHub Container Registry), but adds a step to all Docker publishing jobs to mirror the images to docker.io. This will allow us to build and publish images without running into the Docker Hub rate limit while still making them available on the platform most users are familiar with.