### PR TITLE
Replace get_response_paging_info

### DIFF
--- a/libsplinter/src/oauth/rest_api/actix/list_users.rs
+++ b/libsplinter/src/oauth/rest_api/actix/list_users.rs
@@ -20,7 +20,7 @@ use crate::oauth::rest_api::{
 };
 use crate::rest_api::{
     actix_web_1::{Method, ProtocolVersionRangeGuard, Resource},
-    paging::get_response_paging_info,
+    paging::PagingBuilder,
     ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 use futures::future::IntoFuture;
@@ -55,16 +55,15 @@ pub fn make_oauth_list_users_resource(
                         .skip(paging_query.offset)
                         .take(paging_query.limit)
                         .collect::<Vec<_>>();
+                    let paging = PagingBuilder::new(link, total)
+                        .with_limit(paging_query.limit)
+                        .with_offset(paging_query.offset)
+                        .build();
 
                     HttpResponse::Ok()
                         .json(ListOAuthUserResponse {
                             data: oauth_users.iter().map(OAuthUserResponse::from).collect(),
-                            paging: get_response_paging_info(
-                                Some(paging_query.limit),
-                                Some(paging_query.offset),
-                                &link,
-                                total,
-                            ),
+                            paging,
                         })
                         .into_future()
                 }
@@ -100,14 +99,13 @@ pub fn make_oauth_list_users_resource(
                         .skip(paging_query.offset)
                         .take(paging_query.limit)
                         .collect::<Vec<_>>();
+                    let paging = PagingBuilder::new(lint, total)
+                        .with_limit(paging_query.limit)
+                        .with_offset(paging_query.offset)
+                        .build();
                     Ok(HttpResponse::Ok().json(ListOAuthUserResponse {
                         data: oauth_users.iter().map(OAuthUserResponse::from).collect(),
-                        paging: get_response_paging_info(
-                            Some(paging_query.limit),
-                            Some(paging_query.offset),
-                            &link,
-                            total,
-                        ),
+                        paging,
                     }))
                 }
                 Err(err) => {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/assignments.rs
@@ -30,7 +30,7 @@ use crate::rest_api::{
         },
         RBAC_READ_PERMISSION, RBAC_WRITE_PERMISSION,
     },
-    paging::get_response_paging_info,
+    paging::PagingBuilder,
     ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
@@ -115,12 +115,10 @@ fn list_assignments(
                 Ok((assignments, link, paging_query, total)) => {
                     Ok(HttpResponse::Ok().json(ListAssignmentsResponse {
                         data: assignments.iter().map(AssignmentResponse::from).collect(),
-                        paging: get_response_paging_info(
-                            Some(paging_query.limit),
-                            Some(paging_query.offset),
-                            &link,
-                            total,
-                        ),
+                        paging: PagingBuilder::new(link, total)
+                            .with_limit(paging_query.limit)
+                            .with_offset(paging_query.offset)
+                            .build(),
                     }))
                 }
                 Err(err) => {

--- a/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
+++ b/libsplinter/src/rest_api/auth/authorization/rbac/rest_api/actix_web_1/roles.rs
@@ -31,7 +31,7 @@ use crate::rest_api::{
         },
         RBAC_READ_PERMISSION, RBAC_WRITE_PERMISSION,
     },
-    paging::get_response_paging_info,
+    paging::PagingBuilder,
     ErrorResponse, SPLINTER_PROTOCOL_VERSION,
 };
 
@@ -117,12 +117,10 @@ fn list_roles(
                 Ok((roles, link, paging_query, total)) => {
                     Ok(HttpResponse::Ok().json(ListRoleResponse {
                         data: roles.iter().map(RoleResponse::from).collect(),
-                        paging: get_response_paging_info(
-                            Some(paging_query.limit),
-                            Some(paging_query.offset),
-                            &link,
-                            total,
-                        ),
+                        paging: PagingBuilder::new(link, total)
+                            .with_limit(paging_query.limit)
+                            .with_offset(paging_query.offset)
+                            .build(),
                     }))
                 }
                 Err(err) => {

--- a/libsplinter/src/rest_api/paging.rs
+++ b/libsplinter/src/rest_api/paging.rs
@@ -28,59 +28,6 @@ pub struct Paging {
     pub last: String,
 }
 
-pub fn get_response_paging_info(
-    limit: Option<usize>,
-    offset: Option<usize>,
-    link: &str,
-    query_count: usize,
-) -> Paging {
-    let limit = limit.unwrap_or(DEFAULT_LIMIT);
-    let offset = offset.unwrap_or(DEFAULT_OFFSET);
-
-    let base_link = {
-        // if the link does not already contain ? add it to the end
-        if !link.contains('?') {
-            format!("{}?limit={}&", link, limit)
-        } else {
-            format!("{}limit={}&", link, limit)
-        }
-    };
-
-    let current_link = format!("{}offset={}", base_link, offset);
-
-    let first_link = format!("{}offset=0", base_link);
-
-    let previous_offset = if offset > limit { offset - limit } else { 0 };
-
-    let previous_link = format!("{}offset={}", base_link, previous_offset);
-
-    let last_offset = if query_count > 0 {
-        ((query_count - 1) / limit) * limit
-    } else {
-        0
-    };
-    let last_link = format!("{}offset={}", base_link, last_offset);
-
-    let next_offset = if offset + limit > last_offset {
-        last_offset
-    } else {
-        offset + limit
-    };
-
-    let next_link = format!("{}offset={}", base_link, next_offset);
-
-    Paging {
-        current: current_link,
-        offset,
-        limit,
-        total: query_count,
-        first: first_link,
-        prev: previous_link,
-        next: next_link,
-        last: last_link,
-    }
-}
-
 pub struct PagingBuilder {
     link: String,
     limit: Option<usize>,
@@ -174,7 +121,7 @@ mod tests {
     #[test]
     fn test_default_paging_response() {
         // Create paging response from default limit, default offset, a total of 1000
-        let test_paging_response = get_response_paging_info(None, None, TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000).build();
         let generated_paging_response =
             create_test_paging_response(DEFAULT_OFFSET, DEFAULT_LIMIT, 100, 0, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -183,7 +130,9 @@ mod tests {
     #[test]
     fn test_50offset_paging_response() {
         // Create paging response from default limit, offset of 50, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(50), TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000)
+            .with_offset(50)
+            .build();
         let generated_paging_response = create_test_paging_response(50, DEFAULT_LIMIT, 150, 0, 900);
         assert_eq!(test_paging_response, generated_paging_response);
     }
@@ -191,7 +140,9 @@ mod tests {
     #[test]
     fn test_550offset_paging_response() {
         // Create paging response from default limit, offset value of 150, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(550), TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000)
+            .with_offset(550)
+            .build();
         let generated_paging_response =
             create_test_paging_response(550, DEFAULT_LIMIT, 650, 450, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -200,7 +151,9 @@ mod tests {
     #[test]
     fn test_950offset_paging_response() {
         // Create paging response from default limit, offset value of 950, and a total of 1000
-        let test_paging_response = get_response_paging_info(None, Some(950), TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000)
+            .with_offset(950)
+            .build();
         let generated_paging_response =
             create_test_paging_response(950, DEFAULT_LIMIT, 900, 850, 900);
         assert_eq!(test_paging_response, generated_paging_response);
@@ -209,7 +162,9 @@ mod tests {
     #[test]
     fn test_50limit_paging_response() {
         // Create paging response from default limit, offset of 50, and a total of 1000
-        let test_paging_response = get_response_paging_info(Some(50), None, TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000)
+            .with_limit(50)
+            .build();
         let generated_paging_response = create_test_paging_response(DEFAULT_OFFSET, 50, 50, 0, 950);
         assert_eq!(test_paging_response, generated_paging_response);
     }
@@ -217,7 +172,10 @@ mod tests {
     #[test]
     fn test_50limit_150offset_paging_response() {
         // Create paging response from limit of 50, offset of 150, and total of 1000
-        let test_paging_response = get_response_paging_info(Some(50), Some(150), TEST_LINK, 1000);
+        let test_paging_response = PagingBuilder::new(TEST_LINK.to_string(), 1000)
+            .with_limit(50)
+            .with_offset(150)
+            .build();
         let generated_paging_response = create_test_paging_response(150, 50, 200, 100, 950);
         assert_eq!(test_paging_response, generated_paging_response);
     }


### PR DESCRIPTION
This PR replaces all the uses of the get_response_paging_info fn in libsplinter and the actix_web_1 crate