### PR TITLE
Auto cleanup scabbard pruning

### DIFF
--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -164,6 +164,7 @@ pub struct ScabbardFactoryBuilder {
     state_storage_configuration: Option<ScabbardLmdbStateConfiguration>,
     storage_configuration: Option<ScabbardStorageConfiguration>,
     signature_verifier_factory: Option<Arc<Mutex<Box<dyn VerifierFactory>>>>,
+    enable_state_autocleanup: Option<bool>,
 }
 
 impl ScabbardFactoryBuilder {
@@ -222,6 +223,11 @@ impl ScabbardFactoryBuilder {
                 config
             });
 
+        self
+    }
+
+    pub fn with_state_autocleanup_enabled(mut self, enable: bool) -> Self {
+        self.enable_state_autocleanup = Some(enable);
         self
     }
 
@@ -311,12 +317,15 @@ impl ScabbardFactoryBuilder {
             state_storage_configuration.db_size,
         );
 
+        let state_autocleanup_enabled = self.enable_state_autocleanup.unwrap_or_default();
+
         Ok(ScabbardFactory {
             service_types: vec![SERVICE_TYPE.into()],
             #[cfg(feature = "lmdb")]
             state_store_factory,
             #[cfg(feature = "lmdb")]
             enable_lmdb_state: state_storage_configuration.enable_lmdb,
+            state_autocleanup_enabled,
             store_factory_config,
             signature_verifier_factory,
         })
@@ -486,6 +495,8 @@ pub struct ScabbardFactory {
     store_factory_config: ScabbardFactoryStorageConfig,
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
     signature_verifier_factory: Arc<Mutex<Box<dyn VerifierFactory>>>,
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    state_autocleanup_enabled: bool,
 }
 
 pub struct ScabbardArgValidator;
@@ -768,7 +779,7 @@ impl ScabbardFactory {
             version,
             peer_services,
             merkle_state,
-            false,
+            self.state_autocleanup_enabled,
             commit_hash_store,
             receipt_store,
             state_purge,
@@ -1138,6 +1149,7 @@ mod tests {
                 None,
             ),
             enable_lmdb_state: false,
+            state_autocleanup_enabled: false,
             store_factory_config,
             signature_verifier_factory: Arc::new(Mutex::new(Box::new(Secp256k1Context::new()))),
         }

