### PR TITLE
Split authorization mod

### DIFF
--- a/libsplinter/src/rest_api/auth/authorization/authorization_handler_result.rs
+++ b/libsplinter/src/rest_api/auth/authorization/authorization_handler_result.rs
@@ -1,0 +1,24 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// An authorization handler's decision about whether to allow, deny, or pass on the request
+pub enum AuthorizationHandlerResult {
+    /// The authorization handler has granted the requested permission
+    Allow,
+    /// The authorization handler has denied the requested permission
+    Deny,
+    /// The authorization handler is not able to determine if the requested permission should be
+    /// granted or denied
+    Continue,
+}

--- a/libsplinter/src/rest_api/auth/authorization/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/mod.rs
@@ -18,6 +18,7 @@
 pub mod allow_keys;
 #[cfg(feature = "authorization-handler-maintenance")]
 pub mod maintenance;
+mod permission;
 mod permission_map;
 #[cfg(feature = "authorization-handler-rbac")]
 pub mod rbac;
@@ -27,31 +28,11 @@ use crate::error::InternalError;
 
 use super::identity::Identity;
 
+pub use permission::Permission;
 pub use permission_map::PermissionMap;
 
 #[cfg(test)]
 pub use permission_map::Method;
-
-/// A permission assigned to an endpoint
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Permission {
-    /// Check that the authenticated client has the specified permission.
-    Check {
-        /// The permission ID that's passed to [`AuthorizationHandler::has_permission`]
-        permission_id: &'static str,
-        /// The human-readable name for the permission
-        permission_display_name: &'static str,
-        /// A description for the permission
-        permission_description: &'static str,
-    },
-    /// Allow any request that has been authenticated (the client's identity has been determined).
-    /// This may be used by endpoints that need to know the client's identity but do not require a
-    /// special permission to be checked (the Biome key management and OAuth logout routes are an
-    /// example of this).
-    AllowAuthenticated,
-    /// Allow any request without checking for authorization.
-    AllowUnauthenticated,
-}
 
 /// An authorization handler's decision about whether to allow, deny, or pass on the request
 pub enum AuthorizationHandlerResult {

--- a/libsplinter/src/rest_api/auth/authorization/mod.rs
+++ b/libsplinter/src/rest_api/auth/authorization/mod.rs
@@ -16,6 +16,7 @@
 
 #[cfg(feature = "authorization-handler-allow-keys")]
 pub mod allow_keys;
+mod authorization_handler_result;
 #[cfg(feature = "authorization-handler-maintenance")]
 pub mod maintenance;
 mod permission;
@@ -28,22 +29,12 @@ use crate::error::InternalError;
 
 use super::identity::Identity;
 
+pub use authorization_handler_result::AuthorizationHandlerResult;
 pub use permission::Permission;
 pub use permission_map::PermissionMap;
 
 #[cfg(test)]
 pub use permission_map::Method;
-
-/// An authorization handler's decision about whether to allow, deny, or pass on the request
-pub enum AuthorizationHandlerResult {
-    /// The authorization handler has granted the requested permission
-    Allow,
-    /// The authorization handler has denied the requested permission
-    Deny,
-    /// The authorization handler is not able to determine if the requested permission should be
-    /// granted or denied
-    Continue,
-}
 
 /// Determines if a client has some permissions
 pub trait AuthorizationHandler: Send + Sync {

--- a/libsplinter/src/rest_api/auth/authorization/permission.rs
+++ b/libsplinter/src/rest_api/auth/authorization/permission.rs
@@ -1,0 +1,34 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A permission assigned to an endpoint
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Permission {
+    /// Check that the authenticated client has the specified permission.
+    Check {
+        /// The permission ID that's passed to [`AuthorizationHandler::has_permission`]
+        permission_id: &'static str,
+        /// The human-readable name for the permission
+        permission_display_name: &'static str,
+        /// A description for the permission
+        permission_description: &'static str,
+    },
+    /// Allow any request that has been authenticated (the client's identity has been determined).
+    /// This may be used by endpoints that need to know the client's identity but do not require a
+    /// special permission to be checked (the Biome key management and OAuth logout routes are an
+    /// example of this).
+    AllowAuthenticated,
+    /// Allow any request without checking for authorization.
+    AllowUnauthenticated,
+}


### PR DESCRIPTION
This splits out the Permission and AuthorizationHandlerResult types into their own files. 