### PR TITLE
Update Timer to keep track of which service are active

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -206,6 +206,7 @@ service-message-sender-factory-peer = [
     "service-message-sender-factory"
 ]
 service-timer =[
+  "defered-send",
   "runtime-service",
   "service-message-sender-factory",
   "service-timer-filter",

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -121,6 +121,7 @@ experimental = [
     "biome-client",
     "biome-client-reqwest",
     "client-reqwest",
+    "defered-send",
     "https-bind",
     "registry-client",
     "registry-client-reqwest",
@@ -168,6 +169,7 @@ challenge-authorization = []
 circuit-template = ["admin-service", "glob"]
 client-reqwest = ["reqwest"]
 cylinder-jwt = ["cylinder/jwt", "rest-api"]
+defered-send = []
 events = ["actix-http", "futures", "hyper", "tokio", "awc"]
 https-bind = ["actix-web/ssl"]
 memory = ["sqlite"]

--- a/libsplinter/src/channel/defered.rs
+++ b/libsplinter/src/channel/defered.rs
@@ -1,0 +1,38 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::sync::mpsc::Sender;
+
+pub struct DeferedSend<M> {
+    sender: Sender<M>,
+    msg: Option<M>,
+}
+
+impl<M> DeferedSend<M> {
+    pub fn new(sender: Sender<M>, msg: M) -> Self {
+        DeferedSend {
+            sender,
+            msg: Some(msg),
+        }
+    }
+}
+
+impl<M> Drop for DeferedSend<M> {
+    fn drop(&mut self) {
+        if let Some(msg) = self.msg.take() {
+            if self.sender.send(msg).is_err() {
+                error!("Unable to send message for defered send")
+            }
+        }
+    }
+}

--- a/libsplinter/src/channel/mod.rs
+++ b/libsplinter/src/channel/mod.rs
@@ -16,6 +16,8 @@
 // that is used must have the following Receiver trait implemented, then the receiver end of the
 // channel can be passed to the NetworkMessageSender.
 mod crossbeam;
+#[cfg(feature = "defered-send")]
+mod defered;
 mod error;
 #[cfg(test)]
 pub mod mock;
@@ -24,6 +26,8 @@ mod mpsc;
 use std::time::Duration;
 
 pub use super::channel::error::{RecvError, RecvTimeoutError, SendError, TryRecvError};
+#[cfg(feature = "defered-send")]
+pub use defered::DeferedSend;
 
 pub trait Receiver<T>: Send {
     fn recv(&self) -> Result<T, RecvError>;

--- a/libsplinter/src/runtime/service/timer/message.rs
+++ b/libsplinter/src/runtime/service/timer/message.rs
@@ -23,5 +23,8 @@ pub enum TimerMessage {
         service_type: ServiceType<'static>,
         service_id: Option<FullyQualifiedServiceId>,
     },
+    Complete {
+        service_id: FullyQualifiedServiceId,
+    },
     Shutdown,
 }


### PR DESCRIPTION
Adds a DeferedSend struct that will send a message when dropped.  The Timer will use this struct to send a complete message when the thread is terminated, allowing the Timer to keep track of which service has an active thread. 
This allows the Timer to not accidentally spin up two threads for the same service that results in double execution. The message is sent even if the thread panics. 