### PR TITLE
Update Scabbard v3 TimerHandlerFactory and TimerHandler to use the ConsensusRunner

### DIFF
--- a/libsplinter/src/store/command/executor/mod.rs
+++ b/libsplinter/src/store/command/executor/mod.rs
@@ -22,7 +22,7 @@ use crate::store::command::StoreCommand;
 pub use self::diesel::DieselStoreCommandExecutor;
 
 /// Provides an API for executing `StoreCommand`s
-pub trait StoreCommandExecutor {
+pub trait StoreCommandExecutor: Sync + Send {
     type Context;
 
     /// Execute each [`StoreCommand`] in `store_commands`

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -104,6 +104,7 @@ scabbardv3-consensus-action-runner = [
     ]
 scabbardv3-consensus-runner = ["scabbardv3-consensus-action-runner"]
 scabbardv3 = [
+    "scabbardv3-consensus-runner",
     "scabbardv3-store",
     "splinter/service-arguments-converter",
     "splinter/service-lifecycle",
@@ -114,6 +115,7 @@ scabbardv3 = [
     "splinter/service-timer-filter",
     "splinter/service-timer-handler",
     "splinter/service-timer-handler-factory",
+    "splinter/service-message-sender-factory",
     ]
 scabbardv3-store = []
 splinter-service = ["log", "sawtooth"]

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/builder.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/builder.rs
@@ -53,7 +53,7 @@ where
     >,
     scabbard_store_factory:
         Option<Arc<dyn ScabbardStoreFactory<<E as StoreCommandExecutor>::Context>>>,
-    store_command_executor: Option<E>,
+    store_command_executor: Option<Arc<E>>,
     message_sender_factory: Option<Box<dyn MessageSenderFactory<Vec<u8>>>>,
     notify_observer: Option<Box<dyn NotifyObserver<<E as StoreCommandExecutor>::Context>>>,
 }
@@ -105,7 +105,7 @@ where
         self
     }
 
-    pub fn with_store_command_executor(mut self, store_command_executor: E) -> Self {
+    pub fn with_store_command_executor(mut self, store_command_executor: Arc<E>) -> Self {
         self.store_command_executor = Some(store_command_executor);
         self
     }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -20,6 +20,7 @@ mod event_source;
 mod store_sources;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use augrim::Algorithm;
 use splinter::error::InternalError;
@@ -61,7 +62,7 @@ where
     >,
     consensus_store_command_factory:
         ConsensusStoreCommandFactory<<E as StoreCommandExecutor>::Context>,
-    store_command_executor: E,
+    store_command_executor: Arc<E>,
 }
 
 impl<E> ConsensusRunner<E>
@@ -212,9 +213,9 @@ mod tests {
             )
             .expect("unable to event to the scabbard store");
 
-        let store_command_executor = SqliteCommandExecutor {
+        let store_command_executor = Arc::new(SqliteCommandExecutor {
             pool: pool.clone().into(),
-        };
+        });
         let test_messsage_factory = TestMessageSenderFactory::default();
 
         let message_sender_factory = Box::new(test_messsage_factory.clone());

--- a/services/scabbard/libscabbard/src/service/v3/timer_handler.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_handler.rs
@@ -12,25 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use log::info;
-
 use splinter::{
     error::InternalError,
     service::{FullyQualifiedServiceId, MessageSender, TimerHandler},
+    store::command::StoreCommandExecutor,
 };
 
 use crate::protocol::v3::message::ScabbardMessage;
+use crate::store::{AlarmType, ConsensusEvent, Event, ScabbardStore};
 
-#[derive(Default)]
-pub struct ScabbardTimerHandler {}
+use super::ConsensusRunner;
 
-impl ScabbardTimerHandler {
-    pub fn new() -> Self {
-        Self {}
+pub struct ScabbardTimerHandler<E>
+where
+    E: StoreCommandExecutor + 'static,
+{
+    consensus_runner: ConsensusRunner<E>,
+    store: Box<dyn ScabbardStore>,
+}
+
+impl<E: StoreCommandExecutor + 'static> ScabbardTimerHandler<E> {
+    pub fn new(consensus_runner: ConsensusRunner<E>, store: Box<dyn ScabbardStore>) -> Self {
+        Self {
+            consensus_runner,
+            store,
+        }
     }
 }
 
-impl TimerHandler for ScabbardTimerHandler {
+impl<E: StoreCommandExecutor + 'static> TimerHandler for ScabbardTimerHandler<E> {
     type Message = ScabbardMessage;
 
     fn handle_timer(
@@ -38,7 +48,25 @@ impl TimerHandler for ScabbardTimerHandler {
         _sender: &dyn MessageSender<Self::Message>,
         service: FullyQualifiedServiceId,
     ) -> Result<(), InternalError> {
-        info!("handling scabbard timer for: {}", service);
-        Ok(())
+        // Check store if we have an alarm that have expired
+        if let Some(alarm) = self
+            .store
+            .get_alarm(&service, &AlarmType::TwoPhaseCommit)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?
+        {
+            // If the alarm has passed, elapsed will return OK and a duration for how long ago
+            // it was. If it is still in the future an error is returned with how long until
+            // the alarm has passed. Therefore if ok, the alarm has passed and an alarm event
+            // should be added to state.
+            if alarm.elapsed().is_ok() {
+                let alarm_event = ConsensusEvent::TwoPhaseCommit(Event::Alarm());
+                self.store
+                    .add_consensus_event(&service, alarm_event)
+                    .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            }
+        }
+
+        // always run the consensus runner, there is some pending work
+        self.consensus_runner.run(&service)
     }
 }

--- a/services/scabbard/libscabbard/src/service/v3/timer_handler_factory.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_handler_factory.rs
@@ -12,59 +12,161 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use splinter::error::{InternalError, InvalidArgumentError};
-use splinter::service::{TimerHandler, TimerHandlerFactory};
+use std::sync::Arc;
 
-use crate::store::PooledScabbardStoreFactory;
+use augrim::two_phase_commit::TwoPhaseCommitAlgorithm;
+use augrim::Algorithm;
+use splinter::error::{InternalError, InvalidArgumentError};
+use splinter::service::{MessageSenderFactory, TimerHandler, TimerHandlerFactory};
+use splinter::store::command::StoreCommandExecutor;
+
+use crate::store::{PooledScabbardStoreFactory, ScabbardStoreFactory};
 
 use super::ScabbardMessageByteConverter;
 use super::ScabbardTimerHandler;
+use super::{
+    CommandNotifyObserver, ConsensusRunnerBuilder, StoreContextSource,
+    StoreUnprocessedActionSource, StoreUnprocessedEventSource,
+};
 
 #[derive(Clone)]
-pub struct ScabbardTimerHandlerFactory {
-    store_factory: Box<dyn PooledScabbardStoreFactory>,
+pub struct ScabbardTimerHandlerFactory<E>
+where
+    E: StoreCommandExecutor + 'static,
+{
+    pooled_store_factory: Box<dyn PooledScabbardStoreFactory>,
+    store_factory: Arc<dyn ScabbardStoreFactory<<E as StoreCommandExecutor>::Context>>,
+    message_sender_factory: Box<dyn MessageSenderFactory<Vec<u8>>>,
+    store_command_executor: Arc<E>,
 }
 
-impl ScabbardTimerHandlerFactory {
-    pub fn store_factory(&self) -> &dyn PooledScabbardStoreFactory {
-        &*self.store_factory
+impl<E: StoreCommandExecutor + 'static> ScabbardTimerHandlerFactory<E> {
+    pub fn pooled_store_factory(&self) -> &dyn PooledScabbardStoreFactory {
+        &*self.pooled_store_factory
     }
 }
 
-impl TimerHandlerFactory for ScabbardTimerHandlerFactory {
+impl<E: StoreCommandExecutor + 'static> TimerHandlerFactory for ScabbardTimerHandlerFactory<E> {
     type Message = Vec<u8>;
 
     fn new_handler(&self) -> Result<Box<dyn TimerHandler<Message = Self::Message>>, InternalError> {
-        let timer_handler = ScabbardTimerHandler::new();
+        let consensus_runner = ConsensusRunnerBuilder::new()
+            .with_scabbard_store_factory(self.store_factory.clone())
+            .with_unprocessed_action_source(Box::new(StoreUnprocessedActionSource::new(Box::new(
+                self.pooled_store_factory.new_store(),
+            ))))
+            .with_unprocessed_event_source(Box::new(StoreUnprocessedEventSource::new(Box::new(
+                self.pooled_store_factory.new_store(),
+            ))))
+            .with_store_command_executor(self.store_command_executor.clone())
+            .with_context_source(Box::new(StoreContextSource::new(Box::new(
+                self.pooled_store_factory.new_store(),
+            ))))
+            .with_message_sender_factory(self.message_sender_factory.clone())
+            .with_notify_observer(Box::new(CommandNotifyObserver::new(
+                self.store_factory.clone(),
+                self.pooled_store_factory.new_store(),
+            )))
+            .with_algorithm(
+                "two-phase-commit",
+                Box::new(
+                    TwoPhaseCommitAlgorithm::new(augrim::SystemTimeFactory::new()).into_algorithm(),
+                ),
+            )
+            .build()
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        let timer_handler =
+            ScabbardTimerHandler::new(consensus_runner, self.pooled_store_factory.new_store());
         Ok(Box::new(
             timer_handler.into_handler(ScabbardMessageByteConverter {}),
         ))
     }
 
     fn clone_box(&self) -> Box<dyn TimerHandlerFactory<Message = Self::Message>> {
-        Box::new(self.clone())
+        Box::new({
+            Self {
+                pooled_store_factory: self.pooled_store_factory.clone(),
+                store_factory: self.store_factory.clone(),
+                message_sender_factory: self.message_sender_factory.clone(),
+                store_command_executor: self.store_command_executor.clone(),
+            }
+        })
     }
 }
 
 #[derive(Default)]
-pub struct ScabbardTimerHandlerFactoryBuilder {
-    store_factory: Option<Box<dyn PooledScabbardStoreFactory>>,
+pub struct ScabbardTimerHandlerFactoryBuilder<E>
+where
+    E: StoreCommandExecutor + 'static,
+{
+    pooled_store_factory: Option<Box<dyn PooledScabbardStoreFactory>>,
+    store_factory: Option<Arc<dyn ScabbardStoreFactory<<E as StoreCommandExecutor>::Context>>>,
+    message_sender_factory: Option<Box<dyn MessageSenderFactory<Vec<u8>>>>,
+    store_command_executor: Option<Arc<E>>,
 }
 
-impl ScabbardTimerHandlerFactoryBuilder {
+impl<E: StoreCommandExecutor + 'static> ScabbardTimerHandlerFactoryBuilder<E> {
+    pub fn new() -> Self {
+        Self {
+            pooled_store_factory: None,
+            store_factory: None,
+            message_sender_factory: None,
+            store_command_executor: None,
+        }
+    }
+
+    pub fn with_pooled_store_factory(
+        mut self,
+        pooled_store_factory: Box<dyn PooledScabbardStoreFactory>,
+    ) -> Self {
+        self.pooled_store_factory = Some(pooled_store_factory);
+        self
+    }
+
     pub fn with_store_factory(
         mut self,
-        store_factory: Box<dyn PooledScabbardStoreFactory>,
+        store_factory: Arc<dyn ScabbardStoreFactory<<E as StoreCommandExecutor>::Context>>,
     ) -> Self {
         self.store_factory = Some(store_factory);
         self
     }
 
-    pub fn build(self) -> Result<ScabbardTimerHandlerFactory, InvalidArgumentError> {
+    pub fn with_message_sender_factory(
+        mut self,
+        message_sender_factory: Box<dyn MessageSenderFactory<Vec<u8>>>,
+    ) -> Self {
+        self.message_sender_factory = Some(message_sender_factory);
+        self
+    }
+
+    pub fn with_store_command_executor(mut self, store_command_executor: Arc<E>) -> Self {
+        self.store_command_executor = Some(store_command_executor);
+        self
+    }
+
+    pub fn build(self) -> Result<ScabbardTimerHandlerFactory<E>, InvalidArgumentError> {
+        let pooled_store_factory = self
+            .pooled_store_factory
+            .ok_or_else(|| InvalidArgumentError::new("pooled_store_factory", "must be set"))?;
+
         let store_factory = self
             .store_factory
             .ok_or_else(|| InvalidArgumentError::new("store_factory", "must be set"))?;
 
-        Ok(ScabbardTimerHandlerFactory { store_factory })
+        let message_sender_factory = self
+            .message_sender_factory
+            .ok_or_else(|| InvalidArgumentError::new("message_sender_factory", "must be set"))?;
+
+        let store_command_executor = self
+            .store_command_executor
+            .ok_or_else(|| InvalidArgumentError::new("store_command_executor", "must be set"))?;
+
+        Ok(ScabbardTimerHandlerFactory {
+            pooled_store_factory,
+            store_factory,
+            message_sender_factory,
+            store_command_executor,
+        })
     }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/factory/mod.rs
@@ -35,7 +35,7 @@ impl<C> ScabbardStoreFactory<C> for Box<dyn ScabbardStoreFactory<C>> {
 }
 
 pub trait PooledScabbardStoreFactory: Sync + Send {
-    fn new_store(&self) -> Box<dyn ScabbardStore + Send>;
+    fn new_store(&self) -> Box<dyn ScabbardStore>;
 
     fn clone_box(&self) -> Box<dyn PooledScabbardStoreFactory>;
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/factory/postgres.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/factory/postgres.rs
@@ -55,7 +55,7 @@ impl PooledPgScabbardStoreFactory {
 }
 
 impl PooledScabbardStoreFactory for PooledPgScabbardStoreFactory {
-    fn new_store(&self) -> Box<dyn ScabbardStore + Send> {
+    fn new_store(&self) -> Box<dyn ScabbardStore> {
         Box::new(DieselScabbardStore::new_with_write_exclusivity(
             self.pool.clone(),
         ))

--- a/services/scabbard/libscabbard/src/store/scabbard_store/factory/sqlite.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/factory/sqlite.rs
@@ -55,7 +55,7 @@ impl PooledSqliteScabbardStoreFactory {
 }
 
 impl PooledScabbardStoreFactory for PooledSqliteScabbardStoreFactory {
-    fn new_store(&self) -> Box<dyn ScabbardStore + Send> {
+    fn new_store(&self) -> Box<dyn ScabbardStore> {
         Box::new(DieselScabbardStore::new_with_write_exclusivity(
             self.pool.clone(),
         ))

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -160,7 +160,7 @@ oauth = [
     "splinter/oauth"
 ]
 rest-api-cors = ["splinter/rest-api-cors"]
-scabbardv3 = ["scabbard/scabbardv3", "service2"]
+scabbardv3 = ["scabbard/scabbardv3", "service2", "scabbard/scabbardv3-consensus",]
 service-endpoint = []
 service-timer-interval = []
 service2 = [

--- a/splinterd/src/daemon/timer.rs
+++ b/splinterd/src/daemon/timer.rs
@@ -1,0 +1,135 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "scabbardv3")]
+use std::sync::Arc;
+
+#[cfg(feature = "scabbardv3")]
+use scabbard::service::v3::{ScabbardTimerFilter, ScabbardTimerHandlerFactoryBuilder};
+#[cfg(all(feature = "scabbardv3", feature = "database-postgres"))]
+use scabbard::store::PgScabbardStoreFactory;
+#[cfg(all(feature = "scabbardv3", feature = "database-sqlite"))]
+use scabbard::store::SqliteScabbardStoreFactory;
+#[cfg(feature = "scabbardv3")]
+use splinter::circuit::routing::RoutingTableReader;
+use splinter::error::InternalError;
+#[cfg(feature = "scabbardv3")]
+use splinter::peer::interconnect::NetworkMessageSender;
+#[cfg(feature = "scabbardv3")]
+use splinter::runtime::service::NetworkMessageSenderFactory;
+use splinter::service::{TimerFilter, TimerHandlerFactory};
+#[cfg(feature = "scabbardv3")]
+use splinter::store::command::DieselStoreCommandExecutor;
+
+use super::store::ConnectionPool;
+
+#[cfg(feature = "service2")]
+type TimerFilterCollection = Vec<(
+    Box<dyn TimerFilter + Send>,
+    Box<dyn TimerHandlerFactory<Message = Vec<u8>>>,
+)>;
+
+pub fn create_timer_handlers(
+    connection_pool: &ConnectionPool,
+    node_id: &str,
+    network_sender: NetworkMessageSender,
+    routing_reader: Box<dyn RoutingTableReader>,
+) -> Result<TimerFilterCollection, InternalError> {
+    #[cfg_attr(not(feature = "scabbardv3"), allow(clippy::redundant_clone))]
+    let mut timer_filter_collection: TimerFilterCollection = vec![];
+
+    #[cfg(feature = "scabbardv3")]
+    {
+        match connection_pool {
+            #[cfg(feature = "database-postgres")]
+            ConnectionPool::Postgres { pool } => {
+                let mut timer_scabbard_factory_builder = ScabbardTimerHandlerFactoryBuilder::new()
+                    .with_message_sender_factory(Box::new(NetworkMessageSenderFactory::new(
+                        node_id,
+                        network_sender,
+                        routing_reader,
+                    )));
+
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_pooled_store_factory(Box::new(
+                        scabbard::store::PooledPgScabbardStoreFactory::new(pool.clone()),
+                    ));
+
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_store_factory(Arc::new(PgScabbardStoreFactory));
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_store_command_executor(Arc::new(DieselStoreCommandExecutor::new(
+                        pool.clone(),
+                    )));
+                let timer_scabbard_factory: Box<dyn TimerHandlerFactory<Message = Vec<u8>>> =
+                    Box::new(
+                        timer_scabbard_factory_builder
+                            .build()
+                            .map_err(|err| InternalError::from_source(Box::new(err)))?,
+                    );
+
+                let scabbard_timer_filter = ScabbardTimerFilter::new(Box::new(
+                    scabbard::store::PooledPgScabbardStoreFactory::new(pool.clone()),
+                ));
+                timer_filter_collection
+                    .push((Box::new(scabbard_timer_filter), timer_scabbard_factory));
+
+                Ok(timer_filter_collection)
+            }
+            #[cfg(feature = "database-sqlite")]
+            ConnectionPool::Sqlite { pool } => {
+                let mut timer_scabbard_factory_builder = ScabbardTimerHandlerFactoryBuilder::new()
+                    .with_message_sender_factory(Box::new(NetworkMessageSenderFactory::new(
+                        node_id,
+                        network_sender,
+                        routing_reader,
+                    )));
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_pooled_store_factory(Box::new(
+                    scabbard::store::PooledSqliteScabbardStoreFactory::new_with_write_exclusivity(
+                        pool.clone(),
+                    ),
+                ));
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_store_factory(Arc::new(SqliteScabbardStoreFactory));
+                timer_scabbard_factory_builder = timer_scabbard_factory_builder
+                    .with_store_command_executor(Arc::new(
+                        DieselStoreCommandExecutor::new_with_write_exclusivity(pool.clone()),
+                    ));
+
+                let timer_scabbard_factory: Box<dyn TimerHandlerFactory<Message = Vec<u8>>> =
+                    Box::new(
+                        timer_scabbard_factory_builder
+                            .build()
+                            .map_err(|err| InternalError::from_source(Box::new(err)))?,
+                    );
+
+                let scabbard_timer_filter = ScabbardTimerFilter::new(Box::new(
+                    scabbard::store::PooledSqliteScabbardStoreFactory::new_with_write_exclusivity(
+                        pool.clone(),
+                    ),
+                ));
+
+                timer_filter_collection
+                    .push((Box::new(scabbard_timer_filter), timer_scabbard_factory));
+
+                Ok(timer_filter_collection)
+            }
+            // This will have failed in create_store_factory above, but we return () to make
+            // the compiler/linter happy under the following conditions
+            #[cfg(not(any(feature = "database-postgres", feature = "database-sqlite")))]
+            store::ConnectionPool::Unsupported => Ok(timer_filter_collection),
+        }
+    }
+}


### PR DESCRIPTION
This PR is enables running the ConsensusRunner within the timer handler. As of these changes, setting up a scabbard::v3 circuit tries to come to agreement using TwoPhaseCommit. Currently, the services fail with the following errors.

One side:
```
[2022-05-13 16:23:01.957] T[TimerThread--1] ERROR [splinter::runtime::service::timer::thread] UNIQUE constraint failed: scabbard_v3_commit_history.service_id, scabbard_v3_commit_history.epoch
```

and the other:
```
[4:24](https://bitwiseio.slack.com/archives/C02RHCJ7STG/p1652477046388599)
[2022-05-13 16:23:02.007] T[TimerThread--1] ERROR [splinter::runtime::service::timer::thread] Alarm unexpected in WaitForVoteRequest state
```

Different errors are raised after #1966 goes in

