### PR TITLE
Fix circuit and proposal display strings

### DIFF
--- a/cli/src/action/circuit/api.rs
+++ b/cli/src/action/circuit/api.rs
@@ -262,14 +262,14 @@ impl fmt::Display for CircuitSlice {
         }
 
         if let Some(status) = &self.circuit_status {
-            writeln!(display_string, "Circuit Status: {}    ", status)?;
+            writeln!(display_string, "    Circuit Status: {}    ", status)?;
         } else {
-            display_string += "Circuit Status: Active\n    ";
+            display_string += "    Circuit Status: Active\n    ";
         }
 
         writeln!(
             display_string,
-            "Schema Version: {}\n    Management Type: {}",
+            "    Schema Version: {}\n    Management Type: {}",
             self.circuit_version, self.management_type
         )?;
 
@@ -368,7 +368,7 @@ impl fmt::Display for ProposalSlice {
 
         write!(
             display_string,
-            "Schema Version: {}\n    Management Type: {}\n",
+            "    Schema Version: {}\n    Management Type: {}\n",
             self.circuit.circuit_version, self.circuit.management_type
         )?;
 


### PR DESCRIPTION
This commit fixes the formatting for the display strings used
in showing circuit and proposals in the splinter CLI.

They were accidently changed when handle the format_push_string
lint added in Rust 1.62

For circuit before output looked like:
```
Circuit: a3YgC-K98LL
    Display Name: circuit01    
Circuit Status: Active    
Schema Version: 2
    Management Type: test
```

After it is back to:
```
Circuit: a3YgC-K98LL
    Display Name: circuit01    
    Circuit Status: Active    
    Schema Version: 2
    Management Type: test
```

For proposal before output looked like:
```
Proposal to create: IQIRT-qUo4Z
    Display Name: -
    Circuit Status: Active    
Schema Version: 2
    Management Type: test
```

After it is back to:
```
Proposal to create: IQIRT-qUo4Z
    Display Name: -
    Circuit Status: Active    
    Schema Version: 2
    Management Type: test
```