### PR TITLE
Remove unused Method enums

### DIFF
--- a/libsplinter/src/rest_api/auth/authorization/permission_map/method.rs
+++ b/libsplinter/src/rest_api/auth/authorization/permission_map/method.rs
@@ -22,10 +22,6 @@ pub enum Method {
     Patch,
     Delete,
     Head,
-    Options,
-    Connect,
-    Trace,
-    Extension(String),
 }
 
 impl From<&Actix1Method> for Method {


### PR DESCRIPTION
There are several unused `Method` enums that can't be constructed in the
provided `From` implementations. They were originally included to more
completely model all the http method types available. This commit
removes them until such a time as actix-web or any other frameworks
`Method` type includes those types.

Signed-off-by: Caleb Hill <hill@bitwise.io>