### PR TITLE
Scabbard store - remove position column

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-133219-remove-action-and-event-position/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-133219-remove-action-and-event-position/down.sql
@@ -1,0 +1,97 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Drop foreign key constraints
+ALTER TABLE consensus_2pc_update_context_action DROP CONSTRAINT consensus_2pc_update_context_action_action_id_fkey;
+ALTER TABLE consensus_2pc_update_context_action_participant DROP CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey;
+ALTER TABLE consensus_2pc_send_message_action DROP CONSTRAINT consensus_2pc_send_message_action_action_id_fkey;
+ALTER TABLE consensus_2pc_notification_action DROP CONSTRAINT consensus_2pc_notification_action_action_id_fkey;
+
+ALTER TABLE consensus_2pc_deliver_event DROP CONSTRAINT consensus_2pc_deliver_event_event_id_fkey;
+ALTER TABLE consensus_2pc_start_event DROP CONSTRAINT consensus_2pc_start_event_event_id_fkey;
+ALTER TABLE consensus_2pc_vote_event DROP CONSTRAINT consensus_2pc_vote_event_event_id_fkey;
+
+-- Recreate the tables with the position column
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        BIGSERIAL PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    position                  INTEGER NOT NULL,
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        BIGSERIAL PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    position                  INTEGER NOT NULL,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+);
+
+-- Move data from the old tables into the updated tables setting position to the value stored in id
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        position
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        id
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type,
+        position
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type,
+        id
+    FROM consensus_2pc_event;
+
+-- Drop the old tables
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+
+-- Rename the new tables to the old names
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+-- Recreate the foreign key constraints
+ALTER TABLE consensus_2pc_update_context_action ADD CONSTRAINT consensus_2pc_update_context_action_action_id_fkey FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id);
+ALTER TABLE consensus_2pc_update_context_action_participant ADD CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id);
+ALTER TABLE consensus_2pc_send_message_action ADD CONSTRAINT consensus_2pc_send_message_action_action_id_fkey FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id);
+ALTER TABLE consensus_2pc_notification_action ADD CONSTRAINT consensus_2pc_notification_action_action_id_fkey FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id);
+
+ALTER TABLE consensus_2pc_deliver_event ADD CONSTRAINT consensus_2pc_deliver_event_event_id_fkey FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id);
+ALTER TABLE consensus_2pc_start_event ADD CONSTRAINT consensus_2pc_start_event_event_id_fkey FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id);
+ALTER TABLE consensus_2pc_vote_event ADD CONSTRAINT consensus_2pc_vote_event_event_id_fkey FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id);

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-133219-remove-action-and-event-position/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-133219-remove-action-and-event-position/up.sql
@@ -1,0 +1,18 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE consensus_2pc_action DROP COLUMN position;
+
+ALTER TABLE consensus_2pc_event DROP COLUMN position;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-133219-remove-action-and-event-position/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-133219-remove-action-and-event-position/down.sql
@@ -1,0 +1,81 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+-- Recreate the tables with the position column
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    position                  INTEGER NOT NULL,
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    position                  INTEGER NOT NULL,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+);
+
+-- Move data from the old tables into the updated tables
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        position
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        id
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type,
+        position
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type,
+        id
+    FROM consensus_2pc_event;
+
+-- Drop the old tables
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+
+-- Rename the new tables to the old names
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-133219-remove-action-and-event-position/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-133219-remove-action-and-event-position/up.sql
@@ -1,0 +1,75 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+-- Recreate the tables without the position column
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+);
+
+-- Move data from the old tables into the updated tables
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    )
+    SELECT
+        id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    FROM consensus_2pc_event;
+
+-- Drop the old tables
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+
+-- Rename the new tables to the old names
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models.rs
@@ -648,7 +648,6 @@ pub struct Consensus2pcActionModel {
     pub service_id: String,
     pub created_at: SystemTime,
     pub executed_at: Option<i64>,
-    pub position: i32,
 }
 
 #[derive(Debug, PartialEq, Insertable)]
@@ -656,7 +655,6 @@ pub struct Consensus2pcActionModel {
 pub struct InsertableConsensus2pcActionModel {
     pub service_id: String,
     pub executed_at: Option<i64>,
-    pub position: i32,
 }
 
 impl From<&Notification> for String {
@@ -692,7 +690,6 @@ pub struct Consensus2pcEventModel {
     pub service_id: String,
     pub created_at: SystemTime,
     pub executed_at: Option<i64>,
-    pub position: i32,
     pub event_type: String,
 }
 
@@ -701,7 +698,6 @@ pub struct Consensus2pcEventModel {
 pub struct InsertableConsensus2pcEventModel {
     pub service_id: String,
     pub executed_at: Option<i64>,
-    pub position: i32,
     pub event_type: String,
 }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
@@ -78,22 +78,9 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     )))
                 })?;
 
-            let position = consensus_2pc_action::table
-                .filter(consensus_2pc_action::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_action::position.desc())
-                .select(consensus_2pc_action::position)
-                .first::<i32>(self.conn)
-                .optional()
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?
-                .unwrap_or(0)
-                + 1;
-
             let insertable_action = InsertableConsensus2pcActionModel {
                 service_id: format!("{}", service_id),
                 executed_at: None,
-                position,
             };
 
             insert_into(consensus_2pc_action::table)
@@ -248,22 +235,9 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                     )))
                 })?;
 
-            let position = consensus_2pc_action::table
-                .filter(consensus_2pc_action::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_action::position.desc())
-                .select(consensus_2pc_action::position)
-                .first::<i32>(self.conn)
-                .optional()
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?
-                .unwrap_or(0)
-                + 1;
-
             let insertable_action = InsertableConsensus2pcActionModel {
                 service_id: format!("{}", service_id),
                 executed_at: None,
-                position,
             };
 
             let action_id: i64 = insert_into(consensus_2pc_action::table)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -74,22 +74,9 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                     )))
                 })?;
 
-            let position = consensus_2pc_event::table
-                .filter(consensus_2pc_event::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_event::position.desc())
-                .select(consensus_2pc_event::position)
-                .first::<i32>(self.conn)
-                .optional()
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?
-                .unwrap_or(0)
-                + 1;
-
             let insertable_event = InsertableConsensus2pcEventModel {
                 service_id: format!("{}", service_id),
                 executed_at: None,
-                position,
                 event_type: String::from(&event),
             };
 
@@ -212,22 +199,9 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                     )))
                 })?;
 
-            let position = consensus_2pc_event::table
-                .filter(consensus_2pc_event::service_id.eq(format!("{}", service_id)))
-                .order(consensus_2pc_event::position.desc())
-                .select(consensus_2pc_event::position)
-                .first::<i32>(self.conn)
-                .optional()
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?
-                .unwrap_or(0)
-                + 1;
-
             let insertable_event = InsertableConsensus2pcEventModel {
                 service_id: format!("{}", service_id),
                 executed_at: None,
-                position,
                 event_type: String::from(&event),
             };
 


### PR DESCRIPTION
Remove the position column/field from the consensus event and action
tables in scabbard store. This field was initially meant to order
events and actions within an epoch but since epoch was removed from
these tables the id column can be used for ordering events and actions
instead.