### PR TITLE
Stabilize service-message-converter feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -129,7 +129,6 @@ experimental = [
     "service-lifecycle",
     "service-lifecycle-executor",
     "service-lifecycle-store",
-    "service-message-converter",
     "service-message-handler",
     "service-message-handler-dispatch",
     "service-message-handler-factory",
@@ -198,10 +197,9 @@ service-arguments-converter = ["service"]
 service-lifecycle = ["service", "service-arguments-converter", "store"]
 service-lifecycle-executor = ["runtime-service", "service-lifecycle", "service-lifecycle-store"]
 service-lifecycle-store = ["service", "service-lifecycle"]
-service-message-converter = ["service"]
-service-message-handler = ["service", "service-message-converter", "service-message-sender"]
+service-message-handler = ["service", "service-message-sender"]
 service-message-handler-factory = ["service", "service-message-handler"]
-service-message-sender = ["service", "service-message-converter"]
+service-message-sender = ["service"]
 service-message-sender-factory = ["service", "service-message-sender"]
 service-message-sender-factory-peer = [
     "service-message-sender",
@@ -219,7 +217,7 @@ service-timer =[
 service-timer-alarm = []
 service-timer-alarm-factory = ["service-timer-alarm"]
 service-timer-filter = ["service"]
-service-timer-handler = ["service", "service-message-converter", "service-message-sender"]
+service-timer-handler = ["service", "service-message-sender"]
 service-message-handler-dispatch = [
     "runtime-service",
     "service-message-handler",

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -41,7 +41,6 @@ mod id;
 pub mod instance;
 #[cfg(feature = "service-lifecycle")]
 mod lifecycle;
-#[cfg(feature = "service-message-converter")]
 mod message_converter;
 #[cfg(feature = "service-message-handler")]
 mod message_handler;
@@ -71,7 +70,6 @@ pub use arguments_converter::ArgumentsConverter;
 pub use id::{CircuitId, FullyQualifiedServiceId, ServiceId};
 #[cfg(feature = "service-lifecycle")]
 pub use lifecycle::Lifecycle;
-#[cfg(feature = "service-message-converter")]
 pub use message_converter::MessageConverter;
 #[cfg(feature = "service-message-handler")]
 pub use message_handler::MessageHandler;

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -108,7 +108,6 @@ scabbardv3 = [
     "scabbardv3-store",
     "splinter/service-arguments-converter",
     "splinter/service-lifecycle",
-    "splinter/service-message-converter",
     "splinter/service-message-handler",
     "splinter/service-message-handler-factory",
     "splinter/service-message-sender",


### PR DESCRIPTION
This stabilizes the feature by removing it; the code becomes part of the
"service" feature.