### PR TITLE
Log error instead of propagate on prune cleanup

### DIFF
--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -351,12 +351,12 @@ impl ScabbardState {
                         })?;
 
                     if self.state_autocleanup_enabled {
-                        self.merkle_state.remove_pruned_entries().map_err(|err| {
-                            ScabbardStateError(format!(
-                                "failed to cleanup pruned state entries {}: {}",
+                        if let Err(err) = self.merkle_state.remove_pruned_entries() {
+                            error!(
+                                "failed to cleanup pruned state for root {}: {}",
                                 previous_state_root, err
-                            ))
-                        })?;
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
This change logs the error instead of propagating it, as any issues with pruning cleanup are local to a node and should not be fatal to the progress of the circuit as a whole. The issue could be solved by a DBA in the database.
