### PR TITLE
Update Ubuntu / OS X build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,19 @@ following commands.
 
 Homebrew (OS X):
 ```bash
-brew install openssl zeromq pkg-config protobuf postgresql
+brew install openssl pkg-config protobuf libpq
 ```
 
 APT (Ubuntu):
 ```bash
-apt install libssl-dev libzmq3-dev pkg-config libprotobuf-dev postgresql
+apt install \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    libsqlite3-dev \
+    libpq-dev \
+    openssl
 ```
 
 Once you have the prerequisites installed, build Splinter by running `cargo


### PR DESCRIPTION
Replaced postgres with libpq / libpq-dev, as a full postgres
installation is not strictly necessary. Removed libzmq as it is no
longer used as of 0.5.23.

For Ubuntu: Replaced insufficient libprotobuf-dev with the more accurate
protobuf-compiler dependency. Added required openssl, libsqlite3-dev,
pkg-config, and build-essential.

Signed-off-by: Amelia Bradley <bradley@bitwise.io>