### PR TITLE
Replace the use of epoch with id in CommitEntry

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-05-153027_scabbard_commit_history/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-04-05-153027_scabbard_commit_history/up.sql
@@ -28,9 +28,9 @@ CREATE TABLE IF NOT EXISTS scabbard_peer (
 
 CREATE TABLE IF NOT EXISTS scabbard_v3_commit_history (
     service_id TEXT NOT NULL,
-    epoch      INTEGER NOT NULL,
+    id      INTEGER NOT NULL,
     value      TEXT NOT NULL,
     decision   TEXT,
     CHECK ( decision IN ('COMMIT', 'ABORT') ),
-    PRIMARY KEY (service_id, epoch)
+    PRIMARY KEY (service_id, id)
 );

--- a/services/scabbard/libscabbard/src/store/scabbard_store/commit.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/commit.rs
@@ -20,7 +20,7 @@ use splinter::service::FullyQualifiedServiceId;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitEntry {
     service_id: FullyQualifiedServiceId,
-    epoch: Option<u64>,
+    id: Option<i64>,
     value: String,
     decision: Option<ConsensusDecision>,
 }
@@ -31,9 +31,9 @@ impl CommitEntry {
         &self.service_id
     }
 
-    /// Returns the epoch for the commit entry
-    pub fn epoch(&self) -> &Option<u64> {
-        &self.epoch
+    /// Returns the ID for the commit entry
+    pub fn id(&self) -> &Option<i64> {
+        &self.id
     }
 
     /// Returns the value for the commit entry
@@ -49,7 +49,7 @@ impl CommitEntry {
     pub fn into_builder(self) -> CommitEntryBuilder {
         CommitEntryBuilder {
             service_id: Some(self.service_id),
-            epoch: self.epoch,
+            id: self.id,
             value: Some(self.value),
             decision: self.decision,
         }
@@ -59,7 +59,7 @@ impl CommitEntry {
 #[derive(Default, Clone)]
 pub struct CommitEntryBuilder {
     service_id: Option<FullyQualifiedServiceId>,
-    epoch: Option<u64>,
+    id: Option<i64>,
     value: Option<String>,
     decision: Option<ConsensusDecision>,
 }
@@ -70,9 +70,9 @@ impl CommitEntryBuilder {
         self.service_id.clone()
     }
 
-    /// Returns the epoch for the commit entry
-    pub fn epoch(&self) -> Option<u64> {
-        self.epoch
+    /// Returns the ID for the commit entry
+    pub fn id(&self) -> Option<i64> {
+        self.id
     }
 
     /// Returns the value for the commit entry
@@ -95,13 +95,13 @@ impl CommitEntryBuilder {
         self
     }
 
-    /// Sets the epoch
+    /// Sets the ID
     ///
     /// # Arguments
     ///
-    ///  * `epoch` - The epoch for commit entry
-    pub fn with_epoch(mut self, epoch: u64) -> CommitEntryBuilder {
-        self.epoch = Some(epoch);
+    ///  * `id` - The ID for commit entry
+    pub fn with_id(mut self, id: i64) -> CommitEntryBuilder {
+        self.id = Some(id);
         self
     }
 
@@ -127,7 +127,7 @@ impl CommitEntryBuilder {
 
     /// Builds the `CommitEntry`
     ///
-    /// Returns an error if the service ID, epoch, or value is not set
+    /// Returns an error if the service ID or value is not set
     pub fn build(self) -> Result<CommitEntry, InvalidStateError> {
         let service_id = self.service_id.ok_or_else(|| {
             InvalidStateError::with_message(
@@ -135,7 +135,7 @@ impl CommitEntryBuilder {
             )
         })?;
 
-        let epoch = self.epoch;
+        let id = self.id;
 
         let value = self.value.ok_or_else(|| {
             InvalidStateError::with_message("unable to build, missing field: `value`".to_string())
@@ -143,7 +143,7 @@ impl CommitEntryBuilder {
 
         Ok(CommitEntry {
             service_id,
-            epoch,
+            id,
             value,
             decision: self.decision,
         })

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1321,7 +1321,6 @@ pub mod tests {
 
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
-            .with_epoch(1)
             .with_value("commit entry value")
             .with_decision(&ConsensusDecision::Commit)
             .build()
@@ -1329,15 +1328,21 @@ pub mod tests {
 
         assert!(store.add_commit_entry(commit_entry.clone()).is_ok());
 
+        // update commit_entry to add expected id
+        let id_commit_entry = commit_entry
+            .into_builder()
+            .with_id(1)
+            .build()
+            .expect("failed to build commit entry");
+
         let get_last_commit_entry = store
             .get_last_commit_entry(&service_fqsi.clone())
             .expect("failed to get commit entry");
 
-        assert_eq!(get_last_commit_entry, Some(commit_entry));
+        assert_eq!(get_last_commit_entry, Some(id_commit_entry));
 
         let bad_commit_entry = CommitEntryBuilder::default()
             .with_service_id(&FullyQualifiedServiceId::new_random())
-            .with_epoch(1)
             .with_value("commit entry value")
             .with_decision(&ConsensusDecision::Commit)
             .build()
@@ -1397,7 +1402,6 @@ pub mod tests {
 
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
-            .with_epoch(1)
             .with_value("commit entry value")
             .with_decision(&ConsensusDecision::Commit)
             .build()
@@ -1405,11 +1409,18 @@ pub mod tests {
 
         assert!(store.add_commit_entry(commit_entry.clone()).is_ok());
 
+        // update commit_entry for expected id
+        let id_commit_entry = commit_entry
+            .into_builder()
+            .with_id(1)
+            .build()
+            .expect("failed to build commit entry with id");
+
         let get_last_commit_entry = store
             .get_last_commit_entry(&service_fqsi.clone())
             .expect("failed to get commit entry");
 
-        assert_eq!(get_last_commit_entry, Some(commit_entry));
+        assert_eq!(get_last_commit_entry, Some(id_commit_entry));
 
         let get_last_commit_entry = store
             .get_last_commit_entry(&FullyQualifiedServiceId::new_random())
@@ -1469,7 +1480,6 @@ pub mod tests {
 
         let commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
-            .with_epoch(1)
             .with_value("commit entry value")
             .build()
             .expect("failed to build commit entry");
@@ -1480,7 +1490,8 @@ pub mod tests {
 
         let update_commit_entry = CommitEntryBuilder::default()
             .with_service_id(&service_fqsi)
-            .with_epoch(1)
+            // set expected id
+            .with_id(1)
             .with_value("commit entry value")
             .with_decision(&ConsensusDecision::Commit)
             .build()

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
@@ -46,7 +46,7 @@ where
         self.conn.transaction::<_, _, _>(|| {
             scabbard_v3_commit_history::table
                 .filter(scabbard_v3_commit_history::service_id.eq(format!("{}", service_id)))
-                .order(scabbard_v3_commit_history::epoch.desc())
+                .order(scabbard_v3_commit_history::id.desc())
                 .first::<CommitEntryModel>(self.conn)
                 .optional()?
                 .map(CommitEntry::try_from)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -28,9 +28,9 @@ table! {
 }
 
 table! {
-    scabbard_v3_commit_history (service_id, epoch) {
+    scabbard_v3_commit_history (service_id, id) {
         service_id  -> Text,
-        epoch -> BigInt,
+        id -> BigInt,
         value -> VarChar,
         decision -> Nullable<Text>,
     }


### PR DESCRIPTION
This removes a dependency between the commit entry used
for the scabbard prototype and the context which should
be internal to consensus.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>