### PR TITLE
Fix redundant slicing of the whole range lint

### DIFF
--- a/libsplinter/src/transport/socket/frame.rs
+++ b/libsplinter/src/transport/socket/frame.rs
@@ -277,7 +277,7 @@ impl FrameHeader {
                 cursor.get_mut()[HEADER_LENGTH] =
                     compute_checksum(&cursor.get_ref()[..HEADER_LENGTH]);
 
-                writer.write_all(&cursor.into_inner()[..])?;
+                writer.write_all(cursor.into_inner())?;
             }
         }
 


### PR DESCRIPTION
This change fixes a lint that occurs with the release of Rust 1.61.0. It
indicates an unnecessary slicing of a byte array.

See
https://rust-lang.github.io/rust-clippy/master/index.html#redundant_slicing
for more information.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>