### PR TITLE
Fix jitter bounds in test

### DIFF
--- a/services/echo/libecho/src/service/timer_handler.rs
+++ b/services/echo/libecho/src/service/timer_handler.rs
@@ -180,8 +180,8 @@ mod tests {
     #[test]
     fn test_get_jitter() {
         let jitter = get_jitter(45).expect("failed to get jitter");
-        assert!(jitter > (-45));
-        assert!(jitter < (45));
+        assert!(jitter >= (-45));
+        assert!(jitter <= (45));
 
         let jitter = get_jitter(0).expect("failed to get jitter");
         assert_eq!(jitter, 0);


### PR DESCRIPTION
The `get_jitter` function returns a jitter value between -`jitter` and
`jitter` but the test checks that it returns something greater than
-`jitter` and less than `jitter` which can be off by one from what the
function actually does. This commit updates the asserts to include those
boundry values as valid return values.

ie:
```
let input = 1;

// jitter could be -1,0,1
let jitter = get_jitter(input);

// This assert will fail 1/3 of the time when jitter == 1
assert!(jitter < input);

// This assert will fail 1/3 of the time when jitter == -1
assert!(jitter > -input);

// These assert statements accurately include the boundry values.
assert!(jitter <= input);
assert!(jitter >= -input);
// They should pass unless get_jitter returns jitter < -input or
// jitter > input

```

Signed-off-by: Caleb Hill <hill@bitwise.io>