### PR TITLE
Fix publish release workflow to use correct action name

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Start EC2 runner
         id: start_buildx_cluster
-        uses: ./.github/actions/ec2-docker-buildx
+        uses: ./.github/actions/ec2-runners
         with:
           action: start
           amd_ami_id: ${{ secrets.AMD_AMI_ID }}
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Destroy cluster
-        uses: ./.github/actions/ec2-docker-buildx
+        uses: ./.github/actions/ec2-runners
         with:
           action: stop
           label: ${{ needs.start_cluster.outputs.label }}


### PR DESCRIPTION
The action was renamed in commit ae6bfecbf but this workflow was
incorrectly still using the old name.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>