### PR TITLE
Scabbard store enhancements

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
@@ -1,0 +1,278 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Drop foreign key constraints
+ALTER TABLE scabbard_alarm
+  DROP CONSTRAINT scabbard_alarm_service_id_fkey;
+ALTER TABLE scabbard_peer
+  DROP CONSTRAINT scabbard_peer_service_id_fkey;
+
+ALTER TABLE consensus_2pc_action
+  DROP CONSTRAINT consensus_2pc_action_service_id_fkey;
+ALTER TABLE consensus_2pc_context_participant
+  DROP CONSTRAINT consensus_2pc_context_participant_service_id_fkey;
+
+ALTER TABLE consensus_2pc_notification_action
+  DROP CONSTRAINT consensus_2pc_notification_action_action_id_fkey;
+ALTER TABLE consensus_2pc_send_message_action
+  DROP CONSTRAINT consensus_2pc_send_message_action_action_id_fkey;
+ALTER TABLE consensus_2pc_update_context_action
+  DROP CONSTRAINT consensus_2pc_update_context_action_action_id_fkey;
+ALTER TABLE consensus_2pc_update_context_action_participant
+  DROP CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey;
+
+ALTER TABLE consensus_2pc_deliver_event
+  DROP CONSTRAINT consensus_2pc_deliver_event_event_id_fkey;
+ALTER TABLE consensus_2pc_start_event
+  DROP CONSTRAINT consensus_2pc_start_event_event_id_fkey;
+ALTER TABLE consensus_2pc_vote_event
+  DROP CONSTRAINT consensus_2pc_vote_event_event_id_fkey;
+
+-- Recreate the tables without the circuit_id columns
+CREATE TABLE IF NOT EXISTS new_scabbard_service (
+    service_id                TEXT PRIMARY KEY,
+    status                    scabbard_service_status_type NOT NULL,
+    consensus                 scabbard_consensus NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(service_id, peer_service_id)
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  decision_type,
+    PRIMARY KEY (circuit_id, service_id, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    service_id                TEXT PRIMARY KEY,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     context_state NOT NULL,
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') )
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    PRIMARY KEY (service_id, process)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        BIGSERIAL PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        BIGSERIAL PRIMARY KEY,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                event_type NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    service_id                TEXT NOT NULL,
+    alarm_type                alarm_type NOT NULL,
+    alarm                     BIGINT NOT NULL,
+    PRIMARY KEY (service_id, alarm_type)
+);
+
+-- Move data from the old tables into the updated tables
+INSERT INTO new_scabbard_service
+    (
+        service_id,
+        status,
+        consensus
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        status,
+        consensus
+    FROM scabbard_service;
+
+INSERT INTO new_scabbard_peer
+    (
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+INSERT INTO new_consensus_2pc_context
+    (
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at
+    )
+    SELECT
+        id,
+        circuit_id || '::' || service_id,
+        created_at,
+        executed_at
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        service_id,
+        executed_at,
+        created_at,
+        event_type
+    )
+    SELECT
+        id,
+        circuit_id || '::' || service_id,
+        executed_at,
+        created_at,
+        event_type
+    FROM consensus_2pc_event;
+
+INSERT INTO new_scabbard_alarm
+    (
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+-- Drop the old tables
+DROP TABLE scabbard_service;
+DROP TABLE scabbard_peer;
+DROP TABLE scabbard_v3_commit_history;
+DROP TABLE consensus_2pc_context;
+DROP TABLE consensus_2pc_context_participant;
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+DROP TABLE scabbard_alarm;
+
+-- Rename the new tables
+ALTER TABLE new_scabbard_service RENAME TO scabbard_service;
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+-- Recreate the foreign key constraints
+ALTER TABLE scabbard_alarm ADD CONSTRAINT scabbard_alarm_service_id_fkey
+  FOREIGN KEY (service_id) REFERENCES scabbard_service(service_id);
+ALTER TABLE scabbard_peer ADD CONSTRAINT scabbard_peer_service_id_fkey
+  FOREIGN KEY (service_id) REFERENCES scabbard_service(service_id);
+
+ALTER TABLE consensus_2pc_action
+  ADD CONSTRAINT consensus_2pc_action_service_id_fkey
+  FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id);
+ALTER TABLE consensus_2pc_context_participant
+  ADD CONSTRAINT consensus_2pc_context_participant_service_id_fkey
+  FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id);
+
+ALTER TABLE consensus_2pc_notification_action
+  ADD CONSTRAINT consensus_2pc_notification_action_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_send_message_action
+  ADD CONSTRAINT consensus_2pc_send_message_action_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_update_context_action
+  ADD CONSTRAINT consensus_2pc_update_context_action_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_update_context_action_participant
+  ADD CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+
+ALTER TABLE consensus_2pc_deliver_event
+  ADD CONSTRAINT consensus_2pc_deliver_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_start_event
+  ADD CONSTRAINT consensus_2pc_start_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_vote_event
+  ADD CONSTRAINT consensus_2pc_vote_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
@@ -40,6 +40,21 @@ ALTER TABLE consensus_2pc_start_event
 ALTER TABLE consensus_2pc_vote_event
   DROP CONSTRAINT consensus_2pc_vote_event_event_id_fkey;
 
+ALTER TABLE scabbard_peer
+  DROP CONSTRAINT scabbard_peer_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_v3_commit_history
+  DROP CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context
+  DROP CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context_participant
+  DROP CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_action
+  DROP CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_event
+  DROP CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_alarm
+  DROP CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey;
+
 -- Recreate the tables without the circuit_id columns
 CREATE TABLE IF NOT EXISTS new_scabbard_service (
     service_id                TEXT PRIMARY KEY,

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -1,0 +1,306 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Drop foreign key constraints
+ALTER TABLE scabbard_alarm
+  DROP CONSTRAINT scabbard_alarm_service_id_fkey;
+ALTER TABLE scabbard_peer
+  DROP CONSTRAINT scabbard_peer_service_id_fkey;
+
+ALTER TABLE consensus_2pc_action
+  DROP CONSTRAINT consensus_2pc_action_service_id_fkey;
+ALTER TABLE consensus_2pc_context_participant
+  DROP CONSTRAINT consensus_2pc_context_participant_service_id_fkey;
+
+ALTER TABLE consensus_2pc_notification_action
+  DROP CONSTRAINT consensus_2pc_notification_action_action_id_fkey;
+ALTER TABLE consensus_2pc_send_message_action
+  DROP CONSTRAINT consensus_2pc_send_message_action_action_id_fkey;
+ALTER TABLE consensus_2pc_update_context_action
+  DROP CONSTRAINT consensus_2pc_update_context_action_action_id_fkey;
+ALTER TABLE consensus_2pc_update_context_action_participant
+  DROP CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey;
+
+ALTER TABLE consensus_2pc_deliver_event
+  DROP CONSTRAINT consensus_2pc_deliver_event_event_id_fkey;
+ALTER TABLE consensus_2pc_start_event
+  DROP CONSTRAINT consensus_2pc_start_event_event_id_fkey;
+ALTER TABLE consensus_2pc_vote_event
+  DROP CONSTRAINT consensus_2pc_vote_event_event_id_fkey;
+
+-- Recreate the tables with the circuit_id column
+CREATE TABLE IF NOT EXISTS new_scabbard_service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    status                    scabbard_service_status_type NOT NULL,
+    consensus                 scabbard_consensus NOT NULL,
+    PRIMARY KEY(circuit_id, service_id)
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(circuit_id, service_id, peer_service_id)
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  decision_type,
+    PRIMARY KEY (circuit_id, service_id, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     context_state NOT NULL,
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    PRIMARY KEY (circuit_id, service_id)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    PRIMARY KEY (circuit_id, service_id, process)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        BIGSERIAL PRIMARY KEY,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        BIGSERIAL PRIMARY KEY,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                event_type NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    alarm_type                alarm_type NOT NULL,
+    alarm                     BIGINT NOT NULL,
+    PRIMARY KEY (circuit_id, service_id, alarm_type)
+);
+
+-- Move data from the old tables into the updated tables, splitting service_id into its two parts
+-- circuit_id and service_id
+
+INSERT INTO new_scabbard_service
+    (
+        circuit_id,
+        service_id,
+        status,
+        consensus
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        status,
+        consensus
+    FROM scabbard_service;
+
+INSERT INTO new_scabbard_peer
+    (
+        circuit_id,
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+INSERT INTO new_consensus_2pc_context
+    (
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at
+    )
+    SELECT
+        id,
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        created_at,
+        executed_at
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    )
+    SELECT
+        id,
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        created_at,
+        executed_at,
+        event_type
+    FROM consensus_2pc_event;
+
+INSERT INTO new_scabbard_alarm
+    (
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        split_part(service_id, '::', 1) circuit_id,
+        split_part(service_id, '::', 2) service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+-- Drop the old tables
+DROP TABLE scabbard_service;
+DROP TABLE scabbard_peer;
+DROP TABLE scabbard_v3_commit_history;
+DROP TABLE consensus_2pc_context;
+DROP TABLE consensus_2pc_context_participant;
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+DROP TABLE scabbard_alarm;
+
+-- Rename the new tables
+ALTER TABLE new_scabbard_service RENAME TO scabbard_service;
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+-- Recreate the foreign key constraints
+ALTER TABLE scabbard_alarm ADD CONSTRAINT scabbard_alarm_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_peer ADD CONSTRAINT scabbard_peer_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+
+ALTER TABLE consensus_2pc_action
+  ADD CONSTRAINT consensus_2pc_action_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES consensus_2pc_context(circuit_id, service_id);
+ALTER TABLE consensus_2pc_context_participant
+  ADD CONSTRAINT consensus_2pc_context_participant_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES consensus_2pc_context(circuit_id, service_id);
+
+ALTER TABLE consensus_2pc_notification_action
+  ADD CONSTRAINT consensus_2pc_notification_action_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_send_message_action 
+  ADD CONSTRAINT consensus_2pc_send_message_action_action_id_fkey 
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_update_context_action
+  ADD CONSTRAINT consensus_2pc_update_context_action_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_update_context_action_participant
+  ADD CONSTRAINT consensus_2pc_update_context_action_participant_action_id_fkey
+  FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;
+
+ALTER TABLE consensus_2pc_deliver_event
+  ADD CONSTRAINT consensus_2pc_deliver_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_start_event
+  ADD CONSTRAINT consensus_2pc_start_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_vote_event
+  ADD CONSTRAINT consensus_2pc_vote_event_event_id_fkey
+  FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -297,3 +297,26 @@ ALTER TABLE consensus_2pc_start_event
 ALTER TABLE consensus_2pc_vote_event
   ADD CONSTRAINT consensus_2pc_vote_event_event_id_fkey
   FOREIGN KEY (event_id) REFERENCES consensus_2pc_event(id) ON DELETE CASCADE;
+
+--Add new foreign key constraints
+ALTER TABLE scabbard_peer
+  ADD CONSTRAINT scabbard_peer_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_v3_commit_history
+  ADD CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_context
+  ADD CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_context_participant
+  ADD CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_action
+  ADD CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_event
+  ADD CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_alarm
+  ADD CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -275,13 +275,6 @@ ALTER TABLE scabbard_alarm ADD CONSTRAINT scabbard_alarm_service_id_fkey
 ALTER TABLE scabbard_peer ADD CONSTRAINT scabbard_peer_service_id_fkey
   FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
 
-ALTER TABLE consensus_2pc_action
-  ADD CONSTRAINT consensus_2pc_action_service_id_fkey
-  FOREIGN KEY (circuit_id, service_id) REFERENCES consensus_2pc_context(circuit_id, service_id);
-ALTER TABLE consensus_2pc_context_participant
-  ADD CONSTRAINT consensus_2pc_context_participant_service_id_fkey
-  FOREIGN KEY (circuit_id, service_id) REFERENCES consensus_2pc_context(circuit_id, service_id);
-
 ALTER TABLE consensus_2pc_notification_action
   ADD CONSTRAINT consensus_2pc_notification_action_action_id_fkey
   FOREIGN KEY (action_id) REFERENCES consensus_2pc_action(id) ON DELETE CASCADE;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/down.sql
@@ -1,0 +1,229 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+
+PRAGMA foreign_keys=off;
+
+-- Recreate the tables without the circuit_id columns
+CREATE TABLE IF NOT EXISTS new_scabbard_service (
+    service_id       TEXT PRIMARY KEY NOT NULL,
+    status           TEXT NOT NULL
+    CHECK ( status IN ('PREPARED', 'FINALIZED', 'RETIRED') ),
+    consensus                 scabbard_consensus NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(service_id, peer_service_id),
+    FOREIGN KEY(service_id) REFERENCES scabbard_service(service_id)
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  TEXT,
+    CHECK ( decision IN ('COMMIT', 'ABORT') ),
+    PRIMARY KEY (service_id, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    service_id                TEXT PRIMARY KEY,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     TEXT NOT NULL
+    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') )
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    PRIMARY KEY (service_id, process),
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+);
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    service_id                TEXT NOT NULL,
+    alarm_type                TEXT NOT NULL
+    CHECK ( alarm_type IN ('TWOPHASECOMMIT')),
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (service_id) REFERENCES scabbard_service(service_id) ON DELETE CASCADE,
+    PRIMARY KEY (service_id, alarm_type)
+);
+
+-- Move data from the old tables into the updated tables
+INSERT INTO new_scabbard_service
+    (
+        service_id,
+        status,
+        consensus
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        status,
+        consensus
+    FROM scabbard_service;
+
+INSERT INTO new_scabbard_peer
+    (
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+INSERT INTO new_consensus_2pc_context
+    (
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        service_id,
+        created_at,
+        executed_at
+    )
+    SELECT
+        id,
+        circuit_id || '::' || service_id,
+        created_at,
+        executed_at
+    FROM consensus_2pc_action;
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        service_id,
+        executed_at,
+        created_at,
+        event_type
+    )
+    SELECT
+        id,
+        circuit_id || '::' || service_id,
+        executed_at,
+        created_at,
+        event_type
+    FROM consensus_2pc_event;
+
+INSERT INTO new_scabbard_alarm
+    (
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        circuit_id || '::' || service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+-- Drop the old tables
+DROP TABLE scabbard_service;
+DROP TABLE scabbard_peer;
+DROP TABLE scabbard_v3_commit_history;
+DROP TABLE consensus_2pc_context;
+DROP TABLE consensus_2pc_context_participant;
+DROP TABLE consensus_2pc_action;
+DROP TABLE consensus_2pc_event;
+DROP TABLE scabbard_alarm;
+
+-- Rename the new tables
+ALTER TABLE new_scabbard_service RENAME TO scabbard_service;
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -74,7 +74,8 @@ CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
     value                     TEXT NOT NULL,
     decision                  TEXT,
     CHECK ( decision IN ('COMMIT', 'ABORT') ),
-    PRIMARY KEY (circuit_id, service_id, epoch)
+    PRIMARY KEY (circuit_id, service_id, epoch),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
 );
 
 INSERT INTO new_scabbard_v3_commit_history
@@ -111,7 +112,8 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
     CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
     decision_timeout_start    BIGINT
     CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
-    PRIMARY KEY (circuit_id, service_id)
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
 );
 
 INSERT INTO new_consensus_2pc_context
@@ -149,7 +151,8 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    PRIMARY KEY (circuit_id, service_id, process)
+    PRIMARY KEY (circuit_id, service_id, process),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
 );
 
 INSERT INTO new_consensus_2pc_context_participant
@@ -177,7 +180,8 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    executed_at               BIGINT
+    executed_at               BIGINT,
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
 );
 
 INSERT INTO new_consensus_2pc_action
@@ -207,7 +211,8 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     executed_at               BIGINT,
     event_type                TEXT NOT NULL
-    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') ),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
 );
 
 INSERT INTO new_consensus_2pc_event

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -1,0 +1,265 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+-- Recreate the tables with the circuit_id column
+CREATE TABLE IF NOT EXISTS new_scabbard_service (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    status                    TEXT NOT NULL
+    CHECK ( status IN ('PREPARED', 'FINALIZED', 'RETIRED') ),
+    consensus                 scabbard_consensus NOT NULL,
+    PRIMARY KEY(circuit_id, service_id)
+);
+
+INSERT INTO new_scabbard_service
+    (
+        circuit_id,
+        service_id,
+        status,
+        consensus
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        status,
+        consensus
+    FROM scabbard_service;
+
+DROP TABLE scabbard_service;
+
+ALTER TABLE new_scabbard_service RENAME TO scabbard_service;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(circuit_id, service_id, peer_service_id)
+    FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+INSERT INTO new_scabbard_peer
+    (
+        circuit_id,
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+DROP TABLE scabbard_peer;
+
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  TEXT,
+    CHECK ( decision IN ('COMMIT', 'ABORT') ),
+    PRIMARY KEY (circuit_id, service_id, epoch)
+);
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+DROP TABLE scabbard_v3_commit_history;
+
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     TEXT NOT NULL
+    CHECK ( state IN ( 'WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    PRIMARY KEY (circuit_id, service_id)
+);
+
+INSERT INTO new_consensus_2pc_context
+    (
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+DROP TABLE consensus_2pc_context;
+
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    PRIMARY KEY (circuit_id, service_id, process),
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+DROP TABLE consensus_2pc_context_participant;
+
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_consensus_2pc_action
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at
+    )
+    SELECT
+        id,
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        created_at,
+        executed_at
+    FROM consensus_2pc_action;
+
+DROP TABLE consensus_2pc_action;
+
+ALTER TABLE new_consensus_2pc_action RENAME TO consensus_2pc_action;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') )
+);
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    )
+    SELECT
+        id,
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        created_at,
+        executed_at,
+        event_type
+    FROM consensus_2pc_event;
+
+DROP TABLE consensus_2pc_event;
+
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    alarm_type                TEXT NOT NULL
+    CHECK ( alarm_type IN ('TWOPHASECOMMIT')),
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id),
+    PRIMARY KEY (circuit_id, service_id, alarm_type)
+);
+
+INSERT INTO new_scabbard_alarm
+    (
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        substr(service_id, 1, instr(service_id, '::')-1) AS circuit_id,
+        substr(service_id, instr(service_id, '::')+2) AS service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+DROP TABLE scabbard_alarm;
+
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-06-08-164819-update-consensus-service-id/up.sql
@@ -149,8 +149,7 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
     process                   TEXT NOT NULL,
     vote                      TEXT
     CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
-    PRIMARY KEY (circuit_id, service_id, process),
-    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+    PRIMARY KEY (circuit_id, service_id, process)
 );
 
 INSERT INTO new_consensus_2pc_context_participant
