### PR TITLE
Remove epoch from ScabbardStore api

### DIFF
--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/actions.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/actions.rs
@@ -25,7 +25,6 @@ use crate::store::ScabbardStoreFactory;
 
 pub struct ExecuteActionCommand<C> {
     service_id: FullyQualifiedServiceId,
-    epoch: u64,
     action_id: i64,
     store_factory: Arc<dyn ScabbardStoreFactory<C>>,
 }
@@ -33,13 +32,11 @@ pub struct ExecuteActionCommand<C> {
 impl<C> ExecuteActionCommand<C> {
     pub fn new(
         service_id: FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         store_factory: Arc<dyn ScabbardStoreFactory<C>>,
     ) -> Self {
         Self {
             service_id,
-            epoch,
             action_id,
             store_factory,
         }
@@ -52,12 +49,7 @@ impl<C> StoreCommand for ExecuteActionCommand<C> {
     fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
         self.store_factory
             .new_store(&*conn)
-            .update_consensus_action(
-                &self.service_id,
-                self.epoch,
-                self.action_id,
-                SystemTime::now(),
-            )
+            .update_consensus_action(&self.service_id, self.action_id, SystemTime::now())
             .map_err(|e| InternalError::from_source(Box::new(e)))
     }
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/notifications.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/commands/notifications.rs
@@ -27,7 +27,6 @@ use crate::store::ScabbardStoreFactory;
 pub struct AddEventCommand<C> {
     store_factory: Arc<dyn ScabbardStoreFactory<C>>,
     service_id: FullyQualifiedServiceId,
-    epoch: u64,
     event: ConsensusEvent,
 }
 
@@ -35,13 +34,11 @@ impl<C> AddEventCommand<C> {
     pub fn new(
         store_factory: Arc<dyn ScabbardStoreFactory<C>>,
         service_id: FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Self {
         Self {
             store_factory,
             service_id,
-            epoch,
             event,
         }
     }
@@ -53,7 +50,7 @@ impl<C> StoreCommand for AddEventCommand<C> {
     fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
         self.store_factory
             .new_store(&*conn)
-            .add_consensus_event(&self.service_id, self.epoch, self.event.clone())
+            .add_consensus_event(&self.service_id, self.event.clone())
             .map_err(|e| InternalError::from_source(Box::new(e)))?;
 
         Ok(())

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
@@ -105,7 +105,6 @@ impl<C: 'static> ConsensusActionRunner<C> {
                     // add command to mark the action as executed
                     commands.push(Box::new(ExecuteActionCommand::new(
                         service_id.clone(),
-                        epoch,
                         action.id,
                         self.store_factory.clone(),
                     )));
@@ -126,7 +125,6 @@ impl<C: 'static> ConsensusActionRunner<C> {
                     // add command to mark the action as executed
                     commands.push(Box::new(ExecuteActionCommand::new(
                         service_id.clone(),
-                        epoch,
                         action.id,
                         self.store_factory.clone(),
                     )));
@@ -141,7 +139,6 @@ impl<C: 'static> ConsensusActionRunner<C> {
                     // add command to mark the action as executed
                     commands.push(Box::new(ExecuteActionCommand::new(
                         service_id.clone(),
-                        epoch,
                         action.id,
                         self.store_factory.clone(),
                     )));

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
@@ -431,7 +431,7 @@ mod tests {
             .expect("unable to add context to scabbard store");
 
         let actions = scabbard_store
-            .list_consensus_actions(&service_fqsi, 1)
+            .list_consensus_actions(&service_fqsi)
             .expect("unable to get actions");
 
         let commands = action_runner
@@ -442,7 +442,7 @@ mod tests {
 
         // verify that all actions were handled
         assert!(scabbard_store
-            .list_consensus_actions(&service_fqsi, 1)
+            .list_consensus_actions(&service_fqsi)
             .expect("unable to get actions")
             .is_empty());
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/mod.rs
@@ -413,7 +413,6 @@ mod tests {
                     Some(SystemTime::now()),
                 )),
                 &service_fqsi,
-                1,
             )
             .expect("unable to add context to scabbard store");
 
@@ -424,7 +423,6 @@ mod tests {
                     Message::DecisionRequest(1),
                 )),
                 &service_fqsi,
-                1,
             )
             .expect("unable to add context to scabbard store");
 
@@ -432,7 +430,6 @@ mod tests {
             .add_consensus_action(
                 ConsensusAction::TwoPhaseCommit(Action::Notify(Notification::RequestForStart())),
                 &service_fqsi,
-                1,
             )
             .expect("unable to add context to scabbard store");
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
@@ -90,7 +90,6 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                 commands.push(Box::new(AddEventCommand::new(
                     self.store_factory.clone(),
                     service_id.clone(),
-                    epoch,
                     ConsensusEvent::TwoPhaseCommit(Event::Start(s.into_bytes())),
                 )));
                 commands.push(Box::new(AddCommitEntryCommand::new(
@@ -103,7 +102,6 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                 commands.push(Box::new(AddEventCommand::new(
                     self.store_factory.clone(),
                     service_id.clone(),
-                    epoch,
                     ConsensusEvent::TwoPhaseCommit(Event::Vote(true)),
                 )));
             }
@@ -123,7 +121,6 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                 commands.push(Box::new(AddEventCommand::new(
                     self.store_factory.clone(),
                     service_id.clone(),
-                    epoch,
                     ConsensusEvent::TwoPhaseCommit(Event::Vote(true)),
                 )));
                 commands.push(Box::new(AddCommitEntryCommand::new(

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/action_source.rs
@@ -22,6 +22,5 @@ pub trait UnprocessedActionSource {
     fn get_unprocessed_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, InternalError>;
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
@@ -38,13 +38,11 @@ where
     pub fn new_save_actions_command(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         actions: Vec<ConsensusAction>,
     ) -> Box<dyn StoreCommand<Context = C>> {
         Box::new(SaveActionsCommand {
             factory: self.factory.clone(),
             service_id: service_id.clone(),
-            epoch,
             actions: RefCell::new(actions),
         })
     }
@@ -67,7 +65,6 @@ where
 struct SaveActionsCommand<C> {
     factory: Arc<dyn ScabbardStoreFactory<C>>,
     service_id: FullyQualifiedServiceId,
-    epoch: u64,
     actions: RefCell<Vec<ConsensusAction>>,
 }
 
@@ -82,7 +79,7 @@ where
 
         for action in self.actions.borrow_mut().drain(..) {
             store
-                .add_consensus_action(action, &self.service_id, self.epoch)
+                .add_consensus_action(action, &self.service_id)
                 .map_err(|e| InternalError::from_source(Box::new(e)))?;
         }
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/consensus_store_command_factory.rs
@@ -50,13 +50,11 @@ where
     pub fn new_mark_event_complete_command(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
     ) -> Box<dyn StoreCommand<Context = C>> {
         Box::new(MarkEventCompleteCommand {
             factory: self.factory.clone(),
             service_id: service_id.clone(),
-            epoch,
             event_id,
         })
     }
@@ -90,7 +88,6 @@ where
 struct MarkEventCompleteCommand<C> {
     factory: Arc<dyn ScabbardStoreFactory<C>>,
     service_id: FullyQualifiedServiceId,
-    epoch: u64,
     event_id: i64,
 }
 
@@ -103,12 +100,7 @@ where
     fn execute(&self, conn: &Self::Context) -> Result<(), InternalError> {
         let store = self.factory.new_store(conn);
         store
-            .update_consensus_event(
-                &self.service_id,
-                self.epoch,
-                self.event_id,
-                SystemTime::now(),
-            )
+            .update_consensus_event(&self.service_id, self.event_id, SystemTime::now())
             .map_err(|e| InternalError::from_source(Box::new(e)))?;
 
         Ok(())

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/event_source.rs
@@ -24,6 +24,5 @@ pub trait UnprocessedEventSource {
     fn get_next_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Option<Identified<ConsensusEvent>>, InternalError>;
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -96,9 +96,7 @@ where
                 )?);
             }
 
-            let unprocessed_event = self
-                .unprocessed_event_source
-                .get_next_event(service_id, epoch)?;
+            let unprocessed_event = self.unprocessed_event_source.get_next_event(service_id)?;
 
             let event = match unprocessed_event {
                 Some(event) => event,

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -213,7 +213,6 @@ mod tests {
         scabbard_store
             .add_consensus_event(
                 &service_id,
-                1,
                 ConsensusEvent::TwoPhaseCommit(Event::Start(b"test".to_vec())),
             )
             .expect("unable to event to the scabbard store");

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -124,7 +124,7 @@ where
 
             commands.push(
                 self.consensus_store_command_factory
-                    .new_save_actions_command(service_id, epoch, actions),
+                    .new_save_actions_command(service_id, actions),
             );
             commands.push(
                 self.consensus_store_command_factory

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -85,7 +85,7 @@ where
 
             let unprocessed_actions = self
                 .unprocessed_action_source
-                .get_unprocessed_actions(service_id, epoch)?;
+                .get_unprocessed_actions(service_id)?;
 
             let mut commands = vec![];
             if !unprocessed_actions.is_empty() {

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -128,7 +128,7 @@ where
             );
             commands.push(
                 self.consensus_store_command_factory
-                    .new_mark_event_complete_command(service_id, epoch, event_id),
+                    .new_mark_event_complete_command(service_id, event_id),
             );
             self.store_command_executor.execute(commands)?;
         }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
@@ -64,10 +64,9 @@ impl UnprocessedActionSource for StoreUnprocessedActionSource {
     fn get_unprocessed_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, InternalError> {
         self.store
-            .list_consensus_actions(service_id, epoch)
+            .list_consensus_actions(service_id)
             .map_err(|err| InternalError::from_source(Box::new(err)))
     }
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/store_sources.rs
@@ -38,11 +38,10 @@ impl UnprocessedEventSource for StoreUnprocessedEventSource {
     fn get_next_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Option<Identified<ConsensusEvent>>, InternalError> {
         Ok(self
             .store
-            .list_consensus_events(service_id, epoch)
+            .list_consensus_events(service_id)
             .map_err(|err| InternalError::from_source(Box::new(err)))?
             .get(0)
             .cloned())

--- a/services/scabbard/libscabbard/src/service/v3/message_handler.rs
+++ b/services/scabbard/libscabbard/src/service/v3/message_handler.rs
@@ -72,7 +72,6 @@ impl MessageHandler for ScabbardMessageHandler {
                     self.store
                         .add_consensus_event(
                             &to_service,
-                            message.epoch(),
                             ConsensusEvent::TwoPhaseCommit(Event::Deliver(
                                 from_service,
                                 into_store_msg(message),

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -251,7 +251,7 @@ mod tests {
 
         // add a new event for the second service
         store
-            .add_consensus_event(&fqsi2, 1, ConsensusEvent::TwoPhaseCommit(Event::Alarm()))
+            .add_consensus_event(&fqsi2, ConsensusEvent::TwoPhaseCommit(Event::Alarm()))
             .expect("failed to add event for second service");
 
         let ids = scabbard_timer_filter.filter().expect("failed to filter");

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -229,7 +229,7 @@ mod tests {
         // update the second service's action's executed_at time so that it appears to have
         // been executed
         store
-            .update_consensus_action(&fqsi2, 1, action_id2, SystemTime::now())
+            .update_consensus_action(&fqsi2, action_id2, SystemTime::now())
             .expect("failed to update action");
 
         let ids = scabbard_timer_filter.filter().expect("failed to filter");
@@ -241,7 +241,7 @@ mod tests {
         // update the first service's action's executed_at time so that it appears to have
         // been executed
         store
-            .update_consensus_action(&fqsi, 1, action_id, SystemTime::now())
+            .update_consensus_action(&fqsi, action_id, SystemTime::now())
             .expect("failed to update action");
 
         let ids = scabbard_timer_filter.filter().expect("failed to filter");

--- a/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
+++ b/services/scabbard/libscabbard/src/service/v3/timer_filter.rs
@@ -154,7 +154,7 @@ mod tests {
 
         // add an unexecuted action for the first service
         let action_id = store
-            .add_consensus_action(action, &fqsi, 1)
+            .add_consensus_action(action, &fqsi)
             .expect("failed to add action");
 
         let scabbard_timer_filter = ScabbardTimerFilter::new(Box::new(
@@ -203,7 +203,7 @@ mod tests {
 
         // add an unexecuted action for the second service
         let action_id2 = store
-            .add_consensus_action(action2, &fqsi2, 1)
+            .add_consensus_action(action2, &fqsi2)
             .expect("failed to add action2");
 
         let ids = scabbard_timer_filter.filter().expect("failed to filter");

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -88,19 +88,17 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         (&**self).update_consensus_action(service_id, action_id, executed_at)
     }
 
-    /// List all coordinator actions for a given service_id and epoch
+    /// List all coordinator actions for a given service_id
     ///
     /// # Arguments
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service for which actions
     ///    should be listed
-    /// * `epoch` - The epoch for which actions should be listed
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
-        (&**self).list_consensus_actions(service_id, epoch)
+        (&**self).list_consensus_actions(service_id)
     }
 
     /// List ready services

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -173,15 +173,13 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the event
     ///    belongs to
-    /// * `epoch` - The epoch that the event belongs to
     /// * `event` - The `ConsensusEvent` to be added
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError> {
-        (&**self).add_consensus_event(service_id, epoch, event)
+        (&**self).add_consensus_event(service_id, event)
     }
 
     /// Update an existing consensus event

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -63,14 +63,12 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     /// * `action` - The `ConsensusAction` to be added to the database
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the action
     ///    belongs to
-    /// * `epoch` - The epoch that the given action belongs to
     fn add_consensus_action(
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError> {
-        (&**self).add_consensus_action(action, service_id, epoch)
+        (&**self).add_consensus_action(action, service_id)
     }
 
     /// Update an existing 2 phase commit action

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -124,7 +124,7 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         (&**self).add_commit_entry(commit_entry)
     }
 
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     ///
     /// # Arguments
     ///

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -188,17 +188,15 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the event
     ///    belongs to
-    /// * `epoch` - The epoch that the event belongs to
     /// * `event_id` - The ID of the event to be updated
     /// * `executed_at` - The time that the event was executed
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
-        (&**self).update_consensus_event(service_id, epoch, event_id, executed_at)
+        (&**self).update_consensus_event(service_id, event_id, executed_at)
     }
 
     /// List all consensus events for a given service_id and epoch

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -199,19 +199,17 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         (&**self).update_consensus_event(service_id, event_id, executed_at)
     }
 
-    /// List all consensus events for a given service_id and epoch
+    /// List all consensus events for a given service_id
     ///
     /// # Arguments
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service for which events
     ///    should be listed
-    /// * `epoch` - The epoch for which events should be listed
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
-        (&**self).list_consensus_events(service_id, epoch)
+        (&**self).list_consensus_events(service_id)
     }
 
     /// Get the current context for a given service

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -77,17 +77,15 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the action
     ///    belongs to
-    /// * `epoch` - The epoch that the action belongs to
     /// * `action_id` - The ID of the action being updated
     /// * `executed_at` - The time that the action was executed
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
-        (&**self).update_consensus_action(service_id, epoch, action_id, executed_at)
+        (&**self).update_consensus_action(service_id, action_id, executed_at)
     }
 
     /// List all coordinator actions for a given service_id and epoch

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -109,10 +109,9 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).add_consensus_action(action, service_id, epoch)
+            ScabbardStoreOperations::new(conn).add_consensus_action(action, service_id)
         })
     }
     /// Update an existing 2 phase commit action
@@ -304,10 +303,9 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).add_consensus_action(action, service_id, epoch)
+            ScabbardStoreOperations::new(conn).add_consensus_action(action, service_id)
         })
     }
     /// Update an existing 2 phase commit action
@@ -513,10 +511,8 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection)
-            .add_consensus_action(action, service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).add_consensus_action(action, service_id)
     }
     /// Update an existing 2 phase commit action
     fn update_consensus_action(
@@ -674,10 +670,8 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection)
-            .add_consensus_action(action, service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).add_consensus_action(action, service_id)
     }
     /// Update an existing 2 phase commit action
     fn update_consensus_action(
@@ -921,7 +915,7 @@ pub mod tests {
         let action = ConsensusAction::TwoPhaseCommit(Action::Notify(notification));
 
         assert!(store
-            .add_consensus_action(action, &coordinator_fqsi, 1)
+            .add_consensus_action(action, &coordinator_fqsi)
             .is_ok());
     }
 
@@ -990,10 +984,10 @@ pub mod tests {
         ));
 
         let action_id1 = store
-            .add_consensus_action(action1, &coordinator_fqsi, 1)
+            .add_consensus_action(action1, &coordinator_fqsi)
             .expect("failed to add actions");
         let action_id2 = store
-            .add_consensus_action(action2, &coordinator_fqsi, 1)
+            .add_consensus_action(action2, &coordinator_fqsi)
             .expect("failed to add actions");
 
         let action_list = store
@@ -1159,7 +1153,7 @@ pub mod tests {
         ));
 
         let action_id = store
-            .add_consensus_action(action, &coordinator_fqsi, 1)
+            .add_consensus_action(action, &coordinator_fqsi)
             .expect("failed to add actions");
 
         assert!(store
@@ -1281,7 +1275,7 @@ pub mod tests {
 
         // add an action for the service
         let action_id = store
-            .add_consensus_action(action, &service_fqsi, 1)
+            .add_consensus_action(action, &service_fqsi)
             .expect("failed to add actions");
 
         let ready_services = store

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -118,14 +118,12 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_action(
                 service_id,
-                epoch,
                 action_id,
                 executed_at,
             )
@@ -312,14 +310,12 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_action(
                 service_id,
-                epoch,
                 action_id,
                 executed_at,
             )
@@ -518,13 +514,11 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_action(
             service_id,
-            epoch,
             action_id,
             executed_at,
         )
@@ -677,13 +671,11 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_action(
             service_id,
-            epoch,
             action_id,
             executed_at,
         )
@@ -1157,7 +1149,7 @@ pub mod tests {
             .expect("failed to add actions");
 
         assert!(store
-            .update_consensus_action(&coordinator_fqsi, 1, action_id, SystemTime::now())
+            .update_consensus_action(&coordinator_fqsi, action_id, SystemTime::now())
             .is_ok());
     }
 
@@ -1286,7 +1278,7 @@ pub mod tests {
         assert_eq!(&ready_services[0], &service_fqsi);
 
         store
-            .update_consensus_action(&service_fqsi, 1, action_id, SystemTime::now())
+            .update_consensus_action(&service_fqsi, action_id, SystemTime::now())
             .expect("failed to update action");
 
         // check that no services are returned because there are no un-exectuted actions or

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -153,7 +153,7 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
         self.pool
             .execute_write(|conn| ScabbardStoreOperations::new(conn).add_commit_entry(commit_entry))
     }
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     fn get_last_commit_entry(
         &self,
         service_id: &FullyQualifiedServiceId,
@@ -340,7 +340,7 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
         self.pool
             .execute_write(|conn| ScabbardStoreOperations::new(conn).add_commit_entry(commit_entry))
     }
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     fn get_last_commit_entry(
         &self,
         service_id: &FullyQualifiedServiceId,
@@ -532,7 +532,7 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     fn add_commit_entry(&self, commit_entry: CommitEntry) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).add_commit_entry(commit_entry)
     }
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     fn get_last_commit_entry(
         &self,
         service_id: &FullyQualifiedServiceId,
@@ -684,7 +684,7 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     fn add_commit_entry(&self, commit_entry: CommitEntry) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).add_commit_entry(commit_entry)
     }
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     fn get_last_commit_entry(
         &self,
         service_id: &FullyQualifiedServiceId,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -129,14 +129,13 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
             )
         })
     }
-    /// List all coordinator actions for a given service_id and epoch
+    /// List all coordinator actions for a given service_id
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.pool.execute_read(|conn| {
-            ScabbardStoreOperations::new(conn).list_consensus_actions(service_id, epoch)
+            ScabbardStoreOperations::new(conn).list_consensus_actions(service_id)
         })
     }
     /// List ready services
@@ -321,14 +320,13 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
             )
         })
     }
