### PR TITLE
Bug fix: Add unintentionally deleted line back

### DIFF
--- a/splinterd/src/daemon/mod.rs
+++ b/splinterd/src/daemon/mod.rs
@@ -730,6 +730,8 @@ impl SplinterDaemon {
                     .resources(),
                 );
             }
+
+            rest_api_builder = rest_api_builder.with_authorization_handlers(authorization_handlers)
         }
 
         #[cfg(feature = "rest-api-cors")]


### PR DESCRIPTION
The line where authorization handlers were added in splinterd was
unintentionally deleted. This commit adds the deleted line back.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>