@@ -178,8 +177,7 @@ CREATE TABLE IF NOT EXISTS new_consensus_2pc_action (
     circuit_id                TEXT NOT NULL,
     service_id                TEXT NOT NULL,
     created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    executed_at               BIGINT,
-    FOREIGN KEY (service_id) REFERENCES consensus_2pc_context(service_id) ON DELETE CASCADE
+    executed_at               BIGINT
 );
 
 INSERT INTO new_consensus_2pc_action

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1990,7 +1990,7 @@ pub mod tests {
 
         store
             .update_consensus_context(&coordinator_fqsi, context3.clone())
-            .expect("failed to add context");
+            .expect("failed to update context");
 
         let current_context = store
             .get_current_consensus_context(&coordinator_fqsi)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -815,6 +815,16 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
+
         let coordinator_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
@@ -866,6 +876,16 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
+
         let coordinator_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
@@ -906,6 +926,16 @@ pub mod tests {
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
         let participant_service_id = ServiceId::new_random();
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
 
         let coordinator_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
@@ -1015,6 +1045,16 @@ pub mod tests {
 
         let participant_service_id = ServiceId::new_random();
 
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
+
         let coordinator_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
@@ -1079,6 +1119,16 @@ pub mod tests {
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
         let participant_service_id = ServiceId::new_random();
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&coordinator_fqsi)
+            .with_peers(&[participant_service_id.clone()])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
 
         let coordinator_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
@@ -1588,6 +1638,19 @@ pub mod tests {
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
 
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&participant_fqsi)
+            .with_peers(&[
+                coordinator_fqsi.service_id().clone(),
+                participant2_fqsi.service_id().clone(),
+            ])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
+
         let participant_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
             .with_epoch(1)
@@ -1641,6 +1704,19 @@ pub mod tests {
 
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&participant_fqsi)
+            .with_peers(&[
+                coordinator_fqsi.service_id().clone(),
+                participant2_fqsi.service_id().clone(),
+            ])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
 
         let participant_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())
@@ -1698,6 +1774,19 @@ pub mod tests {
 
         let participant_fqsi = FullyQualifiedServiceId::new_random();
         let participant2_fqsi = FullyQualifiedServiceId::new_random();
+
+        let service = ScabbardServiceBuilder::default()
+            .with_service_id(&participant_fqsi)
+            .with_peers(&[
+                coordinator_fqsi.service_id().clone(),
+                participant2_fqsi.service_id().clone(),
+            ])
+            .with_consensus(&ConsensusType::TwoPC)
+            .with_status(&ServiceStatus::Finalized)
+            .build()
+            .expect("failed to build service");
+
+        store.add_service(service).expect("failed to add service");
 
         let participant_context = ContextBuilder::default()
             .with_coordinator(coordinator_fqsi.clone().service_id())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_commit_entry.rs
@@ -42,7 +42,14 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnectio
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", commit_entry.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -57,7 +64,12 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnectio
             // check to see if a context with the given service_id exists
             let context = consensus_2pc_context::table
                 .filter(
-                    consensus_2pc_context::service_id.eq(format!("{}", commit_entry.service_id())),
+                    consensus_2pc_context::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        ),
                 )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
@@ -98,7 +110,14 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given epoch and service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", commit_entry.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -113,7 +132,12 @@ impl<'a> AddCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection> {
             // check to see if a context with the given service_id exists
             let context = consensus_2pc_context::table
                 .filter(
-                    consensus_2pc_context::service_id.eq(format!("{}", commit_entry.service_id())),
+                    consensus_2pc_context::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        ),
                 )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
@@ -25,14 +25,14 @@ use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        Consensus2pcContextModel, Consensus2pcNotificationModel,
-        Consensus2pcSendMessageActionModel, Consensus2pcUpdateContextActionModel,
-        InsertableConsensus2pcActionModel, UpdateContextActionParticipantList,
+        Consensus2pcNotificationModel, Consensus2pcSendMessageActionModel,
+        Consensus2pcUpdateContextActionModel, InsertableConsensus2pcActionModel,
+        ScabbardServiceModel, UpdateContextActionParticipantList,
     },
     schema::{
-        consensus_2pc_action, consensus_2pc_context, consensus_2pc_notification_action,
-        consensus_2pc_send_message_action, consensus_2pc_update_context_action,
-        consensus_2pc_update_context_action_participant,
+        consensus_2pc_action, consensus_2pc_notification_action, consensus_2pc_send_message_action,
+        consensus_2pc_update_context_action, consensus_2pc_update_context_action_participant,
+        scabbard_service,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -63,25 +63,21 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             let ConsensusAction::TwoPhaseCommit(action) = action;
 
-            // check to see if a context with the given service_id exists
-            consensus_2pc_context::table
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
                 .filter(
-                    consensus_2pc_context::circuit_id
+                    scabbard_service::circuit_id
                         .eq(service_id.circuit_id().to_string())
-                        .and(
-                            consensus_2pc_context::service_id
-                                .eq(service_id.service_id().to_string()),
-                        ),
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
                 )
-                .first::<Consensus2pcContextModel>(self.conn)
+                .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
                     ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
                 })?
                 .ok_or_else(|| {
-                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Cannot add consensus action, context with service ID {} does not exist",
-                        service_id,
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Service does not exist",
                     )))
                 })?;
 