-    /// List all coordinator actions for a given service_id and epoch
+    /// List all coordinator actions for a given service_id
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).list_consensus_actions(service_id, epoch)
+            ScabbardStoreOperations::new(conn).list_consensus_actions(service_id)
         })
     }
     /// List ready services
@@ -523,13 +521,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
             executed_at,
         )
     }
-    /// List all coordinator actions for a given service_id and epoch
+    /// List all coordinator actions for a given service_id
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id)
     }
     /// List ready services
     fn list_ready_services(&self) -> Result<Vec<FullyQualifiedServiceId>, ScabbardStoreError> {
@@ -680,13 +677,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
             executed_at,
         )
     }
-    /// List all coordinator actions for a given service_id and epoch
+    /// List all coordinator actions for a given service_id
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).list_consensus_actions(service_id)
     }
     /// List ready services
     fn list_ready_services(&self) -> Result<Vec<FullyQualifiedServiceId>, ScabbardStoreError> {
@@ -983,7 +979,7 @@ pub mod tests {
             .expect("failed to add actions");
 
         let action_list = store
-            .list_consensus_actions(&coordinator_fqsi, 1)
+            .list_consensus_actions(&coordinator_fqsi)
             .expect("failed to list all actions");
 
         let expected_update_context = ContextBuilder::default()

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -185,11 +185,10 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).add_consensus_event(service_id, epoch, event)
+            ScabbardStoreOperations::new(conn).add_consensus_event(service_id, event)
         })
     }
     /// Update an existing consensus event
