### PR TITLE
Backport 0-4: Fix redundant slicing of the whole range lint

### DIFF
--- a/libsplinter/src/transport/socket/frame.rs
+++ b/libsplinter/src/transport/socket/frame.rs
@@ -277,7 +277,7 @@ impl FrameHeader {
                 cursor.get_mut()[HEADER_LENGTH] =
                     compute_checksum(&cursor.get_ref()[..HEADER_LENGTH]);
 
-                writer.write_all(&cursor.into_inner()[..])?;
+                writer.write_all(cursor.into_inner())?;
             }
         }
 


### PR DESCRIPTION
Backport of PR #1973 