### PR TITLE
Fix several bugs to enable properly purging a scabbard v3 circuit

### DIFF
--- a/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/models.rs
+++ b/libsplinter/src/runtime/service/lifecycle_executor/store/diesel/models.rs
@@ -465,7 +465,7 @@ impl FromSql<CommandTypeModelMapping, Pg> for CommandTypeModel {
         match bytes {
             Some(b"PREPARE") => Ok(CommandTypeModel::Prepare),
             Some(b"FINALIZE") => Ok(CommandTypeModel::Finalize),
-            Some(b"RETURE") => Ok(CommandTypeModel::Retire),
+            Some(b"RETIRE") => Ok(CommandTypeModel::Retire),
             Some(b"PURGE") => Ok(CommandTypeModel::Purge),
             Some(v) => Err(format!(
                 "Unrecognized enum variant: '{}'",

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-01-135648_fix_remove_service/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-01-135648_fix_remove_service/down.sql
@@ -1,0 +1,52 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE scabbard_alarm DROP CONSTRAINT scabbard_alarm_service_id_fkey;
+ALTER TABLE scabbard_peer DROP CONSTRAINT scabbard_peer_service_id_fkey;
+ALTER TABLE scabbard_peer DROP CONSTRAINT scabbard_peer_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_v3_commit_history DROP CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context DROP CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context_participant DROP CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_action DROP CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_event DROP CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_alarm DROP CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey;
+
+
+-- Recreate the foreign key constraints with on delete cascade
+ALTER TABLE scabbard_alarm ADD CONSTRAINT scabbard_alarm_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_peer ADD CONSTRAINT scabbard_peer_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_peer
+  ADD CONSTRAINT scabbard_peer_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_v3_commit_history
+  ADD CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_context
+  ADD CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_context_participant
+  ADD CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_action
+  ADD CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE consensus_2pc_event
+  ADD CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);
+ALTER TABLE scabbard_alarm
+  ADD CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id);

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-01-135648_fix_remove_service/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-01-135648_fix_remove_service/up.sql
@@ -1,0 +1,52 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE scabbard_alarm DROP CONSTRAINT scabbard_alarm_service_id_fkey;
+ALTER TABLE scabbard_peer DROP CONSTRAINT scabbard_peer_service_id_fkey;
+ALTER TABLE scabbard_peer DROP CONSTRAINT scabbard_peer_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_v3_commit_history DROP CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context DROP CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_context_participant DROP CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_action DROP CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey;
+ALTER TABLE consensus_2pc_event DROP CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey;
+ALTER TABLE scabbard_alarm DROP CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey;
+
+
+-- Recreate the foreign key constraints with on delete cascade
+ALTER TABLE scabbard_alarm ADD CONSTRAINT scabbard_alarm_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE scabbard_peer ADD CONSTRAINT scabbard_peer_service_id_fkey
+  FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE scabbard_peer
+  ADD CONSTRAINT scabbard_peer_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE scabbard_v3_commit_history
+  ADD CONSTRAINT scabbard_v3_commit_history_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_context
+  ADD CONSTRAINT consensus_2pc_context_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_context_participant
+  ADD CONSTRAINT consensus_2pc_context_participant_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_action
+  ADD CONSTRAINT consensus_2pc_action_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE consensus_2pc_event
+  ADD CONSTRAINT consensus_2pc_event_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;
+ALTER TABLE scabbard_alarm
+  ADD CONSTRAINT scabbard_alarm_circuit_id_service_id_fkey
+  FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-01-135648_fix_remove_service/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-01-135648_fix_remove_service/down.sql
@@ -1,0 +1,217 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     TEXT NOT NULL
+    CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED', 'WAITING_FOR_DECISION_ACK') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    ack_timeout_start         BIGINT
+    CHECK ( (ack_timeout_start IS NOT NULL) OR ( state != 'WAITING_FOR_DECISION_ACK') ),
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+
+INSERT INTO new_consensus_2pc_context
+    (
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+
+DROP TABLE consensus_2pc_context;
+
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(circuit_id, service_id, peer_service_id)
+    FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+INSERT INTO new_scabbard_peer
+    (
+        circuit_id,
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+DROP TABLE scabbard_peer;
+
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  TEXT,
+    CHECK ( decision IN ('COMMIT', 'ABORT') ),
+    PRIMARY KEY (circuit_id, service_id, epoch),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+DROP TABLE scabbard_v3_commit_history;
+
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    decision_ack NUMERIC NOT NULL DEFAULT 0,
+    PRIMARY KEY (circuit_id, service_id, process),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+DROP TABLE consensus_2pc_context_participant;
+
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') ), 
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id)
+);
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    )
+    SELECT
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    FROM consensus_2pc_event;
+
+DROP TABLE consensus_2pc_event;
+
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    alarm_type                TEXT NOT NULL
+    CHECK ( alarm_type IN ('TWOPHASECOMMIT')),
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id),
+    PRIMARY KEY (circuit_id, service_id, alarm_type)
+);
+
+INSERT INTO new_scabbard_alarm
+    (
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+DROP TABLE scabbard_alarm;
+
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-01-135648_fix_remove_service/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-01-135648_fix_remove_service/up.sql
@@ -1,0 +1,217 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    coordinator               TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    last_commit_epoch         BIGINT,
+    state                     TEXT NOT NULL
+    CHECK ( state IN ('WAITINGFORSTART', 'VOTING', 'WAITINGFORVOTE', 'ABORT', 'COMMIT', 'WAITINGFORVOTEREQUEST', 'VOTED', 'WAITING_FOR_DECISION_ACK') ),
+    vote_timeout_start        BIGINT
+    CHECK ( (vote_timeout_start IS NOT NULL) OR ( state != 'VOTING') ),
+    vote                      TEXT
+    CHECK ( (vote IN ('TRUE' , 'FALSE')) OR ( state != 'VOTED') ),
+    decision_timeout_start    BIGINT
+    CHECK ( (decision_timeout_start IS NOT NULL) OR ( state != 'VOTED') ),
+    ack_timeout_start         BIGINT
+    CHECK ( (ack_timeout_start IS NOT NULL) OR ( state != 'WAITING_FOR_DECISION_ACK') ),
+    PRIMARY KEY (circuit_id, service_id),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+
+INSERT INTO new_consensus_2pc_context
+    (
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        coordinator,
+        epoch,
+        last_commit_epoch,
+        state,
+        vote_timeout_start,
+        vote,
+        decision_timeout_start
+    FROM consensus_2pc_context;
+
+
+DROP TABLE consensus_2pc_context;
+
+ALTER TABLE new_consensus_2pc_context RENAME TO consensus_2pc_context;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_peer (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    peer_service_id           TEXT,
+    PRIMARY KEY(circuit_id, service_id, peer_service_id)
+    FOREIGN KEY(circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_scabbard_peer
+    (
+        circuit_id,
+        service_id,
+        peer_service_id
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        peer_service_id
+    FROM scabbard_peer;
+
+DROP TABLE scabbard_peer;
+
+ALTER TABLE new_scabbard_peer RENAME TO scabbard_peer;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_v3_commit_history (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     INTEGER NOT NULL,
+    value                     TEXT NOT NULL,
+    decision                  TEXT,
+    CHECK ( decision IN ('COMMIT', 'ABORT') ),
+    PRIMARY KEY (circuit_id, service_id, epoch),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_scabbard_v3_commit_history
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        epoch,
+        value,
+        decision
+    FROM scabbard_v3_commit_history;
+
+DROP TABLE scabbard_v3_commit_history;
+
+ALTER TABLE new_scabbard_v3_commit_history RENAME TO scabbard_v3_commit_history;
+
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_context_participant (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    epoch                     BIGINT NOT NULL,
+    process                   TEXT NOT NULL,
+    vote                      TEXT
+    CHECK ( vote IN ('TRUE' , 'FALSE') OR vote IS NULL ),
+    decision_ack NUMERIC NOT NULL DEFAULT 0,
+    PRIMARY KEY (circuit_id, service_id, process),
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_consensus_2pc_context_participant
+    (
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        epoch,
+        process,
+        vote
+    FROM consensus_2pc_context_participant;
+
+DROP TABLE consensus_2pc_context_participant;
+
+ALTER TABLE new_consensus_2pc_context_participant RENAME TO consensus_2pc_context_participant;
+
+CREATE TABLE IF NOT EXISTS new_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    created_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    executed_at               BIGINT,
+    event_type                TEXT NOT NULL
+    CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') ), 
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+INSERT INTO new_consensus_2pc_event
+    (
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    )
+    SELECT
+        id,
+        circuit_id,
+        service_id,
+        created_at,
+        executed_at,
+        event_type
+    FROM consensus_2pc_event;
+
+DROP TABLE consensus_2pc_event;
+
+ALTER TABLE new_consensus_2pc_event RENAME TO consensus_2pc_event;
+
+CREATE TABLE IF NOT EXISTS new_scabbard_alarm (
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    alarm_type                TEXT NOT NULL
+    CHECK ( alarm_type IN ('TWOPHASECOMMIT')),
+    alarm                     BIGINT NOT NULL,
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE,
+    PRIMARY KEY (circuit_id, service_id, alarm_type)
+);
+
+INSERT INTO new_scabbard_alarm
+    (
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    )
+    SELECT
+        circuit_id,
+        service_id,
+        alarm_type,
+        alarm
+    FROM scabbard_alarm;
+
+DROP TABLE scabbard_alarm;
+
+ALTER TABLE new_scabbard_alarm RENAME TO scabbard_alarm;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/remove_service.rs
@@ -20,9 +20,7 @@ use diesel::{dsl::delete, prelude::*};
 use splinter::service::FullyQualifiedServiceId;
 
 use crate::store::scabbard_store::diesel::operations::get_service::GetServiceOperation;
-use crate::store::scabbard_store::diesel::schema::{
-    consensus_2pc_context, scabbard_peer, scabbard_service, scabbard_v3_commit_history,
-};
+use crate::store::scabbard_store::diesel::schema::scabbard_service;
 use crate::store::scabbard_store::ScabbardStoreError;
 
 use super::ScabbardStoreOperations;
@@ -56,45 +54,6 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, SqliteConnection
                             OPERATION_NAME.to_string(),
                         )
                     })?;
-                delete(
-                    scabbard_peer::table.filter(
-                        scabbard_peer::circuit_id
-                            .eq(&circuit_id)
-                            .and(scabbard_peer::service_id.eq(&service_id)),
-                    ),
-                )
-                .execute(self.conn)
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?;
-
-                // delete all commit history for the service
-                delete(
-                    scabbard_v3_commit_history::table.filter(
-                        scabbard_v3_commit_history::circuit_id
-                            .eq(&circuit_id)
-                            .and(scabbard_v3_commit_history::service_id.eq(&service_id)),
-                    ),
-                )
-                .execute(self.conn)
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?;
-
-                // delete all consensus state associated with the services
-                //
-                // delete cascade will remove the remaining associated consensus components
-                delete(
-                    consensus_2pc_context::table.filter(
-                        consensus_2pc_context::circuit_id
-                            .eq(&circuit_id)
-                            .and(consensus_2pc_context::service_id.eq(&service_id)),
-                    ),
-                )
-                .execute(self.conn)
-                .map_err(|err| {
-                    ScabbardStoreError::from_source_with_operation(err, OPERATION_NAME.to_string())
-                })?;
 
                 Ok(())
             })
@@ -123,54 +82,6 @@ impl<'a> RemoveServiceOperation for ScabbardStoreOperations<'a, PgConnection> {
                                 OPERATION_NAME.to_string(),
                             )
                         })?;
-                    delete(
-                        scabbard_peer::table.filter(
-                            scabbard_peer::circuit_id
-                                .eq(&circuit_id)
-                                .and(scabbard_peer::service_id.eq(&service_id)),
-                        ),
-                    )
-                    .execute(self.conn)
-                    .map_err(|err| {
-                        ScabbardStoreError::from_source_with_operation(
-                            err,
-                            OPERATION_NAME.to_string(),
-                        )
-                    })?;
-
-                    // delete all commit history for the service
-                    delete(
-                        scabbard_v3_commit_history::table.filter(
-                            scabbard_v3_commit_history::circuit_id
-                                .eq(&circuit_id)
-                                .and(scabbard_v3_commit_history::service_id.eq(&service_id)),
-                        ),
-                    )
-                    .execute(self.conn)
-                    .map_err(|err| {
-                        ScabbardStoreError::from_source_with_operation(
-                            err,
-                            OPERATION_NAME.to_string(),
-                        )
-                    })?;
-
-                    // delete all consensus state associated with the services
-                    //
-                    // delete cascade will remove the remaining associated consensus components
-                    delete(
-                        consensus_2pc_context::table.filter(
-                            consensus_2pc_context::circuit_id
-                                .eq(&circuit_id)
-                                .and(consensus_2pc_context::service_id.eq(&service_id)),
-                        ),
-                    )
-                    .execute(self.conn)
-                    .map_err(|err| {
-                        ScabbardStoreError::from_source_with_operation(
-                            err,
-                            OPERATION_NAME.to_string(),
-                        )
-                    })?;
 
                     Ok(())
                 })


### PR DESCRIPTION
- Adds "ON DELETE CASCADE" to foreign key constraints that were missing it.
- Simplifies the remove_service operation to only call delete on scabbard_service
- Enforces foreign key constraints on scabbard store unit tests
- Fixes a typo in the postgres model for command type