### PR TITLE
Add echo service to splinter-dev.dockerfile

### DIFF
--- a/ci/splinter-dev.dockerfile
+++ b/ci/splinter-dev.dockerfile
@@ -87,6 +87,7 @@ COPY services/scabbard/cli/Cargo.toml /build/services/scabbard/cli/Cargo.toml
 COPY services/scabbard/libscabbard/build.rs /build/services/scabbard/libscabbard/build.rs
 COPY services/scabbard/libscabbard/Cargo.toml /build/services/scabbard/libscabbard/Cargo.toml
 COPY services/scabbard/libscabbard/protos /build/services/scabbard/libscabbard/protos
+COPY services/echo/libecho/Cargo.toml /build/services/echo/libecho/Cargo.toml
 
 # Do release builds for each Cargo.toml
 # Workaround for https://github.com/koalaman/shellcheck/issues/1894


### PR DESCRIPTION
Copy the libecho Cargo.toml file to the build directory
in the `Copy over splinter files` section of the splinter-dev.dockerfile

Signed-off-by: Isabel Tomb <tomb@bitwise.io>