@@ -228,25 +224,21 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             let ConsensusAction::TwoPhaseCommit(action) = action;
 
-            // check to see if a context with the given service_id exists
-            consensus_2pc_context::table
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
                 .filter(
-                    consensus_2pc_context::circuit_id
+                    scabbard_service::circuit_id
                         .eq(service_id.circuit_id().to_string())
-                        .and(
-                            consensus_2pc_context::service_id
-                                .eq(service_id.service_id().to_string()),
-                        ),
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
                 )
-                .first::<Consensus2pcContextModel>(self.conn)
+                .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
                     ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
                 })?
                 .ok_or_else(|| {
-                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Cannot add consensus event, context with service ID {} does not exist",
-                        service_id,
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Service does not exist",
                     )))
                 })?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_action.rs
@@ -65,7 +65,14 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
 
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -79,7 +86,8 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 })?;
 
             let insertable_action = InsertableConsensus2pcActionModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 executed_at: None,
             };
 
@@ -222,7 +230,14 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
 
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -236,7 +251,8 @@ impl<'a> AddActionOperation for ScabbardStoreOperations<'a, PgConnection> {
                 })?;
 
             let insertable_action = InsertableConsensus2pcActionModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 executed_at: None,
             };
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -61,7 +61,14 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
             let ConsensusEvent::TwoPhaseCommit(event) = event;
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -75,7 +82,8 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 })?;
 
             let insertable_event = InsertableConsensus2pcEventModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 executed_at: None,
                 event_type: String::from(&event),
             };
