### PR TITLE
Event table fixes

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,9 +95,14 @@ ci-shellcheck:
 ci-test:
     #!/usr/bin/env sh
     set -e
+
+    trap "docker-compose -f tests/test-splinter.yaml down" EXIT
+
     docker-compose -f tests/test-splinter.yaml build unit-test-splinter
-    docker-compose -f tests/test-splinter.yaml up \
-      --abort-on-container-exit unit-test-splinter
+
+    docker-compose -f tests/test-splinter.yaml up --detach postgres-db
+
+    docker-compose -f tests/test-splinter.yaml up --abort-on-container-exit unit-test-splinter
 
 ci-test-gameroom: test-gameroom
 

--- a/services/scabbard/libscabbard/Cargo.toml
+++ b/services/scabbard/libscabbard/Cargo.toml
@@ -81,6 +81,7 @@ experimental = [
   # The experimental feature extends stable:
   "stable",
   # The following features are experimental:
+  "diesel-postgres-tests",
   "https",
   "scabbardv3",
   "scabbardv3-consensus",
@@ -92,6 +93,7 @@ experimental = [
 authorization = ["splinter/authorization"]
 client = []
 client-reqwest = ["client", "log", "reqwest"]
+diesel-postgres-tests = ["postgres"]
 events = ["splinter/events"]
 https = []
 lmdb = []

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-05-014045-event-table-updates/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-05-014045-event-table-updates/down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- DROP the executed_epoch column
+ALTER TABLE consensus_2pc_event DROP COLUMN executed_epoch;
+
+-- Revert the executed_at column to be BIGINT of unix epoch milliseconds
+ALTER TABLE consensus_2pc_event ADD COLUMN temp_executed_at BIGINT NULL;
+
+UPDATE consensus_2pc_event
+   SET temp_executed_at = (extract(epoch from executed_at) * 1000)::BIGINT
+   WHERE executed_at IS NOT NULL;
+
+ALTER TABLE consensus_2pc_event
+  ALTER COLUMN executed_at TYPE BIGINT USING temp_executed_at;
+
+ALTER TABLE consensus_2pc_event DROP COLUMN temp_executed_at;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-05-014045-event-table-updates/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-05-014045-event-table-updates/up.sql
@@ -1,0 +1,38 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Add the executed_epoch column
+ALTER TABLE consensus_2pc_event
+    ADD COLUMN executed_epoch BIGINT;
+
+-- Default all executed columns to the most recent epoch
+UPDATE consensus_2pc_event
+SET executed_epoch = ctx.epoch
+FROM consensus_2pc_context ctx
+WHERE ctx.circuit_id = consensus_2pc_event.circuit_id
+  AND ctx.service_id = consensus_2pc_event.service_id
+  AND consensus_2pc_event.executed_at IS NOT NULL;
+
+-- Change the executed_at column to be a timestamp data type.
+ALTER TABLE consensus_2pc_event ADD COLUMN temp_executed_at TIMESTAMP without time zone NULL;
+
+UPDATE consensus_2pc_event
+   SET temp_executed_at = TO_TIMESTAMP(executed_at::double precision / 1000)
+   WHERE executed_at IS NOT NULL;
+
+ALTER TABLE consensus_2pc_event
+  ALTER COLUMN executed_at TYPE TIMESTAMP without time zone USING temp_executed_at;
+
+ALTER TABLE consensus_2pc_event DROP COLUMN temp_executed_at;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-05-014045-event-table-updates/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-05-014045-event-table-updates/down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- DROP the executed_epoch column
+ALTER TABLE consensus_2pc_event DROP COLUMN executed_epoch;
+
+-- Revert the executed_at column to be BIGINT of unix epoch milliseconds
+ALTER TABLE consensus_2pc_event ADD COLUMN temp_executed_at BIGINT NULL;
+
+UPDATE consensus_2pc_event
+   SET temp_executed_at = (extract(epoch from executed_at) * 1000)::BIGINT
+   WHERE executed_at IS NOT NULL;
+
+ALTER TABLE consensus_2pc_event
+  ALTER COLUMN executed_at TYPE BIGINT USING temp_executed_at;
+
+ALTER TABLE consensus_2pc_event DROP COLUMN temp_executed_at;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-05-014045-event-table-updates/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-05-014045-event-table-updates/up.sql
@@ -1,0 +1,64 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+-- Add the executed_epoch column
+
+-- Default all executed columns to the most recent epoch
+CREATE TABLE temp_consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    event_type                TEXT NOT NULL,
+    created_at                TEXT NOT NULL,
+    executed_at               TEXT
+);
+
+INSERT INTO temp_consensus_2pc_event
+SELECT id, circuit_id, service_id, event_type,
+       strftime('%Y-%m-%d %H:%M:%f', created_at) as created_at,
+       strftime('%Y-%m-%d %H:%M:%f', executed_at, "unixepoch") as executed_at
+FROM consensus_2pc_event;
+
+DROP TABLE consensus_2pc_event;
+
+CREATE TABLE consensus_2pc_event (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    circuit_id                TEXT NOT NULL,
+    service_id                TEXT NOT NULL,
+    event_type                TEXT NOT NULL
+        CHECK ( event_type IN ('ALARM', 'DELIVER', 'START', 'VOTE') ),
+    created_at                TEXT
+        DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')) NOT NULL,
+    executed_at               TEXT,
+    executed_epoch            BIGINT,
+    FOREIGN KEY (circuit_id, service_id) REFERENCES scabbard_service(circuit_id, service_id) ON DELETE CASCADE
+);
+
+INSERT INTO consensus_2pc_event
+SELECT t.id, t.circuit_id, t.service_id, t.event_type, t.created_at, t.executed_at,
+       CASE
+           WHEN t.executed_at IS NOT NULL THEN ctx.epoch
+           ELSE NULL
+       END as executed_epoch
+FROM temp_consensus_2pc_event t,
+     consensus_2pc_context ctx
+WHERE ctx.circuit_id = t.circuit_id
+  AND ctx.service_id = t.service_id;
+
+DROP TABLE temp_consensus_2pc_event;
+
+PRAGMA foreign_keys=on;

--- a/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
+++ b/services/scabbard/libscabbard/src/service/v3/consensus/consensus_runner/mod.rs
@@ -102,6 +102,8 @@ where
                     ))
                 })?;
 
