### PR TITLE
Unpin error-stack-parser

### DIFF
--- a/examples/gameroom/gameroom-app/package.json
+++ b/examples/gameroom/gameroom-app/package.json
@@ -39,7 +39,6 @@
     "@vue/cli-plugin-babel": "^3.9.0",
     "@vue/cli-plugin-typescript": "^3.9.0",
     "@vue/cli-service": "^3.9.0",
-    "error-stack-parser": "2.0.6",
     "cross-env": "^5.2.0",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
Version 2.1.4 was released which fixes the issue that necessitated pinning.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>