@@ -186,7 +194,14 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
             let ConsensusEvent::TwoPhaseCommit(event) = event;
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -200,7 +215,8 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 })?;
 
             let insertable_event = InsertableConsensus2pcEventModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 executed_at: None,
                 event_type: String::from(&event),
             };

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_service.rs
@@ -40,7 +40,14 @@ impl<'a> AddServiceOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if the service already exists
             if scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -82,7 +89,14 @@ impl<'a> AddServiceOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if the service already exists
             if scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_alarm.rs
@@ -51,7 +51,11 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -65,8 +69,9 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
 
             scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .select(scabbard_alarm::alarm)
@@ -100,7 +105,11 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -114,8 +123,9 @@ impl<'a> GetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
 
             scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .select(scabbard_alarm::alarm)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_current_consensus_context.rs
@@ -46,7 +46,14 @@ where
     ) -> Result<Option<ConsensusContext>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
             let context = consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -57,8 +64,12 @@ where
                 let participants: Vec<Consensus2pcContextParticipantModel> =
                     consensus_2pc_context_participant::table
                         .filter(
-                            consensus_2pc_context_participant::service_id
-                                .eq(format!("{}", service_id)),
+                            consensus_2pc_context_participant::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context_participant::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
                         )
                         .load::<Consensus2pcContextParticipantModel>(self.conn)
                         .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_last_commit_entry.rs