@@ -376,11 +375,10 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).add_consensus_event(service_id, epoch, event)
+            ScabbardStoreOperations::new(conn).add_consensus_event(service_id, event)
         })
     }
     /// Update an existing consensus event
@@ -566,10 +564,9 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).add_consensus_event(service_id, epoch, event)
+        ScabbardStoreOperations::new(self.connection).add_consensus_event(service_id, event)
     }
     /// Update an existing consensus event
     fn update_consensus_event(
@@ -721,10 +718,9 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).add_consensus_event(service_id, epoch, event)
+        ScabbardStoreOperations::new(self.connection).add_consensus_event(service_id, event)
     }
     /// Update an existing consensus event
     fn update_consensus_event(
@@ -1579,11 +1575,11 @@ pub mod tests {
         ));
 
         assert!(store
-            .add_consensus_event(&participant_fqsi, 1, event.clone())
+            .add_consensus_event(&participant_fqsi, event.clone())
             .is_ok());
 
         assert!(store
-            .add_consensus_event(&participant2_fqsi, 1, event)
+            .add_consensus_event(&participant2_fqsi, event)
             .is_err());
     }
 
@@ -1633,7 +1629,7 @@ pub mod tests {
         ));
 
         let event_id = store
-            .add_consensus_event(&participant_fqsi, 1, event)
+            .add_consensus_event(&participant_fqsi, event)
             .expect("failed to add event");
 
         assert!(store
@@ -1690,7 +1686,7 @@ pub mod tests {
         ));
 
         let event_id = store
