### PR TITLE
Add scabbard store view: `consensus_2pc_events_and_contexts_all`

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-085317-add-update-context-action-id/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-085317-add-update-context-action-id/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE consensus_2pc_event DROP COLUMN update_context_action_id;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-085317-add-update-context-action-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-085317-add-update-context-action-id/up.sql
@@ -1,0 +1,33 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- add a new column to consensus_2pc_event
+ALTER TABLE consensus_2pc_event ADD COLUMN update_context_action_id INTEGER;
+
+-- set the consensus_2pc_event column for each event based on 
+UPDATE consensus_2pc_event SET update_context_action_id = 
+CASE consensus_2pc_event.executed_at
+    WHEN NULL THEN NULL
+    ELSE (
+        SELECT a.id
+        FROM consensus_2pc_action a, consensus_2pc_update_context_action uc
+        WHERE a.id = uc.action_id
+            AND consensus_2pc_event.circuit_id = a.circuit_id
+            AND consensus_2pc_event.service_id = a.service_id
+            AND a.executed_at < consensus_2pc_event.executed_at
+        ORDER BY a.executed_at DESC
+        LIMIT 1
+    )
+    END;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+DROP VIEW consensus_2pc_events_and_contexts_all;

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/up.sql
@@ -1,0 +1,49 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+CREATE VIEW consensus_2pc_events_and_contexts_all AS
+SELECT id AS e_id,
+       circuit_id,
+       service_id,
+       event_type,
+       consensus_2pc_deliver_event.epoch AS d_epoch,
+       consensus_2pc_deliver_event.receiver_service_id AS d_receiver_service_id,
+       consensus_2pc_deliver_event.message_type AS d_message_type,
+       consensus_2pc_deliver_event.vote_response AS d_vote_response,
+       consensus_2pc_deliver_event.vote_request AS d_vote_request,
+       consensus_2pc_start_event.value AS s_value,
+       consensus_2pc_vote_event.vote AS v_vote,
+       created_at AS e_created_at,
+       executed_at AS e_executed_at,
+       executed_epoch AS e_executed_epoch,
+       consensus_2pc_update_context_action.coordinator AS ctx_coordinator,
+       consensus_2pc_update_context_action.epoch AS ctx_epoch,
+       consensus_2pc_update_context_action.last_commit_epoch AS ctx_last_commit_epoch,
+       consensus_2pc_update_context_action.state AS ctx_state,
+       consensus_2pc_update_context_action.vote_timeout_start AS ctx_vote_timeout_start,
+       consensus_2pc_update_context_action.vote AS ctx_vote,
+       consensus_2pc_update_context_action.decision_timeout_start AS ctx_decision_timeout_start,
+       consensus_2pc_update_context_action.action_alarm AS ctx_action_alarm,
+       consensus_2pc_update_context_action.ack_timeout_start AS ctx_ack_timeout_start
+FROM consensus_2pc_event
+LEFT JOIN consensus_2pc_deliver_event
+    ON consensus_2pc_event.id=consensus_2pc_deliver_event.event_id
+LEFT JOIN consensus_2pc_start_event
+    ON consensus_2pc_event.id=consensus_2pc_start_event.event_id
+LEFT JOIN consensus_2pc_vote_event
+    ON consensus_2pc_event.id=consensus_2pc_vote_event.event_id
+LEFT JOIN consensus_2pc_update_context_action 
+    ON consensus_2pc_event.update_context_action_id = consensus_2pc_update_context_action.action_id
+ORDER BY id;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-085317-add-update-context-action-id/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-085317-add-update-context-action-id/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE consensus_2pc_event DROP COLUMN update_context_action_id;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-085317-add-update-context-action-id/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-085317-add-update-context-action-id/up.sql
@@ -1,0 +1,35 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=off;
+
+-- add a new column to consensus_2pc_event
+ALTER TABLE consensus_2pc_event ADD COLUMN update_context_action_id INTEGER;
+
+-- set the consensus_2pc_event column for each event based on 
+UPDATE consensus_2pc_event SET update_context_action_id = 
+CASE consensus_2pc_event.executed_at
+    WHEN NULL THEN NULL
+    ELSE (
+        SELECT a.id
+        FROM consensus_2pc_action a, consensus_2pc_update_context_action uc
+        WHERE a.id = uc.action_id
+            AND consensus_2pc_event.circuit_id == a.circuit_id
+            AND consensus_2pc_event.service_id == a.service_id
+            AND a.executed_at < consensus_2pc_event.executed_at
+        ORDER BY a.executed_at DESC
+        LIMIT 1
+    )
+    END;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+DROP VIEW consensus_2pc_events_and_contexts_all;