@@ -47,7 +47,14 @@ where
     ) -> Result<Option<CommitEntry>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
             scabbard_v3_commit_history::table
-                .filter(scabbard_v3_commit_history::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_v3_commit_history::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            scabbard_v3_commit_history::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .order(scabbard_v3_commit_history::epoch.desc())
                 .first::<CommitEntryModel>(self.conn)
                 .optional()

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/get_service.rs
@@ -47,7 +47,11 @@ where
     ) -> Result<Option<ScabbardService>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
             let service_model: ScabbardServiceModel = match scabbard_service::table
-                .filter(scabbard_service::service_id.eq(&service_id.to_string()))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(&service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(&service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -58,7 +62,11 @@ where
             };
 
             let service_peers: Vec<ServiceId> = scabbard_peer::table
-                .filter(scabbard_peer::service_id.eq(&service_id.to_string()))
+                .filter(
+                    scabbard_peer::circuit_id
+                        .eq(&service_id.circuit_id().to_string())
+                        .and(scabbard_peer::service_id.eq(&service_id.service_id().to_string())),
+                )
                 .order(scabbard_peer::peer_service_id.asc())
                 .load(self.conn)
                 .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -22,13 +22,13 @@ use splinter::service::ServiceId;
 
 use crate::store::scabbard_store::diesel::{
     models::{
-        Consensus2pcContextModel, Consensus2pcNotificationModel,
-        Consensus2pcSendMessageActionModel, Consensus2pcUpdateContextActionModel,
+        Consensus2pcNotificationModel, Consensus2pcSendMessageActionModel,
+        Consensus2pcUpdateContextActionModel, ScabbardServiceModel,
     },
     schema::{
-        consensus_2pc_action, consensus_2pc_context, consensus_2pc_notification_action,
-        consensus_2pc_send_message_action, consensus_2pc_update_context_action,
-        consensus_2pc_update_context_action_participant,
+        consensus_2pc_action, consensus_2pc_notification_action, consensus_2pc_send_message_action,
+        consensus_2pc_update_context_action, consensus_2pc_update_context_action_participant,
+        scabbard_service,
     },
 };
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -61,29 +61,33 @@ where
         service_id: &FullyQualifiedServiceId,
     ) -> Result<Vec<Identified<ConsensusAction>>, ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            // check to see if a context with the given service_id exists
-            consensus_2pc_context::table
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
                 .filter(
-                    consensus_2pc_context::circuit_id.eq(service_id.circuit_id().to_string())
-                    .and(consensus_2pc_context::service_id.eq(service_id.service_id().to_string()))
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
                 )
-                .first::<Consensus2pcContextModel>(self.conn)
+                .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
                     ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
                 })?
                 .ok_or_else(|| {
-                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Cannot list consensus actions, context with service ID {} and does not exist",
-                        service_id,
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Service does not exist",
                     )))
                 })?;
 
             let action_ids = consensus_2pc_action::table
                 .filter(
-                    consensus_2pc_action::circuit_id.eq(service_id.circuit_id().to_string())
-                    .and(consensus_2pc_action::service_id.eq(service_id.service_id().to_string())
-                        .and(consensus_2pc_action::executed_at.is_null())),
+                    consensus_2pc_action::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_action::service_id
+                                .eq(service_id.service_id().to_string())
+                                .and(consensus_2pc_action::executed_at.is_null()),
+                        ),
                 )
                 .order(consensus_2pc_action::id.desc())
                 .select(consensus_2pc_action::id)
@@ -225,10 +229,7 @@ where
                     .with_epoch(update_context.epoch as u64)
                     .with_participants(final_participants)
                     .with_state(state)
-                    .with_this_process(
-                        service_id
-                            .service_id(),
-                    );
+                    .with_this_process(service_id.service_id());
 
                 if let Some(last_commit_epoch) = update_context.last_commit_epoch {
                     context = context.with_last_commit_epoch(last_commit_epoch as u64)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/list_consensus_actions.rs
@@ -63,7 +63,10 @@ where
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id.eq(service_id.circuit_id().to_string())
+                    .and(consensus_2pc_context::service_id.eq(service_id.service_id().to_string()))
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -78,9 +81,9 @@ where
 
             let action_ids = consensus_2pc_action::table
                 .filter(
-                    consensus_2pc_action::service_id
-                        .eq(format!("{}", service_id))
-                        .and(consensus_2pc_action::executed_at.is_null()),
+                    consensus_2pc_action::circuit_id.eq(service_id.circuit_id().to_string())
+                    .and(consensus_2pc_action::service_id.eq(service_id.service_id().to_string())
+                        .and(consensus_2pc_action::executed_at.is_null())),
                 )
                 .order(consensus_2pc_action::id.desc())
                 .select(consensus_2pc_action::id)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/set_alarm.rs
@@ -54,7 +54,11 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -68,8 +72,9 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
 
             let current_alarm = scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
@@ -79,7 +84,8 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 })?;
 
             let new_alarm = ScabbardAlarmModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 alarm_type: String::from(alarm_type),
                 alarm: get_timestamp(alarm)?,
             };
@@ -88,8 +94,9 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 // delete the current alarm
                 delete(
                     scabbard_alarm::table.filter(
-                        scabbard_alarm::service_id
-                            .eq(format!("{}", service_id))
+                        scabbard_alarm::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
@@ -122,7 +129,11 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -136,8 +147,9 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
 
             let current_alarm = scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
@@ -147,7 +159,8 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                 })?;
 
             let new_alarm = ScabbardAlarmModel {
-                service_id: format!("{}", service_id),
+                circuit_id: service_id.circuit_id().to_string(),
+                service_id: service_id.service_id().to_string(),
                 alarm_type: String::from(alarm_type),
                 alarm: get_timestamp(alarm)?,
             };
