### PR TITLE
Update epoch usage in event tables

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -19,7 +19,6 @@ CREATE TYPE deliver_event_message_type AS ENUM ('VOTERESPONSE', 'DECISIONREQUEST
 CREATE TABLE IF NOT EXISTS consensus_2pc_event (
     id                        BIGSERIAL PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
@@ -43,7 +42,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     value                     BYTEA,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
@@ -52,7 +50,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-21-174800_scabbard_consensus_event_tables/up.sql
@@ -16,7 +16,6 @@
 CREATE TABLE IF NOT EXISTS consensus_2pc_event (
     id                        INTEGER PRIMARY KEY AUTOINCREMENT,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     position                  INTEGER NOT NULL,
@@ -42,7 +41,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_deliver_event (
 CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     value                     BINARY,
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,
     FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
@@ -51,7 +49,6 @@ CREATE TABLE IF NOT EXISTS consensus_2pc_start_event (
 CREATE TABLE IF NOT EXISTS consensus_2pc_vote_event (
     event_id                  INTEGER PRIMARY KEY,
     service_id                TEXT NOT NULL,
-    epoch                     BIGINT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') ),
     FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE,

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -712,7 +712,6 @@ impl From<&Message> for String {
 pub struct Consensus2pcEventModel {
     pub id: i64,
     pub service_id: String,
-    pub epoch: i64,
     pub created_at: SystemTime,
     pub executed_at: Option<i64>,
     pub position: i32,
@@ -723,7 +722,6 @@ pub struct Consensus2pcEventModel {
 #[table_name = "consensus_2pc_event"]
 pub struct InsertableConsensus2pcEventModel {
     pub service_id: String,
-    pub epoch: i64,
     pub executed_at: Option<i64>,
     pub position: i32,
     pub event_type: String,
@@ -761,7 +759,6 @@ pub struct Consensus2pcDeliverEventModel {
 pub struct Consensus2pcStartEventModel {
     pub event_id: i64,
     pub service_id: String,
-    pub epoch: i64,
     pub value: Vec<u8>,
 }
 
@@ -772,7 +769,6 @@ pub struct Consensus2pcStartEventModel {
 pub struct Consensus2pcVoteEventModel {
     pub event_id: i64,
     pub service_id: String,
-    pub epoch: i64,
     pub vote: String, // TRUE or FALSE
 }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -129,7 +129,6 @@ table! {
     consensus_2pc_event (id) {
         id -> Int8,
         service_id -> Text,
-        epoch -> BigInt,
         created_at -> Timestamp,
         executed_at -> Nullable<BigInt>,
         position -> Integer,
@@ -153,7 +152,6 @@ table! {
     consensus_2pc_start_event (event_id) {
         event_id -> Int8,
         service_id -> Text,
-        epoch -> BigInt,
         value -> Binary,
     }
 }
@@ -162,7 +160,6 @@ table! {
     consensus_2pc_vote_event (event_id) {
         event_id -> Int8,
         service_id -> Text,
-        epoch -> BigInt,
         vote -> Text,
     }
 }


### PR DESCRIPTION
Remove the epoch column/field from the tables and models for
consensus_2pc_event, consensus_2pc_start_event, and
consensus_2pc_vote_event. Only deliver events have an associated epoch
because of the message it contains so consensus_2pc_deliver_event should
be the only event related table with an epoch column.

Previously the epoch was being set for vote and start events based on
the epoch in the current context which caused a bug in scabbard consensus.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>