### PR TITLE
Fix ServiceRequestGuard trait impl

### DIFF
--- a/libsplinter/src/rest_api/actix_web_1/resource.rs
+++ b/libsplinter/src/rest_api/actix_web_1/resource.rs
@@ -228,6 +228,11 @@ impl Resource {
         self
     }
 
+    pub fn add_service_request_guard(mut self, guard: Arc<dyn RequestGuard + 'static>) -> Self {
+        self.request_guards.push(guard);
+        self
+    }
+
     #[cfg(feature = "authorization")]
     pub(super) fn into_route(self) -> (actix_web::Resource, PermissionMap<Method>) {
         let mut resource = web::resource(&self.route);

--- a/rest_api/actix_web_1/src/service/mod.rs
+++ b/rest_api/actix_web_1/src/service/mod.rs
@@ -58,7 +58,8 @@ impl ServiceOrchestratorRestResourceProvider {
                         let mut resource_builder = Resource::build(&route);
 
                         for request_guard in endpoint.request_guards.into_iter() {
-                            resource_builder = resource_builder.add_request_guard(request_guard);
+                            resource_builder =
+                                resource_builder.add_service_request_guard(request_guard);
                         }
 
                         let service_type = endpoint.service_type;

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/batch_statuses.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/batch_statuses.rs
@@ -118,7 +118,7 @@ pub fn make_get_batch_status_endpoint() -> ServiceEndpoint {
                 ),
             }
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_BATCH_STATUSES_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/batches.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/batches.rs
@@ -99,7 +99,7 @@ pub fn make_add_batches_to_queue_endpoint() -> ServiceEndpoint {
                     }),
             )
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_ADD_BATCHES_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state.rs
@@ -86,7 +86,7 @@ pub fn make_get_state_with_prefix_endpoint() -> ServiceEndpoint {
                 }
             })
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_LIST_STATE_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],
@@ -362,7 +362,7 @@ mod tests {
     ) -> Resource {
         let mut resource = Resource::build(&service_endpoint.route);
         for request_guard in service_endpoint.request_guards.into_iter() {
-            resource = resource.add_request_guard(request_guard);
+            resource = resource.add_service_request_guard(request_guard);
         }
         let handler = service_endpoint.handler;
         #[cfg(feature = "authorization")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_address.rs
@@ -62,7 +62,7 @@ pub fn make_get_state_at_address_endpoint() -> ServiceEndpoint {
                 }
             })
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_GET_STATE_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],
@@ -247,7 +247,7 @@ mod tests {
     ) -> Resource {
         let mut resource = Resource::build(&service_endpoint.route);
         for request_guard in service_endpoint.request_guards.into_iter() {
-            resource = resource.add_request_guard(request_guard);
+            resource = resource.add_service_request_guard(request_guard);
         }
         let handler = service_endpoint.handler;
         #[cfg(feature = "authorization")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/state_root.rs
@@ -54,7 +54,7 @@ pub fn make_get_state_root_endpoint() -> ServiceEndpoint {
                 }
             })
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_STATE_ROOT_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],
@@ -226,7 +226,7 @@ mod tests {
     ) -> Resource {
         let mut resource = Resource::build(&service_endpoint.route);
         for request_guard in service_endpoint.request_guards.into_iter() {
-            resource = resource.add_request_guard(request_guard);
+            resource = resource.add_service_request_guard(request_guard);
         }
         let handler = service_endpoint.handler;
         #[cfg(feature = "authorization")]

--- a/services/scabbard/libscabbard/src/service/rest_api/actix/ws_subscribe.rs
+++ b/services/scabbard/libscabbard/src/service/rest_api/actix/ws_subscribe.rs
@@ -133,7 +133,7 @@ pub fn make_subscribe_endpoint() -> ServiceEndpoint {
                 }
             }
         }),
-        request_guards: vec![Box::new(ProtocolVersionRangeGuard::new(
+        request_guards: vec![Arc::new(ProtocolVersionRangeGuard::new(
             protocol::SCABBARD_SUBSCRIBE_PROTOCOL_MIN,
             protocol::SCABBARD_PROTOCOL_VERSION,
         ))],


### PR DESCRIPTION
The code this commit replaces could generate essentially endless cloned
boxes and would overflow the stack. This change replaces the trait with
a type declaration of an Arc wrapping the relevant trait object. This
makes it so we don't actually need to duplicate the trait object
everywhere and can just operate on references to to same one.

Signed-off-by: Caleb Hill <hill@bitwise.io>