@@ -156,8 +169,9 @@ impl<'a> SetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                 // delete the current alarm
                 delete(
                     scabbard_alarm::table.filter(
-                        scabbard_alarm::service_id
-                            .eq(format!("{}", service_id))
+                        scabbard_alarm::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/unset_alarm.rs
@@ -49,7 +49,11 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -63,8 +67,9 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
 
             let current_alarm = scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
@@ -77,8 +82,9 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 // delete the current alarm
                 delete(
                     scabbard_alarm::table.filter(
-                        scabbard_alarm::service_id
-                            .eq(format!("{}", service_id))
+                        scabbard_alarm::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )
@@ -103,7 +109,11 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a service with the given service_id exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -117,8 +127,9 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
 
             let current_alarm = scabbard_alarm::table
                 .filter(
-                    scabbard_alarm::service_id
-                        .eq(format!("{}", service_id))
+                    scabbard_alarm::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                         .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                 )
                 .first::<ScabbardAlarmModel>(self.conn)
@@ -131,8 +142,9 @@ impl<'a> UnsetAlarmOperation for ScabbardStoreOperations<'a, PgConnection> {
                 // delete the current alarm
                 delete(
                     scabbard_alarm::table.filter(
-                        scabbard_alarm::service_id
-                            .eq(format!("{}", service_id))
+                        scabbard_alarm::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(scabbard_alarm::service_id.eq(service_id.service_id().to_string()))
                             .and(scabbard_alarm::alarm_type.eq(String::from(alarm_type))),
                     ),
                 )

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_commit_entry.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_commit_entry.rs
@@ -43,8 +43,12 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnec
             // check to see if a commit entry with the given service_id and epoch exists
             scabbard_v3_commit_history::table
                 .filter(
-                    scabbard_v3_commit_history::service_id
-                        .eq(format!("{}", commit_entry.service_id()))
+                    scabbard_v3_commit_history::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_v3_commit_history::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        )
                         .and(scabbard_v3_commit_history::epoch.eq(epoch)),
                 )
                 .first::<CommitEntryModel>(self.conn)
@@ -58,10 +62,11 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, SqliteConnec
                     )))
                 })?;
 
-            delete(
-                scabbard_v3_commit_history::table
-                    .find((format!("{}", commit_entry.service_id()), epoch)),
-            )
+            delete(scabbard_v3_commit_history::table.find((
+                commit_entry.service_id().circuit_id().to_string(),
+                commit_entry.service_id().service_id().to_string(),
+                epoch,
+            )))
             .execute(self.conn)
             .map_err(|err| {
                 ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
@@ -92,8 +97,12 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection
             // check to see if a commit entry with the given service_id and epoch exists
             scabbard_v3_commit_history::table
                 .filter(
-                    scabbard_v3_commit_history::service_id
-                        .eq(format!("{}", commit_entry.service_id()))
+                    scabbard_v3_commit_history::circuit_id
+                        .eq(commit_entry.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_v3_commit_history::service_id
+                                .eq(commit_entry.service_id().service_id().to_string()),
+                        )
                         .and(scabbard_v3_commit_history::epoch.eq(epoch)),
                 )
                 .first::<CommitEntryModel>(self.conn)
@@ -107,10 +116,11 @@ impl<'a> UpdateCommitEntryOperation for ScabbardStoreOperations<'a, PgConnection
                     )))
                 })?;
 
-            delete(
-                scabbard_v3_commit_history::table
-                    .find((format!("{}", commit_entry.service_id()), epoch)),
-            )
+            delete(scabbard_v3_commit_history::table.find((
+                commit_entry.service_id().circuit_id().to_string(),
+                commit_entry.service_id().service_id().to_string(),
+                epoch,
+            )))
             .execute(self.conn)
             .map_err(|err| {
                 ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -20,8 +20,8 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::Consensus2pcContextModel,
-    schema::{consensus_2pc_action, consensus_2pc_context},
+    models::ScabbardServiceModel,
+    schema::{consensus_2pc_action, scabbard_service},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -51,25 +51,21 @@ where
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            // check to see if a context with the given service_id exists
-            consensus_2pc_context::table
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
                 .filter(
-                    consensus_2pc_context::circuit_id
+                    scabbard_service::circuit_id
                         .eq(service_id.circuit_id().to_string())
-                        .and(
-                            consensus_2pc_context::service_id
-                                .eq(service_id.service_id().to_string()),
-                        ),
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
                 )
-                .first::<Consensus2pcContextModel>(self.conn)
+                .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
                     ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
                 })?
                 .ok_or_else(|| {
-                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Cannot update action, context with service ID {} does not exist",
-                        service_id,
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Service does not exist",
                     )))
                 })?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_action.rs