-            .add_consensus_event(&participant_fqsi, 1, event)
+            .add_consensus_event(&participant_fqsi, event)
             .expect("failed to add event");
 
         let events = store
@@ -1712,7 +1708,7 @@ pub mod tests {
         let event2 = ConsensusEvent::TwoPhaseCommit(Event::Alarm());
 
         let event_id2 = store
-            .add_consensus_event(&participant_fqsi, 1, event2)
+            .add_consensus_event(&participant_fqsi, event2)
             .expect("failed to add event");
 
         let events = store

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -206,14 +206,13 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
             )
         })
     }
-    /// List all consensus events for a given service_id and epoch
+    /// List all consensus events for a given service_id
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).list_consensus_events(service_id, epoch)
+            ScabbardStoreOperations::new(conn).list_consensus_events(service_id)
         })
     }
     /// Get the current context for a given service
@@ -394,14 +393,13 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
             )
         })
     }
-    /// List all consensus events for a given service_id and epoch
+    /// List all consensus events for a given service_id
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
         self.pool.execute_write(|conn| {
-            ScabbardStoreOperations::new(conn).list_consensus_events(service_id, epoch)
+            ScabbardStoreOperations::new(conn).list_consensus_events(service_id)
         })
     }
     /// Get the current context for a given service
@@ -577,13 +575,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
             executed_at,
         )
     }
