### PR TITLE
Remove unnecessary generic parameter

### DIFF
--- a/libsplinter/src/service/message_handler.rs
+++ b/libsplinter/src/service/message_handler.rs
@@ -42,7 +42,7 @@ pub trait MessageHandler {
         message: Self::Message,
     ) -> Result<(), InternalError>;
 
-    fn into_handler<C, R>(self, converter: C) -> IntoMessageHandler<Self, C, Self::Message, R>
+    fn into_handler<C, R>(self, converter: C) -> IntoMessageHandler<Self, C, R>
     where
         Self: Sized,
         C: MessageConverter<Self::Message, R>,
@@ -51,32 +51,30 @@ pub trait MessageHandler {
     }
 }
 
-pub struct IntoMessageHandler<H, C, L, R> {
+pub struct IntoMessageHandler<H, C, R> {
     inner: H,
     converter: C,
-    _left: std::marker::PhantomData<L>,
     _right: std::marker::PhantomData<R>,
 }
 
-impl<H, C, L, R> IntoMessageHandler<H, C, L, R>
+impl<H, C, R> IntoMessageHandler<H, C, R>
 where
-    H: MessageHandler<Message = L>,
-    C: MessageConverter<L, R>,
+    H: MessageHandler,
+    C: MessageConverter<<H as MessageHandler>::Message, R>,
 {
     fn new(inner: H, converter: C) -> Self {
         Self {
             inner,
             converter,
-            _left: std::marker::PhantomData,
             _right: std::marker::PhantomData,
         }
     }
 }
 
-impl<H, C, L, R> MessageHandler for IntoMessageHandler<H, C, L, R>
+impl<H, C, R> MessageHandler for IntoMessageHandler<H, C, R>
 where
-    H: MessageHandler<Message = L>,
-    C: MessageConverter<L, R>,
+    H: MessageHandler,
+    C: MessageConverter<<H as MessageHandler>::Message, R>,
 {
     type Message = R;
 

--- a/libsplinter/src/service/message_handler_factory.rs
+++ b/libsplinter/src/service/message_handler_factory.rs
@@ -95,12 +95,7 @@ where
         + 'static,
     R: 'static,
 {
-    type MessageHandler = IntoMessageHandler<
-        <F as MessageHandlerFactory>::MessageHandler,
-        C,
-        <<F as MessageHandlerFactory>::MessageHandler as MessageHandler>::Message,
-        R,
-    >;
+    type MessageHandler = IntoMessageHandler<<F as MessageHandlerFactory>::MessageHandler, C, R>;
 
     fn new_handler(&self) -> Self::MessageHandler {
         let handler = self.inner.new_handler();


### PR DESCRIPTION
This change removes an unnecessary generic parameter from `service::MessageHandler`.  `IntoMessageHandler` doesn't require the left message type as a parameter as this is already encoded in the handler parameter via its associated type parameter.
