### PR TITLE
Remove `EnvironmentError` extraneous explanation

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -43,9 +43,7 @@ impl fmt::Display for CliError {
             CliError::InvalidSubcommand => write!(f, "An invalid subcommand was specified"),
             CliError::ClapError(err) => f.write_str(&err.message),
             CliError::ActionError(msg) => write!(f, "Subcommand encountered an error: {}", msg),
-            CliError::EnvironmentError(msg) => {
-                write!(f, "Environment not valid for subcommand: {}", msg)
-            }
+            CliError::EnvironmentError(msg) => f.write_str(msg),
         }
     }
 }


### PR DESCRIPTION
The previous EnvironmentError text was confusing, because it was not
clear what was meant by "Environment". This change removes the
extraneous explanation so the user receives a more succinct explanation
of the problem.

Signed-off-by: Amelia Bradley <bradley@bitwise.io>