-    /// List all consensus events for a given service_id and epoch
+    /// List all consensus events for a given service_id
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id)
     }
     /// Get the current context for a given service
     fn get_current_consensus_context(
@@ -729,13 +726,12 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
             executed_at,
         )
     }
-    /// List all consensus events for a given service_id and epoch
+    /// List all consensus events for a given service_id
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError> {
-        ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id, epoch)
+        ScabbardStoreOperations::new(self.connection).list_consensus_events(service_id)
     }
     /// Get the current context for a given service
     fn get_current_consensus_context(
@@ -1682,7 +1678,7 @@ pub mod tests {
             .expect("failed to add event");
 
         let events = store
-            .list_consensus_events(&participant_fqsi, 1)
+            .list_consensus_events(&participant_fqsi)
             .expect("failed to list events");
 
         assert_eq!(events.len(), 1);
@@ -1704,7 +1700,7 @@ pub mod tests {
             .expect("failed to add event");
 
         let events = store
-            .list_consensus_events(&participant_fqsi, 1)
+            .list_consensus_events(&participant_fqsi)
             .expect("failed to list events");
 
         assert_eq!(events.len(), 2);
@@ -1731,7 +1727,7 @@ pub mod tests {
             .expect("failed to update event");
 
         let events = store
-            .list_consensus_events(&participant_fqsi, 1)
+            .list_consensus_events(&participant_fqsi)
             .expect("failed to list events");
 
         assert_eq!(events.len(), 1);

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -195,14 +195,12 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_event(
                 service_id,
-                epoch,
                 event_id,
                 executed_at,
             )
@@ -385,14 +383,12 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_event(
                 service_id,
-                epoch,
                 event_id,
                 executed_at,
             )
@@ -572,13 +568,11 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_event(
             service_id,
-            epoch,
             event_id,
             executed_at,
         )
@@ -726,13 +720,11 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_event(
             service_id,
-            epoch,
             event_id,
             executed_at,
         )
@@ -1633,7 +1625,7 @@ pub mod tests {
             .expect("failed to add event");
 
         assert!(store
-            .update_consensus_event(&participant_fqsi, 1, event_id, SystemTime::now())
+            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now())
             .is_ok());
     }
 
@@ -1735,7 +1727,7 @@ pub mod tests {
         );
 
         store
-            .update_consensus_event(&participant_fqsi, 1, event_id, SystemTime::now())
+            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now())
             .expect("failed to update event");
 
         let events = store

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::time::Duration;
 use std::time::SystemTime;
 
@@ -45,7 +44,6 @@ pub(in crate::store::scabbard_store::diesel) trait ListActionsOperation {
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError>;
 }
 
@@ -60,25 +58,17 @@ where
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            let epoch = i64::try_from(epoch).map_err(|err| {
-                ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
-            })?;
-            // check to see if a context with the given epoch and service_id exists
+            // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(
-                    consensus_2pc_context::epoch
-                        .eq(epoch)
-                        .and(consensus_2pc_context::service_id.eq(format!("{}", service_id))),
-                )
+                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Context with service ID {} and epoch {} does not exist",
-                        service_id, epoch,
+                        "Context with service ID {} and does not exist",
+                        service_id,
                     )))
                 })?;
 
