### PR TITLE
Scabbard store updates

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -18,7 +18,7 @@ CREATE TYPE message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST', 'VOTEREQUES
 CREATE TYPE notification_type AS ENUM ('REQUESTFORSTART', 'COORDINATORREQUESTFORVOTE', 'PARTICIPANTREQUESTFORVOTE', 'COMMIT', 'ABORT', 'MESSAGEDROPPED');
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context (
-    service_id                TEXT NOT NULL,
+    service_id                TEXT PRIMARY KEY,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
@@ -28,8 +28,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     vote                      TEXT
     CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
     decision_timeout_start    BIGINT
-    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
-    PRIMARY KEY (service_id, epoch)
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') )
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
@@ -38,8 +37,8 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    PRIMARY KEY (service_id, process),
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -49,7 +48,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
@@ -67,7 +66,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
     action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
@@ -81,7 +80,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
@@ -94,7 +93,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
     request_for_vote_value    BYTEA
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action_participant (

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     vote_request              BYTEA
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BYTEA,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
@@ -56,5 +56,5 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-03-29-160500-create-scabbard-store-tables/up.sql
@@ -14,7 +14,7 @@
 -- -----------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context (
-    service_id                TEXT NOT NULL,
+    service_id                TEXT PRIMARY KEY,
     coordinator               TEXT NOT NULL,
     epoch                     BIGINT NOT NULL,
     last_commit_epoch         BIGINT,
@@ -25,8 +25,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_context (
     vote                      TEXT
     CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
     decision_timeout_start    BIGINT
-    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
-    PRIMARY KEY (service_id, epoch)
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') )
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
@@ -35,8 +34,8 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_context_participant (
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    PRIMARY KEY (service_id, epoch, process),
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    PRIMARY KEY (service_id, process),
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_action (
@@ -46,7 +45,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_action (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
@@ -65,7 +64,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action (
     CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
     action_alarm  BIGINT,
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
@@ -80,7 +79,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_send_message_action (
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
@@ -94,7 +93,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_notification_action (
     request_for_vote_value    BINARY
     CHECK ( (request_for_vote_value IS NOT NULL) OR (notification_type != 'PARTICIPANTREQUESTFORVOTE') ),
     FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_update_context_action_participant (

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
     vote_request              BINARY
     CHECK ( (vote_request IS NOT NULL) OR (message_type != 'VOTEREQUEST') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     epoch                     BIGINT NOT NULL,
     value                     BINARY,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
@@ -55,5 +55,5 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
-    FOREIGN KEY (service_id, epoch) REFERENCES consensus_2pc_context(service_id, epoch) ON DELETE CASCADE
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
 );

--- a/services/scabbard/libscabbard/src/service/v3/arguments.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments.rs
@@ -17,7 +17,7 @@ use std::convert::TryFrom;
 use splinter::error::InvalidArgumentError;
 use splinter::service::ServiceId;
 
-use crate::store::service::ConsensusType;
+use crate::store::ConsensusType;
 
 pub struct ScabbardArguments {
     peers: Vec<ServiceId>,

--- a/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/arguments_converter.rs
@@ -19,7 +19,7 @@ use splinter::{
     service::{ArgumentsConverter, ServiceId},
 };
 
-use crate::store::service::ConsensusType;
+use crate::store::ConsensusType;
 
 use super::{ScabbardArguments, ScabbardArgumentsBuilder};
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/context.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/context.rs
@@ -21,8 +21,8 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
-use crate::store::alarm::AlarmType;
-use crate::store::context::ConsensusContext;
+use crate::store::AlarmType;
+use crate::store::ConsensusContext;
 use crate::store::ScabbardStoreFactory;
 
 pub struct UpdateContextCommand<C> {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/notifications.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/notifications.rs
@@ -20,8 +20,8 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
-use crate::store::commit::CommitEntry;
-use crate::store::event::ConsensusEvent;
+use crate::store::CommitEntry;
+use crate::store::ConsensusEvent;
 use crate::store::ScabbardStoreFactory;
 
 pub struct AddEventCommand<C> {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/mod.rs
@@ -25,7 +25,7 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
-use crate::store::context::ConsensusContext;
+use crate::store::ConsensusContext;
 
 pub use store::ScabbardStoreContextUpdater;
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/store.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/context_updater/store.rs
@@ -23,7 +23,7 @@ use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
 use crate::service::v3::consensus::consensus_action_runner::UpdateContextCommand;
-use crate::store::context::ConsensusContext;
+use crate::store::ConsensusContext;
 use crate::store::ScabbardStoreFactory;
 
 use super::ContextUpdater;

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
@@ -27,8 +27,8 @@ use splinter::service::FullyQualifiedServiceId;
 use splinter::service::MessageSenderFactory;
 use splinter::store::command::StoreCommand;
 
-use crate::store::action::IdentifiedConsensusAction;
-use crate::store::two_phase_commit::Action;
+use crate::store::Action;
+use crate::store::IdentifiedConsensusAction;
 use crate::store::ScabbardStoreFactory;
 
 pub use self::commands::actions::ExecuteActionCommand;
@@ -179,15 +179,9 @@ mod tests {
     use crate::migrations::run_sqlite_migrations;
     use crate::store::pool::ConnectionPool;
     use crate::store::{
-        action::ConsensusAction,
-        alarm::AlarmType,
-        context::ConsensusContext,
-        service::{ConsensusType, ScabbardService, ScabbardServiceBuilder, ServiceStatus},
-        two_phase_commit::Message,
-        two_phase_commit::Notification,
-        two_phase_commit::State,
-        two_phase_commit::{Context, ContextBuilder, Participant},
-        DieselScabbardStore, ScabbardStore, SqliteScabbardStoreFactory,
+        AlarmType, ConsensusAction, ConsensusContext, ConsensusType, Context, ContextBuilder,
+        DieselScabbardStore, Message, Notification, Participant, ScabbardService,
+        ScabbardServiceBuilder, ScabbardStore, ServiceStatus, SqliteScabbardStoreFactory, State,
     };
 
     struct TestMessageSender {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
@@ -24,12 +24,8 @@ use splinter::store::command::StoreCommand;
 use crate::service::v3::consensus::consensus_action_runner::commands::notifications::{
     AddCommitEntryCommand, AddEventCommand, UpdateCommitEntryCommand,
 };
-use crate::store::two_phase_commit::Notification;
-use crate::store::{
-    commit::{CommitEntryBuilder, ConsensusDecision},
-    event::ConsensusEvent,
-    two_phase_commit::Event,
-};
+use crate::store::Notification;
+use crate::store::{CommitEntryBuilder, ConsensusDecision, ConsensusEvent, Event};
 use crate::store::{ScabbardStore, ScabbardStoreFactory};
 
 use super::NotifyObserver;

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/mod.rs
@@ -23,7 +23,7 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
-use crate::store::two_phase_commit::Notification;
+use crate::store::Notification;
 
 pub use command::CommandNotifyObserver;
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
@@ -15,7 +15,7 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::IdentifiedConsensusAction;
+use crate::store::{ConsensusAction, Identified};
 
 pub trait UnprocessedActionSource {
     /// Returns actions for a given service that require processing.
@@ -23,5 +23,5 @@ pub trait UnprocessedActionSource {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, InternalError>;
+    ) -> Result<Vec<Identified<ConsensusAction>>, InternalError>;
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
@@ -15,7 +15,7 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::action::IdentifiedConsensusAction;
+use crate::store::IdentifiedConsensusAction;
 
 pub trait UnprocessedActionSource {
     /// Returns actions for a given service that require processing.

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/builder.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/builder.rs
@@ -23,8 +23,8 @@ use splinter::store::command::StoreCommandExecutor;
 use crate::service::v3::consensus::consensus_action_runner::{
     NotifyObserver, ScabbardStoreContextUpdater,
 };
-use crate::store::action::ConsensusAction;
-use crate::store::event::ConsensusEvent;
+use crate::store::ConsensusAction;
+use crate::store::ConsensusEvent;
 use crate::store::ScabbardStoreFactory;
 
 use super::{

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
@@ -20,7 +20,7 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommand;
 
-use crate::store::action::ConsensusAction;
+use crate::store::ConsensusAction;
 use crate::store::ScabbardStoreFactory;
 
 pub struct ConsensusStoreCommandFactory<C> {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/context_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/context_source.rs
@@ -15,7 +15,7 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::context::ConsensusContext;
+use crate::store::ConsensusContext;
 
 pub trait ContextSource {
     fn get_context(

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
@@ -15,7 +15,8 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::IdentifiedConsensusEvent;
+use crate::store::ConsensusEvent;
+use crate::store::Identified;
 
 pub trait UnprocessedEventSource {
     /// Returns the next event for a given service that requires processing,
@@ -24,5 +25,5 @@ pub trait UnprocessedEventSource {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Option<IdentifiedConsensusEvent>, InternalError>;
+    ) -> Result<Option<Identified<ConsensusEvent>>, InternalError>;
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
@@ -15,7 +15,7 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::event::IdentifiedConsensusEvent;
+use crate::store::IdentifiedConsensusEvent;
 
 pub trait UnprocessedEventSource {
     /// Returns the next event for a given service that requires processing,

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -26,9 +26,9 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 use splinter::store::command::StoreCommandExecutor;
 
-use crate::store::action::ConsensusAction;
-use crate::store::context::ConsensusContext;
-use crate::store::event::ConsensusEvent;
+use crate::store::ConsensusAction;
+use crate::store::ConsensusContext;
+use crate::store::ConsensusEvent;
 
 use super::{ConsensusActionRunner, ScabbardProcess};
 
@@ -151,13 +151,9 @@ mod tests {
     use crate::service::v3::CommandNotifyObserver;
     use crate::store::pool::ConnectionPool;
     use crate::store::{
-        alarm::AlarmType,
-        context::ConsensusContext,
-        service::{ConsensusType, ScabbardServiceBuilder, ServiceStatus},
-        two_phase_commit::Event,
-        two_phase_commit::State,
-        two_phase_commit::{ContextBuilder, Participant},
-        DieselScabbardStore, ScabbardStore, SqliteScabbardStoreFactory,
+        AlarmType, ConsensusContext, ConsensusType, ContextBuilder, DieselScabbardStore, Event,
+        Participant, ScabbardServiceBuilder, ScabbardStore, ServiceStatus,
+        SqliteScabbardStoreFactory, State,
     };
 
     use self::store_sources::{

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
@@ -19,10 +19,9 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::{
-    action::IdentifiedConsensusAction, context::ConsensusContext, event::IdentifiedConsensusEvent,
+    IdentifiedConsensusAction, ConsensusContext, IdentifiedConsensusEvent,
     ScabbardStore,
 };
-
 use super::{ContextSource, UnprocessedActionSource, UnprocessedEventSource};
 
 pub struct StoreUnprocessedEventSource {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
@@ -19,9 +19,10 @@ use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::{
-    IdentifiedConsensusAction, ConsensusContext, IdentifiedConsensusEvent,
+    ConsensusAction, Identified, ConsensusContext, IdentifiedConsensusEvent,
     ScabbardStore,
 };
+
 use super::{ContextSource, UnprocessedActionSource, UnprocessedEventSource};
 
 pub struct StoreUnprocessedEventSource {
@@ -67,7 +68,7 @@ impl UnprocessedActionSource for StoreUnprocessedActionSource {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, InternalError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, InternalError> {
         self.store
             .list_consensus_actions(service_id, epoch)
             .map_err(|err| InternalError::from_source(Box::new(err)))

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
@@ -18,10 +18,7 @@
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::{
-    ConsensusAction, Identified, ConsensusContext, IdentifiedConsensusEvent,
-    ScabbardStore,
-};
+use crate::store::{ConsensusAction, ConsensusContext, ConsensusEvent, Identified, ScabbardStore};
 
 use super::{ContextSource, UnprocessedActionSource, UnprocessedEventSource};
 
@@ -42,7 +39,7 @@ impl UnprocessedEventSource for StoreUnprocessedEventSource {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Option<IdentifiedConsensusEvent>, InternalError> {
+    ) -> Result<Option<Identified<ConsensusEvent>>, InternalError> {
         Ok(self
             .store
             .list_consensus_events(service_id, epoch)

--- a/services/scabbard/libscabbard/src/service/v3/lifecycle.rs
+++ b/services/scabbard/libscabbard/src/service/v3/lifecycle.rs
@@ -21,9 +21,8 @@ use splinter::{
 };
 
 use crate::store::{
-    service::{ScabbardServiceBuilder, ServiceStatus},
     ScabbardFinalizeServiceCommand, ScabbardPrepareServiceCommand, ScabbardPurgeServiceCommand,
-    ScabbardRetireServiceCommand, ScabbardStoreFactory,
+    ScabbardRetireServiceCommand, ScabbardServiceBuilder, ScabbardStoreFactory, ServiceStatus,
 };
 
 use super::ScabbardArguments;

--- a/services/scabbard/libscabbard/src/service/v3/message_handler.rs
+++ b/services/scabbard/libscabbard/src/service/v3/message_handler.rs
@@ -25,12 +25,7 @@ use crate::protocol::v3::{
     },
 };
 use crate::protos::FromBytes as _;
-use crate::store::{
-    event::ConsensusEvent,
-    service::ConsensusType,
-    two_phase_commit::{Event, Message},
-    ScabbardStore,
-};
+use crate::store::{ConsensusEvent, ConsensusType, Event, Message, ScabbardStore};
 
 pub struct ScabbardMessageHandler {
     store: Box<dyn ScabbardStore>,

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -60,18 +60,15 @@ mod tests {
     use splinter::service::ServiceId;
 
     use crate::migrations::run_sqlite_migrations;
-    use crate::store::service::ServiceStatus;
-    use crate::store::service::{ConsensusType, ScabbardServiceBuilder};
     use crate::store::DieselScabbardStore;
     use crate::store::PooledSqliteScabbardStoreFactory;
     use crate::store::ScabbardStore;
+    use crate::store::ServiceStatus;
     use crate::store::{
-        action::ConsensusAction,
-        alarm::AlarmType,
-        context::ConsensusContext,
-        event::ConsensusEvent,
-        two_phase_commit::{Action, ContextBuilder, Event, Notification, Participant, State},
+        Action, AlarmType, ConsensusAction, ConsensusContext, ConsensusEvent, ContextBuilder,
+        Event, Notification, Participant, State,
     };
+    use crate::store::{ConsensusType, ScabbardServiceBuilder};
 
     /// Test that the `ScabbardTimerFilter`'s `filter` function works
     ///

--- a/services/scabbard/libscabbard/src/store/command/finalize_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/finalize_service.rs
@@ -19,7 +19,7 @@ use splinter::{
     error::InternalError, service::FullyQualifiedServiceId, store::command::StoreCommand,
 };
 
-use crate::store::{alarm::AlarmType, service::ServiceStatus, ScabbardStoreFactory};
+use crate::store::{AlarmType, ScabbardStoreFactory, ServiceStatus};
 
 pub struct ScabbardFinalizeServiceCommand<C> {
     store_factory: Arc<dyn ScabbardStoreFactory<C>>,

--- a/services/scabbard/libscabbard/src/store/command/prepare_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/prepare_service.rs
@@ -17,10 +17,8 @@ use std::sync::Arc;
 use splinter::{error::InternalError, service::ServiceId, store::command::StoreCommand};
 
 use crate::store::{
-    context::ConsensusContext,
-    service::ScabbardService,
-    two_phase_commit::{Context, ContextBuilder, Participant, State},
-    ScabbardStoreFactory,
+    ConsensusContext, Context, ContextBuilder, Participant, ScabbardService, ScabbardStoreFactory,
+    State,
 };
 
 pub struct ScabbardPrepareServiceCommand<C> {

--- a/services/scabbard/libscabbard/src/store/command/retire_service.rs
+++ b/services/scabbard/libscabbard/src/store/command/retire_service.rs
@@ -18,7 +18,7 @@ use splinter::{
     error::InternalError, service::FullyQualifiedServiceId, store::command::StoreCommand,
 };
 
-use crate::store::{service::ServiceStatus, ScabbardStoreFactory};
+use crate::store::{ScabbardStoreFactory, ServiceStatus};
 
 pub struct ScabbardRetireServiceCommand<C> {
     store_factory: Arc<dyn ScabbardStoreFactory<C>>,

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -41,7 +41,7 @@ pub use scabbard_store::PooledScabbardStoreFactory;
 pub use scabbard_store::{
     Action, AlarmType, CommitEntry, CommitEntryBuilder, ConsensusAction, ConsensusContext,
     ConsensusDecision, ConsensusEvent, ConsensusType, Context, ContextBuilder, Event,
-    IdentifiedConsensusAction, IdentifiedConsensusEvent, Message, Notification, Participant,
+    Identified, IdentifiedConsensusEvent, Message, Notification, Participant,
     ScabbardService, ScabbardServiceBuilder, ScabbardStore, ScabbardStoreFactory, ServiceStatus,
     State,
 };

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -40,10 +40,9 @@ pub use scabbard_store::PooledScabbardStoreFactory;
 #[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::{
     Action, AlarmType, CommitEntry, CommitEntryBuilder, ConsensusAction, ConsensusContext,
-    ConsensusDecision, ConsensusEvent, ConsensusType, Context, ContextBuilder, Event,
-    Identified, IdentifiedConsensusEvent, Message, Notification, Participant,
-    ScabbardService, ScabbardServiceBuilder, ScabbardStore, ScabbardStoreFactory, ServiceStatus,
-    State,
+    ConsensusDecision, ConsensusEvent, ConsensusType, Context, ContextBuilder, Event, Identified,
+    Message, Notification, Participant, ScabbardService, ScabbardServiceBuilder, ScabbardStore,
+    ScabbardStoreFactory, ServiceStatus, State,
 };
 #[cfg(all(feature = "scabbardv3-store", feature = "postgres"))]
 pub use scabbard_store::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -34,13 +34,16 @@ pub use commit_hash::transact;
 pub use commit_hash::{CommitHashStore, CommitHashStoreError};
 
 #[cfg(all(feature = "scabbardv3-store", feature = "diesel"))]
-pub use scabbard_store::diesel::DieselScabbardStore;
+pub use scabbard_store::DieselScabbardStore;
 #[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::PooledScabbardStoreFactory;
 #[cfg(feature = "scabbardv3-store")]
 pub use scabbard_store::{
-    action, alarm, commit, context, event, service, two_phase_commit, ScabbardStore,
-    ScabbardStoreFactory,
+    Action, AlarmType, CommitEntry, CommitEntryBuilder, ConsensusAction, ConsensusContext,
+    ConsensusDecision, ConsensusEvent, ConsensusType, Context, ContextBuilder, Event,
+    IdentifiedConsensusAction, IdentifiedConsensusEvent, Message, Notification, Participant,
+    ScabbardService, ScabbardServiceBuilder, ScabbardStore, ScabbardStoreFactory, ServiceStatus,
+    State,
 };
 #[cfg(all(feature = "scabbardv3-store", feature = "postgres"))]
 pub use scabbard_store::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
@@ -22,7 +22,7 @@ use augrim::{error::InternalError, two_phase_commit::TwoPhaseCommitAction};
 
 #[cfg(feature = "scabbardv3-consensus")]
 use crate::service::v3::{ScabbardProcess, ScabbardValue};
-use crate::store::scabbard_store::two_phase_commit::Action;
+use crate::store::scabbard_store::Action;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConsensusAction {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/action.rs
@@ -29,20 +29,6 @@ pub enum ConsensusAction {
     TwoPhaseCommit(Action),
 }
 
-// A scabbard consensus action that includes the action ID associated with the action
-#[derive(Debug, PartialEq, Clone)]
-pub enum IdentifiedConsensusAction {
-    TwoPhaseCommit(i64, Action),
-}
-
-impl IdentifiedConsensusAction {
-    pub fn deconstruct(self) -> (i64, ConsensusAction) {
-        match self {
-            Self::TwoPhaseCommit(id, action) => (id, ConsensusAction::TwoPhaseCommit(action)),
-        }
-    }
-}
-
 #[cfg(feature = "scabbardv3-consensus")]
 impl TryFrom<TwoPhaseCommitAction<ScabbardProcess, ScabbardValue, SystemTime>> for ConsensusAction {
     type Error = InternalError;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -18,12 +18,8 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
-    action::IdentifiedConsensusAction,
-    alarm::AlarmType,
-    commit::CommitEntry,
-    event::{ConsensusEvent, IdentifiedConsensusEvent},
-    service::ScabbardService,
-    ConsensusAction, ConsensusContext,
+    AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent, IdentifiedConsensusEvent,
+    IdentifiedConsensusAction, ScabbardService,
 };
 
 use super::ScabbardStore;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -19,7 +19,7 @@ use splinter::service::FullyQualifiedServiceId;
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
     AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent, IdentifiedConsensusEvent,
-    IdentifiedConsensusAction, ScabbardService,
+    Identified, ScabbardService,
 };
 
 use super::ScabbardStore;
@@ -103,7 +103,7 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         (&**self).list_consensus_actions(service_id, epoch)
     }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -18,8 +18,8 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
-    AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent, IdentifiedConsensusEvent,
-    Identified, ScabbardService,
+    AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent, Identified,
+    ScabbardService,
 };
 
 use super::ScabbardStore;
@@ -220,7 +220,7 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusEvent>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
         (&**self).list_consensus_events(service_id, epoch)
     }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1880,7 +1880,7 @@ pub mod tests {
         let context3 = ConsensusContext::TwoPhaseCommit(coordinator_context);
 
         store
-            .add_consensus_context(&coordinator_fqsi, context3.clone())
+            .update_consensus_context(&coordinator_fqsi, context3.clone())
             .expect("failed to add context");
 
         let current_context = store
@@ -1903,7 +1903,7 @@ pub mod tests {
         let context4 = ConsensusContext::TwoPhaseCommit(participant_context);
 
         store
-            .add_consensus_context(&coordinator_fqsi.clone(), context4.clone())
+            .update_consensus_context(&coordinator_fqsi.clone(), context4.clone())
             .expect("failed to add context");
 
         let current_context = store

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -32,12 +32,8 @@ use diesel::{
 use crate::store::pool::ConnectionPool;
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
-    action::IdentifiedConsensusAction,
-    alarm::AlarmType,
-    commit::CommitEntry,
-    event::{ConsensusEvent, IdentifiedConsensusEvent},
-    service::ScabbardService,
-    ConsensusAction, ConsensusContext,
+    AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent,
+    IdentifiedConsensusAction, IdentifiedConsensusEvent, ScabbardService,
 };
 
 use super::ScabbardStore;
@@ -825,11 +821,11 @@ pub mod tests {
     use crate::migrations::run_sqlite_migrations;
 
     use crate::store::scabbard_store::{
-        commit::{CommitEntryBuilder, ConsensusDecision},
         service::{ConsensusType, ScabbardServiceBuilder, ServiceStatus},
         two_phase_commit::{
             Action, ContextBuilder, Event, Message, Notification, Participant, State,
         },
+        CommitEntryBuilder, ConsensusDecision,
     };
 
     use diesel::{

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1038,8 +1038,6 @@ pub mod tests {
     /// 1. Add a valid context to the store
     /// 2. Create a valid updated context
     /// 3. Attempt to update the original context, check that the operation is successful
-    /// 4. Create an invalid updated context
-    /// 5. Attempt to update the original context, check that the operation returns an error
     #[test]
     fn scabbard_store_update_context() {
         let pool = create_connection_pool_and_migrate();
@@ -1097,25 +1095,6 @@ pub mod tests {
                 ConsensusContext::TwoPhaseCommit(update_context)
             )
             .is_ok());
-
-        let bad_update_context = ContextBuilder::default()
-            .with_coordinator(coordinator_fqsi.clone().service_id())
-            .with_epoch(0)
-            .with_participants(vec![Participant {
-                process: participant_service_id.clone(),
-                vote: None,
-            }])
-            .with_state(State::Voting { vote_timeout_start })
-            .with_this_process(coordinator_fqsi.clone().service_id())
-            .build()
-            .expect("failed to build update context");
-
-        assert!(store
-            .update_consensus_context(
-                &coordinator_fqsi,
-                ConsensusContext::TwoPhaseCommit(bad_update_context)
-            )
-            .is_err());
     }
 
     /// Test that the scabbard store `update_consensus_action` operation is successful.

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -33,7 +33,7 @@ use crate::store::pool::ConnectionPool;
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
     AlarmType, CommitEntry, ConsensusAction, ConsensusContext, ConsensusEvent,
-    IdentifiedConsensusAction, IdentifiedConsensusEvent, ScabbardService,
+    Identified, IdentifiedConsensusEvent, ScabbardService,
 };
 
 use super::ScabbardStore;
@@ -137,7 +137,7 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.pool.execute_read(|conn| {
             ScabbardStoreOperations::new(conn).list_consensus_actions(service_id, epoch)
         })
@@ -332,7 +332,7 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).list_consensus_actions(service_id, epoch)
         })
@@ -538,7 +538,7 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id, epoch)
     }
     /// List ready services
@@ -699,7 +699,7 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError> {
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id, epoch)
     }
     /// List ready services
@@ -1014,20 +1014,22 @@ pub mod tests {
 
         assert_eq!(
             action_list[0],
-            IdentifiedConsensusAction::TwoPhaseCommit(
-                action_id1,
-                Action::Notify(Notification::RequestForStart())
-            )
+            Identified {
+                id: action_id1,
+                record: ConsensusAction::TwoPhaseCommit(Action::Notify(
+                    Notification::RequestForStart()
+                )),
+            },
         );
         assert_eq!(
             action_list[1],
-            IdentifiedConsensusAction::TwoPhaseCommit(
-                action_id2,
-                Action::Update(
+            Identified {
+                id: action_id2,
+                record: ConsensusAction::TwoPhaseCommit(Action::Update(
                     ConsensusContext::TwoPhaseCommit(expected_update_context),
                     None,
-                )
-            )
+                )),
+            },
         );
     }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -214,7 +214,7 @@ pub struct ScabbardAlarmModel {
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_context"]
-#[primary_key(service_id, epoch)]
+#[primary_key(service_id)]
 pub struct Consensus2pcContextModel {
     pub service_id: String,
     pub coordinator: String,
@@ -407,7 +407,7 @@ impl TryFrom<(&Context, &FullyQualifiedServiceId)> for Consensus2pcContextModel 
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]
 #[table_name = "consensus_2pc_context_participant"]
-#[primary_key(service_id, epoch, process)]
+#[primary_key(service_id, process)]
 pub struct Consensus2pcContextParticipantModel {
     pub service_id: String,
     pub epoch: i64,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -21,9 +21,9 @@ use splinter::service::{FullyQualifiedServiceId, ServiceId};
 use crate::store::scabbard_store::{
     alarm::AlarmType,
     commit::{CommitEntry, CommitEntryBuilder, ConsensusDecision},
-    context::ConsensusContext,
     service::{ConsensusType, ScabbardService, ServiceStatus},
     two_phase_commit::{Context, ContextBuilder, Event, Message, Notification, Participant, State},
+    ConsensusContext,
 };
 
 use super::schema::{

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -34,8 +34,8 @@ use crate::store::scabbard_store::diesel::{
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 use crate::store::scabbard_store::{
-    event::ConsensusEvent,
     two_phase_commit::{Event, Message},
+    ConsensusEvent,
 };
 
 use super::ScabbardStoreOperations;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
@@ -22,12 +22,12 @@ use diesel::sqlite::SqliteConnection;
 use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::alarm::AlarmType;
 use crate::store::scabbard_store::diesel::{
     models::ScabbardServiceModel,
     schema::{scabbard_alarm, scabbard_service},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
+use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -45,7 +45,6 @@ where
         self.conn.transaction::<_, _, _>(|| {
             let context = consensus_2pc_context::table
                 .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_context::epoch.desc())
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()?;
 
@@ -54,8 +53,7 @@ where
                     consensus_2pc_context_participant::table
                         .filter(
                             consensus_2pc_context_participant::service_id
-                                .eq(format!("{}", service_id))
-                                .and(consensus_2pc_context_participant::epoch.eq(context.epoch)),
+                                .eq(format!("{}", service_id)),
                         )
                         .load::<Consensus2pcContextParticipantModel>(self.conn)?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -21,7 +21,7 @@ use crate::store::scabbard_store::diesel::{
     models::{Consensus2pcContextModel, Consensus2pcContextParticipantModel},
     schema::{consensus_2pc_context, consensus_2pc_context_participant},
 };
-use crate::store::scabbard_store::{context::ConsensusContext, ScabbardStoreError};
+use crate::store::scabbard_store::{ConsensusContext, ScabbardStoreError};
 
 use super::ScabbardStoreOperations;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_ready_services.rs
@@ -19,11 +19,11 @@ use diesel::prelude::*;
 use splinter::error::InternalError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::alarm::AlarmType;
 use crate::store::scabbard_store::diesel::schema::{
     consensus_2pc_action, consensus_2pc_event, scabbard_alarm, scabbard_service,
 };
 use crate::store::scabbard_store::ScabbardStoreError;
+use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
@@ -23,12 +23,12 @@ use diesel::{delete, dsl::insert_into, prelude::*};
 use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::alarm::AlarmType;
 use crate::store::scabbard_store::diesel::{
     models::{ScabbardAlarmModel, ScabbardServiceModel},
     schema::{scabbard_alarm, scabbard_service},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
+use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
@@ -20,12 +20,12 @@ use diesel::{delete, prelude::*};
 use splinter::error::InvalidStateError;
 use splinter::service::FullyQualifiedServiceId;
 
-use crate::store::alarm::AlarmType;
 use crate::store::scabbard_store::diesel::{
     models::{ScabbardAlarmModel, ScabbardServiceModel},
     schema::{scabbard_alarm, scabbard_service},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
+use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -45,7 +45,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_context (service_id, epoch) {
+    consensus_2pc_context (service_id) {
         service_id -> Text,
         coordinator -> Text,
         epoch -> BigInt,
@@ -58,7 +58,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_context_participant (service_id, epoch, process) {
+    consensus_2pc_context_participant (service_id, process) {
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/event.rs
@@ -35,20 +35,6 @@ impl ConsensusEvent {
     }
 }
 
-// A scabbard consensus event that includes the event ID associated with the event
-#[derive(Debug, PartialEq, Clone)]
-pub enum IdentifiedConsensusEvent {
-    TwoPhaseCommit(i64, Event),
-}
-
-impl IdentifiedConsensusEvent {
-    pub fn deconstruct(self) -> (i64, ConsensusEvent) {
-        match self {
-            Self::TwoPhaseCommit(id, event) => (id, ConsensusEvent::TwoPhaseCommit(event)),
-        }
-    }
-}
-
 #[cfg(feature = "scabbardv3-consensus")]
 impl TryFrom<ConsensusEvent> for TwoPhaseCommitEvent<ScabbardProcess, ScabbardValue> {
     type Error = InternalError;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/identified.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/identified.rs
@@ -1,0 +1,26 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A struct used to pair a type to an ID
+#[derive(Debug, PartialEq, Clone)]
+pub struct Identified<T: Clone> {
+    pub id: i64,
+    pub record: T,
+}
+
+impl<T: Clone> Identified<T> {
+    pub fn deconstruct(self) -> (i64, T) {
+        (self.id, self.record)
+    }
+}

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -33,11 +33,12 @@ pub(crate) use error::ScabbardStoreError;
 
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 pub use self::diesel::DieselScabbardStore;
-pub use action::{ConsensusAction, IdentifiedConsensusAction};
+pub use action::ConsensusAction;
 pub use alarm::AlarmType;
 pub use commit::{CommitEntry, CommitEntryBuilder, ConsensusDecision};
 pub use context::ConsensusContext;
 pub use event::{ConsensusEvent, IdentifiedConsensusEvent};
+pub use identified::Identified;
 pub use service::{ConsensusType, ScabbardService, ScabbardServiceBuilder, ServiceStatus};
 pub use two_phase_commit::{
     Action, Context, ContextBuilder, Event, Message, Notification, Participant, State,
@@ -120,7 +121,7 @@ pub trait ScabbardStore {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusAction>, ScabbardStoreError>;
+    ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError>;
 
     /// List ready services
     fn list_ready_services(&self) -> Result<Vec<FullyQualifiedServiceId>, ScabbardStoreError>;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -12,30 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod action;
-pub mod alarm;
+mod action;
+mod alarm;
 mod boxed;
-pub mod commit;
-pub mod context;
+mod commit;
+mod context;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
-pub mod diesel;
+mod diesel;
 mod error;
-pub mod event;
+mod event;
 mod factory;
-pub mod service;
-pub mod two_phase_commit;
+mod service;
+mod two_phase_commit;
 
+use splinter::service::FullyQualifiedServiceId;
 use std::time::SystemTime;
 
 pub(crate) use error::ScabbardStoreError;
 
-use action::{ConsensusAction, IdentifiedConsensusAction};
-use alarm::AlarmType;
-use commit::CommitEntry;
-use context::ConsensusContext;
-use event::{ConsensusEvent, IdentifiedConsensusEvent};
-use service::ScabbardService;
-use splinter::service::FullyQualifiedServiceId;
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub use self::diesel::DieselScabbardStore;
+pub use action::{ConsensusAction, IdentifiedConsensusAction};
+pub use alarm::AlarmType;
+pub use commit::{CommitEntry, CommitEntryBuilder, ConsensusDecision};
+pub use context::ConsensusContext;
+pub use event::{ConsensusEvent, IdentifiedConsensusEvent};
+pub use service::{ConsensusType, ScabbardService, ScabbardServiceBuilder, ServiceStatus};
+pub use two_phase_commit::{
+    Action, Context, ContextBuilder, Event, Message, Notification, Participant, State,
+};
 
 #[cfg(feature = "postgres")]
 pub use factory::{PgScabbardStoreFactory, PooledPgScabbardStoreFactory};

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -22,6 +22,7 @@ mod diesel;
 mod error;
 mod event;
 mod factory;
+mod identified;
 mod service;
 mod two_phase_commit;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -37,7 +37,7 @@ pub use action::ConsensusAction;
 pub use alarm::AlarmType;
 pub use commit::{CommitEntry, CommitEntryBuilder, ConsensusDecision};
 pub use context::ConsensusContext;
-pub use event::{ConsensusEvent, IdentifiedConsensusEvent};
+pub use event::ConsensusEvent;
 pub use identified::Identified;
 pub use service::{ConsensusType, ScabbardService, ScabbardServiceBuilder, ServiceStatus};
 pub use two_phase_commit::{
@@ -218,7 +218,7 @@ pub trait ScabbardStore {
         &self,
         service_id: &FullyQualifiedServiceId,
         epoch: u64,
-    ) -> Result<Vec<IdentifiedConsensusEvent>, ScabbardStoreError>;
+    ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError>;
 
     /// Get the current context for a given service
     ///

--- a/services/scabbard/libscabbard/src/store/scabbard_store/service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/service.rs
@@ -80,7 +80,7 @@ impl ScabbardServiceBuilder {
         self.consensus.clone()
     }
 
-    /// Returns the peers for the service
+    /// Returns the status for the service
     pub fn status(&self) -> Option<ServiceStatus> {
         self.status.clone()
     }


### PR DESCRIPTION
- Fix a doc comment
- Fix module visibility
- Replace IdentifiedConsensusAction and IdentifiedConsensusEvent with a generic Identified<T> struct
- Remove epoch from the context table's primary key - there should only be one context per `service_id` when a new epoch starts the existing context should be updated rather than adding a new context