--- a/services/scabbard/libscabbard/src/service/factory/mod.rs
+++ b/services/scabbard/libscabbard/src/service/factory/mod.rs
@@ -768,6 +768,7 @@ impl ScabbardFactory {
             version,
             peer_services,
             merkle_state,
+            false,
             commit_hash_store,
             receipt_store,
             state_purge,

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -141,6 +141,7 @@ impl Scabbard {
 
         let state = ScabbardState::new(
             merkle_state,
+            false,
             commit_hash_store,
             receipt_store,
             #[cfg(feature = "metrics")]

--- a/services/scabbard/libscabbard/src/service/mod.rs
+++ b/services/scabbard/libscabbard/src/service/mod.rs
@@ -118,6 +118,7 @@ impl Scabbard {
         // List of other scabbard services on the same circuit that this service shares state with
         peer_services: HashSet<String>,
         merkle_state: MerkleState,
+        state_autocleanup_enabled: bool,
         commit_hash_store: Arc<dyn CommitHashStore + Sync + Send>,
         receipt_store: Arc<dyn ReceiptStore>,
         purge_handler: Box<dyn ScabbardStatePurgeHandler>,
@@ -141,7 +142,7 @@ impl Scabbard {
 
         let state = ScabbardState::new(
             merkle_state,
-            false,
+            state_autocleanup_enabled,
             commit_hash_store,
             receipt_store,
             #[cfg(feature = "metrics")]
@@ -565,6 +566,7 @@ pub mod tests {
             ScabbardVersion::V1,
             HashSet::new(),
             merkle_state,
+            false,
             commit_hash_store,
             Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),
@@ -589,6 +591,7 @@ pub mod tests {
             ScabbardVersion::V1,
             HashSet::new(),
             merkle_state,
+            false,
             commit_hash_store,
             Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),
@@ -612,6 +615,7 @@ pub mod tests {
             ScabbardVersion::V1,
             HashSet::new(),
             merkle_state,
+            false,
             commit_hash_store,
             Arc::new(MockReceiptStore),
             Box::new(NoOpScabbardStatePurgeHandler),

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -221,6 +221,7 @@ mod tests {
             ScabbardVersion::V1,
             Default::default(),
             merkle_state,
+            false,
             commit_hash_store,
             receipt_store,
             Box::new(NoOpScabbardStatePurgeHandlerHandler),

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -179,6 +179,7 @@ mod tests {
         {
             let mut state = ScabbardState::new(
                 merkle_state.clone(),
+                false,
                 commit_hash_store.clone(),
                 receipt_store.clone(),
                 #[cfg(feature = "metrics")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -188,6 +188,7 @@ mod tests {
             ScabbardVersion::V1,
             Default::default(),
             merkle_state,
+            false,
             commit_hash_store,
             receipt_store,
             Box::new(NoOpScabbardStatePurgeHandlerHandler),

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -148,6 +148,7 @@ mod tests {
         {
             let mut state = ScabbardState::new(
                 merkle_state.clone(),
+                false,
                 commit_hash_store.clone(),
                 receipt_store.clone(),
                 #[cfg(feature = "metrics")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -138,6 +138,7 @@ mod tests {
         let expected_state_root = {
             let mut state = ScabbardState::new(
                 merkle_state.clone(),
+                false,
                 commit_hash_store.clone(),
                 receipt_store.clone(),
                 #[cfg(feature = "metrics")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -181,6 +181,7 @@ mod tests {
             ScabbardVersion::V1,
             Default::default(),
             merkle_state,
+            false,
             commit_hash_store,
             receipt_store,
             Box::new(NoOpScabbardStatePurgeHandlerHandler),

--- a/services/scabbard/libscabbard/src/service/state/merkle_state.rs
+++ b/services/scabbard/libscabbard/src/service/state/merkle_state.rs
@@ -188,6 +188,20 @@ impl MerkleState {
                 .map_err(|err| InternalError::from_source(Box::new(err))),
         }
     }
+
+    pub fn remove_pruned_entries(&self) -> Result<(), InternalError> {
+        match self {
+            MerkleState::KeyValue { .. } => Ok(()),
+            #[cfg(feature = "postgres")]
+            MerkleState::SqlPostgres { state } => state
+                .remove_pruned_entries()
+                .map_err(|err| InternalError::from_source(Box::new(err))),
+            #[cfg(feature = "sqlite")]
+            MerkleState::SqlSqlite { state } => state
+                .remove_pruned_entries()
+                .map_err(|err| InternalError::from_source(Box::new(err))),
+        }
+    }
 }
 
 impl Read for MerkleState {

--- a/splinterd/Cargo.toml
+++ b/splinterd/Cargo.toml
@@ -104,6 +104,7 @@ experimental = [
     "stable",
     # The following features are experimental:
     "authorization-handler-maintenance",
+    "disable-scabbard-autocleanup",
     "https-bind",
     "lifecycle-executor-interval",
     "node",
@@ -132,6 +133,7 @@ biome-profile = ["splinter/biome-profile"]
 config-allow-keys = ["authorization-handler-allow-keys"]
 database-postgres = ["diesel", "diesel/postgres", "scabbard/postgres", "splinter/postgres"]
 database-sqlite = ["diesel", "diesel/sqlite", "scabbard/sqlite", "splinter/sqlite"]
+disable-scabbard-autocleanup = []
 https-bind = ["splinter/https-bind"]
 lifecycle-executor-interval = []
 tap = [

--- a/splinterd/man/splinterd.1.md
+++ b/splinterd/man/splinterd.1.md
@@ -64,6 +64,9 @@ FLAGS
 `--enable-biome-credentials`
 : Enables Biome credentials for REST API authentication.
 
+`--disable-scabbard-autocleanup`
+: Disable autocleanup of pruned scabbard merkle state.
+
 `-h`, `--help`
 : Prints help information.
 

--- a/splinterd/packaging/splinterd.toml.example
+++ b/splinterd/packaging/splinterd.toml.example
@@ -31,6 +31,10 @@ version = "1"
 # files will be created in the Splinter state_dir.
 #scabbard_state = "database"
 
+# Enable Auto-cleanup of Scabbard state.
+# This setting is experimental.
+#scabbard_enable_autocleanup = true
+
 # Identifier for this node. Must be unique on the network. This value will be
 # used to initialize a "node_id" file in the Splinter state directory. Once
 # node_id is created, the value in the configuration below must match the

--- a/splinterd/src/config/builder.rs
+++ b/splinterd/src/config/builder.rs
@@ -431,6 +431,11 @@ impl ConfigBuilder {
                 .iter()
                 .find_map(|p| p.scabbard_state().map(|v| (v, p.source())))
                 .ok_or_else(|| ConfigError::MissingValue("scabbard_state".to_string()))?,
+            scabbard_autocleanup: self
+                .partial_configs
+                .iter()
+                .find_map(|p| p.scabbard_autocleanup().map(|v| (v, p.source())))
+                .ok_or_else(|| ConfigError::MissingValue("scabbard_autocleanup".to_string()))?,
             #[cfg(feature = "service2")]
             service_timer_interval: self
                 .partial_configs

--- a/splinterd/src/config/clap.rs
+++ b/splinterd/src/config/clap.rs
@@ -216,6 +216,11 @@ impl<'a> PartialConfigBuilder for ClapPartialConfigBuilder<'_> {
                 }
             }));
 
+        #[cfg(feature = "disable-scabbard-autocleanup")]
+        if self.matches.is_present("disable_scabbard_autocleanup") {
+            partial_config = partial_config.with_scabbard_autocleanup(Some(false));
+        }
+
         Ok(partial_config)
     }
 }

--- a/splinterd/src/config/default.rs
+++ b/splinterd/src/config/default.rs
@@ -97,7 +97,8 @@ impl PartialConfigBuilder for DefaultPartialConfigBuilder {
             .with_no_tls(Some(false))
             .with_strict_ref_counts(Some(false))
             .with_peering_key(Some(String::from(PEERING_KEY_NAME)))
-            .with_scabbard_state(Some(ScabbardState::Database));
+            .with_scabbard_state(Some(ScabbardState::Database))
+            .with_scabbard_autocleanup(Some(true));
 
         #[cfg(feature = "https-bind")]
         {

--- a/splinterd/src/config/mod.rs
+++ b/splinterd/src/config/mod.rs
@@ -109,6 +109,7 @@ pub struct Config {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: (String, ConfigSource),
     scabbard_state: (ScabbardState, ConfigSource),
+    scabbard_autocleanup: (bool, ConfigSource),
     #[cfg(feature = "service2")]
     service_timer_interval: (Duration, ConfigSource),
     #[cfg(feature = "service2")]
@@ -636,6 +637,14 @@ impl Config {
         &self.scabbard_state.1
     }
 
+    pub fn scabbard_autocleanup(&self) -> bool {
+        self.scabbard_autocleanup.0
+    }
+
+    pub fn scabbard_autocleanup_source(&self) -> &ConfigSource {
+        &self.scabbard_autocleanup.1
+    }
+
     #[cfg(feature = "service2")]
     pub fn service_timer_interval_source(&self) -> &ConfigSource {
         &self.service_timer_interval.1
@@ -911,6 +920,12 @@ impl Config {
             "Config: scabbard_state: {:?}, (source: {:?})",
             self.scabbard_state(),
             self.scabbard_state_source()
+        );
+
+        debug!(
+            "Config: scabbard_autocleanup: {:?}, (source: {:?})",
+            self.scabbard_autocleanup(),
+            self.scabbard_autocleanup_source()
         );
 
         #[cfg(feature = "service2")]

--- a/splinterd/src/config/partial.rs
+++ b/splinterd/src/config/partial.rs
@@ -100,6 +100,7 @@ pub struct PartialConfig {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: Option<String>,
     scabbard_state: Option<ScabbardState>,
+    scabbard_autocleanup: Option<bool>,
     #[cfg(feature = "service2")]
     service_timer_interval: Option<Duration>,
     #[cfg(feature = "service2")]
@@ -174,6 +175,7 @@ impl PartialConfig {
             #[cfg(feature = "config-allow-keys")]
             allow_keys_file: None,
             scabbard_state: None,
+            scabbard_autocleanup: None,
             #[cfg(feature = "service2")]
             service_timer_interval: None,
             #[cfg(feature = "service2")]
@@ -384,6 +386,10 @@ impl PartialConfig {
 
     pub fn scabbard_state(&self) -> Option<ScabbardState> {
         self.scabbard_state
+    }
+
+    pub fn scabbard_autocleanup(&self) -> Option<bool> {
+        self.scabbard_autocleanup
     }
 
     #[cfg(feature = "service2")]
@@ -928,6 +934,17 @@ impl PartialConfig {
     ///
     pub fn with_scabbard_state(mut self, scabbard_state: Option<ScabbardState>) -> Self {
         self.scabbard_state = scabbard_state;
+        self
+    }
+
+    /// Adds a `scabbard_autocleanup` value to the  `PartialConfig` object.
+    ///
+    /// # Arguments
+    ///
+    /// * `scabbard_autocleanup` - Option of bool value to enable autocleanup of pruned state.
+    ///
+    pub fn with_scabbard_autocleanup(mut self, scabbard_autocleanup: Option<bool>) -> Self {
+        self.scabbard_autocleanup = scabbard_autocleanup;
         self
     }
 

--- a/splinterd/src/config/toml.rs
+++ b/splinterd/src/config/toml.rs
@@ -207,6 +207,8 @@ struct TomlConfig {
     appenders: Option<HashMap<String, TomlUnnamedAppenderConfig>>,
     loggers: Option<HashMap<String, TomlUnnamedLoggerConfig>>,
     scabbard_state: Option<ScabbardStateToml>,
+    #[cfg(feature = "disable-scabbard-autocleanup")]
+    scabbard_enable_autocleanup: Option<bool>,
     config_dir: Option<String>,
     state_dir: Option<String>,
     #[cfg(feature = "service-timer-interval")]
@@ -299,6 +301,12 @@ impl PartialConfigBuilder for TomlPartialConfigBuilder {
             .with_config_dir(self.toml_config.config_dir)
             .with_state_dir(self.toml_config.state_dir)
             .with_scabbard_state(self.toml_config.scabbard_state.map(|inner| inner.into()));
+
+        #[cfg(feature = "disable-scabbard-autocleanup")]
+        {
+            partial_config = partial_config
+                .with_scabbard_autocleanup(self.toml_config.scabbard_enable_autocleanup);
+        }
 
         #[cfg(feature = "https-bind")]
         {

--- a/splinterd/src/daemon/builder.rs
+++ b/splinterd/src/daemon/builder.rs
@@ -66,6 +66,7 @@ pub struct SplinterDaemonBuilder {
     signers: Option<Vec<Box<dyn Signer>>>,
     peering_token: Option<PeerAuthorizationToken>,
     enable_lmdb_state: bool,
+    enable_state_autocleanup: bool,
     #[cfg(feature = "service2")]
     service_timer_interval: Option<Duration>,
     #[cfg(feature = "service2")]
@@ -248,6 +249,11 @@ impl SplinterDaemonBuilder {
         self
     }
 
+    pub fn with_state_autocleanup_enabled(mut self) -> Self {
+        self.enable_state_autocleanup = true;
+        self
+    }
+
     #[cfg(feature = "service2")]
     pub fn with_service_timer_interval(mut self, service_timer_interval: Duration) -> Self {
         self.service_timer_interval = Some(service_timer_interval);
@@ -422,6 +428,7 @@ impl SplinterDaemonBuilder {
             signers,
             peering_token,
             enable_lmdb_state: self.enable_lmdb_state,
+            enable_state_autocleanup: self.enable_state_autocleanup,
             #[cfg(feature = "service2")]
             service_timer_interval,
             #[cfg(feature = "service2")]

--- a/splinterd/src/daemon/mod.rs
+++ b/splinterd/src/daemon/mod.rs
@@ -176,6 +176,7 @@ pub struct SplinterDaemon {
     #[cfg(feature = "config-allow-keys")]
     allow_keys_file: String,
     enable_lmdb_state: bool,
+    enable_state_autocleanup: bool,
     #[cfg(feature = "service2")]
     service_timer_interval: Duration,
     #[cfg(feature = "service2")]
@@ -536,7 +537,8 @@ impl SplinterDaemon {
 
         scabbard_factory_builder = scabbard_factory_builder
             .with_lmdb_state_db_dir(self.state_dir.to_string())
-            .with_lmdb_state_enabled(self.enable_lmdb_state);
+            .with_lmdb_state_enabled(self.enable_lmdb_state)
+            .with_state_autocleanup_enabled(self.enable_state_autocleanup);
 
         let scabbard_factory = scabbard_factory_builder
             .build()

--- a/splinterd/src/main.rs
+++ b/splinterd/src/main.rs
@@ -522,6 +522,13 @@ fn main() {
             .takes_value(true),
     );
 
+    #[cfg(feature = "disable-scabbard-autocleanup")]
+    let app = app.arg(
+        Arg::with_name("disable_scabbard_autocleanup")
+            .long("disable-scabbard-autocleanup")
+            .long_help("Disable autocleanup of pruned scabbard merkle state."),
+    );
+
     let matches = app.get_matches();
 
     let log_handle = log4rs::init_config(default_log_settings());
@@ -723,6 +730,9 @@ fn start_daemon(matches: ArgMatches, log_handle: Handle) -> Result<(), UserError
     {
         if config.scabbard_state() == &config::ScabbardState::Lmdb {
             daemon_builder = daemon_builder.with_lmdb_state_enabled();
+        }
+        if config.scabbard_autocleanup() {
+            daemon_builder = daemon_builder.with_state_autocleanup_enabled();
         }
     }
 


### PR DESCRIPTION
This PR enables auto cleanup of pruned scabbard state trees by default, or allows the feature to be disabled by the use of the flag `--disable-scabbard-autocleanup`