### PR TITLE
Remove libzmq3-dev library from dockerfiles

### DIFF
--- a/ci/publish-splinter-crates.dockerfile
+++ b/ci/publish-splinter-crates.dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update \
     libpq-dev \
     libsqlite3-dev \
     libssl-dev \
-    libzmq3-dev \
     pkg-config \
     unzip \
  && apt-get clean \

--- a/ci/splinter-dev.dockerfile
+++ b/ci/splinter-dev.dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update \
     libsasl2-dev \
     libssl-dev \
     libsqlite3-dev \
-    libzmq3-dev \
     openssl \
     pandoc \
     pkg-config \


### PR DESCRIPTION
Remove the libzmq3-dev library from dockerfiles, as zmq was removed with
the removal of the zmq-transport feature in 0.5.23.

Signed-off-by: Amelia Bradley <bradley@bitwise.io>