### PR TITLE
Guard service code with stable feature guards

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -100,6 +100,8 @@ stable = [
     "rest-api",
     "rest-api-actix-web-1",
     "rest-api-cors",
+    "runtime-service",
+    "service",
     "sqlite",
     "store",
     "store-factory",
@@ -143,7 +145,7 @@ experimental = [
 # used for turning benchmark tests on
 benchmark = []
 
-admin-service = ["store"]
+admin-service = ["store", "runtime-service"]
 admin-service-client = ["admin-service"]
 admin-service-event-client = ["admin-service-client"]
 admin-service-event-client-actix-web-client = [
@@ -186,33 +188,37 @@ rest-api-actix-web-1 = [
     "rest-api",
 ]
 rest-api-cors = []
-service-arguments-converter = []
-service-lifecycle = ["service-arguments-converter", "store"]
-service-lifecycle-executor = ["service-lifecycle", "service-lifecycle-store"]
-service-lifecycle-store = ["service-lifecycle"]
-service-message-converter = []
-service-message-handler = ["service-message-converter", "service-message-sender"]
-service-message-handler-factory = ["service-message-handler"]
-service-message-sender = ["service-message-converter"]
-service-message-sender-factory = ["service-message-sender"]
+runtime-service = ["service"]
+service = []
+service-arguments-converter = ["service"]
+service-lifecycle = ["service", "service-arguments-converter", "store"]
+service-lifecycle-executor = ["runtime-service", "service-lifecycle", "service-lifecycle-store"]
+service-lifecycle-store = ["service", "service-lifecycle"]
+service-message-converter = ["service"]
+service-message-handler = ["service", "service-message-converter", "service-message-sender"]
+service-message-handler-factory = ["service", "service-message-handler"]
+service-message-sender = ["service", "service-message-converter"]
+service-message-sender-factory = ["service", "service-message-sender"]
 service-message-sender-factory-peer = [
     "service-message-sender",
     "service-message-sender-factory"
 ]
 service-timer =[
+  "runtime-service",
   "service-message-sender-factory",
   "service-timer-filter",
   "service-timer-handler",
   "service-timer-handler-factory"
 ]
-service-timer-filter = []
-service-timer-handler = ["service-message-converter", "service-message-sender"]
+service-timer-filter = ["service"]
+service-timer-handler = ["service", "service-message-converter", "service-message-sender"]
 service-message-handler-dispatch = [
+    "runtime-service",
     "service-message-handler",
     "service-message-handler-factory",
     "service-message-sender-factory",
 ]
-service-timer-handler-factory = ["service-timer-handler"]
+service-timer-handler-factory = ["service", "service-timer-handler"]
 sqlite = ["diesel/sqlite", "diesel_migrations"]
 store = []
 store-factory = ["store"]

--- a/libsplinter/src/lib.rs
+++ b/libsplinter/src/lib.rs
@@ -112,6 +112,7 @@ pub mod registry;
 #[cfg(feature = "rest-api")]
 pub mod rest_api;
 pub mod runtime;
+#[cfg(feature = "service")]
 pub mod service;
 #[cfg(feature = "store")]
 pub mod store;

--- a/libsplinter/src/network/mod.rs
+++ b/libsplinter/src/network/mod.rs
@@ -18,4 +18,5 @@ pub mod auth;
 pub mod connection_manager;
 pub mod dispatch;
 pub mod handlers;
+#[cfg(feature = "runtime-service")]
 pub(crate) mod reply;

--- a/libsplinter/src/runtime/mod.rs
+++ b/libsplinter/src/runtime/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "runtime-service")]
 pub mod service;

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -37,7 +37,7 @@ protobuf = "2.23"
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-splinter = { path = "../../../libsplinter" }
+splinter = { path = "../../../libsplinter", features = ["service"] }
 transact = { version = "0.5", features = ["state-merkle-sql", "family-sabre"] }
 
 [dependencies.augrim]


### PR DESCRIPTION
The service features do not need to be default and should
only be pulled if services are being written/used.

Two features are added. "service" which guards the service
traits and "runtime-service" which guards all runtime service
components. This allows services to only pull in the parts of
the service API they need to implement the traits.

These features are added to stable.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>