### PR TITLE
Update log level when 2pc cannot create a proposal

### DIFF
--- a/libsplinter/src/consensus/two_phase/v1/mod.rs
+++ b/libsplinter/src/consensus/two_phase/v1/mod.rs
@@ -616,7 +616,7 @@ impl TwoPhaseEngine {
             } else {
                 match proposal_manager.create_proposal(None, vec![]) {
                     Ok(()) => self.state = State::AwaitingProposal,
-                    Err(err) => error!("Error while creating proposal: {}", err),
+                    Err(err) => debug!("Error while creating proposal: {}", err),
                 }
             }
         }

--- a/libsplinter/src/consensus/two_phase/v2/mod.rs
+++ b/libsplinter/src/consensus/two_phase/v2/mod.rs
@@ -503,7 +503,7 @@ impl TwoPhaseEngine {
         if self.is_coordinator() && self.state.is_idle() {
             match proposal_manager.create_proposal(None, vec![]) {
                 Ok(()) => self.state = State::AwaitingProposal,
-                Err(err) => error!("Error while creating proposal: {}", err),
+                Err(err) => debug!("Error while creating proposal: {}", err),
             }
         }
     }


### PR DESCRIPTION
This error is raised if a transaction is invalid, however this
is not actually an error. This commit updates the log level to
debug.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>