### PR TITLE
Backport 0-6: Log error instead of propagate on prune cleanup

### DIFF
--- a/services/scabbard/libscabbard/src/service/state/mod.rs
+++ b/services/scabbard/libscabbard/src/service/state/mod.rs
@@ -356,12 +356,12 @@ impl ScabbardState {
                         })?;
 
                     if self.state_autocleanup_enabled {
-                        self.merkle_state.remove_pruned_entries().map_err(|err| {
-                            ScabbardStateError(format!(
-                                "failed to cleanup pruned state entries {}: {}",
+                        if let Err(err) = self.merkle_state.remove_pruned_entries() {
+                            error!(
+                                "failed to cleanup pruned state for root {}: {}",
                                 previous_state_root, err
-                            ))
-                        })?;
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
Backport of #2034 