### PR TITLE
Fix postgresql scabbard store table primary key

### DIFF
--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-26-141800-fix-consensus-2pc-uca-participant-key/down.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-26-141800-fix-consensus-2pc-uca-participant-key/down.sql
@@ -1,0 +1,21 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE consensus_2pc_update_context_action_participant
+DROP CONSTRAINT consensus_2pc_update_context_action_participant_pkey;
+
+ALTER TABLE consensus_2pc_update_context_action_participant
+ADD CONSTRAINT consensus_2pc_update_context_action_participant_pkey
+PRIMARY KEY (action_id);

--- a/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-26-141800-fix-consensus-2pc-uca-participant-key/up.sql
+++ b/services/scabbard/libscabbard/src/migrations/diesel/postgres/migrations/2022-07-26-141800-fix-consensus-2pc-uca-participant-key/up.sql
@@ -1,0 +1,21 @@
+-- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the Licens
+-- You may obtain a copy of the License at
+--
+--     http://www.apachorg/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the Licens
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE consensus_2pc_update_context_action_participant
+DROP CONSTRAINT consensus_2pc_update_context_action_participant_pkey;
+
+ALTER TABLE consensus_2pc_update_context_action_participant
+ADD CONSTRAINT consensus_2pc_update_context_action_participant_pkey
+PRIMARY KEY (action_id, process);

--- a/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
+++ b/services/scabbard/libscabbard/src/store/scabbard_store/diesel/schema.rs
@@ -111,7 +111,7 @@ table! {
 }
 
 table! {
-    consensus_2pc_update_context_action_participant (action_id) {
+    consensus_2pc_update_context_action_participant (action_id, process) {
         action_id -> Int8,
         process -> Text,
         vote -> Nullable<Bool>,


### PR DESCRIPTION
Fix the primary key on the consensus_2pc_update_context_action_participant table. The table in postgresql originally only had `action_id` as the primary key however this was a bug as there can be multiple processes in the table with the same `action_id` so `process` needs to be included in the key. The sqlite table does not need to be updated as it already includes process in the primary key. This was only an issue in postgresql.