@@ -53,7 +53,14 @@ where
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -80,9 +87,14 @@ where
 
             update(consensus_2pc_action::table)
                 .filter(
-                    consensus_2pc_action::id
-                        .eq(action_id)
-                        .and(consensus_2pc_action::service_id.eq(format!("{}", service_id))),
+                    consensus_2pc_action::id.eq(action_id).and(
+                        consensus_2pc_action::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(
+                                consensus_2pc_action::service_id
+                                    .eq(service_id.service_id().to_string()),
+                            ),
+                    ),
                 )
                 .set(consensus_2pc_action::executed_at.eq(Some(update_executed_at)))
                 .execute(self.conn)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -53,7 +53,14 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                 ConsensusContext::TwoPhaseCommit(context) => {
                     // check to see if a context with the given service_id exists
                     consensus_2pc_context::table
-                        .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                        .filter(
+                            consensus_2pc_context::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        )
                         .first::<Consensus2pcContextModel>(self.conn)
                         .optional()
                         .map_err(|err| {
@@ -76,7 +83,14 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         Consensus2pcContextModel::try_from((&context, service_id))?;
 
                     update(consensus_2pc_context::table)
-                        .filter(consensus_2pc_context::service_id.eq(service_id.to_string()))
+                        .filter(
+                            consensus_2pc_context::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        )
                         .set((
                             consensus_2pc_context::coordinator.eq(update_context.coordinator),
                             consensus_2pc_context::epoch.eq(update_context.epoch),
@@ -100,9 +114,16 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                     let updated_participants =
                         ContextParticipantList::try_from((&context, service_id))?.inner;
 
-                    delete(consensus_2pc_context_participant::table.filter(
-                        consensus_2pc_context_participant::service_id.eq(format!("{}", service_id)),
-                    ))
+                    delete(
+                        consensus_2pc_context_participant::table.filter(
+                            consensus_2pc_context_participant::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context_participant::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        ),
+                    )
                     .execute(self.conn)
                     .map_err(|err| {
                         ScabbardStoreError::from_source_with_operation(
@@ -140,7 +161,14 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                 ConsensusContext::TwoPhaseCommit(context) => {
                     // check to see if a context with the given service_id exists
                     consensus_2pc_context::table
-                        .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                        .filter(
+                            consensus_2pc_context::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        )
                         .first::<Consensus2pcContextModel>(self.conn)
                         .optional()
                         .map_err(|err| {
@@ -163,7 +191,14 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         Consensus2pcContextModel::try_from((&context, service_id))?;
 
                     update(consensus_2pc_context::table)
-                        .filter(consensus_2pc_context::service_id.eq(service_id.to_string()))
+                        .filter(
+                            consensus_2pc_context::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        )
                         .set((
                             consensus_2pc_context::coordinator.eq(update_context.coordinator),
                             consensus_2pc_context::epoch.eq(update_context.epoch),
@@ -187,9 +222,16 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                     let updated_participants =
                         ContextParticipantList::try_from((&context, service_id))?.inner;
 
-                    delete(consensus_2pc_context_participant::table.filter(
-                        consensus_2pc_context_participant::service_id.eq(format!("{}", service_id)),
-                    ))
+                    delete(
+                        consensus_2pc_context_participant::table.filter(
+                            consensus_2pc_context_participant::circuit_id
+                                .eq(service_id.circuit_id().to_string())
+                                .and(
+                                    consensus_2pc_context_participant::service_id
+                                        .eq(service_id.service_id().to_string()),
+                                ),
+                        ),
+                    )
                     .execute(self.conn)
                     .map_err(|err| {
                         ScabbardStoreError::from_source_with_operation(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_context.rs
@@ -23,8 +23,8 @@ use splinter::error::InvalidStateError;
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::{Consensus2pcContextModel, ContextParticipantList},
-    schema::{consensus_2pc_context, consensus_2pc_context_participant},
+    models::{Consensus2pcContextModel, ContextParticipantList, ScabbardServiceModel},
+    schema::{consensus_2pc_context, consensus_2pc_context_participant, scabbard_service},
 };
 use crate::store::scabbard_store::ConsensusContext;
 use crate::store::scabbard_store::ScabbardStoreError;
@@ -51,17 +51,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ConsensusContext::TwoPhaseCommit(context) => {
-                    // check to see if a context with the given service_id exists
-                    consensus_2pc_context::table
+                    // check to see if a service with the given service_id exists
+                    scabbard_service::table
                         .filter(
-                            consensus_2pc_context::circuit_id
+                            scabbard_service::circuit_id
                                 .eq(service_id.circuit_id().to_string())
                                 .and(
-                                    consensus_2pc_context::service_id
+                                    scabbard_service::service_id
                                         .eq(service_id.service_id().to_string()),
                                 ),
                         )
-                        .first::<Consensus2pcContextModel>(self.conn)
+                        .first::<ScabbardServiceModel>(self.conn)
                         .optional()
                         .map_err(|err| {
                             ScabbardStoreError::from_source_with_operation(
@@ -71,11 +71,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, SqliteConnection> {
                         })?
                         .ok_or_else(|| {
                             ScabbardStoreError::InvalidState(InvalidStateError::with_message(
-                                format!(
-                                    "Cannot update context, context with service ID {} does \
-                                 not exist",
-                                    service_id
-                                ),
+                                String::from("Service does not exist"),
                             ))
                         })?;
 
@@ -159,17 +155,17 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             match context {
                 ConsensusContext::TwoPhaseCommit(context) => {
-                    // check to see if a context with the given service_id exists
-                    consensus_2pc_context::table
+                    // check to see if a service with the given service_id exists
+                    scabbard_service::table
                         .filter(
-                            consensus_2pc_context::circuit_id
+                            scabbard_service::circuit_id
                                 .eq(service_id.circuit_id().to_string())
                                 .and(
-                                    consensus_2pc_context::service_id
+                                    scabbard_service::service_id
                                         .eq(service_id.service_id().to_string()),
                                 ),
                         )
-                        .first::<Consensus2pcContextModel>(self.conn)
+                        .first::<ScabbardServiceModel>(self.conn)
                         .optional()
                         .map_err(|err| {
                             ScabbardStoreError::from_source_with_operation(
@@ -179,11 +175,7 @@ impl<'a> UpdateContextAction for ScabbardStoreOperations<'a, PgConnection> {
                         })?
                         .ok_or_else(|| {
                             ScabbardStoreError::InvalidState(InvalidStateError::with_message(
-                                format!(
-                                    "Cannot update context, context with service ID {} does \
-                                 not exist",
-                                    service_id,
-                                ),
+                                String::from("Service does not exist"),
                             ))
                         })?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -20,8 +20,8 @@ use splinter::error::{InternalError, InvalidStateError};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::{
-    models::Consensus2pcContextModel,
-    schema::{consensus_2pc_context, consensus_2pc_event},
+    models::ScabbardServiceModel,
+    schema::{consensus_2pc_event, scabbard_service},
 };
 use crate::store::scabbard_store::ScabbardStoreError;
 
@@ -51,25 +51,21 @@ where
         executed_at: SystemTime,
     ) -> Result<(), ScabbardStoreError> {
         self.conn.transaction::<_, _, _>(|| {
-            // check to see if a context with the given service_id exists
-            consensus_2pc_context::table
+            // check to see if a service with the given service_id exists
+            scabbard_service::table
                 .filter(
-                    consensus_2pc_context::circuit_id
+                    scabbard_service::circuit_id
                         .eq(service_id.circuit_id().to_string())
-                        .and(
-                            consensus_2pc_context::service_id
-                                .eq(service_id.service_id().to_string()),
-                        ),
+                        .and(scabbard_service::service_id.eq(service_id.service_id().to_string())),
                 )
-                .first::<Consensus2pcContextModel>(self.conn)
+                .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
                     ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
                 })?
                 .ok_or_else(|| {
-                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(format!(
-                        "Cannot update event, context with service ID {} does not exist",
-                        service_id,
+                    ScabbardStoreError::InvalidState(InvalidStateError::with_message(String::from(
+                        "Service does not exist",
                     )))
                 })?;
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_consensus_event.rs
@@ -53,7 +53,14 @@ where
         self.conn.transaction::<_, _, _>(|| {
             // check to see if a context with the given service_id exists
             consensus_2pc_context::table
-                .filter(consensus_2pc_context::service_id.eq(format!("{}", service_id)))
+                .filter(
+                    consensus_2pc_context::circuit_id
+                        .eq(service_id.circuit_id().to_string())
+                        .and(
+                            consensus_2pc_context::service_id
+                                .eq(service_id.service_id().to_string()),
+                        ),
+                )
                 .first::<Consensus2pcContextModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -80,9 +87,14 @@ where
 
             update(consensus_2pc_event::table)
                 .filter(
-                    consensus_2pc_event::id
-                        .eq(event_id)
-                        .and(consensus_2pc_event::service_id.eq(format!("{}", service_id))),
+                    consensus_2pc_event::id.eq(event_id).and(
+                        consensus_2pc_event::circuit_id
+                            .eq(service_id.circuit_id().to_string())
+                            .and(
+                                consensus_2pc_event::service_id
+                                    .eq(service_id.service_id().to_string()),
+                            ),
+                    ),
                 )
                 .set(consensus_2pc_event::executed_at.eq(Some(update_executed_at)))
                 .execute(self.conn)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/update_service.rs
@@ -40,7 +40,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, SqliteConnection> {
         self.conn.transaction::<_, ScabbardStoreError, _>(|| {
             // check to see if the service exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -53,7 +60,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, SqliteConnection> {
                 })?;
 
             update(scabbard_service::table)
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .set(scabbard_service::status.eq(String::from(service.status())))
                 .execute(self.conn)
                 .map_err(|err| {
@@ -62,8 +76,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, SqliteConnection> {
 
             if !service.peers().is_empty() {
                 delete(
-                    scabbard_peer::table
-                        .filter(scabbard_peer::service_id.eq(format!("{}", service.service_id()))),
+                    scabbard_peer::table.filter(
+                        scabbard_peer::circuit_id
+                            .eq(service.service_id().circuit_id().to_string())
+                            .and(
+                                scabbard_peer::service_id
+                                    .eq(service.service_id().service_id().to_string()),
+                            ),
+                    ),
                 )
                 .execute(self.conn)
                 .map_err(|err| {
@@ -91,7 +111,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, PgConnection> {
         self.conn.transaction::<_, _, _>(|| {
             // check to see if the service exists
             scabbard_service::table
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .first::<ScabbardServiceModel>(self.conn)
                 .optional()
                 .map_err(|err| {
@@ -104,7 +131,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, PgConnection> {
                 })?;
 
             update(scabbard_service::table)
-                .filter(scabbard_service::service_id.eq(format!("{}", service.service_id())))
+                .filter(
+                    scabbard_service::circuit_id
+                        .eq(service.service_id().circuit_id().to_string())
+                        .and(
+                            scabbard_service::service_id
+                                .eq(service.service_id().service_id().to_string()),
+                        ),
+                )
                 .set(scabbard_service::status.eq(String::from(service.status())))
                 .execute(self.conn)
                 .map_err(|err| {
@@ -113,8 +147,14 @@ impl<'a> UpdateServiceAction for ScabbardStoreOperations<'a, PgConnection> {
 
             if !service.peers().is_empty() {
                 delete(
-                    scabbard_peer::table
-                        .filter(scabbard_peer::service_id.eq(format!("{}", service.service_id()))),
+                    scabbard_peer::table.filter(
+                        scabbard_peer::circuit_id
+                            .eq(service.service_id().circuit_id().to_string())
+                            .and(
+                                scabbard_peer::service_id
+                                    .eq(service.service_id().service_id().to_string()),
+                            ),
+                    ),
                 )
                 .execute(self.conn)
                 .map_err(|err| {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 table! {
-    scabbard_service (service_id) {
+    scabbard_service (circuit_id, service_id) {
+        circuit_id  -> Text,
         service_id  -> Text,
         consensus -> Text,
         status -> Text,
@@ -21,14 +22,16 @@ table! {
 }
 
 table! {
-    scabbard_peer (service_id, peer_service_id) {
+    scabbard_peer (circuit_id, service_id, peer_service_id) {
+        circuit_id  -> Text,
         service_id  -> Text,
         peer_service_id  -> Text,
     }
 }
 
 table! {
-    scabbard_v3_commit_history (service_id, epoch) {
+    scabbard_v3_commit_history (circuit_id, service_id, epoch) {
+        circuit_id  -> Text,
         service_id  -> Text,
         epoch -> BigInt,
         value -> VarChar,
@@ -37,7 +40,8 @@ table! {
 }
 
 table! {
-    scabbard_alarm (service_id, alarm_type) {
+    scabbard_alarm (circuit_id, service_id, alarm_type) {
+        circuit_id  -> Text,
         service_id -> Text,
         alarm_type -> Text,
         alarm -> BigInt,
@@ -45,7 +49,8 @@ table! {
 }
 
 table! {
-    consensus_2pc_context (service_id) {
+    consensus_2pc_context (circuit_id, service_id) {
+        circuit_id  -> Text,
         service_id -> Text,
         coordinator -> Text,
         epoch -> BigInt,
@@ -58,7 +63,8 @@ table! {
 }
 
 table! {
-    consensus_2pc_context_participant (service_id, process) {
+    consensus_2pc_context_participant (circuit_id, service_id, process) {
+        circuit_id  -> Text,
         service_id -> Text,
         epoch -> BigInt,
         process -> Text,
@@ -111,6 +117,7 @@ table! {
 table! {
     consensus_2pc_action (id) {
         id -> Int8,
+        circuit_id  -> Text,
         service_id -> Text,
         created_at -> Timestamp,
         executed_at -> Nullable<BigInt>,
@@ -121,6 +128,7 @@ table! {
 table! {
     consensus_2pc_event (id) {
         id -> Int8,
+        circuit_id  -> Text,
         service_id -> Text,
         created_at -> Timestamp,
         executed_at -> Nullable<BigInt>,
@@ -165,6 +173,10 @@ joinable!(consensus_2pc_start_event -> consensus_2pc_event(event_id));
 joinable!(consensus_2pc_vote_event -> consensus_2pc_event(event_id));
 
 allow_tables_to_appear_in_same_query!(
+    scabbard_peer,
+    scabbard_service,
+    scabbard_v3_commit_history,
+    scabbard_alarm,
     consensus_2pc_context,
     consensus_2pc_context_participant,
     consensus_2pc_action,
@@ -176,11 +188,4 @@ allow_tables_to_appear_in_same_query!(
     consensus_2pc_deliver_event,
     consensus_2pc_start_event,
     consensus_2pc_vote_event,
-);
-
-allow_tables_to_appear_in_same_query!(
-    scabbard_peer,
-    scabbard_service,
-    scabbard_v3_commit_history,
-    scabbard_alarm
 );


### PR DESCRIPTION
- Split service_id (fully qualified service ID) in consensus tables into circuit_id and service_id
- Change fk relationship to point to the scabbard_service table rather than consensus_2pc_context