### PR TITLE
0-6: Fix gameroom test by adding tzdata package to test Dockerfile

### DIFF
--- a/examples/gameroom/tests/Dockerfile
+++ b/examples/gameroom/tests/Dockerfile
@@ -17,6 +17,7 @@ FROM splintercommunity/splinter-dev:v8
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
  postgresql-client \
+ tzdata \
  && rm -r /var/lib/apt/lists/*
 
 # Build gameroom cli


### PR DESCRIPTION
Chrono release 0.4.20 introduced a bug that manifests when the timezone is
not set. https://github.com/chronotope/chrono/issues/755

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>