+            let epoch = context.epoch();
+
             let algorithm = self.algorithms.get(event.algorithm_name()).ok_or_else(|| {
                 InternalError::with_message(format!("{} is not configured", event.algorithm_name()))
             })?;
@@ -115,7 +117,7 @@ where
             );
             commands.push(
                 self.consensus_store_command_factory
-                    .new_mark_event_complete_command(service_id, event_id),
+                    .new_mark_event_complete_command(service_id, event_id, epoch),
             );
             self.store_command_executor.execute(commands)?;
         }

--- a/services/scabbard/libscabbard/src/store/diesel_postgres_test.rs
+++ b/services/scabbard/libscabbard/src/store/diesel_postgres_test.rs
@@ -1,0 +1,89 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::error::Error;
+use std::panic;
+
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+
+use crate::migrations::run_postgres_migrations;
+
+/// Execute a test against a postgres database.
+///
+/// This function will create a database, based on the name of the current test being run, if
+/// known. It will then run the migrations against the new database.  After the test completes, it
+/// will drop the test datbase previously created, regardless of success or failure of the test.
+///
+/// The base url for a postgres server is specified by the environment variable
+/// `DIESEL_POSTGRES_TEST_URL` or defaults to `"postgres://postgres:test@localhost:5432"`.
+pub fn run_postgres_test<T>(test: T) -> Result<(), Box<dyn Error>>
+where
+    T: FnOnce(&str) -> Result<(), Box<dyn Error>> + panic::UnwindSafe,
+{
+    let (drop_tables_res, test_result) = {
+        let base_url = match env::var("DIESEL_POSTGRES_TEST_URL").ok() {
+            Some(url) => url,
+            None => {
+                println!(
+                    "Ignoring {}",
+                    std::thread::current().name().unwrap_or("<unknown test>")
+                );
+                return Ok(());
+            }
+        };
+
+        let db_name = db_name();
+        {
+            let conn = PgConnection::establish(&base_url)?;
+            conn.batch_execute(&format!("create database {};", db_name))?;
+        }
+
+        let url = format!("{}/{}", base_url, db_name);
+        {
+            let conn = PgConnection::establish(&url)?;
+            run_postgres_migrations(&conn)?;
+        }
+
+        let result = panic::catch_unwind(move || test(&url));
+
+        // drop all the tables
+        let conn = PgConnection::establish(&base_url)?;
+        let drop_tables_res: Result<(), Box<dyn Error>> = (|| {
+            conn.batch_execute(&format!("DROP DATABASE {};", db_name))?;
+            Ok(())
+        })();
+
+        (drop_tables_res, result)
+    };
+
+    match test_result {
+        Ok(res) => drop_tables_res.and(res),
+        Err(err) => {
+            panic::resume_unwind(err);
+        }
+    }
+}
+
+fn db_name() -> String {
+    let current_thread = std::thread::current();
+    let thread_id = current_thread.name();
+    // thread names during the unit test process are the path of the test being run, minus the
+    // crate name.
+    thread_id
+        .and_then(|test_name| test_name.rsplit("::").next())
+        .unwrap_or("test_db")
+        .to_string()
+}