@@ -86,7 +76,6 @@ where
                 .filter(
                     consensus_2pc_action::service_id
                         .eq(format!("{}", service_id))
-                        .and(consensus_2pc_action::epoch.eq(epoch))
                         .and(consensus_2pc_action::executed_at.is_null()),
                 )
                 .order(consensus_2pc_action::position.desc())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -31,7 +31,6 @@ pub(in crate::store::scabbard_store::diesel) trait UpdateActionOperation {
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError>;
@@ -46,27 +45,19 @@ where
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            let epoch = i64::try_from(epoch).map_err(|err| {
-                ScabbardStoreError::Internal(InternalError::from_source(Box::new(err)))
-            })?;
-            // check to see if a context with the given epoch and service_id exists
+            // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(
-                    consensus_2pc_context::epoch
-                        .eq(epoch)
-                        .and(consensus_2pc_context::service_id.eq(format!("{}", service_id))),
-                )
+                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Context with service ID {} and epoch {} does not exist",
-                        service_id, epoch,
+                        "Context with service ID {} does not exist",
+                        service_id,
                     )))
                 })?;
 
@@ -86,8 +77,7 @@ where
                 .filter(
                     consensus_2pc_action::id
                         .eq(action_id)
-                        .and(consensus_2pc_action::service_id.eq(format!("{}", service_id)))
-                        .and(consensus_2pc_action::epoch.eq(epoch)),
+                        .and(consensus_2pc_action::service_id.eq(format!("{}", service_id))),
                 )
                 .set(consensus_2pc_action::executed_at.eq(Some(update_executed_at)))
                 .execute(self.conn)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -197,17 +197,15 @@ pub trait ScabbardStore {
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError>;
 
-    /// List all pending consensus events for a given service_id and epoch
+    /// List all pending consensus events for a given service_id
     ///
     /// # Arguments
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service for which events
     ///    should be listed
-    /// * `epoch` - The epoch for which events should be listed
     fn list_consensus_events(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusEvent>>, ScabbardStoreError>;
 
     /// Get the current context for a given service

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -106,17 +106,15 @@ pub trait ScabbardStore {
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError>;
 
-    /// List all pending consensus actions for a given service_id and epoch
+    /// List all pending consensus actions for a given service_id
     ///
     /// # Arguments
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service for which actions
     ///    should be listed
-    /// * `epoch` - The epoch for which actions should be listed
     fn list_consensus_actions(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError>;
 
     /// List ready services

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -97,13 +97,11 @@ pub trait ScabbardStore {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the action
     ///    belongs to
-    /// * `epoch` - The epoch that the action belongs to
     /// * `action_id` - The ID of the action being updated
     /// * `executed_at` - The time that the action was executed
     fn update_consensus_action(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         action_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError>;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -134,7 +134,7 @@ pub trait ScabbardStore {
     /// * `commit_entry` - The `CommitEntry` that is to be added to the database
     fn add_commit_entry(&self, commit_entry: CommitEntry) -> Result<(), ScabbardStoreError>;
 
-    /// Get the commit entry for the specified service_id and epoch
+    /// Get the commit entry for the specified service_id
     ///
     /// # Arguments
     ///

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -175,12 +175,10 @@ pub trait ScabbardStore {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the event
     ///    belongs to
-    /// * `epoch` - The epoch that the event belongs to
     /// * `event` - The `ConsensusEvent` to be added
     fn add_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event: ConsensusEvent,
     ) -> Result<i64, ScabbardStoreError>;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -85,12 +85,10 @@ pub trait ScabbardStore {
     /// * `action` - The `ConsensusAction` to be added to the database
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the action
     ///    belongs to
-    /// * `epoch` - The epoch that the given action belongs to
     fn add_consensus_action(
         &self,
         action: ConsensusAction,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<i64, ScabbardStoreError>;
 
     /// Update an existing 2 phase commit action

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -188,13 +188,11 @@ pub trait ScabbardStore {
     ///
     /// * `service_id` - The combined `CircuitId` and `ServiceId` of the service the event
     ///    belongs to
-    /// * `epoch` - The epoch that the event belongs to
     /// * `event_id` - The ID of the event to be updated
     /// * `executed_at` - The time that the event was executed
     fn update_consensus_event(
         &self,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
         event_id: i64,
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError>;


### PR DESCRIPTION
Update the ScabbardStore API to remove the epoch argument from any functions that have it