### PR TITLE
Add store and operation to ConstraintViolationType

### DIFF
--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_commit_entry.rs
@@ -30,6 +30,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "add_commit_entry";
+
 pub(in crate::store::scabbard_store::diesel) trait AddCommitEntryOperation {
     fn add_commit_entry(&self, commit_entry: CommitEntry) -> Result<(), ScabbardStoreError>;
 }
@@ -42,7 +44,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnectio
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", commit_entry.service_id())))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Service does not exist",
@@ -55,7 +60,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnectio
                     consensus_2pc_context::service_id.eq(format!("{}", commit_entry.service_id())),
                 )
                 .first::<Consensus2pcContextModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
                         "Cannot add commit entry, context with service ID {} does not exist",
@@ -74,7 +82,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnectio
 
             insert_into(scabbard_v3_commit_history::table)
                 .values(vec![CommitEntryModel::try_from(&commit_entry)?])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })
@@ -89,7 +100,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", commit_entry.service_id())))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Service does not exist",
@@ -102,7 +116,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection> {
                     consensus_2pc_context::service_id.eq(format!("{}", commit_entry.service_id())),
                 )
                 .first::<Consensus2pcContextModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
                         "Cannot add commit entry, context with service ID {} does not exist",
@@ -121,7 +138,10 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection> {
 
             insert_into(scabbard_v3_commit_history::table)
                 .values(vec![CommitEntryModel::try_from(&commit_entry)?])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_context.rs
@@ -30,6 +30,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "add_consensus_context";
+
 pub(in crate::store::scabbard_store::diesel) trait AddContextOperation {
     fn add_consensus_context(
         &self,
@@ -54,11 +56,23 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, SqliteConnection> {
 
                     insert_into(consensus_2pc_context::table)
                         .values(vec![new_context])
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     insert_into(consensus_2pc_context_participant::table)
                         .values(participants)
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
                 }
             }
             Ok(())
@@ -82,11 +96,23 @@ impl<'a> AddContextOperation for ScabbardStoreOperations<'a, PgConnection> {
 
                     insert_into(consensus_2pc_context::table)
                         .values(vec![new_context])
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     insert_into(consensus_2pc_context_participant::table)
                         .values(participants)
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
                 }
             }
             Ok(())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
@@ -31,6 +31,8 @@ use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "get_alarm";
+
 pub(in crate::store::scabbard_store::diesel) trait GetAlarmOperation {
     fn get_alarm(
         &self,
@@ -51,7 +53,10 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to get scabbard alarm, service does not exist",
@@ -66,7 +71,10 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 )
                 .select(scabbard_alarm::alarm)
                 .first::<i64>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .map(|t| {
                     SystemTime::UNIX_EPOCH
                         .checked_add(Duration::from_secs(t as u64))
@@ -94,7 +102,10 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to get scabbard alarm, service does not exist",
@@ -109,7 +120,10 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                 )
                 .select(scabbard_alarm::alarm)
                 .first::<i64>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .map(|t| {
                     SystemTime::UNIX_EPOCH
                         .checked_add(Duration::from_secs(t as u64))

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
@@ -26,6 +26,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "get_last_commit_entry";
+
 pub(in crate::store::scabbard_store::diesel) trait GetLastCommitEntryOperation {
     fn get_last_commit_entry(
         &self,
@@ -48,7 +50,10 @@ where
                 .filter(scabbard_v3_commit_history::service_id.eq(format!("{}", service_id)))
                 .order(scabbard_v3_commit_history::epoch.desc())
                 .first::<CommitEntryModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .map(CommitEntry::try_from)
                 .transpose()
                 .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
@@ -32,6 +32,8 @@ use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "set_alarm";
+
 pub(in crate::store::scabbard_store::diesel) trait SetAlarmOperation {
     fn set_alarm(
         &self,
@@ -54,7 +56,10 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to set scabbard alarm, service does not exist",
@@ -68,7 +73,10 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
-                .optional()?;
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             let new_alarm = ScabbardAlarmModel {
                 service_id: format!("{}", service_id),
@@ -85,12 +93,18 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
             }
 
             insert_into(scabbard_alarm::table)
                 .values(vec![new_alarm])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })
@@ -110,7 +124,10 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to set scabbard alarm, service does not exist",
@@ -124,7 +141,10 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
-                .optional()?;
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             let new_alarm = ScabbardAlarmModel {
                 service_id: format!("{}", service_id),
@@ -141,12 +161,18 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
             }
 
             insert_into(scabbard_alarm::table)
                 .values(vec![new_alarm])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
@@ -29,6 +29,8 @@ use crate::store::AlarmType;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "unset_alarm";
+
 pub(in crate::store::scabbard_store::diesel) trait UnsetAlarmOperation {
     fn unset_alarm(
         &self,
@@ -49,7 +51,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to unset scabbard alarm, service does not exist",
@@ -63,7 +68,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
-                .optional()?;
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             if current_alarm.is_some() {
                 // delete the current alarm
@@ -74,7 +82,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
             }
 
             Ok(())
@@ -94,7 +105,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
             scabbard_service::table
                 .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
                 .first::<ScabbardServiceModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Failed to unset scabbard alarm, service does not exist",
@@ -108,7 +122,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
-                .optional()?;
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             if current_alarm.is_some() {
                 // delete the current alarm
@@ -119,7 +136,10 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
             }
 
             Ok(())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_commit_entry.rs
@@ -24,6 +24,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "update_commit_entry";
+
 pub(in crate::store::scabbard_store::diesel) trait UpdateCommitEntryOperation {
     fn update_commit_entry(&self, commit_entry: CommitEntry) -> Result<(), ScabbardStoreError>;
 }
@@ -46,7 +48,10 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnec
                         .and(scabbard_v3_commit_history::epoch.eq(epoch)),
                 )
                 .first::<CommitEntryModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Commit entry does not exist",
@@ -57,11 +62,17 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnec
                 scabbard_v3_commit_history::table
                     .find((format!("{}", commit_entry.service_id()), epoch)),
             )
-            .execute(self.conn)?;
+            .execute(self.conn)
+            .map_err(|err| {
+                ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+            })?;
 
             insert_into(scabbard_v3_commit_history::table)
                 .values(vec![CommitEntryModel::try_from(&commit_entry)?])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })
@@ -86,7 +97,10 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection
                         .and(scabbard_v3_commit_history::epoch.eq(epoch)),
                 )
                 .first::<CommitEntryModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
                         "Commit entry does not exist",
@@ -97,11 +111,17 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection
                 scabbard_v3_commit_history::table
                     .find((format!("{}", commit_entry.service_id()), epoch)),
             )
-            .execute(self.conn)?;
+            .execute(self.conn)
+            .map_err(|err| {
+                ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+            })?;
 
             insert_into(scabbard_v3_commit_history::table)
                 .values(vec![CommitEntryModel::try_from(&commit_entry)?])
-                .execute(self.conn)?;
+                .execute(self.conn)
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
 
             Ok(())
         })

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -31,6 +31,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "update_consensus_context";
+
 pub(in crate::store::scabbard_store::diesel) trait UpdateContextAction {
     fn update_consensus_context(
         &self,
@@ -53,7 +55,13 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                     consensus_2pc_context::table
                         .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
                         .first::<Consensus2pcContextModel>(self.conn)
-                        .optional()?
+                        .optional()
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?
                         .ok_or_else(|| {
                             ScabbardStoreError::InvalidState(InvalidStateError::with_message(
                                 format!("Context with service ID {} does not exist", service_id,),
@@ -78,7 +86,12 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                                 .eq(update_context.decision_timeout_start),
                         ))
                         .execute(self.conn)
-                        .map(|_| ())?;
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     let updated_participants =
                         ContextParticipantList::try_from((&context, service_id))?.inner;
@@ -86,11 +99,23 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                     delete(consensus_2pc_context_participant::table.filter(
                         consensus_2pc_context_participant::service_id.eq(format!("{}", service_id)),
                     ))
-                    .execute(self.conn)?;
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        ScabbardStoreError::from_source_with_operation(
+                            err,
+                            OPERATION_NAME.to_string(),
+                        )
+                    })?;
 
                     insert_into(consensus_2pc_context_participant::table)
                         .values(updated_participants)
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     Ok(())
                 }
@@ -113,7 +138,13 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                     consensus_2pc_context::table
                         .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
                         .first::<Consensus2pcContextModel>(self.conn)
-                        .optional()?
+                        .optional()
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?
                         .ok_or_else(|| {
                             ScabbardStoreError::InvalidState(InvalidStateError::with_message(
                                 format!("Context with service ID {} does not exist", service_id,),
@@ -138,7 +169,12 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                                 .eq(update_context.decision_timeout_start),
                         ))
                         .execute(self.conn)
-                        .map(|_| ())?;
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     let updated_participants =
                         ContextParticipantList::try_from((&context, service_id))?.inner;
@@ -146,11 +182,23 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                     delete(consensus_2pc_context_participant::table.filter(
                         consensus_2pc_context_participant::service_id.eq(format!("{}", service_id)),
                     ))
-                    .execute(self.conn)?;
+                    .execute(self.conn)
+                    .map_err(|err| {
+                        ScabbardStoreError::from_source_with_operation(
+                            err,
+                            OPERATION_NAME.to_string(),
+                        )
+                    })?;
 
                     insert_into(consensus_2pc_context_participant::table)
                         .values(updated_participants)
-                        .execute(self.conn)?;
+                        .execute(self.conn)
+                        .map_err(|err| {
+                            ScabbardStoreError::from_source_with_operation(
+                                err,
+                                OPERATION_NAME.to_string(),
+                            )
+                        })?;
 
                     Ok(())
                 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -27,6 +27,8 @@ use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
 
+const OPERATION_NAME: &str = "update_consensus_event";
+
 pub(in crate::store::scabbard_store::diesel) trait UpdateEventOperation {
     fn update_consensus_event(
         &self,
@@ -53,7 +55,10 @@ where
             consensus_2pc_context::table
                 .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
                 .first::<Consensus2pcContextModel>(self.conn)
-                .optional()?
+                .optional()
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?
                 .ok_or_else(|| {
                     ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
                         "Context with service ID {} does not exist",
@@ -81,8 +86,9 @@ where
                 )
                 .set(consensus_2pc_event::executed_at.eq(Some(update_executed_at)))
                 .execute(self.conn)
-                .map(|_| ())
-                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+                .map_err(|err| {
+                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
+                })?;
             Ok(())
         })
     }


### PR DESCRIPTION
Previously, the ConstraintViolationType depended on the
source error to provide helpful information about the
violation. This resulted in errors that were too cryptic
to be helpful.

This commit adds from_source_with_violation_type_with_store
which adds the store name and operation that will be prefixed
in front of the source error:

Store operation: source error