--- a/services/scabbard/libscabbard/src/store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/mod.rs
@@ -17,6 +17,8 @@
 #[cfg(feature = "scabbardv3")]
 mod command;
 mod commit_hash;
+#[cfg(all(test, feature = "diesel-postgres-tests"))]
+pub(crate) mod diesel_postgres_test;
 #[cfg(any(feature = "postgres", feature = "sqlite"))]
 pub(crate) mod pool;
 #[cfg(feature = "scabbardv3-store")]

--- a/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/boxed.rs
@@ -196,8 +196,9 @@ impl ScabbardStore for Box<dyn ScabbardStore> {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError> {
-        (&**self).update_consensus_event(service_id, event_id, executed_at)
+        (&**self).update_consensus_event(service_id, event_id, executed_at, executed_epoch)
     }
 
     /// List all consensus events for a given service_id

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -792,6 +792,8 @@ pub mod tests {
 
     #[cfg(feature = "sqlite")]
     use crate::migrations::run_sqlite_migrations;
+    #[cfg(feature = "diesel-postgres-tests")]
+    use crate::store::diesel_postgres_test::run_postgres_test;
 
     use crate::store::scabbard_store::{
         service::{ConsensusType, ScabbardServiceBuilder, ServiceStatus},
@@ -801,6 +803,8 @@ pub mod tests {
         CommitEntryBuilder, ConsensusDecision,
     };
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    use diesel::pg::PgConnection;
     use diesel::r2d2::{ConnectionManager, Pool};
     #[cfg(feature = "sqlite")]
     use diesel::{
@@ -875,6 +879,20 @@ pub mod tests {
         scabbard_store_add_context(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_add_context() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+
+            let store = DieselScabbardStore::new(pool);
+
+            scabbard_store_add_context(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `add_consensus_action` operation is successful.
     ///
     /// 1. Add a valid context to the store
@@ -939,6 +957,18 @@ pub mod tests {
         let store = DieselScabbardStore::new(pool);
 
         scabbard_store_add_actions(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_add_actions() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_add_actions(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `list_consensus_actions` operation is successful.
@@ -1076,6 +1106,18 @@ pub mod tests {
         scabbard_store_list_actions(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_list_actions() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_list_actions(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `update_consensus_context` operation is successful.
     ///
     /// 1. Add a valid context to the store
@@ -1155,6 +1197,18 @@ pub mod tests {
         let store = DieselScabbardStore::new(pool);
 
         scabbard_store_update_context(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_update_context() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_update_context(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `update_consensus_action` operation is successful.
@@ -1253,6 +1307,18 @@ pub mod tests {
         scabbard_store_update_action(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_update_action() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_update_action(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `get_service` operation is successful.
     ///
     /// 1. Add a service in the finalized state to the database
@@ -1294,6 +1360,18 @@ pub mod tests {
 
         let store = DieselScabbardStore::new(pool);
         scabbard_store_get_service(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_get_service() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_get_service(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `list_ready_services` operation is successful.
@@ -1413,6 +1491,18 @@ pub mod tests {
         scabbard_store_list_ready_services(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_list_ready_services() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_list_ready_services(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `add_commit_entry` operation is successful.
     ///
     /// 1. Add a valid service to the database
@@ -1494,6 +1584,18 @@ pub mod tests {
         scabbard_add_commit_entry(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_add_commit_entry() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_add_commit_entry(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `get_last_commit_entry` operation is successful.
     ///
     /// 1. Add a valid service to the database
@@ -1569,6 +1671,18 @@ pub mod tests {
 
         let store = DieselScabbardStore::new(pool);
         scabbard_get_last_commit_entry(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_get_last_commit_entry() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_get_last_commit_entry(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `update_commit_entry` operation is successful.
@@ -1655,6 +1769,18 @@ pub mod tests {
         scabbard_update_commit_entry(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_update_commit_entry() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_update_commit_entry(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `update_service` operation is successful.
     ///
     /// 1. Add a service in the prepared state to the database
@@ -1734,6 +1860,18 @@ pub mod tests {
         scabbard_store_update_service(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_update_service() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_update_service(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `add_consensus_event` operation is successful.
     ///
     /// 1. Add a valid participant context to the store
@@ -1808,6 +1946,18 @@ pub mod tests {
         scabbard_store_add_event(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_add_event() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_add_event(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `update_consensus_event` operation is successful.
     ///
     /// 1. Add a valid participant context to the store
@@ -1879,6 +2029,18 @@ pub mod tests {
 
         let store = DieselScabbardStore::new(pool);
         scabbard_store_update_event(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_update_event() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_update_event(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `list_consensus_events` operation is successful.
@@ -2013,6 +2175,18 @@ pub mod tests {
 
         let store = DieselScabbardStore::new(pool);
         scabbard_store_list_events(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_list_events() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_list_events(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `get_current_consensus_context` operation is successful.
@@ -2162,6 +2336,18 @@ pub mod tests {
         scabbard_store_get_current_context(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_get_current_context() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_get_current_context(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `remove_service` operation is successful.
     ///
     /// 1. Add a services to the database
@@ -2249,6 +2435,18 @@ pub mod tests {
         scabbard_store_remove_service(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_remove_service() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_remove_service(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `set_alarm` operation is successful.
     ///
     /// 1. Add a service to the database
@@ -2320,6 +2518,18 @@ pub mod tests {
 
         let store = DieselScabbardStore::new(pool);
         scabbard_store_set_alarm(&store);
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_set_alarm() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_set_alarm(&store);
+
+            Ok(())
+        })
     }
 
     /// Test that the scabbard store `unset_alarm` operation is successful.
@@ -2410,6 +2620,18 @@ pub mod tests {
         scabbard_store_unset_alarm(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_unset_alarm() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_unset_alarm(&store);
+
+            Ok(())
+        })
+    }
+
     /// Test that the scabbard store `get_alarm` operation is successful.
     ///
     /// 1. Add a service to the database
@@ -2498,6 +2720,18 @@ pub mod tests {
         scabbard_store_get_alarm(&store);
     }
 
+    #[cfg(feature = "diesel-postgres-tests")]
+    #[test]
+    fn postgres_scabbard_store_get_alarm() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let pool = create_postgres_pool(url)?;
+            let store = DieselScabbardStore::new(pool);
+            scabbard_store_get_alarm(&store);
+
+            Ok(())
+        })
+    }
+
     #[cfg(feature = "sqlite")]
     fn create_sqlite_memory_pool() -> Pool<ConnectionManager<SqliteConnection>> {
         let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
@@ -2530,5 +2764,15 @@ pub mod tests {
             )
             .map_err(diesel::r2d2::Error::QueryError)
         }
+    }
+
+    #[cfg(feature = "diesel-postgres-tests")]
+    fn create_postgres_pool(
+        url: &str,
+    ) -> Result<Pool<ConnectionManager<PgConnection>>, Box<dyn std::error::Error>> {
+        let connection_manager = ConnectionManager::<PgConnection>::new(url);
+        let pool = Pool::builder().build(connection_manager)?;
+
+        Ok(pool)
     }
 }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -198,12 +198,14 @@ impl ScabbardStore for DieselScabbardStore<SqliteConnection> {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_event(
                 service_id,
                 event_id,
                 executed_at,
+                executed_epoch,
             )
         })
     }
@@ -386,12 +388,14 @@ impl ScabbardStore for DieselScabbardStore<PgConnection> {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError> {
         self.pool.execute_write(|conn| {
             ScabbardStoreOperations::new(conn).update_consensus_event(
                 service_id,
                 event_id,
                 executed_at,
+                executed_epoch,
             )
         })
     }
@@ -572,11 +576,13 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, SqliteConnection> {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_event(
             service_id,
             event_id,
             executed_at,
+            executed_epoch,
         )
     }
     /// List all consensus events for a given service_id
@@ -725,11 +731,13 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError> {
         ScabbardStoreOperations::new(self.connection).update_consensus_event(
             service_id,
             event_id,
             executed_at,
+            executed_epoch,
         )
     }
     /// List all consensus events for a given service_id
@@ -2018,7 +2026,7 @@ pub mod tests {
             .expect("failed to add event");
 
         assert!(store
-            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now())
+            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now(), 1)
             .is_ok());
     }
 
@@ -2151,7 +2159,7 @@ pub mod tests {
         );
 
         store
-            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now())
+            .update_consensus_event(&participant_fqsi, event_id, SystemTime::now(), 1)
             .expect("failed to update event");
 
         let events = store

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -783,13 +783,14 @@ impl<'a> ScabbardStore for DieselConnectionScabbardStore<'a, PgConnection> {
     }
 }
 
-#[cfg(all(test, feature = "sqlite"))]
+#[cfg(test)]
 pub mod tests {
     use super::*;
 
     use std::time::Duration;
     use std::time::SystemTime;
 
+    #[cfg(feature = "sqlite")]
     use crate::migrations::run_sqlite_migrations;
 
     use crate::store::scabbard_store::{
@@ -800,10 +801,10 @@ pub mod tests {
         CommitEntryBuilder, ConsensusDecision,
     };
 
+    use diesel::r2d2::{ConnectionManager, Pool};
+    #[cfg(feature = "sqlite")]
     use diesel::{
-        connection::SimpleConnection,
-        r2d2::{ConnectionManager, CustomizeConnection, Pool},
-        sqlite::SqliteConnection,
+        connection::SimpleConnection, r2d2::CustomizeConnection, sqlite::SqliteConnection,
     };
     use splinter::{service::FullyQualifiedServiceId, service::ServiceId};
 
@@ -811,12 +812,7 @@ pub mod tests {
     ///
     /// 1. Add a valid context to the store and check that the operation is successful
     /// 2. Attempt to add the same context to the store again and check that an error is returned
-    #[test]
-    fn scabbard_store_add_context() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_add_context(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -869,17 +865,22 @@ pub mod tests {
             .is_err());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_add_context() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_add_context(&store);
+    }
+
     /// Test that the scabbard store `add_consensus_action` operation is successful.
     ///
     /// 1. Add a valid context to the store
     /// 2. Add an action with the same `service_id` and `epoch` to the store and check
     ///    that the operation was successful
-    #[test]
-    fn scabbard_store_add_actions() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_add_actions(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -930,17 +931,22 @@ pub mod tests {
             .is_ok());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_add_actions() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_add_actions(&store);
+    }
+
     /// Test that the scabbard store `list_consensus_actions` operation is successful.
     ///
     /// 1. Add a valid context to the store
     /// 2. Add two actions with the same `service_id` and `epoch` to the store
     /// 3. List the actions and check that the actions returned match what was added
-    #[test]
-    fn scabbard_store_list_actions() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_list_actions(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1060,17 +1066,22 @@ pub mod tests {
         );
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_list_actions() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_list_actions(&store);
+    }
+
     /// Test that the scabbard store `update_consensus_context` operation is successful.
     ///
     /// 1. Add a valid context to the store
     /// 2. Create a valid updated context
     /// 3. Attempt to update the original context, check that the operation is successful
-    #[test]
-    fn scabbard_store_update_context() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_update_context(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1136,18 +1147,23 @@ pub mod tests {
             .is_ok());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_update_context() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_update_context(&store);
+    }
+
     /// Test that the scabbard store `update_consensus_action` operation is successful.
     ///
     /// 1. Add a valid context to the store
     /// 2. Add an action to the database with the same `service_id` and `epoch`
     /// 3. Attempt to update the action as if it had been executed, check that the operation is
     ///    successful
-    #[test]
-    fn scabbard_store_update_action() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_update_action(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1228,17 +1244,21 @@ pub mod tests {
             .is_ok());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_update_action() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_update_action(&store);
+    }
+
     /// Test that the scabbard store `get_service` operation is successful.
     ///
     /// 1. Add a service in the finalized state to the database
     /// 2. Fetch that service from the store
     /// 3. Verify the correct service was returned
-    #[test]
-    fn scabbard_store_get_service() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_get_service(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1267,6 +1287,15 @@ pub mod tests {
         assert_eq!(service, fetched_service);
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_get_service() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_get_service(&store);
+    }
+
     /// Test that the scabbard store `list_ready_services` operation is successful.
     ///
     /// 1. Add a service in the finalized state to the database
@@ -1277,12 +1306,7 @@ pub mod tests {
     /// 6. Call `list_ready_services` and check that the service is returned
     /// 7. Update the action and event as if it had been executed
     /// 8. Call `list_ready_services` and check that no services are returned
-    #[test]
-    fn scabbard_store_list_ready_services() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_list_ready_services(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1363,7 +1387,7 @@ pub mod tests {
         assert_eq!(&ready_services[0], &service_fqsi);
 
         store
-            .update_consensus_event(&service_fqsi, event_id, SystemTime::now())
+            .update_consensus_event(&service_fqsi, event_id, SystemTime::now(), 1)
             .expect("failed to update action");
 
         store
@@ -1379,6 +1403,16 @@ pub mod tests {
         assert!(ready_services.is_empty());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_list_ready_services() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_list_ready_services(&store);
+    }
+
     /// Test that the scabbard store `add_commit_entry` operation is successful.
     ///
     /// 1. Add a valid service to the database
@@ -1388,12 +1422,7 @@ pub mod tests {
     ///    that was added
     /// 4. Attempt to add a commit entry for a service that does not exist and check that an error
     ///    is returned
-    #[test]
-    fn scabbard_add_commit_entry() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_add_commit_entry(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1456,6 +1485,15 @@ pub mod tests {
         assert!(store.add_commit_entry(bad_commit_entry).is_err());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_add_commit_entry() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_add_commit_entry(&store);
+    }
+
     /// Test that the scabbard store `get_last_commit_entry` operation is successful.
     ///
     /// 1. Add a valid service to the database
@@ -1465,12 +1503,7 @@ pub mod tests {
     ///    that was added
     /// 4. Attempt to call `get_last_commit_entry` with a `service_id` for a service that does not
     ///    exist and check that `None` is returned
-    #[test]
-    fn scabbard_get_last_commit_entry() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_get_last_commit_entry(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1529,6 +1562,15 @@ pub mod tests {
         assert_eq!(get_last_commit_entry, None);
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_get_last_commit_entry() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_get_last_commit_entry(&store);
+    }
+
     /// Test that the scabbard store `update_commit_entry` operation is successful.
     ///
     /// 1. Add a valid service to the database
@@ -1538,12 +1580,7 @@ pub mod tests {
     ///    successful
     /// 4. Use `get_last_commit_entry` and check that the returned commit entry matches the
     ///    updated commit entry
-    #[test]
-    fn scabbard_update_commit_entry() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_update_commit_entry(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1609,6 +1646,15 @@ pub mod tests {
         assert_eq!(get_last_commit_entry, Some(update_commit_entry));
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_update_commit_entry() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_update_commit_entry(&store);
+    }
+
     /// Test that the scabbard store `update_service` operation is successful.
     ///
     /// 1. Add a service in the prepared state to the database
@@ -1616,12 +1662,7 @@ pub mod tests {
     /// 3. Call `list_ready_services` and check that the service is not returned
     /// 4. Attempt to use `update_service` the service to change the service state to finalized
     /// 5. Call `list_ready_services` and check that the service is returned
-    #[test]
-    fn scabbard_store_update_service() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_update_service(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -1684,18 +1725,22 @@ pub mod tests {
         assert_eq!(&ready_services[0], &service_fqsi);
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_update_service() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_update_service(&store);
+    }
+
     /// Test that the scabbard store `add_consensus_event` operation is successful.
     ///
     /// 1. Add a valid participant context to the store
     /// 2. Attempt to add a valid event to the store and check that the operation was successful
     /// 3. Attempt to add a an event for a service_id that does not exist check that an error is
     ///    returned
-    #[test]
-    fn scabbard_store_add_event() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_add_event(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_random();
 
         let participant_fqsi = FullyQualifiedServiceId::new_random();
@@ -1753,18 +1798,23 @@ pub mod tests {
             .is_err());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_add_event() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+
+        scabbard_store_add_event(&store);
+    }
+
     /// Test that the scabbard store `update_consensus_event` operation is successful.
     ///
     /// 1. Add a valid participant context to the store
     /// 2. Add a valid event to the store
     /// 3. Attempt to update the `executed_at` time for the event and check that the operation was
     ///    successful
-    #[test]
-    fn scabbard_store_update_event() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_update_event(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_random();
 
         let participant_fqsi = FullyQualifiedServiceId::new_random();
@@ -1822,6 +1872,15 @@ pub mod tests {
             .is_ok());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_update_event() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_update_event(&store);
+    }
+
     /// Test that the scabbard store `list_consensus_events` operation is successful.
     ///
     /// 1. Add a valid participant context to the store
@@ -1831,12 +1890,7 @@ pub mod tests {
     /// 5. Call `list_consensus_events` and check that both events are returned in the correct order
     /// 6. Update the `executed_at` time for the first event
     /// 7. Call `list_consensus_events` and check that only the second event is returned
-    #[test]
-    fn scabbard_store_list_events() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_list_events(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_random();
 
         let participant_fqsi = FullyQualifiedServiceId::new_random();
@@ -1952,6 +2006,15 @@ pub mod tests {
         );
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_list_events() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_list_events(&store);
+    }
+
     /// Test that the scabbard store `get_current_consensus_context` operation is successful.
     ///
     /// 1. Add two services to the database
@@ -1967,12 +2030,7 @@ pub mod tests {
     /// 8. Add a participant context with a larger epoch for the first service
     /// 9. Call `get_current_consensus_context` with the first service ID and check that the
     ///    participant context that was most recently added is returned
-    #[test]
-    fn scabbard_store_get_current_context() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_get_current_context(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -2095,6 +2153,15 @@ pub mod tests {
         assert_eq!(current_context, Some(context4));
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_get_current_context() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_get_current_context(&store);
+    }
+
     /// Test that the scabbard store `remove_service` operation is successful.
     ///
     /// 1. Add a services to the database
@@ -2102,12 +2169,7 @@ pub mod tests {
     /// 3. Verify both can be fetched
     /// 4. Remove the service
     /// 5. Verify that the service and context were both removed
-    #[test]
-    fn scabbard_store_remove_service() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_remove_service(store: &dyn ScabbardStore) {
         let coordinator_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -2178,6 +2240,15 @@ pub mod tests {
             .is_none());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_remove_service() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_remove_service(&store);
+    }
+
     /// Test that the scabbard store `set_alarm` operation is successful.
     ///
     /// 1. Add a service to the database
@@ -2186,12 +2257,7 @@ pub mod tests {
     /// 4. Set an alarm for the service and check that the operation was successful
     /// 5. Call `list_ready_services` and check that the service is returned because it
     ///    has an alarm that has passed
-    #[test]
-    fn scabbard_store_set_alarm() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_set_alarm(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -2247,6 +2313,15 @@ pub mod tests {
         assert_eq!(&ready_services[0], &service_fqsi);
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_set_alarm() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_set_alarm(&store);
+    }
+
     /// Test that the scabbard store `unset_alarm` operation is successful.
     ///
     /// 1. Add a service to the database
@@ -2257,12 +2332,7 @@ pub mod tests {
     ///    has an alarm that has passed
     /// 6. Unset the alarm for the service
     /// 7. Call `list_ready_services` and check that the service is no longer returned
-    #[test]
-    fn scabbard_store_unset_alarm() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_unset_alarm(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -2331,6 +2401,15 @@ pub mod tests {
         assert!(ready_services.is_empty());
     }
 
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_unset_alarm() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_unset_alarm(&store);
+    }
+
     /// Test that the scabbard store `get_alarm` operation is successful.
     ///
     /// 1. Add a service to the database
@@ -2339,12 +2418,7 @@ pub mod tests {
     /// 4. Call `get_alarm` and check that the alarm is returned
     /// 5. Unset the alarm
     /// 6. Call `get_alarm` and check that the alarm is no longer returned
-    #[test]
-    fn scabbard_store_get_alarm() {
-        let pool = create_connection_pool_and_migrate();
-
-        let store = DieselScabbardStore::new(pool);
-
+    fn scabbard_store_get_alarm(store: &dyn ScabbardStore) {
         let service_fqsi = FullyQualifiedServiceId::new_from_string("abcde-fghij::aa00")
             .expect("creating FullyQualifiedServiceId from string 'abcde-fghij::aa00'");
 
@@ -2415,7 +2489,17 @@ pub mod tests {
         assert_eq!(retrieved_alarm, None);
     }
 
-    fn create_connection_pool_and_migrate() -> Pool<ConnectionManager<SqliteConnection>> {
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_scabbard_store_get_alarm() {
+        let pool = create_sqlite_memory_pool();
+
+        let store = DieselScabbardStore::new(pool);
+        scabbard_store_get_alarm(&store);
+    }
+
+    #[cfg(feature = "sqlite")]
+    fn create_sqlite_memory_pool() -> Pool<ConnectionManager<SqliteConnection>> {
         let connection_manager = ConnectionManager::<SqliteConnection>::new(":memory:");
         let pool = Pool::builder()
             .max_size(1)
@@ -2429,11 +2513,13 @@ pub mod tests {
         pool
     }
 
+    #[cfg(feature = "sqlite")]
     #[derive(Default, Debug)]
     /// Foreign keys must be enabled on a per connection basis. This customizer will be added to the
     /// SQLite pool builder and then ran against every connection returned from the pool.
     pub struct ConnectionCustomizer;
 
+    #[cfg(feature = "sqlite")]
     impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for ConnectionCustomizer {
         fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
             conn.batch_execute(

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
@@ -1326,8 +1326,8 @@ pub struct Consensus2pcEventModel {
     pub id: i64,
     pub circuit_id: String,
     pub service_id: String,
-    pub created_at: SystemTime,
-    pub executed_at: Option<i64>,
+    pub created_at: NaiveDateTime,
+    pub executed_at: Option<NaiveDateTime>,
     pub event_type: EventTypeModel,
 }
 
@@ -1336,7 +1336,7 @@ pub struct Consensus2pcEventModel {
 pub struct InsertableConsensus2pcEventModel {
     pub circuit_id: String,
     pub service_id: String,
-    pub executed_at: Option<i64>,
+    pub executed_at: Option<NaiveDateTime>,
     pub event_type: EventTypeModel,
 }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
@@ -1328,6 +1328,7 @@ pub struct Consensus2pcEventModel {
     pub service_id: String,
     pub created_at: NaiveDateTime,
     pub executed_at: Option<NaiveDateTime>,
+    pub executed_epoch: Option<i64>,
     pub event_type: EventTypeModel,
 }
 

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -138,6 +138,7 @@ table! {
         service_id -> Text,
         created_at -> Timestamp,
         executed_at -> Nullable<Timestamp>,
+        executed_epoch -> Nullable<BigInt>,
         position -> Integer,
         event_type -> crate::store::scabbard_store::diesel::models::EventTypeModelMapping,
     }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -137,7 +137,7 @@ table! {
         circuit_id  -> Text,
         service_id -> Text,
         created_at -> Timestamp,
-        executed_at -> Nullable<BigInt>,
+        executed_at -> Nullable<Timestamp>,
         position -> Integer,
         event_type -> crate::store::scabbard_store::diesel::models::EventTypeModelMapping,
     }

--- a/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/mod.rs
@@ -196,6 +196,7 @@ pub trait ScabbardStore {
         service_id: &FullyQualifiedServiceId,
         event_id: i64,
         executed_at: SystemTime,
+        executed_epoch: u64,
     ) -> Result<(), ScabbardStoreError>;
 
     /// List all pending consensus events for a given service_id

--- a/tests/test-splinter.yaml
+++ b/tests/test-splinter.yaml
@@ -24,8 +24,16 @@ services:
     image: test-splinter:${ISOLATION_ID}
     environment:
       - TEST_MODE=--verbose --release
+      - DIESEL_POSTGRES_TEST_URL=postgres://postgres:test@postgres-db:5432
     command: |
         bash -c "
             just test
         "
     stop_signal: SIGKILL
+
+  postgres-db:
+    image: postgres
+    expose:
+      - 5432
+    environment:
+      POSTGRES_PASSWORD: test


### PR DESCRIPTION
This PR updates the event table to have consistent timestamp values and adds the executed_epoch field.

Additionally, it adds postgres unit tests for the ScabbardStore to start.  These are enabled with the experimental feature `"diesel-postgres-tests"` and actually executed with the existence of the `DIESEL_POSTGRES_TEST_URL` environment variable.