### PR TITLE
Update ScabbardMessageHandler to use a TimerAlarm after msg is received

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -211,7 +211,7 @@ service-timer =[
   "defered-send",
   "runtime-service",
   "service-message-sender-factory",
-  "service-timer-alarm",
+  "service-timer-alarm-factory",
   "service-timer-filter",
   "service-timer-handler",
   "service-timer-handler-factory"

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -138,6 +138,7 @@ experimental = [
     "service-message-sender-factory-peer",
     "service-timer",
     "service-timer-alarm",
+    "service-timer-alarm-factory",
     "service-timer-filter",
     "service-timer-handler",
     "service-timer-handler-factory",
@@ -216,6 +217,7 @@ service-timer =[
   "service-timer-handler-factory"
 ]
 service-timer-alarm = []
+service-timer-alarm-factory = ["service-timer-alarm"]
 service-timer-filter = ["service"]
 service-timer-handler = ["service", "service-message-converter", "service-message-sender"]
 service-message-handler-dispatch = [

--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -137,6 +137,7 @@ experimental = [
     "service-message-sender-factory",
     "service-message-sender-factory-peer",
     "service-timer",
+    "service-timer-alarm",
     "service-timer-filter",
     "service-timer-handler",
     "service-timer-handler-factory",
@@ -209,10 +210,12 @@ service-timer =[
   "defered-send",
   "runtime-service",
   "service-message-sender-factory",
+  "service-timer-alarm",
   "service-timer-filter",
   "service-timer-handler",
   "service-timer-handler-factory"
 ]
+service-timer-alarm = []
 service-timer-filter = ["service"]
 service-timer-handler = ["service", "service-message-converter", "service-message-sender"]
 service-message-handler-dispatch = [

--- a/libsplinter/src/runtime/service/mod.rs
+++ b/libsplinter/src/runtime/service/mod.rs
@@ -61,4 +61,4 @@ pub use lifecycle_executor::{
 #[cfg(feature = "service-message-sender-factory-peer")]
 pub use network_sender_factory::NetworkMessageSenderFactory;
 #[cfg(feature = "service-timer")]
-pub use timer::{Timer, TimerAlarm};
+pub use timer::Timer;

--- a/libsplinter/src/runtime/service/timer/alarm/channel.rs
+++ b/libsplinter/src/runtime/service/timer/alarm/channel.rs
@@ -78,8 +78,8 @@ impl ChannelTimerAlarmFactory {
 /// Used to create new `TimerAlarm` instances.
 impl TimerAlarmFactory for ChannelTimerAlarmFactory {
     /// Returns a new `TimerAlarm`
-    fn new_alarm(&self) -> Result<Box<dyn TimerAlarm>, InternalError> {
-        Ok(Box::new(ChannelTimerAlarm::new(self.sender.clone())))
+    fn new_alarm(&self) -> Box<dyn TimerAlarm> {
+        Box::new(ChannelTimerAlarm::new(self.sender.clone()))
     }
 
     fn clone_box(&self) -> Box<dyn TimerAlarmFactory> {

--- a/libsplinter/src/runtime/service/timer/alarm/mod.rs
+++ b/libsplinter/src/runtime/service/timer/alarm/mod.rs
@@ -15,4 +15,4 @@
 //! An alarm can be used to prematurely wake all or specific message handlers
 mod channel;
 
-pub use channel::ChannelTimerAlarm;
+pub use channel::{ChannelTimerAlarm, ChannelTimerAlarmFactory};

--- a/libsplinter/src/runtime/service/timer/alarm/mod.rs
+++ b/libsplinter/src/runtime/service/timer/alarm/mod.rs
@@ -15,33 +15,4 @@
 //! An alarm can be used to prematurely wake all or specific message handlers
 mod channel;
 
-use crate::error::InternalError;
-use crate::service::{FullyQualifiedServiceId, ServiceType};
-
-use super::message::TimerMessage;
-
 pub use channel::ChannelTimerAlarm;
-
-pub trait TimerAlarm {
-    /// Notify the `Timer` to check all `TimerFilters` for pending work
-    fn wake_up_all(&self) -> Result<(), InternalError>;
-
-    /// Notify the `Timer` to check a specific `TimerFilter` for pending work
-    ///
-    /// # Arguments
-    ///
-    /// * `service_type` - The service type of the the filter that will be checked
-    /// * `service_id` - An optional service ID
-    ///
-    /// If a service ID is provided, only the `TimerHandler` for that ID will be run. The serivce
-    /// ID must be returned from the `TimerFilter` to show there is pending work. If ther service
-    /// ID is not returned, no handlers will be run.
-    ///
-    /// If the service ID is not provided, the handlers for all service IDs returned from the
-    /// `TimerFilter` will be run.
-    fn wake_up(
-        &self,
-        service_type: ServiceType<'static>,
-        service_id: Option<FullyQualifiedServiceId>,
-    ) -> Result<(), InternalError>;
-}

--- a/libsplinter/src/runtime/service/timer/mod.rs
+++ b/libsplinter/src/runtime/service/timer/mod.rs
@@ -23,14 +23,12 @@ use std::sync::mpsc::{channel, Sender};
 use std::time::Duration;
 
 use crate::error::InternalError;
-use crate::service::{MessageSenderFactory, TimerFilter, TimerHandlerFactory};
+use crate::service::{MessageSenderFactory, TimerAlarm, TimerFilter, TimerHandlerFactory};
 use crate::threading::{lifecycle::ShutdownHandle, pacemaker::Pacemaker};
 
 use self::alarm::ChannelTimerAlarm;
 use self::message::TimerMessage;
 use self::thread::TimerThread;
-
-pub use self::alarm::TimerAlarm;
 
 pub struct Timer {
     pacemaker: Pacemaker,

--- a/libsplinter/src/runtime/service/timer/mod.rs
+++ b/libsplinter/src/runtime/service/timer/mod.rs
@@ -23,10 +23,10 @@ use std::sync::mpsc::{channel, Sender};
 use std::time::Duration;
 
 use crate::error::InternalError;
-use crate::service::{MessageSenderFactory, TimerAlarm, TimerFilter, TimerHandlerFactory};
+use crate::service::{MessageSenderFactory, TimerAlarmFactory, TimerFilter, TimerHandlerFactory};
 use crate::threading::{lifecycle::ShutdownHandle, pacemaker::Pacemaker};
 
-use self::alarm::ChannelTimerAlarm;
+use self::alarm::ChannelTimerAlarmFactory;
 use self::message::TimerMessage;
 use self::thread::TimerThread;
 
@@ -73,9 +73,9 @@ impl Timer {
         })
     }
 
-    /// Get a `TimerAlarm` that can be use to prematurely wake up the `Timer`
-    pub fn alarm(&self) -> Box<dyn TimerAlarm> {
-        Box::new(ChannelTimerAlarm::new(self.sender.clone()))
+    /// Get a `TimerAlarmFactory` that can be use to get alarms to prematurely wake up the `Timer`
+    pub fn alarm_factory(&self) -> Box<dyn TimerAlarmFactory> {
+        Box::new(ChannelTimerAlarmFactory::new(self.sender.clone()))
     }
 }
 
@@ -296,7 +296,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
 
         alarm.wake_up_all().unwrap();
 
@@ -336,7 +336,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
 
         alarm
             .wake_up(ServiceType::new("test").unwrap(), None)
@@ -379,7 +379,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
 
         alarm
             .wake_up(
@@ -425,7 +425,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
 
         alarm
             .wake_up(
@@ -469,7 +469,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
         alarm.wake_up_all().unwrap();
 
         if let Ok((_, _, msg_bytes)) = service_recv.recv_timeout(std::time::Duration::from_secs(5))
@@ -520,7 +520,7 @@ mod tests {
 
         let mut timer = Timer::new(filters, wake_up_interval, message_sender_factory).unwrap();
 
-        let alarm = timer.alarm();
+        let alarm = timer.alarm_factory().new_alarm();
         alarm.wake_up_all().unwrap();
 
         // wait for timer handler to panic

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -57,6 +57,8 @@ mod routable;
 mod service_type;
 #[cfg(feature = "service-timer-alarm")]
 mod timer_alarm;
+#[cfg(feature = "service-timer-alarm-factory")]
+mod timer_alarm_factory;
 #[cfg(feature = "service-timer-filter")]
 mod timer_filter;
 #[cfg(feature = "service-timer-handler")]
@@ -88,6 +90,8 @@ pub use routable::Routable;
 pub use service_type::ServiceType;
 #[cfg(feature = "service-timer-alarm")]
 pub use timer_alarm::TimerAlarm;
+#[cfg(feature = "service-timer-alarm-factory")]
+pub use timer_alarm_factory::TimerAlarmFactory;
 #[cfg(feature = "service-timer-filter")]
 pub use timer_filter::TimerFilter;
 #[cfg(feature = "service-timer-handler")]

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -55,6 +55,8 @@ mod message_sender_factory;
 pub mod rest_api;
 mod routable;
 mod service_type;
+#[cfg(feature = "service-timer-alarm")]
+mod timer_alarm;
 #[cfg(feature = "service-timer-filter")]
 mod timer_filter;
 #[cfg(feature = "service-timer-handler")]
@@ -84,6 +86,8 @@ pub use message_sender::MessageSender;
 pub use message_sender_factory::MessageSenderFactory;
 pub use routable::Routable;
 pub use service_type::ServiceType;
+#[cfg(feature = "service-timer-alarm")]
+pub use timer_alarm::TimerAlarm;
 #[cfg(feature = "service-timer-filter")]
 pub use timer_filter::TimerFilter;
 #[cfg(feature = "service-timer-handler")]

--- a/libsplinter/src/service/timer_alarm.rs
+++ b/libsplinter/src/service/timer_alarm.rs
@@ -14,29 +14,12 @@
 
 //! An alarm can be used to prematurely wake all or specific message handlers
 
-use std::sync::mpsc::Sender;
-
 use crate::error::InternalError;
-use crate::runtime::service::timer::message::TimerMessage;
-use crate::service::{FullyQualifiedServiceId, ServiceType, TimerAlarm};
+use crate::service::{FullyQualifiedServiceId, ServiceType};
 
-pub struct ChannelTimerAlarm {
-    sender: Sender<TimerMessage>,
-}
-
-impl ChannelTimerAlarm {
-    pub fn new(sender: Sender<TimerMessage>) -> Self {
-        ChannelTimerAlarm { sender }
-    }
-}
-
-impl TimerAlarm for ChannelTimerAlarm {
+pub trait TimerAlarm {
     /// Notify the `Timer` to check all `TimerFilters` for pending work
-    fn wake_up_all(&self) -> Result<(), InternalError> {
-        self.sender
-            .send(TimerMessage::WakeUpAll)
-            .map_err(|err| InternalError::from_source(Box::new(err)))
-    }
+    fn wake_up_all(&self) -> Result<(), InternalError>;
 
     /// Notify the `Timer` to check a specific `TimerFilter` for pending work
     ///
@@ -55,12 +38,5 @@ impl TimerAlarm for ChannelTimerAlarm {
         &self,
         service_type: ServiceType<'static>,
         service_id: Option<FullyQualifiedServiceId>,
-    ) -> Result<(), InternalError> {
-        self.sender
-            .send(TimerMessage::WakeUp {
-                service_type,
-                service_id,
-            })
-            .map_err(|err| InternalError::from_source(Box::new(err)))
-    }
+    ) -> Result<(), InternalError>;
 }

--- a/libsplinter/src/service/timer_alarm_factory.rs
+++ b/libsplinter/src/service/timer_alarm_factory.rs
@@ -1,0 +1,31 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains `TimerAlarmFactory` trait.
+
+use super::TimerAlarm;
+
+/// Used to create new `TimerAlarm` instances.
+pub trait TimerAlarmFactory: Send {
+    /// Returns a new `TimerAlarm`
+    fn new_alarm(&self) -> Box<dyn TimerAlarm>;
+
+    fn clone_box(&self) -> Box<dyn TimerAlarmFactory>;
+}
+
+impl Clone for Box<dyn TimerAlarmFactory> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -112,6 +112,7 @@ scabbardv3 = [
     "splinter/service-message-handler",
     "splinter/service-message-handler-factory",
     "splinter/service-message-sender",
+    "splinter/service-timer-alarm-factory",
     "splinter/service-timer-filter",
     "splinter/service-timer-handler",
     "splinter/service-timer-handler-factory",


### PR DESCRIPTION
This PR updates the Timer to return a TimerAlarmFactory. Returning the factory enables passing an alarm factory to the ScabbardMessageHandlerFactory so that the ScabbardMessageHandler can use an alarm to wake up the Timer after a message has been received.