### PR TITLE
Pin error-stack-parser

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -39,6 +39,7 @@
     "@vue/cli-plugin-babel": "^3.9.0",
     "@vue/cli-plugin-typescript": "^3.9.0",
     "@vue/cli-service": "^3.9.0",
+    "error-stack-parser": "2.0.6",
     "cross-env": "^5.2.0",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
This change pins the "error-stack-parser" dependency whose recent release has a build-breaking bug.

Related to https://github.com/stacktracejs/error-stack-parser/issues/80