### PR TITLE
Stabilize service-message-sender feature

### DIFF
--- a/libsplinter/Cargo.toml
+++ b/libsplinter/Cargo.toml
@@ -132,7 +132,6 @@ experimental = [
     "service-message-handler",
     "service-message-handler-dispatch",
     "service-message-handler-factory",
-    "service-message-sender",
     "service-message-sender-factory",
     "service-message-sender-factory-peer",
     "service-timer",
@@ -197,14 +196,10 @@ service-arguments-converter = ["service"]
 service-lifecycle = ["service", "service-arguments-converter", "store"]
 service-lifecycle-executor = ["runtime-service", "service-lifecycle", "service-lifecycle-store"]
 service-lifecycle-store = ["service", "service-lifecycle"]
-service-message-handler = ["service", "service-message-sender"]
+service-message-handler = ["service"]
 service-message-handler-factory = ["service", "service-message-handler"]
-service-message-sender = ["service"]
-service-message-sender-factory = ["service", "service-message-sender"]
-service-message-sender-factory-peer = [
-    "service-message-sender",
-    "service-message-sender-factory"
-]
+service-message-sender-factory = ["service"]
+service-message-sender-factory-peer = ["service-message-sender-factory"]
 service-timer =[
   "defered-send",
   "runtime-service",
@@ -217,7 +212,7 @@ service-timer =[
 service-timer-alarm = []
 service-timer-alarm-factory = ["service-timer-alarm"]
 service-timer-filter = ["service"]
-service-timer-handler = ["service", "service-message-sender"]
+service-timer-handler = ["service"]
 service-message-handler-dispatch = [
     "runtime-service",
     "service-message-handler",

--- a/libsplinter/src/service/mod.rs
+++ b/libsplinter/src/service/mod.rs
@@ -46,7 +46,6 @@ mod message_converter;
 mod message_handler;
 #[cfg(feature = "service-message-handler-factory")]
 mod message_handler_factory;
-#[cfg(feature = "service-message-sender")]
 mod message_sender;
 #[cfg(feature = "service-message-sender-factory")]
 mod message_sender_factory;
@@ -75,12 +74,8 @@ pub use message_converter::MessageConverter;
 pub use message_handler::MessageHandler;
 #[cfg(feature = "service-message-handler-factory")]
 pub use message_handler_factory::MessageHandlerFactory;
-#[cfg(all(
-    feature = "service-message-sender",
-    any(feature = "service-timer-handler", feature = "service-message-handler")
-))]
+#[cfg(any(feature = "service-timer-handler", feature = "service-message-handler"))]
 use message_sender::IntoMessageSender;
-#[cfg(feature = "service-message-sender")]
 pub use message_sender::MessageSender;
 #[cfg(feature = "service-message-sender-factory")]
 pub use message_sender_factory::MessageSenderFactory;

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -110,7 +110,6 @@ scabbardv3 = [
     "splinter/service-lifecycle",
     "splinter/service-message-handler",
     "splinter/service-message-handler-factory",
-    "splinter/service-message-sender",
     "splinter/service-timer-alarm-factory",
     "splinter/service-timer-filter",
     "splinter/service-timer-handler",


### PR DESCRIPTION
This stabilized the feature by removing it; the code becomes part of the
"service" feature.