--- a/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/sqlite/migrations/2022-07-25-151237-add-consensus-2pc-event-context-view/up.sql
@@ -1,0 +1,49 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+CREATE VIEW IF NOT EXISTS consensus_2pc_events_and_contexts_all AS
+SELECT id AS e_id,
+       circuit_id,
+       service_id,
+       event_type,
+       consensus_2pc_deliver_event.epoch AS d_epoch,
+       consensus_2pc_deliver_event.receiver_service_id AS d_receiver_service_id,
+       consensus_2pc_deliver_event.message_type AS d_message_type,
+       consensus_2pc_deliver_event.vote_response AS d_vote_response,
+       consensus_2pc_deliver_event.vote_request AS d_vote_request,
+       consensus_2pc_start_event.value AS s_value,
+       consensus_2pc_vote_event.vote AS v_vote,
+       created_at AS e_created_at,
+       executed_at AS e_executed_at,
+       executed_epoch AS e_executed_epoch,
+       consensus_2pc_update_context_action.coordinator AS ctx_coordinator,
+       consensus_2pc_update_context_action.epoch AS ctx_epoch,
+       consensus_2pc_update_context_action.last_commit_epoch AS ctx_last_commit_epoch,
+       consensus_2pc_update_context_action.state AS ctx_state,
+       consensus_2pc_update_context_action.vote_timeout_start AS ctx_vote_timeout_start,
+       consensus_2pc_update_context_action.vote AS ctx_vote,
+       consensus_2pc_update_context_action.decision_timeout_start AS ctx_decision_timeout_start,
+       consensus_2pc_update_context_action.action_alarm AS ctx_action_alarm,
+       consensus_2pc_update_context_action.ack_timeout_start AS ctx_ack_timeout_start
+FROM consensus_2pc_event
+LEFT JOIN consensus_2pc_deliver_event
+    ON consensus_2pc_event.id=consensus_2pc_deliver_event.event_id
+LEFT JOIN consensus_2pc_start_event
+    ON consensus_2pc_event.id=consensus_2pc_start_event.event_id
+LEFT JOIN consensus_2pc_vote_event
+    ON consensus_2pc_event.id=consensus_2pc_vote_event.event_id
+LEFT JOIN consensus_2pc_update_context_action 
+    ON consensus_2pc_event.update_context_action_id = consensus_2pc_update_context_action.action_id
+ORDER BY id;

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/mod.rs
@@ -1608,9 +1608,35 @@ pub mod tests {
         // check that the one service is still returned because it has an unexecuted action
         assert_eq!(&ready_services[0], &service_fqsi);
 
+        let update_context = ContextBuilder::default()
+            .with_coordinator(service_fqsi.clone().service_id())
+            .with_epoch(2)
+            .with_participants(vec![Participant {
+                process: peer_service_id.clone(),
+                vote: None,
+                decision_ack: false,
+            }])
+            .with_state(State::WaitingForStart)
+            .with_this_process(service_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let action = ConsensusAction::TwoPhaseCommit(Action::Update(
+            ConsensusContext::TwoPhaseCommit(update_context),
+            None,
+        ));
+
+        let update_ctx_action_id = store
+            .add_consensus_action(action, &service_fqsi, 1)
+            .expect("failed to add action");
+
+        store
+            .update_consensus_action(&service_fqsi, update_ctx_action_id, SystemTime::now())
+            .expect("failed to update action");
+
         store
             .update_consensus_event(&service_fqsi, event_id, SystemTime::now(), 1)
-            .expect("failed to update action");
+            .expect("failed to update event");
 
         store
             .update_consensus_action(&service_fqsi, action_id, SystemTime::now())
@@ -2161,6 +2187,39 @@ pub mod tests {
             .add_consensus_event(&participant_fqsi, event)
             .expect("failed to add event");
 
+        let update_context = ContextBuilder::default()
+            .with_coordinator(coordinator_fqsi.clone().service_id())
+            .with_epoch(2)
+            .with_participants(vec![
+                Participant {
+                    process: participant_fqsi.service_id().clone(),
+                    vote: None,
+                    decision_ack: false,
+                },
+                Participant {
+                    process: participant2_fqsi.service_id().clone(),
+                    vote: None,
+                    decision_ack: false,
+                },
+            ])
+            .with_state(State::WaitingForVoteRequest)
+            .with_this_process(participant_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let action = ConsensusAction::TwoPhaseCommit(Action::Update(
+            ConsensusContext::TwoPhaseCommit(update_context),
+            None,
+        ));
+
+        let update_ctx_action_id = store
+            .add_consensus_action(action, &participant_fqsi, 1)
+            .expect("failed to add action");
+
+        store
+            .update_consensus_action(&participant_fqsi, update_ctx_action_id, SystemTime::now())
+            .expect("failed to update action");
+
         assert!(store
             .update_consensus_event(&participant_fqsi, event_id, SystemTime::now(), 1)
             .is_ok());
@@ -2293,6 +2352,39 @@ pub mod tests {
                 record: ConsensusEvent::TwoPhaseCommit(Event::Alarm()),
             },
         );
+
+        let update_context = ContextBuilder::default()
+            .with_coordinator(coordinator_fqsi.clone().service_id())
+            .with_epoch(2)
+            .with_participants(vec![
+                Participant {
+                    process: participant_fqsi.service_id().clone(),
+                    vote: None,
+                    decision_ack: false,
+                },
+                Participant {
+                    process: participant2_fqsi.service_id().clone(),
+                    vote: None,
+                    decision_ack: false,
+                },
+            ])
+            .with_state(State::WaitingForVoteRequest)
+            .with_this_process(participant_fqsi.clone().service_id())
+            .build()
+            .expect("failed to build context");
+
+        let action = ConsensusAction::TwoPhaseCommit(Action::Update(
+            ConsensusContext::TwoPhaseCommit(update_context),
+            None,
+        ));
+
+        let update_ctx_action_id = store
+            .add_consensus_action(action, &participant_fqsi, 1)
+            .expect("failed to add action");
+
+        store
+            .update_consensus_action(&participant_fqsi, update_ctx_action_id, SystemTime::now())
+            .expect("failed to update action");
 
         store
             .update_consensus_event(&participant_fqsi, event_id, SystemTime::now(), 1)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/models/consensus.rs
@@ -1290,6 +1290,7 @@ pub struct Consensus2pcEventModel {
     pub executed_at: Option<NaiveDateTime>,
     pub executed_epoch: Option<i64>,
     pub event_type: EventTypeModel,
+    pub update_context_action_id: Option<i64>,
 }
 
 #[derive(Debug, PartialEq, Insertable)]
@@ -1299,6 +1300,7 @@ pub struct InsertableConsensus2pcEventModel {
     pub service_id: String,
     pub executed_at: Option<NaiveDateTime>,
     pub event_type: EventTypeModel,
+    pub update_context_action_id: Option<i64>,
 }
 
 impl From<&Event> for EventTypeModel {

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/operations/add_consensus_event.rs
@@ -83,6 +83,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, SqliteConnection> {
                 service_id: service_id.service_id().to_string(),
                 executed_at: None,
                 event_type: EventTypeModel::from(&event),
+                update_context_action_id: None,
             };
 
             insert_into(consensus_2pc_event::table)
@@ -212,6 +213,7 @@ impl<'a> AddEventOperation for ScabbardStoreOperations<'a, PgConnection> {
                 service_id: service_id.service_id().to_string(),
                 executed_at: None,
                 event_type: EventTypeModel::from(&event),
+                update_context_action_id: None,
             };
 
             let event_id: i64 = insert_into(consensus_2pc_event::table)

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -141,6 +141,7 @@ table! {
         executed_epoch -> Nullable<BigInt>,
         position -> Integer,
         event_type -> crate::store::scabbard_store::diesel::models::EventTypeModelMapping,
+        update_context_action_id -> Nullable<Int8>,
     }
 }
 


### PR DESCRIPTION
Update the scabbard store `consensus_2pc_event` table to have a `update_context_action_id` column so that the `consensus_2pc_update_context_action` and `consensus_2pc_event` tables can be joined in the `consensus_2pc_events_and_contexts_all` view