### PR TITLE
Update CommitEntry to not require having the epoch 

### DIFF
--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
@@ -83,7 +83,6 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                 let entry = CommitEntryBuilder::default()
                     .with_service_id(service_id)
                     .with_value(&s)
-                    .with_epoch(epoch)
                     .build()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
@@ -114,7 +113,6 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                         &String::from_utf8(value)
                             .map_err(|err| InternalError::from_source(Box::new(err)))?,
                     )
-                    .with_epoch(epoch)
                     .build()
                     .map_err(|err| InternalError::from_source(Box::new(err)))?;
 

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/command.rs
@@ -61,12 +61,10 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
     ///
     /// * `notification` - The notification that needs to be handled
     /// * `service_id` - The service ID of of the service the notification is for
-    /// * `epoch` - The current epoch of the consensus algorithm
     fn notify(
         &self,
         notification: Notification,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Box<dyn StoreCommand<Context = C>>>, InternalError> {
         let mut commands: Vec<Box<dyn StoreCommand<Context = C>>> = Vec::new();
         match notification {
@@ -169,10 +167,9 @@ impl<C: 'static> NotifyObserver<C> for CommandNotifyObserver<C> {
                         updated_commit_entry,
                     )));
                 } else {
-                    return Err(InternalError::with_message(format!(
-                        "Received abort for unknown entry: epoch {}",
-                        epoch
-                    )));
+                    return Err(InternalError::with_message(
+                        "Received abort for unknown entry".to_string(),
+                    ));
                 }
             }
             // log dropped message

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_action_runner/notify_observer/mod.rs
@@ -35,11 +35,9 @@ pub trait NotifyObserver<C> {
     ///
     /// * `notification` - The notification that needs to be handled
     /// * `service_id` - The service ID of of the service the notification is for
-    /// * `epoch` - The current epoch of the consensus algorithm
     fn notify(
         &self,
         notification: Notification,
         service_id: &FullyQualifiedServiceId,
-        epoch: u64,
     ) -> Result<Vec<Box<dyn StoreCommand<Context = C>>>, InternalError>;
 }

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -81,19 +81,16 @@ where
                     ))
                 })?;
 
-            let epoch = context.epoch();
-
             let unprocessed_actions = self
                 .unprocessed_action_source
                 .get_unprocessed_actions(service_id)?;
 
             let mut commands = vec![];
             if !unprocessed_actions.is_empty() {
-                commands.extend(self.action_runner.run_actions(
-                    unprocessed_actions,
-                    service_id,
-                    epoch,
-                )?);
+                commands.extend(
+                    self.action_runner
+                        .run_actions(unprocessed_actions, service_id)?,
+                );
             }
 
             let unprocessed_event = self.unprocessed_event_source.get_next_event(service_id)?;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/commit.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/commit.rs
@@ -20,7 +20,7 @@ use splinter::service::FullyQualifiedServiceId;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitEntry {
     service_id: FullyQualifiedServiceId,
-    epoch: u64,
+    epoch: Option<u64>,
     value: String,
     decision: Option<ConsensusDecision>,
 }
@@ -32,8 +32,8 @@ impl CommitEntry {
     }
 
     /// Returns the epoch for the commit entry
-    pub fn epoch(&self) -> u64 {
-        self.epoch
+    pub fn epoch(&self) -> &Option<u64> {
+        &self.epoch
     }
 
     /// Returns the value for the commit entry
@@ -49,7 +49,7 @@ impl CommitEntry {
     pub fn into_builder(self) -> CommitEntryBuilder {
         CommitEntryBuilder {
             service_id: Some(self.service_id),
-            epoch: Some(self.epoch),
+            epoch: self.epoch,
             value: Some(self.value),
             decision: self.decision,
         }
@@ -135,9 +135,7 @@ impl CommitEntryBuilder {
             )
         })?;
 
-        let epoch = self.epoch.ok_or_else(|| {
-            InvalidStateError::with_message("unable to build, missing field: `epoch`".to_string())
-        })?;
+        let epoch = self.epoch;
 
         let value = self.value.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `value`".to_string())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1301,6 +1301,24 @@ pub mod tests {
 
         store.add_service(service).expect("faield to add service");
 
+        let coordinator_context = ContextBuilder::default()
+            .with_coordinator(service_fqsi.clone().service_id())
+            .with_epoch(1)
+            .with_participants(vec![Participant {
+                process: peer_service_id.clone(),
+                vote: None,
+            }])
+            .with_state(State::WaitingForStart)
+            .with_this_process(service_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let context = ConsensusContext::TwoPhaseCommit(coordinator_context);
+
+        store
+            .add_consensus_context(&service_fqsi, context)
+            .expect("failed to add context to store");
+
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
             .with_epoch(1)
@@ -1359,6 +1377,24 @@ pub mod tests {
 
         store.add_service(service).expect("faield to add service");
 
+        let coordinator_context = ContextBuilder::default()
+            .with_coordinator(service_fqsi.clone().service_id())
+            .with_epoch(1)
+            .with_participants(vec![Participant {
+                process: peer_service_id.clone(),
+                vote: None,
+            }])
+            .with_state(State::WaitingForStart)
+            .with_this_process(service_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let context = ConsensusContext::TwoPhaseCommit(coordinator_context);
+
+        store
+            .add_consensus_context(&service_fqsi, context)
+            .expect("failed to add context to store");
+
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
             .with_epoch(1)
@@ -1412,6 +1448,24 @@ pub mod tests {
             .expect("failed to build service");
 
         store.add_service(service).expect("faield to add service");
+
+        let coordinator_context = ContextBuilder::default()
+            .with_coordinator(service_fqsi.clone().service_id())
+            .with_epoch(1)
+            .with_participants(vec![Participant {
+                process: peer_service_id.clone(),
+                vote: None,
+            }])
+            .with_state(State::WaitingForStart)
+            .with_this_process(service_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let context = ConsensusContext::TwoPhaseCommit(coordinator_context);
+
+        store
+            .add_consensus_context(&service_fqsi, context)
+            .expect("failed to add context to store");
 
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -94,8 +94,10 @@ impl TryFrom<&CommitEntry> for CommitEntryModel {
     fn try_from(entry: &CommitEntry) -> Result<Self, Self::Error> {
         Ok(CommitEntryModel {
             service_id: entry.service_id().to_string(),
-            epoch: i64::try_from(entry.epoch())
-                .map_err(|err| InternalError::from_source(Box::new(err)))?,
+            epoch: i64::try_from(entry.epoch().ok_or_else(|| {
+                InternalError::with_message("Epoch is not set on commit entry".to_string())
+            })?)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?,
             value: entry.value().to_string(),
             decision: entry
                 .decision()


### PR DESCRIPTION
The epoch is expected to be set when the commit entry
is added to the database. This removes the
requirement for components to access the context only
to get the epoch.

Also remove passing the epoch to the action runner.