### PR TITLE
Update echo service typos and comments

### DIFF
--- a/services/echo/libecho/src/service/timer_handler.rs
+++ b/services/echo/libecho/src/service/timer_handler.rs
@@ -142,30 +142,6 @@ impl TimerHandler for EchoTimerHandler {
         }
 
         Ok(())
-
-        // -- message generation --
-        // 1) get the arguments for this service which will include:
-        //      peers
-        //      frequency
-        //      jitter
-        //      error_rate
-        // 2) get the list of peers that haven't been send a message in frequency+jitter duration.
-        // 3) for each peer, calculate a unique actual jitter value betwene [-jitter, +jitter]
-        // 4) from the list of peers, keep only those which haven't received a message in
-        //    frequence+actual_jitter
-        // 5) for remaining peers, add a new request to the database with sent=false
-        // -- end of message generation --
-        // -- message sending --
-        // 6) read a list of messages from the database wich are in the sent=false state
-        // 7) for each message:
-        // 7a) using error_rate, determine whether to emulate an error; if so, emulate an error
-        // 7b) otherwise, send message; as each are sent
-        // 7c) using error_rate, determine whether to emulate an error; if so, go to next message
-        // 7d) update the database state to set that message to sent=true
-        // -- end message sending --
-        //
-        // Note: important that the message sending phase picks up any that weren't sent the
-        // previous attempt.
     }
 }
 

--- a/services/echo/libecho/src/store/diesel/operations/update_request_ack.rs
+++ b/services/echo/libecho/src/store/diesel/operations/update_request_ack.rs
@@ -59,7 +59,7 @@ where
                 )));
             }
 
-            let updat_ack_status = match ack {
+            let update_ack_status = match ack {
                 RequestStatus::Sent => 1,
                 RequestStatus::NotSent => 0,
             };
@@ -73,7 +73,7 @@ where
                                 .and(echo_requests::sender_service_id.eq(format!("{}", service))),
                         )
                         .set((
-                            echo_requests::ack.eq(updat_ack_status),
+                            echo_requests::ack.eq(update_ack_status),
                             echo_requests::ack_at.eq(ack_at),
                         ))
                         .execute(self.conn)
@@ -87,7 +87,7 @@ where
                                 .eq(correlation_id)
                                 .and(echo_requests::sender_service_id.eq(format!("{}", service))),
                         )
-                        .set(echo_requests::ack.eq(updat_ack_status))
+                        .set(echo_requests::ack.eq(update_ack_status))
                         .execute(self.conn)
                         .map(|_| ())
                         .map_err(|err| InternalError::from_source(Box::new(err)))?;


### PR DESCRIPTION
- remove an unnecessary comment in echo service
- fix variable name typo updat_ack_status -> update_ack_status